### PR TITLE
ensure rabbitmq_api_url ends with a slash

### DIFF
--- a/checks.d/rabbitmq.py
+++ b/checks.d/rabbitmq.py
@@ -17,6 +17,8 @@ class RabbitMQ(AgentCheck):
 
         # get parameters
         base_url = instance['rabbitmq_api_url']
+        if not base_url.endswith('/'):
+            base_url += '/'
         username = instance.get('rabbitmq_user', 'guest')
         password = instance.get('rabbitmq_pass', 'guest')
 


### PR DESCRIPTION
with urljoin if there is not a trailing slash then when joining 'queues' and 'nodes' will not get appended properly and the check will not run properly
