### PR TITLE
Proper URL in dd-agent for Elasticsearch?

### DIFF
--- a/checks/db/elastic.py
+++ b/checks/db/elastic.py
@@ -9,7 +9,7 @@ from util import json, headers
 
 class ElasticSearch(Check):
 
-    STATS_URL = "/_nodes/stats?all=true"
+    STATS_URL = "/_cluster/nodes/stats?all=true"
 
     METRICS = {
         "docs.count": "gauge",


### PR DESCRIPTION
I have updated all my ES boxes to the latest release - but they all error like this:

```
 Jun 30 13:25:55 es-cluster-03 dd-agent:  - checks - INFO - Fetching elastic search data from: http://xx.xx.xx.xxx:9200/_nodes/stats?all=true
 Jun 30 13:25:55 es-cluster-03 dd-agent:  - checks - ERROR - Unable to get ElasticSearch statistics#012Traceback (most recent call last):#012  File "/usr/share/datadog/agent/checks/db/elastic.py", line 131, in check#012    data = self._get_data(config, url)#012  File "/usr/share/datadog/agent/checks/db/elastic.py", line 79, in _get_data#012    request = urllib2.urlopen(req)#012  File "/usr/lib/python2.6/urllib2.py", line 126, in urlopen#012    return _opener.open(url, data, timeout)#012  File "/usr/lib/python2.6/urllib2.py", line 397, in open#012    response = meth(req, response)#012  File "/usr/lib/python2.6/urllib2.py", line 510, in http_response#012    'http', request, response, code, msg, hdrs)#012  File "/usr/lib/python2.6/urllib2.py", line 435, in error#012    return self._call_chain(*args)#012  File "/usr/lib/python2.6/urllib2.py", line 369, in _call_chain#012    result = func(*args)#012  File "/usr/lib/python2.6/urllib2.py", line 518, in http_error_default#012    raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)#012HTTPError: HTTP Error 400: Bad Request
```

Would this change provide a more compatible way (both 0.18.x and 0.19.x) to get the same data? I'm sorry - I don't have a 0.19.x box on hand to test with at the moment.
