### PR TITLE
Allow environment variable substitution in conf file

### DIFF
--- a/config.py
+++ b/config.py
@@ -322,7 +322,7 @@ def get_config(parse_args=True, cfg_path=None, options=None):
         try:
             for option in config.options('Main'):
                 agentConfig[option] = config.get('Main', option)
-        except ConfigParser.InterpolationMissingOptionError as e:
+        except ConfigParser.InterpolationMissingOptionError:
             sys.stderr.write("The configuration file contains invalid variable substitution. If you want to use environment variables, use the --enable-env option\n")
             sys.exit(3)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -31,15 +31,14 @@ class TestConfig(unittest.TestCase):
             'enable_env': False,
             'use_forwarder': False
         })
-        conf_file = tempfile.NamedTemporaryFile(delete=False)
-        with open(conf_file.name, "w") as f:
-            f.write("[Main]\n")
-            f.write("dd_url:\n")
-            f.write("api_key:\n")
-            f.write("tags: foo:%(BAR)s\n")
-        with self.assertRaises(SystemExit):
-            get_config(parse_args=False, cfg_path=conf_file.name, options=test_options)
-        os.remove(conf_file.name)
+        with tempfile.NamedTemporaryFile() as conf_file:
+            with open(conf_file.name, "w") as f:
+                f.write("[Main]\n")
+                f.write("dd_url:\n")
+                f.write("api_key:\n")
+                f.write("tags: foo:%(BAR)s\n")
+            with self.assertRaises(SystemExit):
+                get_config(parse_args=False, cfg_path=conf_file.name, options=test_options)
 
     def testEnvInterpolationEnabled(self):
         os.environ["BAR"] = "bar"
@@ -51,15 +50,14 @@ class TestConfig(unittest.TestCase):
             'enable_env': True,
             'use_forwarder': False
         })
-        conf_file = tempfile.NamedTemporaryFile(delete=False)
-        with open(conf_file.name, "w") as f:
-            f.write("[Main]\n")
-            f.write("dd_url:\n")
-            f.write("api_key:\n")
-            f.write("tags: foo:%(BAR)s\n")
-        agentConfig = get_config(parse_args=False, cfg_path=conf_file.name, options=test_options)
+        with tempfile.NamedTemporaryFile() as conf_file:
+            with open(conf_file.name, "w") as f:
+                f.write("[Main]\n")
+                f.write("dd_url:\n")
+                f.write("api_key:\n")
+                f.write("tags: foo:%(BAR)s\n")
+            agentConfig = get_config(parse_args=False, cfg_path=conf_file.name, options=test_options)
         self.assertEqual(agentConfig["tags"], "foo:bar")
-        os.remove(conf_file.name)
 
     def testGoodPidFie(self):
         """Verify that the pid file succeeds and fails appropriately"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ import os
 import os.path
 import tempfile
 
-from config import get_config, DATADOG_CONF
+from config import get_config
 from optparse import Values
 from ConfigParser import InterpolationMissingOptionError
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,8 +37,7 @@ class TestConfig(unittest.TestCase):
                 f.write("dd_url:\n")
                 f.write("api_key:\n")
                 f.write("tags: foo:%(BAR)s\n")
-            with self.assertRaises(SystemExit):
-                get_config(parse_args=False, cfg_path=conf_file.name, options=test_options)
+            self.assertRaises(SystemExit, get_config, parse_args=False, cfg_path=conf_file.name, options=test_options)
 
     def testEnvInterpolationEnabled(self):
         os.environ["BAR"] = "bar"


### PR DESCRIPTION
- Enabled with the `--enable-env` command line option
- Opt-in ensures current conf files don't get into ConfigParser
  recursion issues, e.g. `home: %(HOME)s`
- Provide nicer error on exit if the conf file has bad interpolation
- New unit tests with and without command line option present