### PR TITLE
Addressing issue #131 -- Add I/O metrics on Mac

### DIFF
--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -186,11 +186,10 @@ class IO(Check):
         lastline = lines[-1]
         io = {}
         for idx, disk in enumerate(disks):
-            sps, tps, msps = map(float, lastline[(3 * idx):(3 * (idx + 1))]) # 3 cols at a time
+            sps, tps = map(float, lastline[(3 * idx):(3 * idx) + 2]) # 3 cols at a time
             io[disk] = {
-                'system.io.sectors': sps,
-                'system.io.transfers': tps,
-                'system.io.ms_per_transaction': msps, # called ms per seek 
+                'system.io.sectors_per_s': sps,
+                'system.io.transfers_per_s': tps,
             }
         return io
     

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -200,17 +200,15 @@ sda               0.00     0.00  0.00  0.00     0.00     0.00     0.00     0.00 
         self.assertEqual(
             results["disk0"],
             {
-                'system.io.sectors': float(791),
-                'system.io.transfers': float(6),
-                'system.io.ms_per_transaction': float(0),
+                'system.io.sectors_per_s': float(791),
+                'system.io.transfers_per_s': float(6),
             }
         )
         self.assertEqual(
             results["disk1"],
             {
-                'system.io.sectors': float(627),
-                'system.io.transfers': float(29),
-                'system.io.ms_per_transaction': float(0),
+                'system.io.sectors_per_s': float(627),
+                'system.io.transfers_per_s': float(29),
             }
         )
 


### PR DESCRIPTION
Apple's version of iostat reports different metrics than Linux, FreeBSD, or SunOS. This adds three new metrics under system.io to log sectors per second (system.io.sectors), transfers per second (system.io.transfers), and milliseconds per seek (ms_per_seek).
