### PR TITLE
Update cassandra version

### DIFF
--- a/ci/cassandra.rb
+++ b/ci/cassandra.rb
@@ -3,13 +3,13 @@ require './ci/common'
 namespace :ci do
   namespace :cassandra do
     task :before_install => ['ci:common:before_install'] do
-      sh %Q{curl http://apache.mesi.com.ar/cassandra/2.0.9/apache-cassandra-2.0.9-bin.tar.gz | tar -C /tmp -xz}
+      sh %Q{curl http://apache.mesi.com.ar/cassandra/2.0.11/apache-cassandra-2.0.11-bin.tar.gz | tar -C /tmp -xz}
     end
 
     task :install => ['ci:common:install']
 
     task :before_script => ['ci:common:before_script'] do
-      sh %Q{sudo /tmp/apache-cassandra-2.0.9/bin/cassandra}
+      sh %Q{sudo /tmp/apache-cassandra-2.0.11/bin/cassandra}
       # Wait for cassandra to init
       sh %Q{sleep 10}
     end


### PR DESCRIPTION
Just updated cassandra version to 2.0.11 because 2.0.9 is no longer available.
