### PR TITLE
submit load averages as floating-point values

### DIFF
--- a/checks/system.py
+++ b/checks/system.py
@@ -211,7 +211,7 @@ class Load(Check):
                 
         # Split out the 3 load average values
         loadAvrgs = [res.replace(',', '.') for res in re.findall(r'([0-9]+[\.,]\d+)', uptime)]
-        return {'1': loadAvrgs[0], '5': loadAvrgs[1], '15': loadAvrgs[2]}  
+        return {'1': float(loadAvrgs[0]), '5': float(loadAvrgs[1]), '15': float(loadAvrgs[2])}
 
 class Memory(Check):
     def __init__(self, logger):


### PR DESCRIPTION
Accurately reflects "real" data type for custom emitters. Should not
impact use with standard emitter due to server-side coercion.
