### PR TITLE
[config] fix integer to boolean casting helper

### DIFF
--- a/config.py
+++ b/config.py
@@ -176,7 +176,7 @@ def _unix_checksd_path():
 
 def _is_affirmative(s):
     # int or real bool
-    if isinstance(s, bool):
+    if isinstance(s, int):
         return bool(s)
     # try string cast
     return s.lower() in ('yes', 'true', '1')


### PR DESCRIPTION
In python bool is a subclass of int, so when we parse
something from the config, being an int like 0/1 or a
"true" boolean isinstance(s, int) does the job. For
additional security we cast it again as a bool.

This was the intentional behavior from the start...