### PR TITLE
Dogstream clobber

### DIFF
--- a/checks/datadog.py
+++ b/checks/datadog.py
@@ -74,8 +74,8 @@ class Dogstreams(object):
         for dogstream in self.dogstreams:
             try:
                 result = dogstream.check(agentConfig, move_end)
-                # result may contain {"dogstream": [new]}
-                # If output contains {"dostream": [old]} that old value will get clobbered.
+                # result may contain {"dogstream": [new]}. 
+                # If output contains {"dogstream": [old]}, that old value will get concatenated with the new value
                 assert type(result) == type(output), "dogstream.check must return a dictionary"
                 for k in result:
                     if k in output:


### PR DESCRIPTION
@clofresh ran into the problem where only the last custom parser was getting its results saved. That's caused by the `output.update` that was replacing

```
{ 'dogstream': [old, old, old]}
```

with

```
{ 'dogstream': [new, new, new]}
```

Now we should get:

```
{ 'dogstream': [old, old, old, new, new, new] }
```
