### PR TITLE
Fixed warning on SHOW SLAVE STATUS

### DIFF
--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -235,12 +235,15 @@ class MySql(AgentCheck):
                     # cursor.description is a tuple of (column_name, ..., ...)
                     try:
                         col_idx = [d[0].lower() for d in cursor.description].index(field.lower())
-                        if metric_type == GAUGE:
-                            self.gauge(metric, float(result[col_idx]), tags=tags)
-                        elif metric_type == RATE:
-                            self.rate(metric, float(result[col_idx]), tags=tags)
+                        if result[col_idx] is not None:
+                            if metric_type == GAUGE:
+                                self.gauge(metric, float(result[col_idx]), tags=tags)
+                            elif metric_type == RATE:
+                                self.rate(metric, float(result[col_idx]), tags=tags)
+                            else:
+                                self.gauge(metric, float(result[col_idx]), tags=tags)
                         else:
-                            self.gauge(metric, float(result[col_idx]), tags=tags)
+                            self.log.debug("Recieved value is None for index %d" % col_idx)
                     except ValueError:
                         self.log.exception("Cannot find %s in the columns %s" % (field, cursor.description))
             cursor.close()


### PR DESCRIPTION
Hello, 

This PR fixes warning that occurs to us running datadog for monitoring mysql slave. Here is example:

2014-01-28 11:10:16,760 | ERROR | dd.collector | checks.mysql(mysql.py:233) | Error while running SHOW SLAVE STATUS
Traceback (most recent call last):
  File "/usr/share/datadog/agent/checks.d/mysql.py", line 226, in _collect_dict
    self.gauge(metric, float(result[col_idx]), tags=tags)
TypeError: float() argument must be a string or a number

This is not a big problem - but it's annoying while running "datadog-agent info" command and also garbage collector.log. 
