### PR TITLE
Support snmp check on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if sys.platform == 'win32':
         'pymongo==2.3',
         'pg8000==1.9.6',
         'python-memcached==1.48',
-        'adodbapi==2.4.2.2'
+        'adodbapi==2.4.2.2',
         'elementtree==1.2.7.20070827-preview',
         'pycurl==7.19.0',
         'pymysql==0.6.1',


### PR DESCRIPTION
There is two things in here, which I probably should have split up but I did at the same time:
- Fixing the dependencies requirements to put them at the same level than for the self contained agent.
- Addition of pysnmp to the windows agent dependencies to support the SNMP check on windows. We also bundle the standard mibs in the python format to avoid it being a real pain to setup. The import of pysnmp_mibs before the packaging in setup.py is due to the way the mibs are moduled. If it's not done, these mibs are not going to be included so it's necessary.
