### PR TITLE
redisdb: convert port string to integer

### DIFF
--- a/checks.d/redisdb.py
+++ b/checks.d/redisdb.py
@@ -174,7 +174,7 @@ class Redis(AgentCheck):
 
             instances.append({
                 'host': host,
-                'port': port,
+                'port': int(port),
                 'password': password
             })
 


### PR DESCRIPTION
This avoids the following exception on some setups:
  File "/usr/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
TypeError: an integer is required
