### PR TITLE
Add a varnish service check.

### DIFF
--- a/checks.d/varnish.py
+++ b/checks.d/varnish.py
@@ -1,12 +1,29 @@
 # stdlib
-import xml.parsers.expat # python 2.4 compatible
+from collections import defaultdict
 import re
 import subprocess
+import xml.parsers.expat # python 2.4 compatible
 
 # project
 from checks import AgentCheck
 
+
+class BackendStatus(object):
+    HEALTHY = 'healthy'
+    SICK = 'sick'
+    ALL = (HEALTHY, SICK)
+
+    @classmethod
+    def to_check_status(cls, status):
+        if status == cls.HEALTHY:
+            return AgentCheck.OK
+        elif status == cls.SICK:
+            return AgentCheck.CRITICAL
+        return AgentCheck.UNKNOWN
+
 class Varnish(AgentCheck):
+    SERVICE_CHECK_NAME = 'varnish.backend_healthy'
+
     # XML parsing bits, a.k.a. Kafka in Code
     def _reset(self):
         self._current_element = ""
@@ -47,6 +64,79 @@ class Varnish(AgentCheck):
                 self._current_str = data
 
     def check(self, instance):
+        # Not configured? Not a problem.
+        if instance.get("varnishstat", None) is None:
+            raise Exception("varnishstat is not configured")
+        tags = instance.get('tags', [])
+        if tags is None:
+            tags = []
+        else:
+            tags = list(set(tags))
+        varnishstat_path = instance.get("varnishstat")
+        name = instance.get('name')
+
+        # Get version and version-specific args from varnishstat -V.
+        version, use_xml = self._get_version_info(varnishstat_path)
+
+        # Parse metrics from varnishstat.
+        arg = '-x' if use_xml else '-1'
+        cmd = [varnishstat_path, arg]
+
+        if name is not None:
+            cmd.extend(['-n', name])
+            tags += [u'varnish_name:%s' % name]
+        else:
+            tags += [u'varnish_name:default']
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE)
+        output, error = proc.communicate()
+        if error and len(error) > 0:
+            self.log.error(error)
+        self._parse_varnishstat_metrics(varnishstat_path, use_xml, tags)
+
+        # Parse service checks from varnishadm.
+        varnishadm_path = instance.get('varnishadm')
+        if varnishadm_path:
+            secretfile_path = instance.get('secretfile', '/etc/varnish/secret')
+            varnishadm_path = 'sudo %s' % varnishadm_path
+            cmd = [varnishadm_path, '-S', secretfile_path, 'debug.health']
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+            output, _ = proc.communicate()
+            if output:
+                self._parse_varnishadm(output)
+
+    def _get_version_info(self, varnishstat_path):
+        # Get the varnish version from varnishstat
+        output, error = subprocess.Popen([varnishstat_path, "-V"],
+                                         stdout=subprocess.PIPE,
+                                         stderr=subprocess.PIPE).communicate()
+
+        # Assumptions regarding varnish's version
+        use_xml = True
+        version = 3
+
+        m1 = re.search(r"varnish-(\d+)", output, re.MULTILINE)
+        # v2 prints the version on stderr, v3 on stdout
+        m2 = re.search(r"varnish-(\d+)", error, re.MULTILINE)
+
+        if m1 is None and m2 is None:
+            self.log.warn("Cannot determine the version of varnishstat, assuming 3 or greater")
+            self.warning("Cannot determine the version of varnishstat, assuming 3 or greater")
+        else:
+            if m1 is not None:
+                version = int(m1.group(1))
+            elif m2 is not None:
+                version = int(m2.group(1))
+
+        self.log.debug("Varnish version: %d" % version)
+
+        # Location of varnishstat
+        if version <= 2:
+            use_xml = False
+
+        return version, use_xml
+
+    def _parse_varnishstat(self, output, use_xml, tags=None):
         """Extract stats from varnishstat -x
 
         The text option (-1) is not reliable enough when counters get large.
@@ -57,6 +147,7 @@ class Varnish(AgentCheck):
 
         Bitmaps are not supported.
 
+        Example XML output (with `use_xml=True`)
         <varnishstat>
             <stat>
                 <name>fetch_304</name>
@@ -80,64 +171,6 @@ class Varnish(AgentCheck):
             </stat>
         </varnishstat>
         """
-        # Not configured? Not a problem.
-        if instance.get("varnishstat", None) is None:
-            raise Exception("varnishstat is not configured")
-        tags = instance.get('tags', [])
-        if tags is None:
-            tags = []
-        else:
-            tags = list(set(tags))
-        name = instance.get('name')
-
-        # Get the varnish version from varnishstat
-        output, error = subprocess.Popen([instance.get("varnishstat"), "-V"],
-                                         stdout=subprocess.PIPE,
-                                         stderr=subprocess.PIPE).communicate()
-
-        # Assumptions regarding varnish's version
-        use_xml = True
-        arg = "-x" # varnishstat argument
-        version = 3
-
-        m1 = re.search(r"varnish-(\d+)", output, re.MULTILINE)
-        # v2 prints the version on stderr, v3 on stdout
-        m2 = re.search(r"varnish-(\d+)", error, re.MULTILINE)
-
-        if m1 is None and m2 is None:
-            self.log.warn("Cannot determine the version of varnishstat, assuming 3 or greater")
-            self.warning("Cannot determine the version of varnishstat, assuming 3 or greater")
-        else:
-            if m1 is not None:
-                version = int(m1.group(1))
-            elif m2 is not None:
-                version = int(m2.group(1))
-
-        self.log.debug("Varnish version: %d" % version)
-
-        # Location of varnishstat
-        if version <= 2:
-            use_xml = False
-            arg = "-1"
-
-        cmd = [instance.get("varnishstat"), arg]
-        if name is not None:
-            cmd.extend(['-n', name])
-            tags += [u'varnish_name:%s' % name]
-        else:
-            tags += [u'varnish_name:default']
-        try:
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                         stderr=subprocess.PIPE)
-            output, error = proc.communicate()
-        except Exception:
-            self.log.error(u"Failed to run %s" % repr(cmd))
-            raise
-        if error and len(error) > 0:
-            self.log.error(error)
-        self._parse_varnishstat(output, use_xml, tags)
-
-    def _parse_varnishstat(self, output, use_xml, tags=None):
         tags = tags or []
         if use_xml:
             p = xml.parsers.expat.ParserCreate()
@@ -165,4 +198,50 @@ class Varnish(AgentCheck):
                     self.log.debug("Varnish (rate) %s %d" % (metric_name, int(gauge_val)))
                     self.rate(metric_name, float(gauge_val), tags=tags)
 
-   
+    def _parse_varnishadm(self, output):
+        """ Parse out service checks from varnishadm.
+
+        Example output:
+
+            Backend b0 is Sick
+            Current states  good:  2 threshold:  3 window:  5
+            Average responsetime of good probes: 0.000000
+            Oldest                                                    Newest
+            ================================================================
+            -------------------------------------------------------------444 Good IPv4
+            -------------------------------------------------------------XXX Good Xmit
+            -------------------------------------------------------------RRR Good Recv
+            ----------------------------------------------------------HHH--- Happy
+            Backend b1 is Sick
+            Current states  good:  2 threshold:  3 window:  5
+            Average responsetime of good probes: 0.000000
+            Oldest                                                    Newest
+            ================================================================
+            ----------------------------------------------------------HHH--- Happy
+
+        """
+        # Process status by backend.
+        backends_by_status = defaultdict(list)
+        backend, status, message = None, None, None
+        for line in output.split("\n"):
+            tokens = line.strip().split(' ')
+            if len(tokens) > 0:
+                if tokens[0] == 'Backend':
+                    backend = tokens[1]
+                    status = tokens[1].lower()
+                elif tokens[0] == 'Current' and backend is not None:
+                    try:
+                        message = ' '.join(tokens[2:]).strip()
+                    except Exception:
+                        # If we can't parse a message still send a status.
+                        self.log.exception('Error when parsing message from varnishadm')
+                        message = ''
+                    backends_by_status[status].append((backend, message))
+
+        for status, backends in backends_by_status.iteritems():
+            check_status = BackendStatus.to_check_status(status)
+            for backend, message in backends:
+                tags = ['backend:%s' % backend]
+                self.service_check(self.SERVICE_CHECK_NAME, check_status,
+                                   tags=tags, message=message)
+

--- a/conf.d/varnish.yaml.example
+++ b/conf.d/varnish.yaml.example
@@ -1,13 +1,28 @@
 init_config:
 
 instances:
-# - varnishstat: (required) String path to varnishstat binary
-#   name: (optional) String name of varnish instance. Passed to the -n parameter of varnishstat. Will also tag each metric with this name.
-#   tags: (optional) Additional tags to tag each metric with
-#
-# Example:
-#
-    - varnishstat: /usr/bin/varnishstat
-      name: myvarnishinstance
-      tags:
-        -   instance:production
+        # The full path to the varnishstat binary
+#   -   varnishstat: /usr/bin/varnishstat
+
+        # The (optional) name will be used in the varnishstat command for the
+        # -n argument and will add a name:$instancename tag to all metrics.
+#       name: myvarnishinstance
+
+        # The (optional) list of tags will be applied to every emitted metric.
+#       tags:
+#         -  instance:production
+
+        # The (optional) path to the varnishadm binary will signal the check to
+        # emit a service check status on backend health using `debug.health`.
+        # The service check will be tagged by backend.
+        # NOTE: The Agent must be able to access varnishadm as with root
+        # privilleges. You can configure your sudoers file for this:
+        #
+        # example /etc/sudoers entry:
+        #   dd-agent ALL=(ALL) NOPASSWD:/usr/bin/varnishadm
+        #
+#       varnishadm: /usr/bin/varnishadm
+
+        # The (optional) path to the varnish secretfile will be used in the
+        # varnishadm command, if enabled.
+#       secretfile: /etc/varnish/secret


### PR DESCRIPTION
The service check uses the `varnishadm debug.health` command to
get the health of available backends. One check per backend will
be submitted, tagged by the backend name.

The BIG question here is how we will let users enable this because
the varnishadm command requires access to the secret key which has
root permissions by default (and is owned by root).

I don't know what the answer is yet but this will open up the discussion.
