### PR TITLE
statsd: option to namespace all metrics

### DIFF
--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -108,6 +108,11 @@ use_mount: no
 # statsd_forward_host: address_of_own_statsd_server
 # statsd_forward_port: 8125
 
+# you may want all statsd metrics coming from this host to be namespaced
+# in some way; if so, configure your namespace here. a metric that looks
+# like `metric.name` will instead become `namespace.metric.name`
+# statsd_metric_namespace:
+
 # ========================================================================== #
 # Service-specific configuration                                             #
 # ========================================================================== #


### PR DESCRIPTION
we are currently unable to run datadog on the machines in our staging or
testing clusters. this is because the code in the applications running there is
set to report metrics directly to datadog. those non-production metrics
nontheless become mixed in with production metrics in datadog.

there are two existing solutions:
- in datadog, always specify an environment tag to exclude non-production metrics
- in applications, always manually namespace the metrics

the first is difficult. we already have many dashboards and alerts which don't
specify any environment. also, naive examination in, e.g., the metric explorer
will still conflate the metrics and cause confusion.

the second is annoying, because we have to make an identical configuration
change throughout multiple applications.

instead, we propose the mechanism here, which allows statsd metrics being
reported to be automatically namespaced.

i wasn't sure how to test this functionality, since there are no existing tests
for the `init` function. i am also not sure about grabbing a direct reference
to the api_formatter function elsewhere in the code.
