### PR TITLE
Remove `yum makecache`, fixes #691

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -87,7 +87,6 @@ if [ $OS = "RedHat" ]; then
     sudo sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = http://yum.datadoghq.com/rpm/\nenabled=1\ngpgcheck=0\npriority=1' > /etc/yum.repos.d/datadog.repo"
 
     printf "\033[34m* Installing the Datadog Agent package\n\033[0m\n"
-    sudo yum makecache
 
     if $DDBASE; then
         sudo yum -y install datadog-agent-base


### PR DESCRIPTION
After testing on some different VMs, it doesn't seem like this is needed
at all.

Opening a pull request for this just so others can see this, in case there's a reason I should leave this line in.
