### PR TITLE
Add SSH flavor test against localhost server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - NOSE_FILTER="not windows"
   matrix:
     - TRAVIS_FLAVOR=default
-    - TRAVIS_FLAVOR=cache,gearman,database
+    - TRAVIS_FLAVOR=cache,gearman,database,ssh
     - TRAVIS_FLAVOR=cassandra,tomcat,jmx # JMX testing machine / need the other ones before
     - TRAVIS_FLAVOR=elasticsearch,network,sysstat,webserver
     - TRAVIS_FLAVOR=mongo

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,7 @@ require './ci/jmx'
 require './ci/mongo'
 require './ci/network'
 require './ci/sysstat'
+require './ci/ssh'
 require './ci/tomcat'
 require './ci/webserver'
 

--- a/ci/ssh.rb
+++ b/ci/ssh.rb
@@ -1,0 +1,28 @@
+require './ci/common'
+
+namespace :ci do
+  namespace :ssh do
+    task :before_install => ['ci:common:before_install'] do
+      apt_update
+    end
+
+    task :install => ['ci:common:install'] do
+      # Should be alreday there on Travis though
+      sh %Q{sudo apt-get install openssh-server}
+    end
+
+    task :before_script => ['ci:common:before_script'] do
+      # Create test/test account
+      sh %Q{sudo useradd -m -p $(perl -e 'print crypt("test", "password")') test}
+    end
+
+    task :script => ['ci:common:script'] do
+      this_provides = [
+        'ssh',
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task :execute => [:before_install, :install, :before_script, :script]
+  end
+end

--- a/tests/test_ssh_check.py
+++ b/tests/test_ssh_check.py
@@ -1,26 +1,27 @@
 import unittest
+from nose.plugins.attrib import attr
 from tests.common import load_check
 from checks import AgentCheck
 
+@attr(requires='ssh')
 class SshTestCase(unittest.TestCase):
 
     def test_ssh(self):
-
         config = {
             'instances': [{
-                'host': 'sdf.org',
+                'host': 'localhost',
                 'port': 22,
-                'username': 'datadog01',
-                'password': 'abcd',
+                'username': 'test',
+                'password': 'test',
                 'sftp_check': False,
                 'private_key_file': '',
                 'add_missing_keys': True
             },
             {
-                'host': 'sdf.org',
+                'host': 'localhost',
                 'port': 22,
-                'username': 'wrongusername',
-                'password': 'wrongpassword',
+                'username': 'test',
+                'password': 'yodawg',
                 'sftp_check': False,
                 'private_key_file': '',
                 'add_missing_keys': True


### PR DESCRIPTION
"Unflakify" the SSH test, it was relying on an external SSH server before which may timeout or be too slow.
Now, we test it against localhost which reduce our chances of failing because of the universe decided so.

@LotharSee I hope this will also fix the regression you introduced when updating the README.
