### PR TITLE
Alert MySQL Last IO/SQL Errors when replication enabled

### DIFF
--- a/conf.d/mysql.yaml.example
+++ b/conf.d/mysql.yaml.example
@@ -10,4 +10,10 @@ instances:
 #        - optional_tag2
 #    options:               # Optional
 #        replication: 0
+
+         # replication_notify is only used when "replication: 1", these are
+         # the users/services which are notified of any MySQL Slave errors
+#        replication_notify:
+#          - user1@domain.com
+#          - pagerduty
 #        galera_cluster: 1


### PR DESCRIPTION
This will send events when the MySQL slave receives a Last_IO_Error or Last_SQL_Error. It also tracks whether an error has occurred or not so it doesn't send events every time this check runs, just when the "status" changes (e.g. there is an error to there are no more errors).

The reasoning behind this is we have found with our MySQL slaves that sometimes they stop replicating when there is a IO or SQL error when replicating and we want a way to receive notifications when this happens.
