### PR TITLE
Info command now return non-zero when errors occur

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -219,7 +219,7 @@ def main():
         agent.status()
 
     elif 'info' == command:
-        agent.info(verbose=options.verbose)
+        return agent.info(verbose=options.verbose)
 
     elif 'foreground' == command:
         logging.info('Running in foreground')

--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -306,7 +306,7 @@ def main(config_path=None):
         elif command == 'status':
             daemon.status()
         elif command == 'info':
-            daemon.info()
+            return daemon.info()
         else:
             sys.stderr.write("Unknown command: %s\n\n" % command)
             parser.print_help()

--- a/packaging/datadog-agent-base-deb/datadog-agent.init
+++ b/packaging/datadog-agent-base-deb/datadog-agent.init
@@ -136,11 +136,15 @@ case "$1" in
         shift # Shift 'info' out of args so we can pass any
               # addtional options to the real command
               # (right now only dd-agent supports additional flags)
-        su $AGENTUSER -c "$AGENTPATH info $@" || true
-        su $AGENTUSER -c "$DOGSTATSDPATH info" || true
+        su $AGENTUSER -c "$AGENTPATH info $@"
+        RETURN_VALUE=$?
+        su $AGENTUSER -c "$DOGSTATSDPATH info"
+        RETURN_VALUE=$(($RETURN_VALUE || $?))
         if [ -f $USE_SUPERVISOR ]; then
-            su $AGENTUSER -c "$USE_SUPERVISOR info" || true
+            su $AGENTUSER -c "$USE_SUPERVISOR info"
+            RETURN_VALUE=$(($RETURN_VALUE || $?))
         fi
+        exit $RETURN_VALUE
         ;;
 
     status)

--- a/packaging/datadog-agent-base-rpm/datadog-agent-redhat
+++ b/packaging/datadog-agent-base-rpm/datadog-agent-redhat
@@ -171,11 +171,15 @@ info() {
     shift # Shift 'info' out of the args so we can pass any
           # additional options to the real command
           # (right now only dd-agent supports additional flags)
-    su $AGENTUSER -c "$AGENTPATH info $@" || true
-    su $AGENTUSER -c "$DOGSTATSDPATH info" || true
+    su $AGENTUSER -c "$AGENTPATH info $@"
+    RETURN_VALUE=$?
+    su $AGENTUSER -c "$DOGSTATSDPATH info"
+    RETURN_VALUE=$(($RETURN_VALUE || $?))
     if [ -f $USE_SUPERVISOR ]; then
-        su $AGENTUSER -c "$USE_SUPERVISOR info" || true
+        su $AGENTUSER -c "$USE_SUPERVISOR info"
+        RETURN_VALUE=$(($RETURN_VALUE || $?))
     fi
+    exit $RETURN_VALUE
 }
 
 

--- a/packaging/datadog-agent/source/agent
+++ b/packaging/datadog-agent/source/agent
@@ -102,9 +102,12 @@ case $action in
         shift # shift to pass the remaining arguments to agent/agent.py info.
               # Currently only agent.py takes additional arguments
         python agent/agent.py info $@
+        RETURN_VALUE=$?
         python agent/dogstatsd.py info
+        RETURN_VALUE=$(($RETURN_VALUE || $?))
         python agent/ddagent.py info
-        exit 0
+        RETURN_VALUE=$(($RETURN_VALUE || $?))
+        exit $RETURN_VALUE
         ;;
 
     *)


### PR DESCRIPTION
Running the info command will now return a non-zero error code when an error is displayed by the command. This includes `checks.d` errors. The feature was requested by @miketheman.

The difference between the error codes emitted by this command and the error codes emitted by the status command is that the status command simply checks that all of the Agent subprocesses are running, while the info command checks that the subprocesses are running _and_ that all the checks have passed.
