### PR TITLE
AttributeError: 'Riak' object has no attribute 'timeout_event'

### DIFF
--- a/checks.d/riak.py
+++ b/checks.d/riak.py
@@ -82,20 +82,20 @@ class Riak(AgentCheck):
 
         self.prev_coord_redirs_total = coord_redirs_total
 
-        def timeout_event(self, url, timeout, aggregation_key):
-            self.event({
-                'timestamp': int(time.time()),
-                'event_type': 'riak_check',
-                'msg_title': 'riak check timeout',
-                'msg_text': '%s timed out after %s seconds.' % (url, timeout),
-                'aggregation_key': aggregation_key
-            })
+    def timeout_event(self, url, timeout, aggregation_key):
+        self.event({
+            'timestamp': int(time.time()),
+            'event_type': 'riak_check',
+            'msg_title': 'riak check timeout',
+            'msg_text': '%s timed out after %s seconds.' % (url, timeout),
+            'aggregation_key': aggregation_key
+        })
 
-        def status_code_event(self, url, r, aggregation_key):
-            self.event({
-                'timestamp': int(time.time()),
-                'event_type': 'riak_check',
-                'msg_title': 'Invalid reponse code for riak check',
-                'msg_text': '%s returned a status of %s' % (url, r.status_code),
-                'aggregation_key': aggregation_key
-            })
+    def status_code_event(self, url, r, aggregation_key):
+        self.event({
+            'timestamp': int(time.time()),
+            'event_type': 'riak_check',
+            'msg_title': 'Invalid reponse code for riak check',
+            'msg_text': '%s returned a status of %s' % (url, r.status_code),
+            'aggregation_key': aggregation_key
+        })


### PR DESCRIPTION
This PR fixes the following error:

```
2013-06-17 12:44:39,239 | ERROR | dd.collector | checks.riak(__init__.py:454) | Check 'riak' instance #0 failed
Traceback (most recent call last):
  File "/usr/share/datadog/agent/checks/__init__.py", line 445, in run
    self.check(instance)
  File "/usr/share/datadog/agent/checks.d/riak.py", line 68, in check
    self.timeout_event(url, timeout, aggregation_key)
AttributeError: 'Riak' object has no attribute 'timeout_event'
```

Note: I don't code python so not sure about validity of this fix.
