### PR TITLE
Add agent install script

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -21,7 +21,7 @@ function on_error() {
 It looks like you hit an issue when trying to install the agent.
 
 Please send an email to help@datadoghq.com with the contents of ddagent-install.log
-and we'll do our very best to help you solve your problem\n\033[0m" 
+and we'll do our very best to help you solve your problem\n\033[0m"
 }
 trap on_error ERR
 


### PR DESCRIPTION
Tested against: Ubuntu Lucid, CentOS 5 & 6, Debian Lenny (all in vagrant with fresh boxes)

I'm by no means an expert in bash scripting, so if you have any pointers on some stuff I did that could be done in a better way, I'm all ears!

Originally I was going to detect the distribution name _and_ version and work out what package install they should get, but it seemed that I could just use the python version number.

@xcolour @alq666 Can you have a look?
