### PR TITLE
Fixed dd-agent hang when using RPM packaging

### DIFF
--- a/packaging/datadog-agent/rpm/supervisor.conf
+++ b/packaging/datadog-agent/rpm/supervisor.conf
@@ -31,7 +31,7 @@ user=dd-agent
 [program:forwarder]
 command=/usr/bin/python2.6 /usr/share/datadog/agent/ddagent.py --pycurl=0
 redirect_stderr=true          ; redirect proc stderr to stdout (default false)
-logfile=/var/log/ddforwarder.log
+stdout_logfile=/var/log/ddforwarder.log
 startsecs=5
 startretries=1
 priority=998
@@ -40,7 +40,7 @@ user=dd-agent
 [program:dogstatsd]
 command=/usr/bin/python2.6 /usr/share/datadog/agent/dogstatsd.py
 redirect_stderr=true
-logfile=/var/log/dogstatsd.log
+stdout_logfile=/var/log/dogstatsd.log
 startsecs=5
 startretries=1
 priority=998


### PR DESCRIPTION
Prior to this fix both ddforwarder.log and dogstatsd.log were
incorrectly specified in the supervisor.conf. In addition to
being inconvenient because the log isn't written this results
in dd-agent hanging on a write to stderr when its pipe to
supervisord fills up.
