### PR TITLE
haproxy - Calculate used session percentage

### DIFF
--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -31,6 +31,7 @@ class HAProxy(AgentCheck):
         "qcur": ("gauge", "queue.current"),
         "scur": ("gauge", "session.current"),
         "slim": ("gauge", "session.limit"),
+        "spct": ("gauge", "session.pct"),    # Calculated as: (scur/slim)*100
         "stot": ("rate", "session.rate"),
         "bin": ("rate", "bytes.in_rate"),
         "bout": ("rate", "bytes.out_rate"),
@@ -114,6 +115,13 @@ class HAProxy(AgentCheck):
                     except Exception:
                         pass
                     data_dict[fields[i]] = val
+
+            # The percentage of used sessions based on 'scur' and 'slim'
+            if 'slim' in data_dict and 'scur' in data_dict:
+                try:
+                    data_dict['spct'] = (data_dict['scur'] / data_dict['slim']) * 100
+                except TypeError, DivideByZeroError:
+                    pass
 
             # Don't create metrics for aggregates
             service = data_dict['svname']


### PR DESCRIPTION
Calculate the percentage of used sessions (spct) from the current number of sessions (scur) and the session limit (slim).

The reasoning behind this was I would like to be able to trigger alerts when the number of current sessions (haproxy.frontend.session.current) approaches the session limit (haproxy.frontend.session.limit). Since one can only alert on a single metric, another metric had to be created, which reflects the percentage of sessions used.

This is quite literally the only python that I've ever hacked up, so feel free to shoot this down if it looks terrible :) That said, I've tested it out and it seems to work as expected on my haproxy installation.
