### PR TITLE
Support building packages targeting non-default Python installations

### DIFF
--- a/packaging/Makefile
+++ b/packaging/Makefile
@@ -1,6 +1,9 @@
 .PHONY: clean deb rpm archivedeb archiverpm archive all installdeb installrpm deb_repo incbuild resetbuild
 
-VERSION=`cd .. && python -c "from config import get_version; print get_version()"`
+PYTHON=python
+INSTALL_LAYOUT_ARG=--install-layout=deb
+
+VERSION=`cd .. && $(PYTHON) -c "from config import get_version; print get_version()"`
 
 clean:
 	rm -rf *.deb
@@ -10,19 +13,19 @@ clean:
 	make -C datadog-agent clean
 
 deb:	ensurebuild
-	VERSION=$(VERSION) BUILDNUMBER=`cat build.number` make -C datadog-agent-lib deb
+	VERSION=$(VERSION) PYTHON=$(PYTHON) INSTALL_LAYOUT_ARG=$(INSTALL_LAYOUT_ARG) BUILDNUMBER=`cat build.number` make -C datadog-agent-lib deb
 	cp datadog-agent-lib/*.deb .
-	VERSION=$(VERSION) BUILDNUMBER=`cat build.number` make -C datadog-agent-base deb
+	VERSION=$(VERSION) PYTHON=$(PYTHON) INSTALL_LAYOUT_ARG=$(INSTALL_LAYOUT_ARG) BUILDNUMBER=`cat build.number` make -C datadog-agent-base deb
 	cp datadog-agent-base/*.deb .
-	VERSION=$(VERSION) BUILDNUMBER=`cat build.number` make -C datadog-agent deb
+	VERSION=$(VERSION) PYTHON=$(PYTHON) INSTALL_LAYOUT_ARG=$(INSTALL_LAYOUT_ARG) BUILDNUMBER=`cat build.number` make -C datadog-agent deb
 	cp datadog-agent/*.deb .
 
 rpm:	ensurebuild
-	VERSION=$(VERSION) BUILDNUMBER=`cat build.number` make -C datadog-agent-lib rpm
+	VERSION=$(VERSION) PYTHON=$(PYTHON) INSTALL_LAYOUT_ARG=$(INSTALL_LAYOUT_ARG) BUILDNUMBER=`cat build.number` make -C datadog-agent-lib rpm
 	cp datadog-agent-lib/*.rpm .
-	VERSION=$(VERSION) BUILDNUMBER=`cat build.number` make -C datadog-agent-base rpm
+	VERSION=$(VERSION) PYTHON=$(PYTHON) INSTALL_LAYOUT_ARG=$(INSTALL_LAYOUT_ARG) BUILDNUMBER=`cat build.number` make -C datadog-agent-base rpm
 	cp datadog-agent-base/*.rpm .
-	VERSION=$(VERSION) BUILDNUMBER=`cat build.number` make -C datadog-agent rpm
+	VERSION=$(VERSION) PYTHON=$(PYTHON) INSTALL_LAYOUT_ARG=$(INSTALL_LAYOUT_ARG) BUILDNUMBER=`cat build.number` make -C datadog-agent rpm
 	cp datadog-agent/*.rpm .
 
 archivedeb:

--- a/packaging/datadog-agent-base/Makefile
+++ b/packaging/datadog-agent-base/Makefile
@@ -1,6 +1,8 @@
 .PHONY: clean links dirs deb rpm install_deb install_rpm install
 
 BUILD=build/package
+PYTHON=python
+INSTALL_LAYOUT_ARG=--install-layout=deb
 CWD=$(shell pwd)
 
 FPM_BUILD=fpm -s dir -C $(BUILD) -e -n "datadog-agent-base" \
@@ -42,7 +44,7 @@ dirs:
 	mkdir -p $(BUILD)
 
 install: dirs links
-	PYTHONPATH=$(BUILD) python setup.py install --root=$(BUILD) --install-layout=deb --install-lib=/usr/share/datadog/agent --install-scripts=/usr/share/datadog/agent --no-compile
+	PYTHONPATH=$(BUILD) $(PYTHON) setup.py install --root=$(BUILD) $(INSTALL_LAYOUT_ARG) --install-lib=/usr/share/datadog/agent --install-scripts=/usr/share/datadog/agent --no-compile
 	mkdir -p $(BUILD)/usr/bin
 	mkdir -p $(BUILD)/etc/init.d
 	rm -rf $(BUILD)/home

--- a/packaging/datadog-agent-lib/Makefile
+++ b/packaging/datadog-agent-lib/Makefile
@@ -2,6 +2,8 @@
 .PHONY: clean links dirs deb rpm install
 
 BUILD=build/package
+PYTHON=python
+INSTALL_LAYOUT_ARG=--install-layout=deb
 CWD=$(shell pwd)
 
 FPM_BUILD=fpm -s dir -e -C $(BUILD) -n "datadog-agent-lib" \
@@ -35,7 +37,7 @@ dirs:
 	mkdir -p $(BUILD)
 
 install: dirs links
-	PYTHONPATH=$(BUILD) python setup.py install --root=$(BUILD) --install-layout=deb --install-lib=/usr/share/datadog/agent --install-scripts=/usr/share/datadog/agent --no-compile
+	PYTHONPATH=$(BUILD) $(PYTHON) setup.py install --root=$(BUILD) $(INSTALL_LAYOUT_ARG) --install-lib=/usr/share/datadog/agent --install-scripts=/usr/share/datadog/agent --no-compile
 	rm -rf $(BUILD)/home
 	rm -rf $(BUILD)/usr/share/datadog/agent/*.egg-info
 


### PR DESCRIPTION
Allow interpreter other than default `python` to be used for setup.py invocations; make `--install-layout=deb` flag (not present on CentOS 5) optional.
