### PR TITLE
[core] Cast system settings proxy port to int

### DIFF
--- a/config.py
+++ b/config.py
@@ -605,7 +605,7 @@ def get_proxy(agentConfig, use_system_settings=False):
                 pass
             px = proxy.split(':')
             proxy_settings['host'] = px[0]
-            proxy_settings['port'] = px[1]
+            proxy_settings['port'] = int(px[1])
             proxy_settings['user'] = None
             proxy_settings['password'] = None
             proxy_settings['system_settings'] = True


### PR DESCRIPTION
Fixes #1414

From http://tornado.readthedocs.org/en/latest/httpclient.html:
```
`proxy_host` (string) – HTTP proxy hostname. To use proxies, proxy_host and proxy_port must be set; proxy_username and proxy_pass are optional. Proxies are currently only supported with curl_httpclient.
`proxy_port` (int) – HTTP proxy port
```