### PR TITLE
Use local-only modules in venv

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ desc 'Setup a development environment for the Agent'
 task "setup_env" do
    `mkdir -p venv`
    `wget -O venv/virtualenv.py https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py`
-   `python venv/virtualenv.py  --no-pip --no-setuptools venv/`
+   `python venv/virtualenv.py  --no-site-packages --no-pip --no-setuptools venv/`
    `wget -O venv/ez_setup.py https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py`
    `venv/bin/python venv/ez_setup.py`
    `wget -O venv/get-pip.py https://raw.github.com/pypa/pip/master/contrib/get-pip.py`


### PR DESCRIPTION
Add `--no-site-packages` flag to `setup_env` Rake task so that Python from the venv isn't going to use Python module from the system.
It should avoid some sneaky situations (such as a failed `rake setup_env` because it uses system pip, or using an unexpected dependency version), and help contributors to run tests by themselves.
