### PR TITLE
Include tags with http service check

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -76,6 +76,10 @@ class HTTPCheck(ServicesCheck):
         nb_failures = self.statuses[name].count(Status.DOWN)
         nb_tries = len(self.statuses[name])
         tags = instance.get('tags', [])
+        url = instance.get('url', None)
+        tags_list = []
+        tags_list.extend(tags)
+        tags_list.append('url:%s' % url)
 
         # Get a custom message that will be displayed in the event
         custom_message = instance.get('message', "")
@@ -134,7 +138,7 @@ class HTTPCheck(ServicesCheck):
              'alert_type': alert_type,
              "source_type_name": source_type,
              "event_object": name,
-             "tags": tags
+             "tags": tags_list
         }
 
 


### PR DESCRIPTION
This makes each check searchable for events, etc, by tag rather than having to tag the host. 
