### PR TITLE
bsd: Pass '-W' to netstat for full interface names on FreeBSD

### DIFF
--- a/checks.d/network.py
+++ b/checks.d/network.py
@@ -240,9 +240,17 @@ class Network(AgentCheck):
             self.log.debug("Unable to read /proc/net/snmp.")
 
     def _check_bsd(self, instance):
-        netstat = subprocess.Popen(["netstat", "-i", "-b"],
-                                   stdout=subprocess.PIPE,
-                                   close_fds=True).communicate()[0]
+        platf = sys.platform
+
+        # FreeBSD's netstat truncates device names unless you pass '-W'
+        if Platform.is_freebsd(platf):
+            netstat = subprocess.Popen(["netstat", "-i", "-b", "-W"],
+                                       stdout=subprocess.PIPE,
+                                       close_fds=True).communicate()[0]
+        else:
+            netstat = subprocess.Popen(["netstat", "-i", "-b"],
+                                       stdout=subprocess.PIPE,
+                                       close_fds=True).communicate()[0]
         # Name  Mtu   Network       Address            Ipkts Ierrs     Ibytes    Opkts Oerrs     Obytes  Coll
         # lo0   16384 <Link#1>                        318258     0  428252203   318258     0  428252203     0
         # lo0   16384 localhost   fe80:1::1           318258     -  428252203   318258     -  428252203     -


### PR DESCRIPTION
By default, `netstat` on FreeBSD only shows the first five characters of an interfaced name, and truncates the rest.  So following the standard VLAN naming convention (`<iface>.<vlan_id>`), we have interface names like `re1.200`, `re1.210`, and `re1.220`.  These are seen as a single interface called `re1.2` by the agent.

Unfortunately, at least OpenBSD has a differing interpretation of `-W` for netstat, so limit the additional flag to just FreeBSD for now.  I don't have access to any other BSD to test right now.  I'm also not sure this is the best way to handle this, but it seemed reasonably clean.