### PR TITLE
[core] improve detection of already running agent at startup

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -19,6 +19,9 @@ import logging
 import errno
 import signal
 
+# 3p
+from psutil import pid_exists
+
 log = logging.getLogger(__name__)
 
 class AgentSupervisor(object):
@@ -158,10 +161,14 @@ class Daemon(object):
         pid = self.pid()
 
         if pid:
-            message = "pidfile %s already exists. Is it already running?\n"
-            log.error(message % self.pidfile)
-            sys.stderr.write(message % self.pidfile)
-            sys.exit(1)
+            # Check if the pid in the pidfile corresponds to a running process
+            if pid_exists(pid):
+                log.error("Not starting, another instance is already running"\
+                          " (using pidfile {0})".format(self.pidfile))
+                sys.exit(1)
+            else:
+                log.warn('pidfile contains the pid of a stopped process.'\
+                         ' Starting normally')
 
         log.info("Pidfile: %s" % self.pidfile)
         if not foreground:


### PR DESCRIPTION
Solve all problems related to the agent receiving a SIGKILL and not cleaning its pidfile.
Check if the pid in the pidfile is valid, if it is, abort, otherwise ignore and continue its start.
With this change, even if the collector (or any other agent process) receives a SIGKILL, it will just be restarted by supervisor.

So the question is: do we want to have a _Phoenix_ agent which will always arise from its ashes (but may hide any error causing its death), or an agent which need a manual restart after a *critical* error ?

----
It was the default behaviour before 5.2 because processes started by supervisor didn't have a pidfile.