### PR TITLE
Add a query for checking replication slave status via Slave_running variable

### DIFF
--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -109,7 +109,9 @@ class MySql(AgentCheck):
 
         if 'replication' in options and options['replication']:
             self._collect_dict(GAUGE, {"Seconds_behind_master": "mysql.replication.seconds_behind_master"}, "SHOW SLAVE STATUS", db, tags=tags)
-    
+            slave_running = self._collect_scalar("SELECT 'Slave_running', IF(VARIABLE_VALUE like 'On',1,0) from information_schema.global_status where variable_name = 'Slave_running'", db)
+            self.gauge("mysql.replication.slave_running", slave_running, tags=tags)
+
     def _rate_or_gauge_statuses(self, statuses, dbResults, tags):
         for status, metric in statuses.iteritems():
             metric_name, metric_type = metric


### PR DESCRIPTION
I am currently using this to graph and alert on slave status. This variable should be reliable enough on more recent versions of mysql to ascertain slave status. 

I looked into grabbing Slave_IO_Running and Slave_SQL_Running, but the show slave status command does not allow isolation of those variables so we would have to manipulate the text post query which would have been a deeper change.

This also might help address issue #425
