### PR TITLE
Agent should not barf when config lines begin with white space

### DIFF
--- a/tests/badconfig.conf
+++ b/tests/badconfig.conf
@@ -1,0 +1,32 @@
+[Main]
+
+# The host of the Datadog intake server to send agent data to 
+dd_url: https://app.datadoghq.com
+
+# The Datadog api key to associate your agent's data with your organization. 
+# Can be found here: 
+# https://app.datadoghq.com/account/settings
+api_key: 1234
+
+# Boolean to enable debug_mode, which outputs massive amounts of log messages 
+# to the /tmp/ directory.  
+debug_mode: no 
+
+# Force the hostname to whatever you want.
+#hostname: mymachine.mydomain
+
+# Use the amazon EC2 instance-id instead of hostname (unless hostname is
+# explicitly set)
+use_ec2_instance_id: no
+
+# Use mount points instead of volumes to track disk and fs metrics
+use_mount: no
+
+
+# Start a graphite listener on this port
+# graphite_listen_port: 17124
+
+    nagios_log: /var/log/nagios3/nagios.log
+    nagios_perf_cfg: /var/log/blah.log
+
+graphite_listen_port: 17126

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,13 @@
+import unittest
+import os.path
+from config import *
+
+class TestConfig(unittest.TestCase):
+    def testWhiteSpaceConfig(self):
+        """Leading whitespace confuse ConfigParser
+        """
+        agentConfig, rawConfig = get_config(cfg_path=os.path.join(os.path.dirname(os.path.realpath(__file__)), "badconfig.conf"))
+        self.assertEquals(agentConfig["ddUrl"], "https://app.datadoghq.com")
+        self.assertEquals(agentConfig["apiKey"], "1234")
+        self.assertEquals(agentConfig["nagios_log"], "/var/log/nagios3/nagios.log")
+        self.assertEquals(agentConfig["graphite_listen_port"], 17126)


### PR DESCRIPTION
The standard ConfigParser in python treats line starting with white space as multilines, which has the potential to confuse any number of parameters (in particular the url to submit data to).

This fixes it by removing leading white spaces from config files before invoking ConfigParser.

And it comes with a small unittest

P.S. If you cringe at the sentence "... to submit data to", you're not [alone](http://www.slate.com/articles/podcasts/lexicon_valley/2012/02/lexicon_valley_why_we_think_we_can_t_end_a_sentence_with_a_preposition_.html)
