### PR TITLE
Fix elasticsearch metrics according to different ES versions

### DIFF
--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -205,6 +205,8 @@ class ElasticSearch(AgentCheck):
                 "jvm.gc.collection_time": ("gauge", "jvm.gc.collection_time_in_millis", lambda v: float(v)/1000),
             }
 
+        self.METRICS.update(additional_metrics)
+
         if version >= [0,90,5]:
             # ES versions 0.90.5 and above
             additional_metrics = {


### PR DESCRIPTION
Tested with ES 0.90.5 -> 0.90.10.
This is related to https://github.com/DataDog/dd-agent/pull/1010
The new JVM metric names were introduced in ES 0.90.10. The other metrics are available starting with ES 0.90.5.
