### PR TITLE
More agressive NTP threshold by default

### DIFF
--- a/checks.d/ntp.py
+++ b/checks.d/ntp.py
@@ -7,7 +7,7 @@ from checks import AgentCheck
 # 3rd party
 import ntplib
 
-DEFAULT_OFFSET_THRESHOLD = 600 # in seconds
+DEFAULT_OFFSET_THRESHOLD = 60 # in seconds
 DEFAULT_NTP_VERSION = 3
 DEFAULT_TIMEOUT = 1 # in seconds
 DEFAULT_HOST = "pool.ntp.org"

--- a/conf.d/ntp.yaml.example
+++ b/conf.d/ntp.yaml.example
@@ -1,7 +1,7 @@
 init_config:
 
 instances:
-  - offset_threshold: 600
+  - offset_threshold: 60
 
     # Optional params:
     #


### PR DESCRIPTION
A host reporting more than 2-3 minutes off NTP time will throw off our alerting engine. We should set the default to 1 minute so when people enable the check they get the best results.

We should also make the change here: https://github.com/DataDog/puppet-datadog-agent/pull/73