### PR TITLE
[snmp] configuration option to ignore non-increasing OIDs

### DIFF
--- a/checks.d/snmp.py
+++ b/checks.d/snmp.py
@@ -41,18 +41,21 @@ class SnmpCheck(AgentCheck):
 
         # Load Custom MIB directory
         mibs_path = None
+        ignore_nonincreasing_oid = False
         if init_config is not None:
             mibs_path = init_config.get("mibs_folder")
-        SnmpCheck.create_command_generator(mibs_path)
+            ignore_nonincreasing_oid = init_config.get("ignore_nonincreasing_oid", False)
+        SnmpCheck.create_command_generator(mibs_path, ignore_nonincreasing_oid)
 
     @classmethod
-    def create_command_generator(cls, mibs_path=None):
+    def create_command_generator(cls, mibs_path, ignore_nonincreasing_oid):
         '''
         Create a command generator to perform all the snmp query.
         If mibs_path is not None, load the mibs present in the custom mibs
         folder. (Need to be in pysnmp format)
         '''
         cls.cmd_generator = cmdgen.CommandGenerator()
+        cls.cmd_generator.ignoreNonIncreasingOid = ignore_nonincreasing_oid
         if mibs_path is not None:
             mib_builder = cls.cmd_generator.snmpEngine.msgAndPduDsp.\
                           mibInstrumController.mibBuilder

--- a/checks.d/snmp.py
+++ b/checks.d/snmp.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 
 # project
 from checks import AgentCheck
+from config import _is_affirmative
 
 # 3rd party
 from pysnmp.entity.rfc3413.oneliner import cmdgen
@@ -44,7 +45,7 @@ class SnmpCheck(AgentCheck):
         ignore_nonincreasing_oid = False
         if init_config is not None:
             mibs_path = init_config.get("mibs_folder")
-            ignore_nonincreasing_oid = init_config.get("ignore_nonincreasing_oid", False)
+            ignore_nonincreasing_oid = _is_affirmative(init_config.get("ignore_nonincreasing_oid", False))
         SnmpCheck.create_command_generator(mibs_path, ignore_nonincreasing_oid)
 
     @classmethod

--- a/conf.d/snmp.yaml.example
+++ b/conf.d/snmp.yaml.example
@@ -1,6 +1,7 @@
 init_config:
 #    #You can specify an additional folder for your custom mib files (python format)
 #    mibs_folder: /path/to/your/mibs/folder
+#    ignore_nonincreasing_oid: False
 
 instances:
 

--- a/tests/test_snmp.py
+++ b/tests/test_snmp.py
@@ -34,6 +34,15 @@ class TestSNMP(unittest.TestCase):
                 custom_folder_represented = True
                 break
         self.assertTrue(custom_folder_represented)
+        self.assertFalse(self.check.cmd_generator.ignoreNonIncreasingOid)
+
+        self.config = {
+            "init_config": {
+                "ignore_nonincreasing_oid": True
+            }
+        }
+        self.check = load_check('snmp', self.config, self.agentConfig)
+        self.assertTrue(self.check.cmd_generator.ignoreNonIncreasingOid)
 
     def test_scalar_SNMPCheck(self):
         self.config = {


### PR DESCRIPTION
Adds a configuration option to walk non-increasing OIDs.  Fixes #1231.