### PR TITLE
Fix posture check when several versions of postgres

### DIFF
--- a/checks.d/postgres.py
+++ b/checks.d/postgres.py
@@ -133,9 +133,9 @@ SELECT relname,
         metrics = self.instance_metrics.get(key)
         if metrics is None:
             if self._is_9_2_or_above(key, db):
-                self.instance_metrics[key] = dict(self.COMMON_METRICS.items() + self.NEWER_92_METRICS.items())
+                self.instance_metrics[key] = dict(self.COMMON_METRICS, **self.NEWER_92_METRICS)
             else:
-                self.instance_metrics[key] = dict(self.COMMON_METRICS.items())
+                self.instance_metrics[key] = dict(self.COMMON_METRICS)
             metrics = self.instance_metrics.get(key)
         return metrics
 


### PR DESCRIPTION
- don't update self.DB_METRICS, use a new dict instead
