### PR TITLE
Updated KafkaClient API - version 0.9.0

### DIFF
--- a/checks.d/kafka_consumer.py
+++ b/checks.d/kafka_consumer.py
@@ -25,8 +25,7 @@ class KafkaCheck(AgentCheck):
         consumer_groups = self.read_config(instance, 'consumer_groups',
                                            cast=self._validate_consumer_groups)
         zk_connect_str = self.read_config(instance, 'zk_connect_str')
-        kafka_host_ports = self.read_config(instance, 'kafka_connect_str',
-                                            cast=self._parse_connect_str)
+        kafka_host_ports = self.read_config(instance, 'kafka_connect_str')
 
         # Construct the Zookeeper path pattern
         zk_prefix = instance.get('zk_prefix', '')
@@ -63,8 +62,7 @@ class KafkaCheck(AgentCheck):
                 self.log.exception('Error cleaning up Zookeeper connection')
 
         # Connect to Kafka
-        kafka_host, kafka_port = random.choice(kafka_host_ports)
-        kafka_conn = KafkaClient(kafka_host, kafka_port)
+        kafka_conn = KafkaClient(kafka_host_ports)
 
         try:
             # Query Kafka for the broker offsets
@@ -120,15 +118,3 @@ consumer_groups:
     mytopic0: [0, 1, 2]
     mytopic1: [10, 12]
 ''')
-
-    def _parse_connect_str(self, val):
-        try:
-            host_port_strs = val.split(',')
-            host_ports = []
-            for hp in host_port_strs:
-                host, port = hp.strip().split(':')
-                host_ports.append((host, int(port)))
-            return host_ports
-        except Exception, e:
-            self.log.exception(e)
-            raise Exception('Could not parse %s. Must be in the form of `host0:port0,host1:port1,host2:port2`' % val)


### PR DESCRIPTION
# Problem - Old kafka-python API

kafka-python updated the latest `__init__` api to use comma delimited host string, this breaks the old api which was used in the check; on the bright side it simplifies the checks code.

info dump

```
    kafka_consumer
    --------------
      - instance #0 [ERROR]: TypeError("object of type 'int' has no len()",)
      - Collected 0 metrics, 0 events & 0 service checks
```

Stack Trace:

```
2014-07-10 18:05:38 UTC | INFO | dd.collector | kazoo.client(connection.py:536) | Closing connection to ec2-54-191-60-165.us-west-2.compute.amazonaws.com:2181
2014-07-10 18:05:38 UTC | INFO | dd.collector | kazoo.client(client.py:439) | Zookeeper session lost, state: CLOSED
2014-07-10 18:05:38 UTC | ERROR | dd.collector | checks.kafka_consumer(__init__.py:507) | Check 'kafka_consumer' instance #0 failed
Traceback (most recent call last):
  File "/usr/share/datadog/agent/checks/__init__.py", line 498, in run
    self.check(copy.deepcopy(instance))
  File "/usr/share/datadog/agent/checks.d/kafka_consumer.py", line 71, in check
    # Connect to Kafka
  File "/usr/local/lib/python2.7/dist-packages/kafka/client.py", line 40, in __init__
    self.load_metadata_for_topics()  # bootstrap with all metadata
  File "/usr/local/lib/python2.7/dist-packages/kafka/client.py", line 252, in load_metadata_for_topics
    request_id, topics)
  File "/usr/local/lib/python2.7/dist-packages/kafka/protocol.py", line 354, in encode_metadata_request
    KafkaProtocol.METADATA_KEY)
  File "/usr/local/lib/python2.7/dist-packages/kafka/protocol.py", line 49, in _encode_message_header
    return struct.pack('>hhih%ds' % len(client_id),
TypeError: object of type 'int' has no len()
```
# Tests

_Note: there we no tests to update so I did not bother writting one_
- [x] Updated local agent, restart and saw the follow under info:

```
    kafka_consumer
    --------------
      - instance #0 [OK]
      - Collected 8 metrics, 0 events & 0 service checks
```
# Reading Material

[kafka-python docs](https://github.com/mumrah/kafka-python#high-level)
[kafka-python KafkaClient.__init__](https://github.com/mumrah/kafka-python/blob/master/kafka/conn.py#L16)
[kafka-python collect_hosts](https://github.com/mumrah/kafka-python/blob/master/kafka/conn.py#L16)
