### PR TITLE
Use a temporary file for df output to avoid PIPE limits.

### DIFF
--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -10,6 +10,7 @@ import socket
 import string
 import subprocess as sp
 import sys
+import tempfile
 import time
 
 # project
@@ -906,12 +907,16 @@ def _get_subprocess_output(command, log):
     Run the given subprocess command and return it's output. Raise an Exception
     if an error occurs.
     """
-    proc = sp.Popen(command, stdout=sp.PIPE, close_fds=True, stderr=sp.PIPE)
-    err = proc.stderr.read()
-    if err:
-        log.debug("Error while running %s : %s" %(" ".join(command), err))
+    with tempfile.TemporaryFile('rw') as stdout_f:
+        proc = sp.Popen(command, close_fds=True, stdout=stdout_f, stderr=sp.PIPE)
+        proc.wait()
+        err = proc.stderr.read()
+        if err:
+            log.debug("Error while running %s : %s" %(" ".join(command), err))
 
-    return proc.stdout.read()
+        stdout_f.seek(0)
+        output = stdout_f.read()
+    return output
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
subprocess.PIPE is limited in size because the data is buffered in
memory. When running the Agent on a host that has many containers,
the number of mountpoints can be very large. Because of this buffer limit,
the shell call can hang for these huge outputs.

To workaround this, we will write the output to a temporary file and
read it from there.

This is a "quick" fix for a specific case and there might be a better
general approach. But either way, we will still need to handle the
case of large outputs from our subprocess commands otherwise the
whole Agent collector simply hangs.

refs:
- http://thraxil.org/users/anders/posts/2008/03/13/Subprocess-Hanging-PIPE-is-your-enemy/
- https://datadog.desk.com/agent/case/17823

cc @remh @LeoCavaille 