### PR TITLE
[varnish] fix `varnishadm` subp call with sudo

### DIFF
--- a/checks.d/varnish.py
+++ b/checks.d/varnish.py
@@ -98,8 +98,7 @@ class Varnish(AgentCheck):
         varnishadm_path = instance.get('varnishadm')
         if varnishadm_path:
             secretfile_path = instance.get('secretfile', '/etc/varnish/secret')
-            varnishadm_path = 'sudo %s' % varnishadm_path
-            cmd = [varnishadm_path, '-S', secretfile_path, 'debug.health']
+            cmd = ['sudo', varnishadm_path, '-S', secretfile_path, 'debug.health']
             proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
             output, _ = proc.communicate()
             if output:


### PR DESCRIPTION
When calling subprocess with an argv-like array, argv[0] needs to
be the program to execute and not a sequence of programs like
`sudo someprogram`.

Otherwise this results in:
`OSError: [Errno 2] No such file or directory` when trying to find
the `sudo someprogram` executable in the PATH.