### PR TITLE
Service check for vSphere

### DIFF
--- a/checks.d/vsphere.py
+++ b/checks.d/vsphere.py
@@ -445,8 +445,16 @@ class VSphereCheck(AgentCheck):
 
             self.server_instances[i_key] = server_instance
 
-        self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
-                tags=service_check_tags)
+        # Test if the connection is working
+        try:
+            server_instance.RetrieveContent()
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
+                    tags=service_check_tags)
+        except Exception as e:
+            err_msg = "Connection to %s died unexpectedly: %s" % (instance.get('host'), e)
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
+                    tags=service_check_tags, message=err_msg)
+            raise Exception(err_msg)
 
         return self.server_instances[i_key]
 


### PR DESCRIPTION
cc @conorbranagan @remh 
I added a call to `RetrieveContent`, I don't think it would add a huge overhead but this is required if we want to give the status at every `get_server_instance`, otherwise we will just get the status at the very beginning.
