### PR TITLE
Don't turn on GC debug mode in Travis so we log a lot less.

### DIFF
--- a/tests/test_mcache.py
+++ b/tests/test_mcache.py
@@ -7,6 +7,9 @@ from tests.common import load_check
 
 
 class TestMemCache(unittest.TestCase):
+    def is_travis(self):
+        return 'TRAVIS' in os.environ
+
     def setUp(self):
         self.agent_config = {
             "memcache_server": "localhost",
@@ -102,7 +105,8 @@ class TestMemCache(unittest.TestCase):
         self.c.get_metrics()
 
         import gc
-        gc.set_debug(gc.DEBUG_LEAK)
+        if not self.is_travis():
+            gc.set_debug(gc.DEBUG_LEAK)
         gc.collect()
         try:
             start = len(gc.garbage)


### PR DESCRIPTION
This should shrink the output from travis runs by a lot and make it much easier to read when there are failures.
