### PR TITLE
Add result and build number to tags for jenkins events

### DIFF
--- a/checks.d/jenkins.py
+++ b/checks.d/jenkins.py
@@ -152,7 +152,8 @@ class Jenkins(AgentCheck):
 
                     tags = [
                         'job_name:%s' % output['job_name'],
-                        'result:%s' % output['result']
+                        'result:%s' % output['result'],
+                        'build_number:%s' % output['number']
                     ]
 
                     if 'branch' in output:

--- a/tests/test_jenkins.py
+++ b/tests/test_jenkins.py
@@ -118,6 +118,7 @@ class TestJenkins(unittest.TestCase):
         for tag in metrics_tags:
             assert 'job_name:foo' in tag.get('tags')
             assert 'result:SUCCESS' in tag.get('tags')
+            assert 'build_number:99' in tag.get('tags')
 
 
     def testCheckUnsuccessfulEvent(self):
@@ -145,6 +146,7 @@ class TestJenkins(unittest.TestCase):
         for tag in metrics_tags:
             assert 'job_name:foo' in tag.get('tags')
             assert 'result:ABORTED' in tag.get('tags')
+            assert 'build_number:99' in tag.get('tags')
 
 
     def testCheckWithRunningBuild(self):


### PR DESCRIPTION
This builds on #1060, which fixes the jenkins agent check for when a build does not yet have results.
