### PR TITLE
Add a service check to the RabbitMQ check based on aliveness.

### DIFF
--- a/checks.d/rabbitmq.py
+++ b/checks.d/rabbitmq.py
@@ -247,8 +247,10 @@ class RabbitMQ(AgentCheck):
                     status = AgentCheck.OK
                 else:
                     status = AgentCheck.CRITICAL
-            except Exception:
+            except Exception as e:
                 # Either we got a bad status code or unparseable JSON.
                 status = AgentCheck.CRITICAL
+                self.warning('Error when checking aliveness for vhost %s: %s'\
+                    % (vhost, str(e)))
 
             self.service_check('rabbitmq.aliveness', status, tags, message=message)

--- a/conf.d/rabbitmq.yaml.example
+++ b/conf.d/rabbitmq.yaml.example
@@ -5,8 +5,6 @@ instances:
     # url of the RabbitMQ Managment Plugin (http://www.rabbitmq.com/management.html)
     # optional: 'rabbitmq_user' (default: guest) and 'rabbitmq_pass' (default: guest)
     #
-    # Metrics:
-    #
     # If you have less than 5 queues, you don't have to set the queues parameters
     # All queues metrics will be collected
     # If you have more than 5 queues: you can set 5 queue names. Metrics will be collected


### PR DESCRIPTION
Changes:
- Adds optional configuration to have a list of vhosts you want to
  monitor. The default case will fetch all vhosts from the API.
- Adds `rabbitmq.aliveness` check, tagged by vhost.
