### PR TITLE
[marathon] add basic auth option

### DIFF
--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -30,11 +30,17 @@ class Marathon(AgentCheck):
 
         # Load values from the instance config
         url = instance['url']
+        user = instance.get('user')
+        password = instance.get('password')
+        if user is not None and password is not None:
+            auth = (user,password)
+        else:
+            auth = None
         instance_tags = instance.get('tags', [])
         default_timeout = self.init_config.get('default_timeout', self.DEFAULT_TIMEOUT)
         timeout = float(instance.get('timeout', default_timeout))
 
-        response = self.get_json(urljoin(url, "/v2/apps"), timeout)
+        response = self.get_json(urljoin(url, "/v2/apps"), timeout, auth)
         if response is not None:
             self.gauge('marathon.apps', len(response['apps']), tags=instance_tags)
             for app in response['apps']:
@@ -44,14 +50,14 @@ class Marathon(AgentCheck):
                         self.gauge('marathon.' + attr, app[attr], tags=tags)
 
                 query_url = urljoin(url, "/v2/apps/{0}/versions".format(app['id']))
-                versions_reply = self.get_json(query_url, timeout)
+                versions_reply = self.get_json(query_url, timeout, auth)
 
                 if versions_reply is not None:
                     self.gauge('marathon.versions', len(versions_reply['versions']), tags=tags)
 
-    def get_json(self, url, timeout):
+    def get_json(self, url, timeout, auth):
         try:
-            r = requests.get(url, timeout=timeout)
+            r = requests.get(url, timeout=timeout, auth=auth)
             r.raise_for_status()
         except requests.exceptions.Timeout:
             # If there's a timeout

--- a/conf.d/marathon.yaml.example
+++ b/conf.d/marathon.yaml.example
@@ -5,3 +5,7 @@ init_config:
 instances:
 # url: the API endpoint of your Marathon master
   # - url: "https://server:port"
+  #
+  #   if marathon is protected by basic auth
+  #   user: "username"
+  #   password: "password"


### PR DESCRIPTION
I like to protect our marathon instances behind basic authentication, so I needed this configuration option.

Launch marathon with --http_credentials "user:password" to require basic authentication, then configure your marathon.yaml with the user and password.

I tested this pull request with and without the user/password fields in marathon.yaml -- both seem to work fine.