### PR TITLE
add another file to detect platform type

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -58,6 +58,9 @@ elif [ -f /etc/debian_version -o "$DISTRIBUTION" == "Debian" -o "$DISTRIBUTION" 
     OS="Debian"
 elif [ -f /etc/redhat-release -o "$DISTRIBUTION" == "RedHat" -o "$DISTRIBUTION" == "CentOS" -o "$DISTRIBUTION" == "openSUSE" -o "$DISTRIBUTION" == "Amazon" ]; then
     OS="RedHat"
+# Some newer distros like Amazon may not have a redhat-release file
+elif [ -f /etc/system-release -o "$DISTRIBUTION" == "Amazon" ]; then
+    OS="RedHat"
 fi
 
 # Root user detection


### PR DESCRIPTION
Amazon Linux distributions may not include a redhat-release file.

Needs some further testing.
