### PR TITLE
Adding custom header support to http_check.

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -11,14 +11,15 @@ class HTTPCheck(ServicesCheck):
         username = instance.get('username', None)
         password = instance.get('password', None)
         timeout = int(instance.get('timeout', 10))
+        headers = instance.get('headers',{})
         url = instance.get('url', None)
         if url is None:
             raise Exception("Bad configuration. You must specify a url")
         include_content = instance.get('include_content', False)
-        return url, username, password, timeout, include_content
+        return url, username, password, timeout, include_content, headers
 
     def _check(self, instance):
-        addr, username, password, timeout, include_content = self._load_conf(instance)
+        addr, username, password, timeout, include_content, headers = self._load_conf(instance)
         content = ''
         start = time.time()
         try:
@@ -26,7 +27,7 @@ class HTTPCheck(ServicesCheck):
             h = Http(timeout=timeout, disable_ssl_certificate_validation=True)
             if username is not None and password is not None:
                 h.add_credentials(username, password)
-            resp, content = h.request(addr, "GET")
+            resp, content = h.request(addr, "GET", headers=headers)
 
         except socket.timeout, e:
             length = int((time.time() - start) * 1000)

--- a/conf.d/http_check.yaml.example
+++ b/conf.d/http_check.yaml.example
@@ -32,6 +32,19 @@ instances:
 
 #        include_content: true
 
+         # The (optional) headers parameter allows you to send extra headers
+         # with the request. This is useful for explicitly specifying the host
+         # header or perhaps adding headers for authorisation purposes. Note
+         # that the http client library converts all headers to lowercase.
+         # This is legal according to RFC2616
+         # (See: http://tools.ietf.org/html/rfc2616#section-4.2)
+         # but may be problematic with some HTTP servers 
+         # (See: https://code.google.com/p/httplib2/issues/detail?id=169)
+
+#        headers:
+#           Host: alternative.host.example.com
+#           X-Auth-Token: SOME-AUTH-TOKEN 
+
 #    -   name: My second service
 #        url: https://another.url.example.com
 


### PR DESCRIPTION
This is a pretty simple change that I'm adding. The only minor issue is that httplib2  downcases the header names and so it cause some fun for those servers which care. I've added some notes to the example httpd_check.yaml.example to call it out.
