### PR TITLE
add two new metrics to nginx check

### DIFF
--- a/checks.d/nginx.py
+++ b/checks.d/nginx.py
@@ -54,7 +54,6 @@ class Nginx(AgentCheck):
             self.gauge("nginx.net.reading", reading, tags=tags)
             self.gauge("nginx.net.writing", writing, tags=tags)
             self.gauge("nginx.net.waiting", waiting, tags=tags)
-            self.gauge("nginx.net.current", reading + writing + waiting, tags=tags)
 
     @staticmethod
     def parse_agent_config(agentConfig):


### PR DESCRIPTION
- nginx.net.conn_opened_per_s, number of new HTTP connections created per second
- nginx.net.current, total number of current HTTP connections, regardless of their state (sum of reading, writing, waiting)

The first one is of interest to us -- we run a service that relies on re-use of HTTP keep-alive sessions, and the cost of establishing new connections is high. The second seems like an obvious convenience, though it could be recreated in charts in DD web.
