### PR TITLE
Add support for forced SNMP data types to help w/ buggy devices

### DIFF
--- a/checks.d/snmp.py
+++ b/checks.d/snmp.py
@@ -282,6 +282,7 @@ class SnmpCheck(AgentCheck):
         tags = instance.get("tags", [])
         tags = tags + ["snmp_device:" + instance.get('ip_address')]
         for metric in instance.get('metrics', []):
+            forced_type = metric.get('forced_type')
             if 'OID' in metric:
                 queried_oid = metric['OID']
                 for oid in results:
@@ -293,7 +294,7 @@ class SnmpCheck(AgentCheck):
                                      queried_oid)
                     continue
                 name = metric.get('name', 'unnamed_metric')
-                self.submit_metric(name, value, tags)
+                self.submit_metric(name, value, forced_type, tags)
 
     def report_table_metrics(self, instance, results):
         '''
@@ -306,6 +307,7 @@ class SnmpCheck(AgentCheck):
         tags = tags + ["snmp_device:"+instance.get('ip_address')]
 
         for metric in instance.get('metrics', []):
+            forced_type = metric.get('forced_type')
             if 'table' in metric:
                 index_based_tags = []
                 column_based_tags = []
@@ -323,7 +325,7 @@ class SnmpCheck(AgentCheck):
                         metric_tags = tags + self.get_index_tags(index, results,
                                                                  index_based_tags,
                                                                  column_based_tags)
-                        self.submit_metric(value_to_collect, val, metric_tags)
+                        self.submit_metric(value_to_collect, val, forced_type, metric_tags)
 
             elif 'symbol' in metric:
                 name = metric['symbol']
@@ -332,7 +334,7 @@ class SnmpCheck(AgentCheck):
                     self.log("Several rows corresponding while the metric is supposed to be a scalar")
                     continue
                 val = result[0][1]
-                self.submit_metric(name, val, tags)
+                self.submit_metric(name, val, forced_type, tags)
             elif 'OID' in metric:
                 pass # This one is already handled by the other batch of requests
             else:
@@ -374,7 +376,7 @@ class SnmpCheck(AgentCheck):
             tags.append("{0}:{1}".format(tag_group, tag_value))
         return tags
 
-    def submit_metric(self, name, snmp_value, tags=[]):
+    def submit_metric(self, name, snmp_value, forced_type, tags=[]):
         '''
         Convert the values reported as pysnmp-Managed Objects to values and
         report them to the aggregator
@@ -385,6 +387,16 @@ class SnmpCheck(AgentCheck):
             return
 
         metric_name = self.normalize(name, prefix="snmp")
+
+        if forced_type:
+            if forced_type.lower() == "gauge":
+                value = int(snmp_value)
+                self.gauge(metric_name, value, tags)
+                return
+            if forced_type.lower() == "counter":
+                value = int(snmp_value)
+                self.rate(metric_name, value, tags)
+                return
 
         # Ugly hack but couldn't find a cleaner way
         # Proper way would be to use the ASN1 method isSameTypeWith but it

--- a/conf.d/snmp.yaml.example
+++ b/conf.d/snmp.yaml.example
@@ -25,6 +25,16 @@ instances:
   #     - OID: 1.3.6.1.2.1.6.5
   #       name: tcpPassiveOpens
   #
+  #     # This monitor auto-detects OID data types from the remote agent's response.
+  #     # If you're dealing with a buggy agent that returns incorrect data types for OIDs,
+  #     # You can force the data type with the 'forced_type' parameter.  Valid options for
+  #     # this parameter are 'gauge' and 'counter'.
+  #     # Example: When a F5 Networks load balancer is queried for this OID, it will return
+  #     # it as a Counter64 when it should be a gauge.  So, we force the data type to gauge:
+  #     - OID: 1.3.6.1.4.1.3375.2.1.1.2.1.8.0
+  #       name: F5_TotalCurrentConnections
+  #       forced_type: gauge
+  #
   #     # You can also query a table and specify
   #     #   - which columns to report as value (symbols)
   #     #   - which columns / indexes to use as tags (metric_tags)


### PR DESCRIPTION
Some SNMP-enabled devices return incorrect data types when certain OIDs are queried.  The F5 1600LTM load balancer is an example of such a device.   This PR allows for the forcing of data types (to 'gauge' or 'counter') in the event of an incorrect response from the remote agent.

It adds a parameter to the metric definition on the YAML, 'forced_type'.

NOTE: The changes in this PR were tested in a back-ported version of this improved snmp check that Datadog provided me.   The check patched here is from a newer version of the agent that I don't have any easy way to test right now.  The changes are the same between the versions and it *should* work but I have no way to test.