### PR TITLE
Tag container count metrics the same way as cgroups metrics

### DIFF
--- a/checks.d/docker.py
+++ b/checks.d/docker.py
@@ -157,7 +157,8 @@ class Docker(AgentCheck):
             running_containers = self._get_containers(instance, with_size=with_size)
             all_containers = self._get_containers(instance, get_all=True)
         except (socket.timeout, urllib2.URLError), e:
-            self.service_check(service_check_name, AgentCheck.CRITICAL, tags=tags)
+            self.service_check(service_check_name, AgentCheck.CRITICAL,
+                message="Unable to list Docker containers: {0}".format(e), tags=tags)
             raise Exception("Failed to collect the list of containers. Exception: {0}".format(e))
         self.service_check(service_check_name, AgentCheck.OK, tags=tags)
 


### PR DESCRIPTION
Unify tags on top of `docker.containers.running` and `docker.containers.stopped`.
Now both are tagged with `image` and `command`.
