### PR TITLE
Determine the Linux distribution logic

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -46,7 +46,9 @@ if [ ! $apikey ]; then
 fi
 
 # OS/Distro Detection
-DISTRIBUTION=$(grep -Eo "(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon)" /etc/issue 2>/dev/null || uname -s)
+# Try lsb_release, fallback with /etc/issue then uname command
+KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon)"
+DISTRIBUTION=$(lsb_release -d 2>/dev/null | grep -Eo $KNOWN_DISTRIBUTION  || grep -Eo $KNOWN_DISTRIBUTION /etc/issue 2>/dev/null || uname -s)
 
 if [ $DISTRIBUTION = "Darwin" ]; then
     printf "\033[31mThis script does not support installing on the Mac.


### PR DESCRIPTION
Try `lsb_release` command to determine the Linux distribution and 
- If failing try `/etc/issue` should contain the release information
- If still failing, rely on the `/etc/*-release` files

More info:
http://unix.stackexchange.com/questions/92199/how-can-i-reliably-get-the-operating-systems-name

Also see:
https://github.com/DataDog/dd-agent-omnibus/pull/8