### PR TITLE
Allow snmpv1

### DIFF
--- a/checks.d/snmp.py
+++ b/checks.d/snmp.py
@@ -83,7 +83,13 @@ class SnmpCheck(AgentCheck):
         '''
         if "community_string" in instance:
             # SNMP v1 - SNMP v2
-            return cmdgen.CommunityData(instance['community_string'])
+
+            # See http://pysnmp.sourceforge.net/docs/current/security-configuration.html
+            if int(instance.get("snmp_version", 2)) == 1:
+                return cmdgen.CommunityData(instance['community_string'],
+                    mpModel=0)
+            return cmdgen.CommunityData(instance['community_string'], mpModel=1)
+
         elif "user" in instance:
             # SNMP v3
             user = instance["user"]

--- a/conf.d/snmp.yaml.example
+++ b/conf.d/snmp.yaml.example
@@ -10,6 +10,7 @@ instances:
   # - ip_address: localhost
   #   port: 161
   #   community_string: public
+  #   snmp_version: 2 # Only required for snmp v1, will default to 2
   #   tags:
   #     - optional_tag_1
   #     - optional_tag_2


### PR DESCRIPTION
Supersedes #1397
Fixes #1374

pysnmp requires mpModel to be set to 0 to use SNMPv1.
This parameter defaults to 1 which means SNMPv2c

See
http://pysnmp.sourceforge.net/docs/current/security-configuration.html