### PR TITLE
Docker check adjustment

### DIFF
--- a/checks.d/docker.py
+++ b/checks.d/docker.py
@@ -143,7 +143,7 @@ class Docker(AgentCheck):
 
         try:
             containers = self._get_containers(instance)
-        except:
+        except socket.timeout:
             raise Exception('Cannot get containers list: timeout during socket connection. Try to refine the containers to collect by editing the configuration file.')
 
         if not containers:
@@ -184,7 +184,7 @@ class Docker(AgentCheck):
                 stat_file = os.path.join(mountpoint, metric["file"] % (self.path_prefix, container["Id"]))
                 stats = self._parse_cgroup_file(stat_file)
                 for key, (dd_key, metric_type) in metric["metrics"].items():
-                    if key.startswith("total_") and not instance.get("total"):
+                    if key.startswith("total_") and not instance.get("collect_total"):
                         continue
                     if key in stats:
                         getattr(self, metric_type)(dd_key, int(stats[key]), tags=container_tags)

--- a/conf.d/docker.yaml.example
+++ b/conf.d/docker.yaml.example
@@ -33,10 +33,10 @@ instances:
 
 # Sub-cgroups metrics
 #
-# If you want to include sub-cgroups metrics, turn the total option on.
+# If you want to include sub-cgroups metrics, turn the collect_total option on.
 # It is useless for a normal usage, as total_ metrics will be the same as normal ones.
 #
 # Example:
 # instances:
 #     - url: "unix://var/run/docker.sock"
-#       total: true
+#       collect_total: true


### PR DESCRIPTION
This PR contains some adjustment to the Docker integration.
- Turns cpu metrics to rates
- Does not collect `total_` metrics by default because most of the time they are redundant
- Catch socket timeouts
- Some cleanup
