### PR TITLE
A new HTTP JSON checker for Datadog

### DIFF
--- a/checks.d/http_json.py
+++ b/checks.d/http_json.py
@@ -1,0 +1,56 @@
+from checks import AgentCheck
+import urllib2
+import json
+
+class HTTPJSONCheck(AgentCheck):
+    def check(self, instance):
+        if 'url' not in instance:
+            self.log.info("Skipping instance, no url found.")
+            return
+
+        default_timeout = self.init_config.get('default_timeout', 5)
+        timeout = float(instance.get('timeout', default_timeout))
+
+        tags = instance.get('tags', None)
+        url = instance['url']
+
+        self.log.debug('Fetching JSON metrics at url: %s' % url)
+
+        # Read our URL 
+        json_data = urllib2.urlopen(url, timeout=timeout)
+
+        # Load the JSON
+        fetched_metrics = json.load(json_data)
+
+        num_metrics_returned = len(fetched_metrics)
+        gauge_metrics = 0
+        counter_metrics = 0
+
+        for metric in fetched_metrics:
+            metric_id = instance['prefix'] + metric
+            if instance['metrics'][metric] == 'gauge':
+                self.gauge(metric_id, fetched_metrics[metric], tags=tags)
+                gauge_metrics += 1
+            elif instance['metrics'][metric] == 'counter':
+                self.count(metric_id, fetched_metrics[metric], tags=tags)
+                counter_metrics += 1
+            else:
+                self.log.debug('Unconfigured metric present in JSON: %s' % metric )
+
+        self.log.debug('Fetched %d metrics from %s' % (num_metrics_returned, url))
+        self.log.debug('- Parsed %d gauge metrics' % (gauge_metrics))
+        self.log.debug('- Parsed %d counter metrics' % (counter_metrics))
+
+        return
+
+
+
+if __name__ == '__main__':
+    check, instances = HTTPJSONCheck.from_yaml('/etc/dd-agent/conf.d/http_json.yaml')
+    for instance in instances:
+        print "\nRunning the check against url: %s" % (instance['url'])
+        check.check(instance)
+        if check.has_events():
+            print 'Events: %s' % (check.get_events())
+        print 'Metrics: %s' % (check.get_metrics())
+

--- a/conf.d/http_json.yaml.example
+++ b/conf.d/http_json.yaml.example
@@ -1,0 +1,30 @@
+init_config:
+    default_timeout: 5
+
+instances:
+        # Each instance should contain a URL which will return a JSON hash (and nothing else)
+        # that contains metrics and their values.
+        #
+        # EXAMPLE OUTPUT:
+        #
+        # {"widgets_processed":82004450,"widgets_in_queue":263}
+    -   url: http://my.app.mycompany.com/metrics/widgets
+        #
+        # Metrics will be submitted to Datadog prefixed with the text specified below
+        #
+        prefix: 'myapp.'
+        #
+        # Optionally apply some tags to this instance's metrics
+        #
+        tags:
+        - widgets
+        - prod
+        #
+        # For each of the metrics, you need to specify a data type.
+        # Currently, only "counter" and "gauge" are supported
+        #
+        # Format is:    metric_name_in_json_hash: metric_type
+        #
+        metrics:
+          widgets_processed: counter
+          widgets_in_queue: gauge


### PR DESCRIPTION
This is a simple check that pulls JSON-formatted metrics from URL(s) and submits them to Datadog.  It's useful for existing applications that offer a JSON metrics endpoint (we have many).   The URL must return a flat JSON hash where the keys are the metric names and the values are the current readings for that metric.

In the configuration file, you specify the instance URL, along with the metric name (the JSON keys) and their types (currently 'gauge' or 'counter').

For example, if you had an endpoint with the url `http://my.app/metrics/widgets` and fetching it returned the following JSON hash:

```
{  
   "widgets_processed":13298409,
   "invalid_widgets":12,
   "widget_processing_time":7.89
}
```

You would configure http_json.yaml like this:

```
init_config:
    default_timeout: 5

instances:
    -   url: http://my.app/metrics/widgets
        prefix: 'widgets.'
        tags:
        - myapp
        metrics:
          widgets_processed: counter
          invalid_widgets: counter
          widget_processing_time: gauge
```

Your metrics would then end up in Datadog named `widgets.widgets_processed`, `widgets.invalid_widgets`, etc.

If this PR is accepted, I will produce a corresponding recipe and template for chef-datadog.

Thanks!
