### PR TITLE
Monotonic rate counters (#23)

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -130,9 +130,15 @@ class Check(object):
             interval = sample2[0] - sample1[0]
             if interval == 0:
                 raise Infinity()
+ 
             delta = sample2[1] - sample1[1]
+            if delta < 0:
+                raise UnknownValue()
+
             return (sample2[0], delta / interval)
         except Infinity:
+            raise
+        except UnknownValue:
             raise
         except Exception, e:
             raise NaN(e)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -42,17 +42,17 @@ class TestCore(unittest.TestCase):
         self.assertEquals(self.c.get_sample("test-counter"), 1.0)
         self.assertEquals(self.c.get_sample_with_timestamp("test-counter"), (2.0, 1.0))
         self.c.save_sample("test-counter", -2.0, 3.0)
-        self.assertEquals(self.c.get_sample_with_timestamp("test-counter"), (3.0, -4.0))
+        self.assertRaises(UnknownValue, self.c.get_sample_with_timestamp, "test-counter")
 
     def test_samples(self):
         self.assertEquals(self.c.get_samples(), {})
         self.c.save_sample("test-metric", 1.0, 0.0)  # value, ts
         self.c.save_sample("test-counter", 1.0, 1.0) # value, ts
-        self.c.save_sample("test-counter", 0.0, 2.0) # value, ts
+        self.c.save_sample("test-counter", 4.0, 2.0) # value, ts
         assert "test-metric"  in self.c.get_samples_with_timestamps(), self.c.get_samples_with_timestamps()
         self.assertEquals(self.c.get_samples_with_timestamps()["test-metric"], (0.0, 1.0))
         assert "test-counter" in self.c.get_samples_with_timestamps(), self.c.get_samples_with_timestamps()
-        self.assertEquals(self.c.get_samples_with_timestamps()["test-counter"], (2.0, -1.0))
+        self.assertEquals(self.c.get_samples_with_timestamps()["test-counter"], (2.0, 3.0))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Make sure we are not reporting metric on a wrapped counter. This works only for increasing counters (not decreasing). An 'UnknownValue' exception is raised if the counter is decreasing, allowing the value not to be picked up at all by the agent.

Updated tests to reflect the change.
