### PR TITLE
Improvements on NetworkCheck class

### DIFF
--- a/checks/network_checks.py
+++ b/checks/network_checks.py
@@ -195,3 +195,4 @@ class NetworkCheck(AgentCheck):
             if now - start_time > TIMEOUT:
                 self.log.critical("Restarting Pool. One check is stuck: %s" % name)
                 self.restart_pool()
+                break


### PR DESCRIPTION
- Removed some unused vars
- Prints the name of the job which is stuck when restarting the thread pool
- Breaks when clearing the ThreadPool otherwise the next iteration of the loop will throw because `self.jobs_status` dictionary is cleared when calling `restart_pool()`
