### PR TITLE
Fixes #1131 by lowering loglevel when stopping

### DIFF
--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -158,7 +158,7 @@ class Reporter(threading.Thread):
 
         except Exception:
             if self.finished.isSet():
-                log.info("Couldn't flush metrics, but that's expected as we're stopping")
+                log.debug("Couldn't flush metrics, but that's expected as we're stopping")
             else:
                 log.exception("Error flushing metrics")
 


### PR DESCRIPTION
When stopping the agent, supervisord sends SIGTERM to both the
forwarder and dogstatsd at the same time. There is a race condition
issue, when the forwarder stops before dogstatsd, the latter will try
to flush the metrics to the forwarder in its loop, causing an exception.
This is expected as we're stopping, so if the stop flag is set just
consider this exception as INFO.

cc @remh 
