### PR TITLE
New source install

### DIFF
--- a/packaging/datadog-agent/source/agent
+++ b/packaging/datadog-agent/source/agent
@@ -2,7 +2,7 @@
 BASEDIR=$(dirname $0)
 cd "$BASEDIR/.."
 
-. venv/bin/activate
+PATH=$BASEDIR/../venv/bin:$PATH
 
 SUPERVISOR_NOT_RUNNING="Supervisor is not running"
 SUPERVISOR_CONF_FILE='supervisord/supervisord.conf'

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -209,9 +209,17 @@ printf "Operating System: $unamestr\n" >> $logfile
 
 # set up a virtual env
 printf "Setting up virtual environment....." | tee -a $logfile
-$dl_cmd $dd_base/virtualenv.py https://raw.github.com/pypa/virtualenv/1.9.1/virtualenv.py >> $logfile 2>&1
+$dl_cmd $dd_base/virtualenv.py https://raw.github.com/pypa/virtualenv/1.11.X/virtualenv.py >> $logfile 2>&1
 python $dd_base/virtualenv.py $dd_base/venv >> $logfile 2>&1
 . $dd_base/venv/bin/activate >> $logfile 2>&1
+print_done
+
+# set up setuptools and pip with wheels support
+printf "Setting up setuptools and pip....." | tee -a $logfile
+$dl_cmd $dd_base/ez_setup.py https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py >> $logfile 2>&1
+$dd_base/venv/bin/python $dd_base/ez_setup.py
+$dl_cmd $dd_base/get-pip.py https://raw.github.com/pypa/pip/master/contrib/get-pip.py >> $logfile 2>&1
+$dd_base/venv/bin/python $dd_base/get-pip.py
 print_done
 
 # install dependencies


### PR DESCRIPTION
virtualenv moved to a wheels-backed install, requiring an upgrade to setuptools and pip to fix #781 

Verified on Mac OS X 10.9, still needs verification on smartos, freebsd.
