### PR TITLE
[docker] Filter events

### DIFF
--- a/checks.d/docker.py
+++ b/checks.d/docker.py
@@ -249,6 +249,8 @@ class Docker(AgentCheck):
                     for key, (dd_key, metric_type, common_metric) in cgroup['metrics'].iteritems():
                         if key in stats and (common_metric or collect_uncommon_metrics):
                             getattr(self, metric_type)(dd_key, int(stats[key]), tags=container_tags)
+        if use_filters:
+            self.log.debug("List of excluded containers: {0}".format(skipped_container_ids))
 
         return skipped_container_ids
 
@@ -283,6 +285,8 @@ class Docker(AgentCheck):
         for event in api_events:
             # Skip events related to filtered containers
             if event['id'] in skipped_container_ids:
+                self.log.debug("Excluded event: container {0} status changed to {1}".format(
+                    event['id'], event['status']))
                 continue
             # Known bug: from may be missing
             if 'from' in event:

--- a/checks.d/docker.py
+++ b/checks.d/docker.py
@@ -194,12 +194,8 @@ class Docker(AgentCheck):
             return False
 
         # Compile regex
-        instance["exclude_patterns"] = []
-        instance["include_patterns"] = []
-        for rule in instance.get("exclude"):
-            instance["exclude_patterns"].append(re.compile(rule))
-        for rule in instance.get("include", []):
-            instance["include_patterns"].append(re.compile(rule))
+        instance["exclude_patterns"] = [re.compile(rule) for rule in instance.get("exclude", [])]
+        instance["include_patterns"] = [re.compile(rule) for rule in instance.get("include", [])]
 
         return True
 

--- a/conf.d/docker.yaml.example
+++ b/conf.d/docker.yaml.example
@@ -27,25 +27,26 @@ instances:
     # Example:
     # tags: ["extra_tag", "env:example"]
 
-    # To include or exclude containers based on their tags, use the include and
-    # exclude keys in your instance.
-    # The reasoning is: if a tag matches an exclude rule, it won't be included
-    # unless it also matches an include rule.
+    # Exclude containers based on their tags
+    # An excluded container will ne longer report performance metrics or events. However,
+    # we still count the number of running and stopped of all containers.
     #
+    # How it works: if a tag matches an exclude rule, it won't be included
+    # unless it also matches an include rule.
     # Examples:
     #
     # exclude all, except ubuntu and debian.
     # include:
-    #   - "image:ubuntu"
-    #   - "image:debian"
+    #   - "docker_image:ubuntu"
+    #   - "docker_image:debian"
     # exclude:
     #   - ".*"
     #
     # include all, except ubuntu and debian.
     # include: []
     # exclude:
-    #   - "image:ubuntu"
-    #   - "image:debian"
+    #   - "docker_image:ubuntu"
+    #   - "docker_image:debian"
     #
     # include: []
     # exclude: []
@@ -55,7 +56,8 @@ instances:
     # collect_events: true
 
     # Collect disk usage per container with docker.disk.size metric.
-    # Warning: Some bugs in Docker (especially Docker 1.2) can break it, use with caution.
+    # Warning: This feature is broken in some version of Docker (such as 1.2).
+    # Test it before running it in production.
     #
     # collect_container_size: false
 


### PR DESCRIPTION
Some improvements around Docker containers filtering.

* Filters also apply to events. Fix #1234
* Performance improvements around filtering and regex
* Fix the logic of our rules: what we were explaining in the documentation (the docker.yaml.example) wasn't matching the real behavior. Fix the code to make it matches.
* Clarify the explanations in the example config.