### PR TITLE
[cassandra] Add some more StorageProxy metrics

### DIFF
--- a/conf.d/cassandra.yaml.example
+++ b/conf.d/cassandra.yaml.example
@@ -40,7 +40,9 @@ init_config:
           - MemtableSwitchCount
           - MinRowSize
           - PendingTasks
+          - RangeOperations
           - ReadCount
+          - ReadOperations
           - RecentHitRate
           - RecentRangeLatencyMicros
           - RecentReadLatencyMicros
@@ -49,10 +51,12 @@ init_config:
           - RowCacheRecentHitRate
           - Size
           - TotalDiskSpaceUsed
+          - TotalRangeLatencyMicros
           - TotalReadLatencyMicros
           - TotalWriteLatencyMicros
           - UpdateInterval
           - WriteCount
+          - WriteOperations
       exclude:
         keyspace: system
     - include:


### PR DESCRIPTION
This adds a few more node-wide metrics that complete the `StorageProxy` section of Cassandra's JMX metrics.
See here for more: http://wiki.apache.org/cassandra/JmxInterface#org.apache.cassandra.service.StorageProxy