### PR TITLE
Fix bug when multiple instances were connecting to the same pg instance

### DIFF
--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -35,10 +35,16 @@ class TestPostgres(AgentCheckTest):
                         },
                         "query": "SELECT datname, %s FROM pg_stat_database WHERE datname = 'datadog_test' LIMIT(1)", 
                         "relation": False,
-                    }
-                ]
+                    }]
+                },
+                {
+                'host': host,
+                'port': port,
+                'username': 'datadog',
+                'password': 'datadog',
+                'dbname': 'postgres'
                 }
-            ]
+                ]
         }
         agentConfig = {
             'version': '0.1',
@@ -51,7 +57,7 @@ class TestPostgres(AgentCheckTest):
         self.check.run()
 
         # FIXME: Not great, should have a function like that available
-        key = '%s:%s:%s' % (host, port, dbname)
+        key = (host, port, dbname)
         db = self.check.dbs[key]
 
         metrics = self.check.get_metrics()
@@ -97,11 +103,11 @@ class TestPostgres(AgentCheckTest):
         service_checks_count = len(service_checks)
         self.assertTrue(type(service_checks) == type([]))
         self.assertTrue(service_checks_count > 0)
-        self.assertEquals(len([sc for sc in service_checks if sc['check'] == "postgres.can_connect"]), 2, service_checks)
+        self.assertEquals(len([sc for sc in service_checks if sc['check'] == "postgres.can_connect"]), 4, service_checks)
         # Assert that all service checks have the proper tags: host, port and db
         self.assertEquals(len([sc for sc in service_checks if "host:localhost" in sc['tags']]), service_checks_count, service_checks)
         self.assertEquals(len([sc for sc in service_checks if "port:%s" % config['instances'][0]['port'] in sc['tags']]), service_checks_count, service_checks)
-        self.assertEquals(len([sc for sc in service_checks if "db:%s" % config['instances'][0]['dbname'] in sc['tags']]), service_checks_count, service_checks)
+        self.assertEquals(len([sc for sc in service_checks if "db:%s" % config['instances'][0]['dbname'] in sc['tags']]), service_checks_count/2, service_checks)
 
         time.sleep(1)
         self.check.run()
@@ -112,7 +118,7 @@ class TestPostgres(AgentCheckTest):
         self.assertEquals(len([m for m in metrics if 'table:persons' in str(m[3].get('tags', [])) ]), 11, metrics)
 
         self.metrics = metrics
-        self.assertMetric("custom.numbackendss")
+        self.assertMetric("custom.numbackends")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix #1211

When multiple instances were connecting to the same pg instance, as metrics are not tagged by instance, We were collecting the same metrics multiple times leading to the errors described here:
https://github.com/DataDog/dd-agent/issues/1211

This fixes it by not collecting common metrics across instances more than once.