### PR TITLE
Fixes deprecated Couchbase REST API URI (couchbase 3.0)

### DIFF
--- a/checks.d/couchbase.py
+++ b/checks.d/couchbase.py
@@ -3,6 +3,9 @@ import urllib2
 import re
 import sys
 
+# exceptions
+from urllib2 import HTTPError
+
 # project
 from util import headers
 from checks import AgentCheck
@@ -113,7 +116,13 @@ class Couchbase(AgentCheck):
                 # Fetch URI for the stats bucket
                 endpoint = bucket['stats']['uri']
                 url = '%s%s' % (server, endpoint)
-                bucket_stats = self._get_stats(url, instance)
+
+                try:
+                    bucket_stats = self._get_stats(url, instance)
+                except HTTPError:
+                    url_backup = '%s/pools/nodes/buckets/%s/stats' % (server, bucket_name)
+                    bucket_stats = self._get_stats(url_backup, instance)
+
                 bucket_samples = bucket_stats['op']['samples']
                 if bucket_samples is not None:
                     couchbase['buckets'][bucket['name']] = bucket_samples


### PR DESCRIPTION
- Fixes depreciated Couchbase REST API URI (Couchbase 3.0).
  ![depreciated](https://cloud.githubusercontent.com/assets/5708089/5115018/a15278be-700b-11e4-8515-5c8c19d00870.jpg)
- Couchbase 1.8+ support
