### PR TITLE
Update source /bin/agent commands to function like deb & redhat versions

### DIFF
--- a/packaging/datadog-agent/source/agent
+++ b/packaging/datadog-agent/source/agent
@@ -13,21 +13,17 @@ if [ ! -n "$action" ]; then
     action="start"
 fi
 
-check_supervisor_status() {
-    # Returns 0 if the supervisor is running, and 1 if not.
+supervisor_running() {
+    # Returns true if the supervisor is running, and false if not.
     # We check if the supervisor is running by checking if
     # SOCK_FILE exists.
-    if [ ! -e $SOCK_FILE ]; then
-        return 1
-    else
-        return 0
-    fi
+    [ -e $SOCK_FILE ]
 }
 
 execute_if_supervisor_running() {
     # Executes `supervisord -c $SUPERVISOR_CONF_FILE $*`
     # if the supervisor is running.
-    if check_supervisor_status; then
+    if supervisor_running; then
         supervisorctl -c $SUPERVISOR_CONF_FILE "$*"
         return $?
     else
@@ -40,7 +36,7 @@ check_agent_status() {
     # Returns 0 if the agent is running, and 1 if not.
 
     # First, we check if supervisor is running:
-    if check_supervisor_status; then
+    if ! supervisor_running; then
         echo $SUPERVISOR_NOT_RUNNING
         return 1
     else
@@ -71,15 +67,15 @@ check_agent_status() {
 
 case $action in
     start)
-        if check_supervisor_status; then
+        if supervisor_running; then
+            echo "Supervisor is already running"
+            exit 0
+        else
             echo "Starting supervisor"
             supervisord -c $SUPERVISOR_CONF_FILE
             # Since the above command currently runs in the foreground, we don't
             # have to worry about checking the status of the agent and setting
             # an exit code here.
-        else
-            echo "Supervisor is already running"
-            exit 0
         fi
         ;;
 


### PR DESCRIPTION
Fixes issue #512, where running any source agent command (status, info, etc.) would start supervisor.

Also updated the source status command to return 1 if the agent is not running, and updated it to check that the correct processes are actually running.

Finally, I updated start, stop, and restart to check if the supervisor is running before executing. Also, now if the commands fail they will also exit with a non-zero exit code.

All of these changes bring the source agent commands more in-line with the Red Hat and Debian agent commands.
