### PR TITLE
Cacti support on CentOS

### DIFF
--- a/config.py
+++ b/config.py
@@ -25,7 +25,7 @@ def get_parsed_args():
     return options, args
 
 def get_version():
-    return "2.2.9"
+    return "2.2.10"
 
 def skip_leading_wsp(f):
     "Works on a file, returns a file-like object"

--- a/packaging/datadog-agent-base/rpm/datadog-agent-redhat
+++ b/packaging/datadog-agent-base/rpm/datadog-agent-redhat
@@ -26,6 +26,7 @@ AGENTPATH="/usr/share/datadog/agent/agent.py"
 AGENTUSER="dd-agent"
 PIDPATH="/var/run/dd-agent/"
 USE_SUPERVISOR="/usr/bin/dd-forwarder"
+SUPERVISOR_CONF="/etc/dd-agent/supervisor.conf"
 
 if [ -x "/usr/bin/python2.6" ]; then
     PYTHON="/usr/bin/python2.6"
@@ -42,8 +43,14 @@ LOCKFILE=/var/lock/subsys/$PROG
 
 check_status() {
     # run checks to determine if the service is running or use generic status
-    if [ -f "$LOCKFILE" ]
-        then
+    if [ -f $USE_SUPERVISOR ]; then
+	p=`supervisorctl -c $SUPERVISOR_CONF status | grep RUNNING | wc -l`
+	if [ $p -eq 2 ]; then
+            echo 'Datadog agent is running'
+    	else
+            echo 'Datadog agent is not running'
+	fi  
+    elif [ -f $LOCKFILE ]; then
             echo 'Datadog agent is running'
     else
             echo 'Datadog agent is not running'
@@ -62,7 +69,7 @@ grab_status() {
 start() {
     if [ -f $USE_SUPERVISOR ]; then
         echo -n "Starting Datadog agent (using supervisorctl):"
-        daemon --pidfile=/var/run/datadog-supervisord.pid supervisord -c /etc/dd-agent/supervisor.conf
+        daemon --pidfile=/var/run/datadog-supervisord.pid supervisord -c $SUPERVISOR_CONF
         echo
         return 0
     else

--- a/packaging/datadog-agent/rpm/supervisor.conf
+++ b/packaging/datadog-agent/rpm/supervisor.conf
@@ -13,7 +13,7 @@ pidfile = /var/run/datadog-supervisord.pid
 logfile_backups = 10
 
 [program:collector]
-command=/usr/bin/python2.6 /usr/share/datadog/agent/agent.py foreground --use-local-forwarder
+command=/usr/bin/python /usr/share/datadog/agent/agent.py foreground --use-local-forwarder
 stdout_logfile=NONE
 stderr_logfile=NONE
 priority=999


### PR DESCRIPTION
This fixes a python version issue and makes installation on CentOS 5 easier since the default python app libraries (e.g. MySQL-python) can be used directly.

Also fixes the agent status not being properly returned when using supervisord.
