### PR TITLE
Better handling of external clusters in Elasticsearch check.

### DIFF
--- a/conf.d/elastic.yaml.example
+++ b/conf.d/elastic.yaml.example
@@ -8,9 +8,15 @@ instances:
     # elasticsearch-http-basic, you will need to specify a value for username
     # and password for every instance that requires authentication.
     #
+    # If your cluster is hosted externally (i.e., you're not pointing to localhost)
+    # you will need to set `is_external` to true otherwise the check will compare
+    # the local hostname against hostnames of the Elasticsearch nodes and only
+    # submit metrics if they match.
+    #
     #-  url: http://localhost:9200
     #   username: username
     #   password: password
+    #   is_external: false
     #   tags:
     #     - 'tag1:key1'
     #     - 'tag2:key2'


### PR DESCRIPTION
- Add `is_external` option to config which will skip the node hostname
  and local hostname check.
- Refactor hostname check into separate function for clarity.
- Remove unecessary closures for clarity.

@remh Can you review? Let me know if something doesn't make sense.
