### PR TITLE
Fix detection of Elasticsearch version for Beta and RC releases

### DIFF
--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -169,7 +169,7 @@ class ElasticSearch(AgentCheck):
         """
         try:
             data = self._get_data(config_url, auth)
-            version = map(int, data['version']['number'].split('.'))
+            version = map(int, data['version']['number'].split('.')[0:3])
         except Exception, e:
             self.warning("Error while trying to get Elasticsearch version from %s %s" % (config_url, str(e)))
             version = [0, 0, 0]


### PR DESCRIPTION
The Elasticsearch check assumes that the version is returned in semver x.y.z format, but Elasticsearch has a nasty habit of having x.y.z.STRING to denote beta releases. 

The side effect is that if you are using a beta or RC version, the version check will assume you are running an old version, and will 404 on various health checks (as the APIs have changed).

The fix is to simply consider the first 3 parts, which should be enough to determine the API version to use.

![image](https://cloud.githubusercontent.com/assets/3114436/4731504/354dcfd2-5a18-11e4-8f57-90da3a4b141b.png)
