### PR TITLE
Fetch the Mongo database name from the URI.

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -126,6 +126,11 @@ class MongoDb(AgentCheck):
                 parsed = {}
         username = parsed.get('username')
         password = parsed.get('password')
+        db_name = parsed.get('database')
+
+        if not db_name:
+            self.log.info('No MongoDB database found in URI. Defaulting to admin.')
+            db_name = 'admin'
 
         do_auth = True
         if username is None or password is None:
@@ -133,7 +138,7 @@ class MongoDb(AgentCheck):
             do_auth = False
 
         conn = Connection(instance['server'], network_timeout=DEFAULT_TIMEOUT)
-        db = conn['admin']
+        db = conn[db_name]
         if do_auth:
             if not db.authenticate(username, password):
                 self.log.error("Mongo: cannot connect with config %s" % instance['server'])


### PR DESCRIPTION
We were always using the `admin` database which is usually not what you want.

For example if your mongo uri is: `mongodb://user:pass@localhost/mydb` then `dbstats` will be called on the correct database.

So I don't know this check well enough to know if there is a particularly reason that we were using the `admin` database by default. I was able to call the other command (`serverStatus`) on any DB but this might be limited for other cases.
