### PR TITLE
Remove taskRateLimit from marathon check

### DIFF
--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -27,7 +27,7 @@ class Marathon(AgentCheck):
             self.gauge('marathon.apps', len(response['apps']), tags=instance_tags)
             for app in response['apps']:
                 tags = ['app_id:' + app['id'], 'version:' + app['version']] + instance_tags
-                for attr in ['taskRateLimit','instances','cpus','mem','tasksStaged','tasksRunning']:
+                for attr in ['instances','cpus','mem','tasksStaged','tasksRunning']:
                     self.gauge('marathon.' + attr, app[attr], tags=tags)
                 versions_reply = self.get_v2_app_versions(url, app['id'], timeout)
                 if versions_reply is not None:
@@ -56,7 +56,7 @@ class Marathon(AgentCheck):
     def get_v2_app_versions(self, url, app_id, timeout):
         # Use a hash of the URL as an aggregation key
         aggregation_key = md5(url).hexdigest()
-        
+
         try:
             r = requests.get(url + "/v2/apps/" + app_id + "/versions", timeout=timeout)
         except requests.exceptions.Timeout as e:


### PR DESCRIPTION
It's been removed from the rest api.
