### PR TITLE
Add delete_misses/delete_hits to memcache

### DIFF
--- a/checks.d/mcache.py
+++ b/checks.d/mcache.py
@@ -9,34 +9,37 @@ from checks import *
 # version           string   Version string of this server
 # pointer_size      32       Default size of pointers on the host OS
 #                            (generally 32 or 64)
-# rusage_user       32u:32u  Accumulated user time for this process 
+# rusage_user       32u:32u  Accumulated user time for this process
 #                            (seconds:microseconds)
-# rusage_system     32u:32u  Accumulated system time for this process 
+# rusage_system     32u:32u  Accumulated system time for this process
 #                            (seconds:microseconds)
 # curr_items        32u      Current number of items stored by the server
-# total_items       32u      Total number of items stored by this server 
+# total_items       32u      Total number of items stored by this server
 #                            ever since it started
-# bytes             64u      Current number of bytes used by this server 
+# bytes             64u      Current number of bytes used by this server
 #                            to store items
 # curr_connections  32u      Number of open connections
-# total_connections 32u      Total number of connections opened since 
+# total_connections 32u      Total number of connections opened since
 #                            the server started running
-# connection_structures 32u  Number of connection structures allocated 
+# connection_structures 32u  Number of connection structures allocated
 #                            by the server
 # cmd_get           64u      Cumulative number of retrieval requests
 # cmd_set           64u      Cumulative number of storage requests
-# get_hits          64u      Number of keys that have been requested and 
+# get_hits          64u      Number of keys that have been requested and
 #                            found present
-# get_misses        64u      Number of items that have been requested 
+# get_misses        64u      Number of items that have been requested
 #                            and not found
+# delete_misses     64u      Number of deletions reqs for missing keys
+# delete_hits       64u      Number of deletion reqs resulting in
+#                            an item being removed.
 # evictions         64u      Number of valid items removed from cache
 #                            to free memory for new items
-# bytes_read        64u      Total number of bytes read by this server 
+# bytes_read        64u      Total number of bytes read by this server
 #                            from network
-# bytes_written     64u      Total number of bytes sent by this server to 
+# bytes_written     64u      Total number of bytes sent by this server to
 #                            network
 # limit_maxbytes    32u      Number of bytes this server is allowed to
-#                            use for storage. 
+#                            use for storage.
 # threads           32u      Number of worker threads requested.
 #                            (see doc/threads.txt)
 #     >>> mc.get_stats()
@@ -77,6 +80,8 @@ class Memcache(AgentCheck):
         "cmd_flush",
         "get_hits",
         "get_misses",
+        "delete_misses",
+        "delete_hits",
         "evictions",
         "bytes_read",
         "bytes_written",


### PR DESCRIPTION
See https://github.com/memcached/memcached/blob/master/doc/protocol.txt,
there is delete_\* stats we could use to report to datadog.

@remh , please help me out here. I am not sure if I am missing something, I cannot setup the environment to run the tests locally, and I couldn't find any page explaining how to do that. So I changed the code I thought would make sense.
The reason for this is, we need to display `delete_hits` and `delete_misses` to datadog, and right now we dont have those stats, and the memcached protocol says it support them.

Thoughts?
