### PR TITLE
Elasticsearch fix

### DIFF
--- a/checks/db/elastic.py
+++ b/checks/db/elastic.py
@@ -57,9 +57,9 @@ class ElasticSearch(Check):
         for metric in cls.METRICS:
             desc = cls.METRICS[metric]
             if type(desc) == tuple:
-                func("es." + metric,*desc)
+                func("elasticsearch." + metric,*desc)
             else:
-                func("es." + metric,desc,metric)
+                func("elasticsearch." + metric,desc,metric)
 
     def __init__(self, logger):
         Check.__init__(self, logger)


### PR DESCRIPTION
Not a huge change but the lack of checking against the fqdn was causing the check to fail on our elasticsearch staging boxes - and I assume it would have failed on prod as well.

Also just added a bit of consistency in the logging since I ran into some minor trouble when grepping because I expected it be logging "elasticsearch" or "elastic search" not both.

Finally, I'd like to change the namespace to "elasticsearch.*" so it looks better on the infrastructure overview, but I didn't include that unless you disagreed on that. If you think that's a good idea, I'll put it in this pull request as well.
