### PR TITLE
ElasticSearch agent check should only query the local node.

### DIFF
--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -184,7 +184,7 @@ class ElasticSearch(AgentCheck):
         if version >= [0,90,10]:
             # ES versions 0.90.10 and above
             self.HEALTH_URL = "/_cluster/health?pretty=true"
-            self.STATS_URL = "/_nodes/stats?all=true"
+            self.STATS_URL = "/_nodes/_local/stats?all=true"
             self.NODES_URL = "/_nodes?network=true"
 
             additional_metrics = {


### PR DESCRIPTION
The current ElasticSearch agent check will cause all nodes in an ElasticSearch cluster to cease reporting metrics if one ElasticSearch node fails or is slow to respond to the request. This is because ElasticSearch will query all nodes in the cluster before providing a response. In practice, Bazaarvoice has seen this produce troubling side-effects in Datadog graphs: all the nodes in the cluster suddenly stop reporting metrics. This is particularly problematic when looking at historical data and trying to draw conclusions based on the data -- because the Datadog graphs draw a line between two visible data points, it is rarely obvious that no data was reported during a certain period of time; rather, it just looks like very unusual and sometimes frightening metrics were being sent from the ElasticSearch nodes.

The easy way to fix all of this is, of course, to simply inform ElasticSearch that it should only look at the local node stats, and allow all the other ElasticSearch nodes to do the same.

Tested with ElasticSearch 0.90.13 and later.
