### PR TITLE
Update mongo.yml.example to add database

### DIFF
--- a/conf.d/mongo.yaml.example
+++ b/conf.d/mongo.yaml.example
@@ -1,7 +1,8 @@
 init_config:
 
 instances:
-  - server: mongodb://localhost:27017
+  # Specify the MongoDB URI, with database to use for reporting (defaults to "admin")
+  - server: mongodb://localhost:27017/admin
     # tags:
     #   - optional_tag1
     #   - optional_tag2


### PR DESCRIPTION
If you follow the mongo.yml example, you end up with a series of messages cluttering the logs rather noisily:
```
Feb  3 22:00:51 my-awesome-host dd.collector[16860]: INFO (mongo.py:183): No MongoDB database found in URI. Defaulting to admin.
```

Updating the example file would go a long way towards making this explicit, although it could be a better change to silence (or change the level to DEBUG) of the message above.