### PR TITLE
Nagios| Fix retrocompatibility

### DIFF
--- a/checks.d/nagios.py
+++ b/checks.d/nagios.py
@@ -78,7 +78,8 @@ class Nagios(AgentCheck):
                     instance_key = conf_path
                 if 'nagios_log' in instance:
                     nagios_conf["log_file"] = instance['nagios_log']
-                    instance_key = conf_path or instance['nagios_log']
+                    if instance_key is None:
+                        instance_key = instance['nagios_log']
                 # End of retrocompatibility code
                 if not nagios_conf:
                     self.log.warning("Missing path to nagios_conf")


### PR DESCRIPTION
Fix compatibility in case only `nagios_log` is specified in the `datadog.conf` file.
