### PR TITLE
On second thoughts, let's not go to old metrics!

### DIFF
--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -186,10 +186,9 @@ class IO(Check):
         lastline = lines[-1]
         io = {}
         for idx, disk in enumerate(disks):
-            sps, tps = map(float, lastline[(3 * idx):(3 * idx) + 2]) # 3 cols at a time
+            kb_t, tps, mb_s = map(float, lastline[(3 * idx):(3 * idx) + 3]) # 3 cols at a time
             io[disk] = {
-                'system.io.sectors_per_s': sps,
-                'system.io.transfers_per_s': tps,
+                'system.io.bytes_per_s': mb_s * 10**6,
             }
         return io
     
@@ -305,13 +304,13 @@ class IO(Check):
                     for i in range(1, len(cols)):
                         io[cols[0]][self.xlate(headers[i], "freebsd")] = cols[i]
             elif sys.platform == 'darwin':
-                iostat = subprocess.Popen(['iostat', '-o', '-d', '-c', '2', '-w', '1'], 
+                iostat = subprocess.Popen(['iostat', '-d', '-c', '2', '-w', '1'], 
                                           stdout=subprocess.PIPE,
                                           close_fds=True).communicate()[0]
-                #        disk0        disk1     <-- number of disks
-                #  sps tps msps  sps tps msps 
-                # 1422  39  0.0    2   0  0.0 
-                #  104  13  0.0    0   0  0.0   <-- line of interest
+                #          disk0           disk1          <-- number of disks
+                #    KB/t tps  MB/s     KB/t tps  MB/s  
+                #   21.11  23  0.47    20.01   0  0.00  
+                #    6.67   3  0.02     0.00   0  0.00    <-- line of interest
                 return self._parse_darwin(iostat)
             else:
                 return False

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -188,10 +188,11 @@ sda               0.00     0.00  0.00  0.00     0.00     0.00     0.00     0.00 
 
         # iostat -o -d -c 2 -w 1
         # OS X 10.8.3 (internal SSD + USB flash attached)
-        darwin_iostat_output = """       disk0        disk1 
- sps tps msps  sps tps msps 
-1157  31  0.0    1   0  0.0 
- 791   6  0.0  627  29  0.0 """
+        darwin_iostat_output = """          disk0           disk1 
+    KB/t tps  MB/s     KB/t tps  MB/s 
+   21.11  23  0.47    20.01   0  0.00 
+    6.67   3  0.02     0.00   0  0.00 
+"""
         checker = IO(logger)
         results = checker._parse_darwin(darwin_iostat_output)
         self.assertTrue("disk0" in results.keys())
@@ -199,17 +200,11 @@ sda               0.00     0.00  0.00  0.00     0.00     0.00     0.00     0.00 
 
         self.assertEqual(
             results["disk0"],
-            {
-                'system.io.sectors_per_s': float(791),
-                'system.io.transfers_per_s': float(6),
-            }
+            {'system.io.bytes_per_s': float(0.02 * 10**6),}
         )
         self.assertEqual(
             results["disk1"],
-            {
-                'system.io.sectors_per_s': float(627),
-                'system.io.transfers_per_s': float(29),
-            }
+            {'system.io.bytes_per_s': float(0),}
         )
 
     def testNetwork(self):


### PR DESCRIPTION
Sectors per second is not that useful if you don't have the sector
size on hand. Even though reads and writes are combined, one knows
more or less what bytes per second means.
