### PR TITLE
[kafka] upgraded jmx keys for version 0.8.2

### DIFF
--- a/conf.d/kafka.yaml.example
+++ b/conf.d/kafka.yaml.example
@@ -26,47 +26,54 @@ init_config:
         # Aggregate cluster stats
         #
         - include:
-            domain: '"kafka.server"'
-            bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsBytesOutPerSec"'
+            domain: 'kafka.server'
+            bean: 'kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec'
             attribute:
                 MeanRate:
                     metric_type: gauge
                     alias: kafka.net.bytes_out
         - include:
-            domain: '"kafka.server"'
-            bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsBytesInPerSec"'
+            domain: 'kafka.server'
+            bean: 'kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec'
             attribute:
                 MeanRate:
                     metric_type: gauge
                     alias: kafka.net.bytes_in
         - include:
-            domain: '"kafka.server"'
-            bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsMessagesInPerSec"'
+            domain: 'kafka.server'
+            bean: 'kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec'
             attribute:
                 MeanRate:
                     metric_type: gauge
                     alias: kafka.messages_in
+        - include:
+            domain: 'kafka.server'
+            bean: 'kafka.server:type=BrokerTopicMetrics,name=BytesRejectedPerSec'
+            attribute:
+                MeanRate:
+                    metric_type: gauge
+                    alias: kafka.net.bytes_rejected
 
         #
         # Request timings
         #
         - include:
-            domain: '"kafka.server"'
-            bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsFailedFetchRequestsPerSec"'
+            domain: 'kafka.server'
+            bean: 'kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec'
             attribute:
                 MeanRate:
                     metric_type: gauge
                     alias: kafka.request.fetch.failed
         - include:
-            domain: '"kafka.server"'
-            bean: '"kafka.server":type="BrokerTopicMetrics",name="AllTopicsFailedProduceRequestsPerSec"'
+            domain: 'kafka.server'
+            bean: 'kafka.server:type=BrokerTopicMetrics,name=FailedProduceRequestsPerSec'
             attribute:
                 MeanRate:
                     metric_type: gauge
                     alias: kafka.request.produce.failed
         - include:
-            domain: '"kafka.network"'
-            bean: '"kafka.network":type="RequestMetrics",name="Produce-TotalTimeMs"'
+            domain: 'kafka.network'
+            bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Produce'
             attribute:
                 Mean:
                     metric_type: gauge
@@ -75,8 +82,8 @@ init_config:
                     metric_type: gauge
                     alias: kafka.request.produce.time.99percentile
         - include:
-            domain: '"kafka.network"'
-            bean: '"kafka.network":type="RequestMetrics",name="Fetch-TotalTimeMs"'
+            domain: 'kafka.network'
+            bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Fetch'
             attribute:
                 Mean:
                     metric_type: gauge
@@ -85,8 +92,8 @@ init_config:
                     metric_type: gauge
                     alias: kafka.request.fetch.time.99percentile
         - include:
-            domain: '"kafka.network"'
-            bean: '"kafka.network":type="RequestMetrics",name="UpdateMetadata-TotalTimeMs"'
+            domain: 'kafka.network'
+            bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=UpdateMetadata'
             attribute:
                 Mean:
                     metric_type: gauge
@@ -95,8 +102,8 @@ init_config:
                     metric_type: gauge
                     alias: kafka.request.update_metadata.time.99percentile
         - include:
-            domain: '"kafka.network"'
-            bean: '"kafka.network":type="RequestMetrics",name="Metadata-TotalTimeMs"'
+            domain: 'kafka.network'
+            bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Metadata'
             attribute:
                 Mean:
                     metric_type: gauge
@@ -105,8 +112,8 @@ init_config:
                     metric_type: gauge
                     alias: kafka.request.metadata.time.99percentile
         - include:
-            domain: '"kafka.network"'
-            bean: '"kafka.network":type="RequestMetrics",name="Offsets-TotalTimeMs"'
+            domain: 'kafka.network'
+            bean: 'kafka.network:type=RequestMetrics,name=TotalTimeMs,request=Offsets'
             attribute:
                 Mean:
                     metric_type: gauge
@@ -114,34 +121,41 @@ init_config:
                 99thPercentile:
                     metric_type: gauge
                     alias: kafka.request.offsets.time.99percentile
+        - include:
+            domain: 'kafka.server'
+            bean: 'kafka.server:type=KafkaRequestHandlerPool,name=RequestHandlerAvgIdlePercent'
+            attribute:
+                MeanRate:
+                    metric_type: gauge
+                    alias: kafka.request.handler.avg.idle.pct
 
         #
         # Replication stats
         #
         - include:
-            domain: '"kafka.server"'
-            bean: '"kafka.server":type="ReplicaManager",name="ISRShrinksPerSec"'
+            domain: 'kafka.server'
+            bean: 'kafka.server:type=ReplicaManager,name=IsrShrinksPerSec'
             attribute:
                 MeanRate:
                     metric_type: gauge
                     alias: kafka.replication.isr_shrinks
         - include:
-            domain: '"kafka.server"'
-            bean: '"kafka.server":type="ReplicaManager",name="ISRExpandsPerSec"'
+            domain: 'kafka.server'
+            bean: 'kafka.server:type=ReplicaManager,name=IsrExpandsPerSec'
             attribute:
                 MeanRate:
                     metric_type: gauge
                     alias: kafka.replication.isr_expands
         - include:
-            domain: '"kafka.server"'
-            bean: '"kafka.server":type="ControllerStats",name="LeaderElectionRateAndTimeMs"'
+            domain: 'kafka.controller'
+            bean: 'kafka.controller:type=ControllerStats,name=LeaderElectionRateAndTimeMs'
             attribute:
                 MeanRate:
                     metric_type: gauge
                     alias: kafka.replication.leader_elections
         - include:
-            domain: '"kafka.server"'
-            bean: '"kafka.server":type="ControllerStats",name="UncleanLeaderElectionsPerSec"'
+            domain: 'kafka.controller'
+            bean: 'kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec'
             attribute:
                 MeanRate:
                     metric_type: gauge
@@ -151,8 +165,8 @@ init_config:
         # Log flush stats
         #
         - include:
-            domain: '"kafka.log"'
-            bean: '"kafka.log":type="LogFlushStats",name="LogFlushRateAndTimeMs"'
+            domain: 'kafka.log'
+            bean: 'kafka.log:type=LogFlushStats,name=LogFlushRateAndTimeMs'
             attribute:
                 MeanRate:
                     metric_type: gauge


### PR DESCRIPTION
This changes upgrades the jmx keys for kafka 0.8.2. This is not backwards compatible with kafka 0.8.1.