### PR TITLE
added support for multi-instance postfix queues (postmulti)

### DIFF
--- a/checks.d/postfix.py
+++ b/checks.d/postfix.py
@@ -12,54 +12,54 @@ class PostfixCheck(AgentCheck):
              dd-agent ALL=(ALL) NOPASSWD:/usr/bin/find
 
     YAML config options:
-        "directory" - the value of 'postconf -h queue_directory'
+        "directories" - the root of your postfix queue directories (ex: /var/spool/postfix, etc..)
         "queues" - the postfix mail queues you would like to get message count totals for
     """
     def check(self, instance):
         config = self._get_config(instance)
 
-        directory = config['directory']
+        directories = config['directories']
         queues = config['queues']
 
-        self._get_queue_count(directory, queues)
+        self._get_queue_count(directories, queues)
 
     def _get_config(self, instance):
-        directory = instance.get('directory', None)
+        directories = instance.get('directories', None)
         queues = instance.get('queues', None)
-        if not queues or not directory:
+        if not queues or not directories:
             raise Exception('missing required yaml config entry')
 
         instance_config = {
-            'directory': directory,
+            'directories': directories,
             'queues': queues
         }
 
         return instance_config
 
-    def _get_queue_count(self, directory, queues):
-        for queue in queues:
-            queue_path = os.path.join(directory, queue)
-            if not os.path.exists(queue_path):
-                raise Exception('%s does not exist' % queue_path)
+    def _get_queue_count(self, directories, queues):
+        for directory in directories:
+            for queue in queues:
+                queue_path = os.path.join(directory, queue)
+                if not os.path.exists(queue_path):
+                    raise Exception('%s does not exist' % queue_path)
 
-            count = 0
-            if os.geteuid() == 0:
-                # dd-agent is running as root (not recommended)
-                count = sum(len(files) for root, dirs, files in os.walk(queue_path))
-            else:
-                # can dd-agent user run sudo?
-                test_sudo = os.system('setsid sudo -l < /dev/null')
-                if test_sudo == 0:
-                    count = os.popen('sudo find %s -type f | wc -l' % queue_path)
-                    count = count.readlines()[0].strip()
+                count = 0
+                if os.geteuid() == 0:
+                    # dd-agent is running as root (not recommended)
+                    count = sum(len(files) for root, dirs, files in os.walk(queue_path))
                 else:
-                    # should we self.log.error instead and disable the check?
-                    self.log.warning('the dd-agent user does not have sudo access')
+                    # can dd-agent user run sudo?
+                    test_sudo = os.system('setsid sudo -l < /dev/null')
+                    if test_sudo == 0:
+                        count = os.popen('sudo find %s -type f | wc -l' % queue_path)
+                        count = count.readlines()[0].strip()
+                    else:
+                        self.log.warning('the dd-agent user does not have sudo access')
 
-            # emit an individually tagged metric
-            self.gauge('postfix.queue.size', count, tags=['queue:%s' % queue])
+                # emit individually tagged metric
+                instance = os.path.basename(directory)
+                self.gauge('postfix.queue.size', count, tags=['queue:%s' % queue, 'instance:%s' % instance])
 
-            # these can be retrieved in a single graph statement
-            # for example:
-            #     sum:postfix.queue.size{role:mta} by {queue}
+                # these can be retrieved in a single graph statement
+                # example: sum:postfix.queue.size{role:mta} by {queue}
 

--- a/conf.d/postfix.yaml.example
+++ b/conf.d/postfix.yaml.example
@@ -1,7 +1,9 @@
 init_config:
 
 instances:
-    - directory: /var/spool/postfix
+    - directories:
+          - /var/spool/postfix
+          - /var/spool/postfix-2
       queues:
           - incoming
           - active


### PR DESCRIPTION
Added support for multiple instances of postfix on the same server (http://www.postfix.org/postmulti.1.html). Multi instance postfix boxes maintain independent queues.
