### PR TITLE
Disables non-local traffic by default (fixes #290)

### DIFF
--- a/config.py
+++ b/config.py
@@ -188,6 +188,8 @@ def get_config(parse_args = True, cfg_path=None, init_logging=False, options=Non
         # Core config
         #
 
+        # FIXME unnecessarily complex
+
         if config.has_option('Main', 'use_dd'):
             agentConfig['use_dd'] = config.get('Main', 'use_dd').lower() in ("yes", "true")
         else:
@@ -195,8 +197,8 @@ def get_config(parse_args = True, cfg_path=None, init_logging=False, options=Non
 
         if options is not None and options.use_forwarder:
             listen_port = 17123
-            if config.has_option('Main','listen_port'):
-                listen_port = config.get('Main','listen_port')
+            if config.has_option('Main', 'listen_port'):
+                listen_port = int(config.get('Main', 'listen_port'))
             agentConfig['dd_url'] = "http://localhost:" + str(listen_port)
         elif options is not None and not options.disable_dd and options.dd_url:
             agentConfig['dd_url'] = options.dd_url
@@ -234,6 +236,11 @@ def get_config(parse_args = True, cfg_path=None, init_logging=False, options=Non
 
         # Debug mode
         agentConfig['debug_mode'] = config.get('Main', 'debug_mode').lower() in ("yes", "true")
+
+        # local traffic only? Default to no
+        agentConfig['non_local_traffic'] = False
+        if config.has_option('Main', 'non_local_traffic'):
+            agentConfig['non_local_traffic'] = config.get('Main', 'non_local_traffic').lower() in ("yes", "true")
 
         # DEPRECATED
         if config.has_option('Main', 'use_ec2_instance_id'):

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -27,6 +27,13 @@ use_mount: no
 # Start a graphite listener on this port
 # graphite_listen_port: 17124
 
+# Allow non-local traffic to this agent
+# This is required when using this agent as a proxy for other agents
+# that might not have an internet connection
+# For more information, please see
+# https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration
+# non_local_traffic: no
+
 # ========================================================================== #
 # Pup configuration
 # ========================================================================== #

--- a/pup/pup.py
+++ b/pup/pup.py
@@ -225,14 +225,17 @@ def run_pup(config):
 
     port = config.get('pup_port', 17125)
 
-    application.listen(port)
+    if config.get('non_local_traffic', False) is True:
+        application.listen(port)
+    else:
+        # localhost in lieu of 127.0.0.1 allows for ipv6
+        application.listen(port, address="localhost")
 
     interval_ms = 2000
     io_loop = ioloop.IOLoop.instance()
     scheduler = ioloop.PeriodicCallback(send_metrics, interval_ms, io_loop=io_loop)
     scheduler.start()
     io_loop.start()
-
 
 def main():
     """ Parses arguments and starts Pup server """


### PR DESCRIPTION
Ports 1712[345] are now bound to localhost, which is a combination of
127.0.0.1, ::1 and fe80::1%lo0 depending on what stack is deployed.
