### PR TITLE
[bugfix] Not use pidfile for foreground processes

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -166,7 +166,7 @@ class Daemon(object):
         log.info("Pidfile: %s" % self.pidfile)
         if not foreground:
             self.daemonize()
-        self.write_pidfile()
+            self.write_pidfile()
         self.run()
 
 


### PR DESCRIPTION
Watchdog sends a SIGKILL when the collector takes too much time, without
cleaning the pidfile, thus resulting in failure for the next start of
the agent.

This is a temporary workaround (#1407).

Tested on debian: the supervisor restart correctly the collector.

```bash
sudo rm -f /tmp/dd-agent.pid /var/run/datadog/dd-agent.pid && sudo wget --quiet -O /opt/datadog-agent/agent/daemon.py https://raw.githubusercontent.com/DataDog/dd-agent/ac0adcc41a904bce3cce6d6f094b5264304ab5f0/daemon.py && sudo /etc/init.d/datadog-agent restart
```