### PR TITLE
[network] Really skip excluded_interfaces

### DIFF
--- a/checks.d/network.py
+++ b/checks.d/network.py
@@ -82,7 +82,7 @@ class Network(AgentCheck):
             self._check_solaris(instance)
 
     def _submit_devicemetrics(self, iface, vals_by_metric):
-        if self._exclude_iface_re and self._exclude_iface_re.match(iface):
+        if iface in self._excluded_ifaces or (self._exclude_iface_re and self._exclude_iface_re.match(iface)):
             # Skip this network interface.
             return False
 
@@ -98,26 +98,11 @@ class Network(AgentCheck):
             assert m in vals_by_metric
         assert len(vals_by_metric) == len(expected_metrics)
 
-        # For reasons i don't understand only these metrics are skipped if a
-        # particular interface is in the `excluded_interfaces` config list.
-        # Not sure why the others aren't included. Until I understand why, I'm
-        # going to keep the same behaviour.
-        exclude_iface_metrics = [
-            'packets_in.count',
-            'packets_in.error',
-            'packets_out.count',
-            'packets_out.error',
-        ]
-
         count = 0
         for metric, val in vals_by_metric.iteritems():
-            if iface in self._excluded_ifaces and metric in exclude_iface_metrics:
-                # skip it!
-                continue
             self.rate('system.net.%s' % metric, val, device_name=iface)
             count += 1
         self.log.debug("tracked %s network metrics for interface %s" % (count, iface))
-
 
     def _parse_value(self, v):
         if v == "-":


### PR DESCRIPTION
Not sure if the comment is still relevant.

At least the current feature is broken and the code guarantees it stays broken.