### PR TITLE
Added Mesos/Marathon requests v1/v2 compatibility

### DIFF
--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -48,10 +48,10 @@ class Marathon(AgentCheck):
             raise Exception("Got %s when hitting %s" % (r.status_code, url))
 
         # Condition for request v1.x backward compatibility
-        if type(r.json) == dict:
-            return r.json
-        else:
+        if hasattr(r.json, '__call__'):
             return r.json()
+        else:
+            return r.json
 
     def get_v2_app_versions(self, url, app_id, timeout):
         # Use a hash of the URL as an aggregation key

--- a/checks.d/mesos.py
+++ b/checks.d/mesos.py
@@ -85,10 +85,10 @@ class Mesos(AgentCheck):
             return None
 
         # Condition for request v1.x backward compatibility
-        if type(r.json) == dict:
-            return r.json
-        else:
+        if hasattr(r.json, '__call__'):
             return r.json()
+        else:
+            return r.json
 
 
     def timeout_event(self, url, timeout, aggregation_key):


### PR DESCRIPTION
# Problem

Marathon check was written for requests v1.x api
# Solution

I added a condition to return if `r.json` is a dict else return the response from the callable method
## Example of error

``` python
>>> import requests
>>> r = requests.get('http://localhost:8080/v2/apps')
>>> r.json
<bound method Response.json of <Response [200]>>
>>> r.json()
{u'apps':
```
# Tests
- [x] Tested datadog info

```
  Checks
  ======

    mesos
    -----
      - instance #0 [OK]
      - Collected 115 metrics, 0 events & 0 service checks

    marathon
    --------
      - instance #0 [OK]
      - Collected 141 metrics, 0 events & 0 service checks

    network
    -------
      - instance #0 [OK]
      - Collected 11 metrics, 0 events & 0 service checks


  Emitters
  ========

    - http_emitter [OK]
```
# Notes
- Since I added the condition to marathon I went ahead and added it to mesos for consistency
