### PR TITLE
Override any locale environment variable

### DIFF
--- a/packaging/datadog-agent-deb/supervisor.conf
+++ b/packaging/datadog-agent-deb/supervisor.conf
@@ -25,7 +25,7 @@ stderr_logfile=NONE
 priority=999
 startsecs=2
 user=dd-agent
-environment=LANG=POSIX
+environment=LC_ALL=POSIX
 
 [program:forwarder]
 command=/usr/bin/dd-forwarder


### PR DESCRIPTION
In one case reported on IRC, having LC_CTYPE=da_DK.UTF8 caused mpstat to report "Middel" instead of "Average".

We had LANG=POSIX but that was obviously not enough. Using LC_ALL overrides all local variables and gets us the desired result.

http://pubs.opengroup.org/onlinepubs/007908799/xbd/envvar.html
