### PR TITLE
Fix source install requirements, fix #1380

### DIFF
--- a/source-optional-requirements.txt
+++ b/source-optional-requirements.txt
@@ -2,3 +2,5 @@ kazoo==1.3.1
 pycurl==7.19.5
 psutil==2.1.1
 pymongo==2.6.3
+pysnmp-mibs==0.1.4
+pysnmp==4.2.5

--- a/source-requirements.txt
+++ b/source-requirements.txt
@@ -5,8 +5,6 @@ kafka-python==0.9.0-9bed11db98387c0d9e456528130b330631dc50af
 ntplib==0.3.2
 pg8000==1.9.6
 PyMySQL==0.6.1
-pysnmp-mibs==0.1.4
-pysnmp==4.2.5
 python-memcached==1.53
 pyyaml==3.11
 redis==2.10.1


### PR DESCRIPTION
pysnmp and pysnmp-mibs require pycrypto which requires a compiler. So
the source install would fail on systems that don’t have a compiler.