### PR TITLE
Fix example nginx config

### DIFF
--- a/conf.d/nginx.yaml.example
+++ b/conf.d/nginx.yaml.example
@@ -12,8 +12,8 @@ instances:
 
   - nginx_status_url: http://localhost/nginx_status/
   #   tags:
-  #     - instance:foo
+  #     - foo
   #
   # - nginx_status_url: http://example2.com:1234/nginx_status/
   #   tags:
-  #     - instance:bar
+  #     - bar


### PR DESCRIPTION
Nginx yaml configuration example includes wrong format. Please review. Thanks!