### PR TITLE
Convert fluentd.buffer_total_queued_size into a rate instead of a gauge

### DIFF
--- a/checks.d/fluentd.py
+++ b/checks.d/fluentd.py
@@ -12,8 +12,11 @@ import simplejson as json
 
 class Fluentd(AgentCheck):
     SERVICE_CHECK_NAME = 'fluentd.is_ok'
-    GAUGES = ['retry_count', 'buffer_queue_length']
-    RATE = 'buffer_total_queued_size'
+    METRICS = [
+        ('retry_count', AgentCheck.gauge),
+        ('buffer_queue_length', AgentCheck.gauge),
+        ('buffer_total_queued_size', AgentCheck.rate),
+    ]
 
     """Tracks basic fluentd metrics via the monitor_agent plugin
     * number of retry_count
@@ -41,14 +44,10 @@ class Fluentd(AgentCheck):
             status = json.loads(res)
 
             for p in status['plugins']:
-                for m in self.GAUGES:
-                    if p.get(m) is None:
+                for m_name, m_func in self.METRICS:
+                    if p.get(m_name) is None or p.get('plugin_id') not in plugin_ids:
                         continue
-                    if p.get('plugin_id') in plugin_ids:
-                        self.gauge('fluentd.%s' % (m), p.get(m), ["plugin_id:%s" % p.get('plugin_id')])
-
-                if p.get(self.RATE) is not None and p.get('plugin_id') in plugin_ids:
-                    self.rate('fluentd.%s' % (self.RATE), p.get(self.RATE), ["plugin_id:%s" % p.get('plugin_id')])
+                    m_func(self, 'fluentd.%s' % m_name, p.get(m_name), ["plugin_id:%s" % p.get('plugin_id')])
         except Exception, e:
             msg = "No stats could be retrieved from %s : %s" % (url, str(e))
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags, message=msg)

--- a/checks.d/fluentd.py
+++ b/checks.d/fluentd.py
@@ -12,7 +12,8 @@ import simplejson as json
 
 class Fluentd(AgentCheck):
     SERVICE_CHECK_NAME = 'fluentd.is_ok'
-    GAUGES = ['retry_count', 'buffer_total_queued_size', 'buffer_queue_length']
+    GAUGES = ['retry_count', 'buffer_queue_length']
+    RATE = 'buffer_total_queued_size'
 
     """Tracks basic fluentd metrics via the monitor_agent plugin
     * number of retry_count
@@ -45,6 +46,9 @@ class Fluentd(AgentCheck):
                         continue
                     if p.get('plugin_id') in plugin_ids:
                         self.gauge('fluentd.%s' % (m), p.get(m), ["plugin_id:%s" % p.get('plugin_id')])
+
+                if p.get(self.RATE) is not None and p.get('plugin_id') in plugin_ids:
+                    self.rate('fluentd.%s' % (self.RATE), p.get(self.RATE), ["plugin_id:%s" % p.get('plugin_id')])
         except Exception, e:
             msg = "No stats could be retrieved from %s : %s" % (url, str(e))
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags, message=msg)

--- a/ci/fluentd.rb
+++ b/ci/fluentd.rb
@@ -9,7 +9,7 @@ namespace :ci do
     end
 
     task :before_script => ['ci:common:before_script'] do
-      sh %(fluentd -c $TRAVIS_BUILD_DIR/ci/resources/fluentd/td-agent.conf &)
+      sh %(fluentd -c $TRAVIS_BUILD_DIR/ci/resources/fluentd/td-agent.conf > /dev/null 2>&1 &)
       sleep_for 10
     end
 
@@ -20,8 +20,9 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
-    task :cleanup => ['ci:common:cleanup']
-    # FIXME: stop fluentd
+    task :cleanup => ['ci:common:cleanup'] do
+      sh %(pkill fluentd)
+    end
 
     task :execute do
       exception = nil

--- a/tests/test_fluentd.py
+++ b/tests/test_fluentd.py
@@ -29,13 +29,11 @@ class TestFluentd(unittest.TestCase):
         check.run()
         metrics = check.get_metrics()
         for m in metrics:
-            if m[0] == 'fluentd.forward.retry_count':
-                self.assertEquals(m[2], 0)
-            elif m[0] == 'fluentd.forward.buffer_queue_length':
-                self.assertEquals(m[2], 0)
-            elif m[0] == 'fluentd.forward.buffer_total_queued_size':
-                self.assertEquals(m[2], 0)
-            self.assertEquals(m[3]['type'], 'gauge')
+            if m[0] == 'fluentd.forward.buffer_total_queued_size':
+                self.assertEquals(m[3]['type'], 'rate')
+            else:
+                self.assertEquals(m[3]['type'], 'gauge')
+            self.assertEquals(m[2], 0)
             self.assertEquals(m[3]['tags'], ['plugin_id:plg1'])
 
         self.assertEquals(len(metrics), 3, metrics)

--- a/tests/test_fluentd.py
+++ b/tests/test_fluentd.py
@@ -29,14 +29,14 @@ class TestFluentd(unittest.TestCase):
         check.run()
         metrics = check.get_metrics()
         for m in metrics:
-            if m[0] == 'fluentd.forward.buffer_total_queued_size':
+            if m[0] == 'fluentd.buffer_total_queued_size':
                 self.assertEquals(m[3]['type'], 'rate')
             else:
                 self.assertEquals(m[3]['type'], 'gauge')
             self.assertEquals(m[2], 0)
             self.assertEquals(m[3]['tags'], ['plugin_id:plg1'])
 
-        self.assertEquals(len(metrics), 3, metrics)
+        self.assertEquals(len(metrics), 2, metrics)
 
         service_checks = check.get_service_checks()
         service_checks_count = len(service_checks)


### PR DESCRIPTION
`buffer_total_queued_size` seems to be a counter that keeps incrementing with every new entry, it is more logical to collect it as a rate.