### PR TITLE
Allow MySQL check configuration via a mysql config file

### DIFF
--- a/conf.d/mysql.yaml.example
+++ b/conf.d/mysql.yaml.example
@@ -5,6 +5,7 @@ instances:
 #    user: my_username
 #    pass: my_password
 #    port: 3306             # Optional
+#    defaults_file: my.cnf  # Alternate configuration mechanism
 #    tags:                  # Optional
 #        - optional_tag1
 #	     - optional_tag2


### PR DESCRIPTION
For more complex configuration (e.g. specifying SSL certificates) it's useful to use a mysql.cnf instead of specifying flags by hand.

For example I have a config like this:

```
[client]
default-character-set=utf8
database=dbname
user=username
password="password"
host=hostname.example.com
ssl-ca=/path/to/mysql-ssl-ca-cert.pem
```

I can then run the check using:

```
init_config:

instances:
   - defaults_file: /path/to/my.cnf
```

This (for example) allows datadog to collect metrics on externally hosted mysql instances over SSL.
