### PR TITLE
Mysql slow query log

### DIFF
--- a/dogstream/mysql_slow_query.py
+++ b/dogstream/mysql_slow_query.py
@@ -78,7 +78,7 @@ def parse_event(query):
             timestamp = int(time.mktime(time.strptime(timestamp, "%y%m%d %H:%M:%S")))
 
     return {
-        "msg_title": "Slow query from %s %s@%s" % (schema_name, user, host),
+        "msg_title": "Slow query from %s@%s" % (user, host),
         "timestamp": timestamp,
         "msg_text": query,
         "alert_type": "warning",


### PR DESCRIPTION
this addresses #25 

Dogstream parser for mysql slow query log

This Dogstream requires slow query log to be enabled in mysql server my.cnf

```
# /etc/mysql/my.cnf
log_slow_queries        = /var/log/mysql/mysql-slow.log
long_query_time         = 2
```

Must also enable this customer log parser in datadog.conf

```
# /etc/dd-agent/datadog.conf
dogstreams: /var/log/mysql/mysql-slow.log:/opt/datadog-agent/agent/dogstream/mysql_slow_query.py:parse_slow_query
```

The outputted events will look like:

```
title:
  Slow query from root[root]@localhost
text:
  # Time: 140923 22:26:00
  # User@Host: root[root] @ localhost []
  # Query_time: 4.000194 Lock_time: 0.000000 Rows_sent: 1 Rows_examined: 0
  SET timestamp=1411525560;
  select sleep(4);
```
