### PR TITLE
Disable Restart Manager

### DIFF
--- a/packaging/datadog-agent/win32/wix/agent.wxs
+++ b/packaging/datadog-agent/win32/wix/agent.wxs
@@ -7,6 +7,7 @@
           InstallerVersion="100" Languages="1033" Compressed="yes" SummaryCodepage="1252" />
 
         <Property Id="PREVIOUSVERSIONSINSTALLED" Secure="yes" />
+        <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
 
         <Upgrade Id="82210ed1-bbe4-4051-aa15-002ea31dde15">
            <UpgradeVersion


### PR DESCRIPTION
Restart Manager would tell the user that the uninstallation would
require a reboot upon uninstallation.

Disabling it will fix that, and if some files are still open and need
to be closed it will tell the user which ones.
