### PR TITLE
Disable tagging by hostname by default for HAProxy service check.

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -289,8 +289,8 @@ class AgentCheck(object):
         self.hostname = agentConfig.get('checksd_hostname') or get_hostname(agentConfig)
         self.log = logging.getLogger('%s.%s' % (__name__, name))
 
-        self.aggregator = MetricsAggregator(self.hostname, 
-            formatter=agent_formatter, 
+        self.aggregator = MetricsAggregator(self.hostname,
+            formatter=agent_formatter,
             recent_point_threshold=agentConfig.get('recent_point_threshold', None))
 
         self.events = []
@@ -532,7 +532,7 @@ class AgentCheck(object):
         instance_statuses = []
         for i, instance in enumerate(self.instances):
             try:
-                min_collection_interval = instance.get('min_collection_interval', 
+                min_collection_interval = instance.get('min_collection_interval',
                     self.init_config.get('min_collection_interval', self.DEFAULT_MIN_COLLECTION_INTERVAL))
                 now = time.time()
                 if now - self.last_collection_time[i] < min_collection_interval:

--- a/conf.d/haproxy.yaml.example
+++ b/conf.d/haproxy.yaml.example
@@ -4,7 +4,28 @@ instances:
 #    -   username: username
 #        password: password
 #        url: https://path/to/haproxy
+
+         # The (optional) status_check paramater will instruct the check to
+         # send events on status changes in the backend. This is DEPRECATED in
+         # favor creation a monitor on the service check status and will be
+         # removed in a future version.
 #        status_check: False
+
+         # The (optional) collect_aggregates_only parameter will instruct the
+         # check to collect metrics only from the aggregate frontend/backend
+         # status lines from the stats output instead of for each backend.
 #        collect_aggregates_only: True
-#        collect_status_metrics: False # set to True to collect status metrics (haproxy.count_per_status)
-#        collect_status_metrics_by_host: False # aggregate status metrics per host instead of per service (if collect_status_metrics is true)
+
+         # The (optional) collect_status_metrics parameter will instruct the
+         # check to collect metrics on status counts (e.g. haproxy.count_per_status)
+#        collect_status_metrics: False
+
+         # The (optional) collect_status_metrics_by_host parameter will instruct
+         # the check to collect status metrics per host instead of per service.
+         # This only applies if collect_status_metrics is True.
+#        collect_status_metrics_by_host: False
+
+         # The (optional) tag_service_check_by_host parameter will instruct the
+         # check to tag the service check status by host on top of other tags.
+         # The default case will only tag by backend and service.
+#        tag_service_check_by_host: False


### PR DESCRIPTION
In general you care about a {backend,service} combination but not the
HAProxy host itself. With tagging by host, the default setup for an
HAProxy monitor will trigger N errors everytime a backend goes down,
where N is the number of haproxy load balancers.

This will make things less noisy but keeps an option to enable the
tagging by hostname if you would like it.

I also updated the formatting on the YAML file to match the HTTP
check so it's more readable/clear.
