### PR TITLE
Bugfix: pass output instead of the path.

### DIFF
--- a/checks.d/varnish.py
+++ b/checks.d/varnish.py
@@ -92,7 +92,7 @@ class Varnish(AgentCheck):
         output, error = proc.communicate()
         if error and len(error) > 0:
             self.log.error(error)
-        self._parse_varnishstat(varnishstat_path, use_xml, tags)
+        self._parse_varnishstat(output, use_xml, tags)
 
         # Parse service checks from varnishadm.
         varnishadm_path = instance.get('varnishadm')


### PR DESCRIPTION
Fixes the following Error : 
```
2015-02-18 13:35:49,980 | ERROR | dd.collector | checks.varnish(__init__.py:556) | Check 'varnish' instance #0 failed
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/checks/__init__.py", line 547, in run
    self.check(copy.deepcopy(instance))
  File "/opt/datadog-agent/agent/checks.d/varnish.py", line 95, in check
    self._parse_varnishstat(varnishstat_path, use_xml, tags)
  File "/opt/datadog-agent/agent/checks.d/varnish.py", line 182, in _parse_varnishstat
    p.Parse(output, True)
```

