### PR TITLE
Make sure all service check messages are strings.

### DIFF
--- a/checks.d/couch.py
+++ b/checks.d/couch.py
@@ -69,7 +69,7 @@ class CouchDb(AgentCheck):
             overall_stats = self._get_stats(url, instance)
         except urllib2.URLError as e:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                tags=service_check_tags, message=e.reason)
+                tags=service_check_tags, message=str(e.reason))
             raise
         except Exception as e:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,

--- a/checks.d/couchbase.py
+++ b/checks.d/couchbase.py
@@ -94,7 +94,7 @@ class Couchbase(AgentCheck):
                 raise Exception("No data returned from couchbase endpoint: %s" % url)
         except urllib2.URLError as e:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                tags=service_check_tags, message=e.reason)
+                tags=service_check_tags, message=str(e.reason))
             raise
         except Exception as e:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,

--- a/checks.d/kyototycoon.py
+++ b/checks.d/kyototycoon.py
@@ -65,7 +65,7 @@ class KyotoTycoonCheck(AgentCheck):
             response = urllib2.urlopen(url)
         except urllib2.URLError as e:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                tags=service_check_tags, message=e.reason)
+                tags=service_check_tags, message=str(e.reason))
             raise
         except Exception as e:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,


### PR DESCRIPTION
`e.reason` is an error type and not simply a string describing the
reason. This was causing errors in the HTTP emitter because these
error types aren't serializable.