### PR TITLE
Enabled regex testing for content_match

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -4,6 +4,7 @@ import os.path
 import socket
 import ssl
 import time
+import re
 from urlparse import urlparse
 
 # 3rd party
@@ -120,7 +121,7 @@ class HTTPCheck(NetworkCheck):
             self.gauge('network.http.response_time', running_time, tags=tags_list)
 
         if content_match and int(resp.status) == 200:
-            if content_match in content:
+            if re.search(content_match, content):
                 self.log.debug("%s is found in return content" % content_match)
             else:
                 self.log.info("%s not found in content" % content_match)

--- a/conf.d/http_check.yaml.example
+++ b/conf.d/http_check.yaml.example
@@ -9,8 +9,17 @@ instances:
 
     # The (optional) content_match parameter will allow the check
     # to look for a particular string within the response. The check
-    # will report as DOWN if the string is not found
-#    content_match: '"status": "green"'
+    # will report as DOWN if the string is not found.
+    #
+    # content_match uses Python regular expressions which means that
+    # you will have to escape the following "special" characters with
+    # a backslash (\) if you're trying to match them in your content:
+    #  . ^ $ * + ? { } [ ] \ | ( )
+    #
+    # Examples:
+    # content_match: 'In Stock'
+    # content_match: '^(Bread|Apples|Very small rocks|Cider|Gravy|Cherries|Mud|Churches|Lead) float(s)? in water'
+    # content_match: '"status": "green"'
 
     # If your service uses basic authentication, you can optionally
     # specify a username and password that will be used in the check.


### PR DESCRIPTION
Here's a quick change to Ryan's http_check.py revisions that enable regex testing for content_match.  This makes content_match more flexible in accommodating situations where a simple if ... in ... match would be insufficient.

Consider this real-life example of content being tested:

```
{"status":"UP","rabbit":{"status":"UP"},"db":{"status":"UP","database":"MySQL","hello":1}}
```

If we want to test for that first ```"status":"UP"```, we need to use a regex because that string is not unique within the content string:

```
   content_match: '^\{"status":"UP"'
```

The one gotcha with regex in content_match is special metacharacters like "?".  I considered creating a content_match_re for regex matching but decided that it would be cleaner to just document in the example YAML the need to escape these characters.