### PR TITLE
[dogstatsd] handle properly utf8 packets

### DIFF
--- a/config.py
+++ b/config.py
@@ -289,6 +289,7 @@ def get_config(parse_args=True, cfg_path=None, options=None):
         'additional_checksd': '/etc/dd-agent/checks.d/',
         'bind_host': get_default_bind_host(),
         'statsd_metric_namespace': None,
+        'utf8_decoding': False
     }
 
     # Config handling
@@ -488,6 +489,10 @@ def get_config(parse_args=True, cfg_path=None, options=None):
         agentConfig["collect_ec2_tags"] = False
         if config.has_option("Main", "collect_ec2_tags"):
             agentConfig["collect_ec2_tags"] = _is_affirmative(config.get("Main", "collect_ec2_tags"))
+
+        agentConfig["utf8_decoding"] = False
+        if config.has_option("Main", "utf8_decoding"):
+            agentConfig["utf8_decoding"] = _is_affirmative(config.get("Main", "utf8_decoding"))
 
     except ConfigParser.NoSectionError, e:
         sys.stderr.write('Config file not found or incorrectly formatted.\n')

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -116,6 +116,13 @@ use_mount: no
 # like `metric.name` will instead become `namespace.metric.name`
 # statsd_metric_namespace:
 
+# By default, dogstatsd supports only plain ASCII packets. However, most
+# (dog)statsd client support UTF8 by encoding packets before sending them
+# this option enables UTF8 decoding in case you need it.
+# However, it comes with a performance overhead of ~10% in the dogstatsd
+# server. This will be taken care of properly in the new gen agent core.
+# utf8_decoding: false
+
 # ========================================================================== #
 # Service-specific configuration                                             #
 # ========================================================================== #

--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -384,6 +384,7 @@ def init(config_path=None, use_watchdog=False, use_forwarder=False, args=None):
         formatter=get_formatter(c),
         histogram_aggregates=c.get('histogram_aggregates'),
         histogram_percentiles=c.get('histogram_percentiles'),
+        utf8_decoding=c['utf8_decoding']
     )
 
     # Start the reporting thread.

--- a/tests/performance/benchmark_aggregator.py
+++ b/tests/performance/benchmark_aggregator.py
@@ -1,11 +1,8 @@
+# -*- coding: utf-8 -*-
 """
 Performance tests for the agent/dogstatsd metrics aggregator.
 """
-
-
 from aggregator import MetricsAggregator, MetricsBucketAggregator
-
-
 
 
 class TestAggregatorPerf(object):
@@ -54,8 +51,63 @@ class TestAggregatorPerf(object):
                     ma.set('set.%s' % j, float(i))
             ma.flush()
 
+    def create_event_packet(self, title, text):
+        p = "_e{{{title_len},{text_len}}}:{title}|{text}".format(
+                title_len=len(title),
+                text_len=len(text),
+                title=title,
+                text=text
+            )
+        return p
+
+
+    def test_dogstatsd_utf8_events(self):
+        ma = MetricsBucketAggregator('my.host')
+
+        for _ in xrange(self.FLUSH_COUNT):
+            for i in xrange(self.LOOPS_PER_FLUSH):
+                for j in xrange(self.METRIC_COUNT):
+
+                    ma.submit_packets(self.create_event_packet(
+                        'Τη γλώσσα μου έδωσαν ελληνική',
+                        """τὸ σπίτι φτωχικὸ στὶς ἀμμουδιὲς τοῦ Ὁμήρου. Μονάχη ἔγνοια ἡ γλῶσσα μου στὶς ἀμμουδιὲς τοῦ Ὁμήρου. ἀπὸ τὸ Ἄξιον ἐστί τοῦ Ὀδυσσέα Ἐλύτη"""
+                    ))
+                    ma.submit_packets(self.create_event_packet(
+                        'ვეპხის ტყაოსანი შოთა რუსთაველი',
+                        """ღმერთსი შემვედრე, ნუთუ კვლა დამხსნას სოფლისა შრომასა, ცეცხლს, წყალსა და მიწასა, ჰაერთა თანა მრომასა; მომცნეს ფრთენი და აღვფრინდე, მივჰხვდე მას ჩემსა ნდომასა, დღისით და ღამით ვჰხედვიდე მზისა ელვათა კრთომაასა.
+                        """
+                    ))
+                    ma.submit_packets(self.create_event_packet(
+                        'Traité sur la tolérance',
+                        """Ose supposer qu'un Ministre éclairé & magnanime, un Prélat humain & sage, un Prince qui sait que son intérêt consiste dans le grand nombre de ses Sujets, & sa gloire dans leur bonheur, daigne jetter les yeux sur cet Ecrit informe & défectueux; il y supplée par ses propres lumieres; il se dit à lui-même: Que risquerai-je à voir la terre cultivée & ornée par plus de mains laborieuses, les tributs augmentés, l'Etat plus florissant?"""
+                    ))
+
+            ma.flush()
+
+    def test_dogstatsd_ascii_events(self):
+        ma = MetricsBucketAggregator('my.host')
+
+        for _ in xrange(self.FLUSH_COUNT):
+            for i in xrange(self.LOOPS_PER_FLUSH):
+                for j in xrange(self.METRIC_COUNT):
+
+                    ma.submit_packets(self.create_event_packet(
+                        'asldkfj fdsaljfas dflksjafs fasdfkjaldsfkjasldf',
+                        """alkdjfa slfalskdfjas lkfdjaoisudhfalsdkjbfaksdhfbasjdk fa;sf ljda fsafksadfh alsdjfhaskjdfgahls d;fjasdlkfh9823udjs dlfhaspdf98as ufdaksjhfaisdhufalskdjfhas df"""
+                    ))
+                    ma.submit_packets(self.create_event_packet(
+                        'kdjfsofuousodifu982309rijdfsljsd  dfsdf sdf',
+                        """dflskjdfs8d9fsdfjs sldfjka ;dlfjapfoia jsdflakjsdfp 0adsfuolwejf wflsdjf lsdkjf0saoiufja dlfjasd of;lasdjf ;askdjf asodfhas lkmfbashudf asd,fasdfna s,dfjas lcjx vjaskdlfjals dfkjasdflk jasldfkj asldkfjas ldfkasjdf a"""
+                    ))
+                    ma.submit_packets(self.create_event_packet(
+                        'asdf askdjf asldfkjsad lfkajsdlfksajd fasdfsdfdf',
+                        """skdfjsld flskdjf alksdjfpasdofuapo sdfjalksdjf ;as.kjdf ;ljLKJL :KJL:KJ l;kdsjf ;lkj :Lkj FLDKFJ LSKFDJ ;LDFJ SLKDJF KSDLjf: Lfjldkj fLKDSJf lSKDjf ls;kdjf s;lkfjs L:KAJ :LFKJDL:DKjf L:SKjf;lKDJfl;SKJDf :LKSDj;lsdfj fsdljfsd ofisunafoialjsflmsdifjas;dlkfaj sdfkasjd flaksjdfnpmsao;difjkas dfnlaksdfa;sodljfas lfdjasdflmajsdlfknaf98wouanepr9qo3ud fadspuf oaisdufpoasid fj askdjn LKJH LKJHFL KJDHSF DSFLHSL JKDFHLSK DJFHLS KJDFHS"""
+                    ))
+
+            ma.flush()
 
 if __name__ == '__main__':
     t = TestAggregatorPerf()
-    t.test_dogstatsd_aggregation_perf()
+    #t.test_dogstatsd_aggregation_perf()
     #t.test_checksd_aggregation_perf()
+    t.test_dogstatsd_utf8_events()


### PR DESCRIPTION
Fixes #1256. We should always consider that dogstatsd
receives a utf-8 encoded string through its socket,
but still support unicode python strings in case we
submit things programatically (e.g. useful for tests)