### PR TITLE
Postgres: Handle negative replication delay

### DIFF
--- a/checks.d/postgres.py
+++ b/checks.d/postgres.py
@@ -228,7 +228,10 @@ SELECT relname,
             # Therefore, you must use the seconds attribute on the timedelta object in order to get the correct metric value.
             result = cursor.fetchone()[0]
             if result is not None:
-                self.HOT_STANDBY_METRIC[2](self, self.HOT_STANDBY_METRIC[1], result.seconds, tags=instance_tags)
+                if result.days < 0:
+                    self.HOT_STANDBY_METRIC[2](self, self.HOT_STANDBY_METRIC[1], 0, tags=instance_tags)
+                else:
+                    self.HOT_STANDBY_METRIC[2](self, self.HOT_STANDBY_METRIC[1], result.seconds, tags=instance_tags)
         cursor.close()
 
     def get_connection(self, key, host, port, user, password, dbname, use_cached=True):


### PR DESCRIPTION
In case the master and slave's clocks are slightly out of sync, and there is virtually no replication delay, we may experience that a negative timedelta in the replication delay check. That is however not detected in the current code, as Python sets the `days` property to `-1` and `seconds` to `86400`, in order to not have a negative number in the `seconds` property.

This change checks if `days` is a negative number, and if it is, we always send 0 seconds as the replication delay.

There's an example of how it can look if it isn't fixed here:
![replication-delay-example](https://cloud.githubusercontent.com/assets/68696/3255721/8bc5c8fa-f20e-11e3-8c5b-de251f355b37.png)
