### PR TITLE
Added explicit declaration of supervisor file in deb script

### DIFF
--- a/packaging/datadog-agent-base-deb/datadog-agent.init
+++ b/packaging/datadog-agent-base-deb/datadog-agent.init
@@ -22,6 +22,7 @@ USE_SUPERVISOR="/usr/bin/dd-forwarder"
 PIDPATH="/var/run/dd-agent"
 NAME="datadog-agent"
 DESC="datadog agent"
+SUPERVISOR_FILE="/etc/supervisor/supervisord.conf"
 
 [ -x $AGENTPATH ] || echo "$AGENTPATH not found"
 
@@ -37,7 +38,7 @@ case "$1" in
 
         if [ -f $USE_SUPERVISOR ]; then
             echo -n "(using supervisorctl) "
-            supervisorctl start datadog-agent:*
+            supervisorctl -c $SUPERVISOR_FILE start datadog-agent:*
         else
             if [ ! -f $PIDPATH ]; then
                 mkdir -p $PIDPATH
@@ -57,7 +58,7 @@ case "$1" in
         echo -n "Stopping $DESC: "
         if [ -f $USE_SUPERVISOR ]; then
 	    # Prevent errors if not under actual supervision
-	    supervised=$(supervisorctl avail | grep datadog-agent | wc -l)
+	    supervised=$(supervisorctl -c $SUPERVISOR_FILE avail | grep datadog-agent | wc -l)
 	    if [ $supervised -gt 1 ]; then
             	echo -n "(using supervisorctl) "
             	supervisorctl stop datadog-agent:*


### PR DESCRIPTION
We had a lot of problems with multiple installation of supervisord in the same server. Since you are using and old version of supervisord on ubuntu and we want to update it to b1 version, this fix keep it compatible with multiple installed versions or I'll have the error:

```
ubuntu@ip-10-0-0-12:/etc$ sudo /etc/init.d/datadog-agent restart
sudo: unable to resolve host ip-10-0-0-12
Stopping datadog agent: Error: No config file found at default paths (/usr/local/etc/supervisord.conf, /usr/local/supervisord.conf, supervisord.conf, etc/supervisord.conf, /etc/supervisord.conf); use the -c option to specify a config file at a different path
For help, use /usr/local/bin/supervisorctl -h
(warning: datadog-agent supervisor config is missing) datadog-agent.
Starting datadog agent: (using supervisorctl) Error: No config file found at default paths (/usr/local/etc/supervisord.conf, /usr/local/supervisord.conf, supervisord.conf, etc/supervisord.conf, /etc/supervisord.conf); use the -c option to specify a config file at a different path
For help, use /usr/local/bin/supervisorctl -h
```

just after a `sudo pip install --upgrade supervisor`
