### PR TITLE
Log cause of line parse exceptions

### DIFF
--- a/checks/datadog.py
+++ b/checks/datadog.py
@@ -226,7 +226,7 @@ class Dogstream(object):
                 else:
                     self._values.append((metric, ts, value, attrs))
         except Exception, e:
-            self.logger.debug("Error while parsing line %s" % line)
+            self.logger.debug("Error while parsing line %s" % line, exc_info=True)
             self._error_count += 1
             self.logger.error("Parser error: %s out of %s" % (self._error_count, self._line_count))
 


### PR DESCRIPTION
Set the `exc_info` flag on logging parse exceptions, to log a stack trace when the log level is set to DEBUG.

Without this set, no information is available on just where the exception took place.
