### PR TITLE
reduce redirect on download of virtualenv.py

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -221,7 +221,7 @@ printf "Operating System: $unamestr\n" >> $logfile
 
 # set up a virtual env
 printf "Setting up virtual environment....." | tee -a $logfile
-$dl_cmd $dd_base/virtualenv.py https://raw.github.com/pypa/virtualenv/1.11.X/virtualenv.py >> $logfile 2>&1
+$dl_cmd $dd_base/virtualenv.py https://raw.githubusercontent.com/pypa/virtualenv/1.11.X/virtualenv.py >> $logfile 2>&1
 
 if [ "$is_openshift" = "1" ]; then
     python $dd_base/virtualenv.py --no-pip --no-setuptools --system-site-packages $dd_base/venv >> $logfile 2>&1


### PR DESCRIPTION
This is pointing to an older GitHub endpoint. Each request will have to
perform a redirect to get the correct file.

``` console
$ curl -IL https://raw.github.com/pypa/virtualenv/1.11.X/virtualenv.py
HTTP/1.1 301 Moved Permanently
Date: Mon, 22 Sep 2014 18:09:21 GMT
Server: Apache
Location:
https://raw.githubusercontent.com/pypa/virtualenv/1.11.X/virtualenv.py
Accept-Ranges: bytes
Via: 1.1 varnish
Age: 0
X-Served-By: cache-jfk1023-JFK
X-Cache: MISS
X-Cache-Hits: 0
Vary: Accept-Encoding

HTTP/1.1 200 OK
Date: Mon, 22 Sep 2014 18:09:22 GMT
Server: Apache
Access-Control-Allow-Origin: https://render.githubusercontent.com
Content-Security-Policy: default-src 'none'
X-XSS-Protection: 1; mode=block
X-Frame-Options: deny
X-Content-Type-Options: nosniff
Strict-Transport-Security: max-age=31536000
ETag: "0329fc98c0382822c458c374945509ba5a8d3ffc"
Content-Type: text/plain; charset=utf-8
Cache-Control: max-age=300
Content-Length: 98477
Accept-Ranges: bytes
Via: 1.1 varnish
X-Served-By: cache-jfk1026-JFK
X-Cache: MISS
X-Cache-Hits: 0
Vary: Authorization,Accept-Encoding
Expires: Mon, 22 Sep 2014 18:14:22 GMT
Source-Age: 0
```
