### PR TITLE
Add message rate metrics to RabbitMQ check.

### DIFF
--- a/checks.d/rabbitmq.py
+++ b/checks.d/rabbitmq.py
@@ -44,7 +44,7 @@ QUEUE_ATTRIBUTES = [
     ('message_stats/publish_details/rate', 'messages.publish.rate'),
 
     ('message_stats/redeliver', 'messages.redeliver.count'),
-    ('message_stats/redeliver/rate', 'messages.redeliver.rate'),
+    ('message_stats/redeliver_details/rate', 'messages.redeliver.rate'),
 ]
 
 NODE_ATTRIBUTES = [


### PR DESCRIPTION
This is useful when you have a queue that's consumed very quickly. In
this case the Agent will always/nearly always report 0 for queue sizes.

New metrics:
    - `rabbitmq.queue.messages.rate`
    - `rabbitmq.queue.messages_ready.rate`
    - `rabbitmq.queue.messages_unacknowledged.rate`
