### PR TITLE
[postfix] Document requiretty requirement on Redhat/Centos for using sudo.

### DIFF
--- a/conf.d/postfix.yaml.example
+++ b/conf.d/postfix.yaml.example
@@ -4,6 +4,8 @@
 # example /etc/sudoers entry:
 #          dd-agent ALL=(ALL) NOPASSWD:/usr/bin/find
 #
+# Redhat/CentOS flavours will need to add:
+#          Defaults:dd-agent !requiretty
 
 init_config:
 


### PR DESCRIPTION
Various CentOS/Redhat flavours require a tty to be allocated when using sudo. Document how to by-pass this requirement per user.