### PR TITLE
Discourage legacy options for Docker and network checks

### DIFF
--- a/conf.d/docker.yaml.example
+++ b/conf.d/docker.yaml.example
@@ -18,7 +18,7 @@ instances:
 
     # Use tag names that don't conflict.
     # Keep it false if you have old dashboard using the old tag names. Default: false.
-    # new_tag_names: true
+    new_tag_names: true
 
     # Tag metrics with the command running inside the container.
     # tag_by_command: false

--- a/conf.d/http_check.yaml.example
+++ b/conf.d/http_check.yaml.example
@@ -68,7 +68,7 @@ instances:
     # create any event to avoid duplicates with a server side service check.
     # This default to False.
     #
-    # skip_event: false
+    skip_event: true
 
     # tags:
     #   - url:http://alternative.host.example.com

--- a/conf.d/tcp_check.yaml.example
+++ b/conf.d/tcp_check.yaml.example
@@ -23,7 +23,7 @@ instances:
     # create any event to avoid duplicates with a server side service check.
     # This default to False.
     #
-    # skip_event: false
+    skip_event: true
 
   # - name: My second service
   #   host: 127.0.0.1


### PR DESCRIPTION
* Restore the proper docker.yaml.example "new_tag_names" option (got commened on 36781988)
* Fix #1317