### PR TITLE
Dogstatsd command line switch for agent/server.

### DIFF
--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -173,15 +173,15 @@ class Dogstatsd(Daemon):
         self.server.start()
 
 
-def init(config_path=None, use_watchdog=False):
+def init(config_path=None, use_watchdog=False, use_forwarder=False):
     c = get_config(parse_args=False, cfg_path=config_path, init_logging=True)
 
     logger.debug("Configuration dogstatsd")
 
     port     = c['dogstatsd_port']
-    target   = c['dogstatsd_target']
     interval = c['dogstatsd_interval']
     api_key  = c['api_key']
+    target   = c['dogstatsd_target'] if use_forwarder else c['dd_url']
 
     hostname = gethostname(c)
 
@@ -201,9 +201,11 @@ def init(config_path=None, use_watchdog=False):
 def main(config_path=None):
     """ The main entry point for the unix version of dogstatsd. """
     parser = optparse.OptionParser("%prog [start|stop|restart|status]")
+    parser.add_option('-u', '--use-local-forwarder', action='store_true',
+                        dest="use_forwarder", default=False)
     opts, args = parser.parse_args()
 
-    reporter, server = init(config_path, use_watchdog=True)
+    reporter, server = init(config_path, use_watchdog=True, use_forwarder=opts.use_forwarder)
 
     # If no args were passed in, run the server in the foreground.
     if not args:

--- a/packaging/datadog-agent/deb/supervisor.conf
+++ b/packaging/datadog-agent/deb/supervisor.conf
@@ -16,7 +16,7 @@ priority=998
 user=dd-agent
 
 [program:dogstatsd]
-command=/usr/bin/dogstatsd
+command=/usr/bin/dogstatsd --use-local-forwarder
 redirect_stderr=true
 stdout_logfile=/var/log/dogstatsd.log
 startsecs=3

--- a/packaging/datadog-agent/rpm/supervisor.conf
+++ b/packaging/datadog-agent/rpm/supervisor.conf
@@ -38,7 +38,7 @@ priority=998
 user=dd-agent
 
 [program:dogstatsd]
-command=/usr/bin/python2.6 /usr/share/datadog/agent/dogstatsd.py
+command=/usr/bin/python2.6 /usr/share/datadog/agent/dogstatsd.py --use-local-forwarder
 redirect_stderr=true
 stdout_logfile=/var/log/dogstatsd.log
 startsecs=5

--- a/packaging/datadog-agent/source/supervisord.conf
+++ b/packaging/datadog-agent/source/supervisord.conf
@@ -33,7 +33,7 @@ priority=998
 startsecs=3
 
 [program:dogstatsd]
-command=python agent/dogstatsd.py
+command=python agent/dogstatsd.py --use-local-forwarder
 stdout_logfile=supervisord/logs/dogstatsd.log
 redirect_stderr=true
 priority=998

--- a/supervisord.dev.conf
+++ b/supervisord.dev.conf
@@ -32,7 +32,7 @@ priority=998
 startsecs=3
 
 [program:dogstatsd]
-command=python dogstatsd.py
+command=python dogstatsd.py --use-local-forwarder
 stdout_logfile=dogstatsd.log
 redirect_stderr=true
 priority=998


### PR DESCRIPTION
Dogstatsd will send to the server by default, and supervisor will tell it to submit to the forwarder.
