### PR TITLE
[elasticsearch] Fix host tagging for external clusters.

### DIFF
--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -10,6 +10,7 @@ import requests
 
 # project
 from checks import AgentCheck
+from config import _is_affirmative
 from util import headers, Platform
 
 
@@ -141,7 +142,7 @@ class ESCheck(AgentCheck):
         if url is None:
             raise Exception("An url must be specified in the instance")
 
-        is_external = instance.get('is_external', False)
+        is_external = _is_affirmative(instance.get('is_external', False))
 
         # Support URLs that have a path in them from the config, for
         # backwards-compatibility.


### PR DESCRIPTION
When using an external Elasticsearch cluster, we should tag the
hostname by the node's given hostname in the stats output. Otherwise
we end up using only the last node's values because each subsequent
gauge metric will stomp on the one before it.

The test is updated to make sure the hostname given in the stats
(which should be the FQDN) matches what we output at the end.

Finally, this change also splits the cluster health metrics into a
seperate dict. This has two benefits: (a) it will clean up a lot of
debugging logging and extra work for `_process_health_data` and
(b) makes it easy to check against just the stats metrics for tests.