### PR TITLE
update nginx yaml doc big

### DIFF
--- a/conf.d/nginx.yaml.example
+++ b/conf.d/nginx.yaml.example
@@ -1,8 +1,13 @@
 init_config:
 
 instances:
-    # For every instance, you have an `nginx_status_url` and (optionally)
-    # a list of tags.
+    # For every instance, you need an `nginx_status_url` and can optionally
+    # supply a list of tags.  This plugin requires nginx to be compiled with
+    # the `status` option.  On debian/ubuntu, this is included in the
+    # `nginx-extras` package.  For more details, see:
+    #
+    #   http://docs.datadoghq.com/integrations/nginx/
+    #
 
     -   nginx_status_url: http://example.com/nginx_status/
         tags:


### PR DESCRIPTION
People just dive into this stuff and then don't find any docs.  Added a brief explanation of the requirements for the integration and a link to our integration docs which can then talk more about nginx plus, configuring the status page, etc.
