### PR TITLE
Support Elasticsearch < 0.19

### DIFF
--- a/checks/db/elastic.py
+++ b/checks/db/elastic.py
@@ -3,13 +3,18 @@
 import urlparse
 import urllib2
 import socket
+import subprocess
+import sys
 
 from checks import Check, gethostname
 from util import json, headers
 
+class NodeNotFound(Exception): pass
+
 class ElasticSearch(Check):
 
     STATS_URL = "/_cluster/nodes/stats?all=true"
+    NODES_URL = "/_cluster/nodes?network=true"
 
     METRICS = {
         "docs.count": "gauge",
@@ -74,7 +79,7 @@ class ElasticSearch(Check):
 
     def _get_data(self, agentConfig, url):
         "Hit a given URL and return the parsed json"
-        
+
         req = urllib2.Request(url, None, headers(agentConfig))
         request = urllib2.urlopen(req)
         response = request.read()
@@ -86,7 +91,6 @@ class ElasticSearch(Check):
     def _process_metric(self, data, metric, path):
 
         value = data.get("indices",None)
-        
         for key in path.split('.'):
             if value is not None:
                 value = value.get(key,None)
@@ -104,16 +108,78 @@ class ElasticSearch(Check):
         for node in data['nodes']:
             node_data = data['nodes'][node]
 
-            # ES nodes will use `hostname` regardless of how the agent is configured
-            hostnames = (
-                gethostname(agentConfig).decode('utf-8'),
-                socket.gethostname().decode('utf-8'),
-                socket.getfqdn().decode('utf-8')
-            )
-            if node_data['hostname'].decode('utf-8') in hostnames:
-                def process_metric(metric, xtype, path):
-                    self._process_metric(node_data, metric, path)
-                self._map_metric(process_metric)
+            def process_metric(metric, xtype, path):
+                self._process_metric(node_data, metric, path)
+
+            if 'hostname' in node_data:
+                # For ES >= 0.19
+                hostnames = (
+                    gethostname(agentConfig).decode('utf-8'),
+                    socket.gethostname().decode('utf-8'),
+                    socket.getfqdn().decode('utf-8')
+                )
+                if node_data['hostname'].decode('utf-8') in hostnames:
+                    self._map_metric(process_metric)
+            else:
+                # ES < 0.19
+                # Fetch interface address from ifconfig or ip addr and check
+                # against the primary IP from ES
+                try:
+                    base_url = self._base_es_url(agentConfig['elasticsearch'])
+                    url = "%s%s" % (base_url, self.NODES_URL)
+                    primary_addr = self._get_primary_addr(agentConfig, url, node)
+                except NodeNotFound:
+                    # Skip any nodes that aren't found
+                    continue
+                if self._host_matches_node(primary_addr):
+                    self._map_metric(process_metric)
+
+    def _get_primary_addr(self, agentConfig, url, node_name):
+        ''' Returns a list of primary interface addresses as seen by ES.
+        Used in ES < 0.19
+        '''
+        req = urllib2.Request(url, None, headers(agentConfig))
+        request = urllib2.urlopen(req)
+        response = request.read()
+        data = json.loads(response)
+
+        if node_name in data['nodes']:
+            node = data['nodes'][node_name]
+            if 'network' in node:
+                return node['network']['primary_interface']['address']
+
+        raise NodeNotFound()
+
+    def _host_matches_node(self, primary_addrs):
+        ''' For < 0.19, check if the current host matches the IP given
+        in the cluster nodes check `/_cluster/nodes`. Uses `ip addr` on Linux
+        and `ifconfig` on Mac
+        '''
+        if sys.platform == 'darwin':
+            ifaces = subprocess.Popen(['ifconfig'], stdout=subprocess.PIPE)
+        else:
+            ifaces = subprocess.Popen(['ip', 'addr'], stdout=subprocess.PIPE)
+        grepper = subprocess.Popen(['grep', 'inet'], stdin=ifaces.stdout,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        ifaces.stdout.close()
+        out, err = grepper.communicate()
+
+        # Capture the list of interface IPs
+        ips = []
+        for iface in out.split("\n"):
+            iface = iface.strip()
+            if iface:
+                ips.append( iface.split(' ')[1].split('/')[0] )
+
+        # Check the interface addresses against the primary address
+        return primary_addrs in ips
+
+    def _base_es_url(self, config_url):
+        parsed = urlparse.urlparse(config_url)
+        if parsed.path == "":
+            return config_url
+        return "%s://%s" % (parsed.scheme, parsed.netloc)
 
     def check(self, config):
         """Extract data from stats URL


### PR DESCRIPTION
If no hostname is given by Elasticsearch, use `/_cluster/nodes` URL to look up the IP for the primary interface and compare that to a list of INET addresses captured by `ifconfig` (on Mac) or `ip addr`. 

This should mean that < 0.19 will have the same functionality as > 0.19.
