### PR TITLE
Aliasing for all

### DIFF
--- a/checks/ec2.py
+++ b/checks/ec2.py
@@ -45,20 +45,6 @@ class EC2(Check):
             except:
                 pass
 
-        # Get fqdn, make sure that hostname only contains local part
-        try:
-            hname = metadata.get("hostname", None)
-            if hname is None:
-                hname = socket.gethostname()
-                metadata["fqdn"] = socket.getfqdn()
-            else:
-                metadata["fqdn"] = metadata["hostname"]
-
-            # Replace hostname with shortname
-            metadata["hostname"] = hname.split(".")[0]
-        except:
-            pass
-
         try:
             if socket_to is None:
                 socket_to = 3


### PR DESCRIPTION
This is a small code change, but a moderately big change in terms of overall effect, so I thought it warranted a pull-request.

Currently, we only trigger aliasing for ec2 hosts. This change would make it so that **all** agent hosts trigger aliasing, and the names would include, at a minimum, _hostname_ and _fqdn_.
