### PR TITLE
haproxy - Calculate used session percentage

### DIFF
--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -120,7 +120,7 @@ class HAProxy(AgentCheck):
             if 'slim' in data_dict and 'scur' in data_dict:
                 try:
                     data_dict['spct'] = (data_dict['scur'] / data_dict['slim']) * 100
-                except TypeError, DivideByZeroError:
+                except (TypeError, ZeroDivisionError):
                     pass
 
             # Don't create metrics for aggregates


### PR DESCRIPTION
Calculate the percentage of used sessions (spct) from the current number of sessions (scur) and the session limit (slim).

The reasoning behind this was I would like to be able to trigger alerts when the number of current sessions (haproxy.frontend.session.current) approaches the session limit (haproxy.frontend.session.limit). Since one can only alert on a single metric, another metric had to be created, which reflects the percentage of sessions used.

This is quite literally the only python that I've ever hacked up, so feel free to shoot this down if it looks terrible :) That said, I've tested it out and it seems to work as expected on my haproxy installation... hopefully the Travis CI tests work this time.

<!---
@huboard:{"order":770.9999999962747}
-->
