### PR TITLE
Update cassandra config

### DIFF
--- a/conf.d/cassandra.yaml.example
+++ b/conf.d/cassandra.yaml.example
@@ -42,6 +42,9 @@ init_config:
           - PendingTasks
           - ReadCount
           - RecentHitRate
+          - RecentRangeLatencyMicros
+          - RecentReadLatencyMicros
+          - RecentWriteLatencyMicros
           - Requests
           - RowCacheRecentHitRate
           - Size

--- a/conf.d/cassandra.yaml.example
+++ b/conf.d/cassandra.yaml.example
@@ -25,12 +25,10 @@ init_config:
           - BloomFilterFalsePositives
           - BloomFilterFalseRatio
           - Capacity
-          - CompressionRatio
           - CompletedTasks
+          - CompressionRatio
           - ExceptionCount
           - Hits
-          - RecentHitRate
-          - RowCacheRecentHitRate
           - KeyCacheRecentHitRate
           - LiveDiskSpaceUsed
           - LiveSSTableCount
@@ -41,15 +39,17 @@ init_config:
           - MemtableDataSize
           - MemtableSwitchCount
           - MinRowSize
+          - PendingTasks
           - ReadCount
+          - RecentHitRate
           - Requests
+          - RowCacheRecentHitRate
           - Size
           - TotalDiskSpaceUsed
           - TotalReadLatencyMicros
           - TotalWriteLatencyMicros
           - UpdateInterval
           - WriteCount
-          - PendingTasks
       exclude:
         keyspace: system
     - include:


### PR DESCRIPTION
- sort cassandra config attributes
- add cassandra monitoring attributes for recent latency
See:
http://wiki.apache.org/cassandra/JmxInterface#org.apache.cassandra.service.StorageProxy.Attributes.RecentRangeLatencyMicros
http://wiki.apache.org/cassandra/JmxInterface#org.apache.cassandra.service.StorageProxy.Attributes.RecentReadLatencyMicros
http://wiki.apache.org/cassandra/JmxInterface#org.apache.cassandra.service.StorageProxy.Attributes.RecentWriteLatencyMicros