### PR TITLE
Create bin/info in the source install to mimic datadog-agent info

### DIFF
--- a/packaging/datadog-agent/source/info
+++ b/packaging/datadog-agent/source/info
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Relative cd to where this script resides
+# http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd $THIS_DIR/..
+source venv/bin/activate
+python agent/agent.py info
+python agent/dogstatsd.py info
+python agent/ddagent.py info
+popd

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -63,7 +63,9 @@ fi
 sed "s/# use_pup:.*/use_pup: yes/" $dd_base/agent/datadog.conf.1 > $dd_base/agent/datadog.conf
 mkdir -p $dd_base/bin
 cp $dd_base/agent/packaging/datadog-agent/source/agent $dd_base/bin/agent
+cp $dd_base/agent/packaging/datadog-agent/source/info  $dd_base/bin/info
 chmod +x $dd_base/bin/agent
+chmod +x $dd_base/bin/info
 
 # This is the script that will be used by SMF
 if [ "$unamestr" = "SunOS" ]; then


### PR DESCRIPTION
This to fix #380. While I sip a beer at DevOpsDays Austin 2013.
