### PR TITLE
io_counters methods

### DIFF
--- a/checks.d/process.py
+++ b/checks.d/process.py
@@ -127,7 +127,10 @@ class ProcessCheck(AgentCheck):
                 # user agent might have access to io counters for some processes and not others
                 if read_count is not None:
                     try:
-                        io_counters = p.io_counters()
+                        try:
+                            io_counters = p.io_counters()
+                        except AttributeError:
+                            io_counters = p.get_io_counters()
                         read_count += io_counters.read_count
                         write_count += io_counters.write_count
                         read_bytes += io_counters.read_bytes


### PR DESCRIPTION
Documentation (http://docs.datadoghq.com/integrations/process/)
recommends using psutil 1.2.1 which uses get_io_counters.
io_counters is a 2.1.2 method. This tries both methods to make sure it
works on both versions.
