### PR TITLE
Add a service check for Riak.

### DIFF
--- a/checks.d/riak.py
+++ b/checks.d/riak.py
@@ -11,6 +11,7 @@ import simplejson as json
 from httplib2 import Http, HttpLib2Error
 
 class Riak(AgentCheck):
+    SERVICE_CHECK_NAME = 'riak.can_connect'
 
     keys = [
         "vnode_gets",
@@ -55,34 +56,29 @@ class Riak(AgentCheck):
 
         self.prev_coord_redirs_total = -1
 
-
     def check(self, instance):
         url             = instance['url']
         default_timeout = self.init_config.get('default_timeout', 5)
         timeout         = float(instance.get('timeout', default_timeout))
-
-        aggregation_key = md5(url).hexdigest()
+        service_check_tags = ['url:%s' % url]
 
         try:
             h = Http(timeout=timeout)
             resp, content = h.request(url, "GET")
-
-        except socket.timeout, e:
-            self.timeout_event(url, timeout, aggregation_key)
-            return
-
-        except socket.error, e:
-            self.timeout_event(url, timeout, aggregation_key)
-            return
-
-        except HttpLib2Error, e:
-            self.timeout_event(url, timeout, aggregation_key)
-            return
+        except (socket.timeout, socket.error, HttpLib2Error) as e:
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
+                message="Unable to fetch Riak stats: %s" % str(e),
+                tags=service_check_tags)
 
         if resp.status != 200:
-            self.status_code_event(url, resp, aggregation_key)
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
+                tags=service_check_tags,
+                message="Unexpected status of %s when fetching Riak stats, " \
+                        "response: %s" % (resp.status, content))
 
         stats = json.loads(content)
+        self.service_check(
+            self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=service_check_tags)
 
         [self.gauge("riak." + k, stats[k]) for k in self.keys if k in stats]
 
@@ -92,21 +88,3 @@ class Riak(AgentCheck):
             self.gauge('riak.coord_redirs', count)
 
         self.prev_coord_redirs_total = coord_redirs_total
-
-    def timeout_event(self, url, timeout, aggregation_key):
-        self.event({
-            'timestamp': int(time.time()),
-            'event_type': 'riak_check',
-            'msg_title': 'riak check timeout',
-            'msg_text': '%s timed out after %s seconds.' % (url, timeout),
-            'aggregation_key': aggregation_key
-        })
-
-    def status_code_event(self, url, r, aggregation_key):
-        self.event({
-            'timestamp': int(time.time()),
-            'event_type': 'riak_check',
-            'msg_title': 'Invalid reponse code for riak check',
-            'msg_text': '%s returned a status of %s' % (url, r.status_code),
-            'aggregation_key': aggregation_key
-        })


### PR DESCRIPTION
Remove the timeout and status code events because they provide the
same functionality as a monitor on this service check.
