### PR TITLE
[tests] Let's cache !

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ script:
   - 'rake ci:run'
   - ls -al $INTEGRATIONS_DIR
 
+
 after_failure:
   - echo "Logs from installation process come here / DEBUG LOGS"
   - cat /tmp/ci.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,15 @@ branches:
     - master
     - /^\d+\.\d+\.x$/ # release forked patches branch
 
-cache:
-  bundler: true
-  directories:
-    - $HOME/.pip-cache
-    - $HOME/embedded
-
 language: python
 python:
   - "2.6"
   - "2.7"
+
+cache:
+  directories:
+    - $HOME/virtualenv/python2.6.9/lib/python2.6/site-packages
+    - $HOME/virtualenv/python2.7.9/lib/python2.7/site-packages
 
 matrix:
   fast_finish: true
@@ -24,47 +23,48 @@ env:
     - CONCURRENCY=2
     - NOSE_FILTER="not windows"
     - INTEGRATIONS_DIR=$HOME/embedded
-    - PIP_CACHE=$HOME/.pip-cache
+    - PIP_CACHE=$HOME/.cache/pip
     - SKIP_CLEANUP=true
     - VOLATILE_DIR=/tmp
+    - DD_CASHER_DIR=/tmp/casher
   matrix:
     - TRAVIS_FLAVOR=default
-    - TRAVIS_FLAVOR=mongo
-    - TRAVIS_FLAVOR=elasticsearch ES_VERSION=1.4.2
-    - TRAVIS_FLAVOR=elasticsearch ES_VERSION=1.3.7
-    - TRAVIS_FLAVOR=elasticsearch ES_VERSION=1.2.4
-    - TRAVIS_FLAVOR=elasticsearch ES_VERSION=1.1.2
-    - TRAVIS_FLAVOR=elasticsearch ES_VERSION=1.0.3
-    - TRAVIS_FLAVOR=elasticsearch ES_VERSION=0.90.13
-    - TRAVIS_FLAVOR=cassandra
-    - TRAVIS_FLAVOR=sysstat
-    - TRAVIS_FLAVOR=redis REDIS_VERSION="2.8"
-    - TRAVIS_FLAVOR=redis REDIS_VERSION="2.6"
-    - TRAVIS_FLAVOR=redis REDIS_VERSION="2.4"
-    - TRAVIS_FLAVOR=memcache
-    - TRAVIS_FLAVOR=postgres PG_VERSION="9.4.0"
-    - TRAVIS_FLAVOR=postgres PG_VERSION="9.3.5"
-    - TRAVIS_FLAVOR=postgres PG_VERSION="9.2.9"
-    - TRAVIS_FLAVOR=postgres PG_VERSION="9.1.14"
-    - TRAVIS_FLAVOR=postgres PG_VERSION="9.0.18"
-# FIXME: cannot enable gearman on Travis right now
-# because it needs boost
-#    - TRAVIS_FLAVOR=gearman
-    - TRAVIS_FLAVOR=tomcat # JMX testing machine / need the other ones before
-    - TRAVIS_FLAVOR=mysql
-    - TRAVIS_FLAVOR=couchdb
-    - TRAVIS_FLAVOR=snmpd
     - TRAVIS_FLAVOR=apache
-    - TRAVIS_FLAVOR=nginx
-    - TRAVIS_FLAVOR=lighttpd
-    - TRAVIS_FLAVOR=haproxy
-    - TRAVIS_FLAVOR=ssh
-    - TRAVIS_FLAVOR=fluentd
-    - TRAVIS_FLAVOR=rabbitmq
+    - TRAVIS_FLAVOR=cassandra
+    - TRAVIS_FLAVOR=couchdb
+    - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=0.90.13
+    - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.0.3
+    - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.1.2
+    - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.2.4
+    - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.3.7
+    - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.4.2
     - TRAVIS_FLAVOR=etcd
+    - TRAVIS_FLAVOR=fluentd
+    # FIXME: cannot enable gearman on Travis right now
+    # because it needs boost
+    # - TRAVIS_FLAVOR=gearman
+    - TRAVIS_FLAVOR=haproxy
+    - TRAVIS_FLAVOR=lighttpd
+    - TRAVIS_FLAVOR=memcache
+    - TRAVIS_FLAVOR=mongo
+    - TRAVIS_FLAVOR=mysql
+    - TRAVIS_FLAVOR=nginx
     - TRAVIS_FLAVOR=pgbouncer
-    - TRAVIS_FLAVOR=supervisord
     - TRAVIS_FLAVOR=phpfpm
+    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION="9.0.18"
+    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION="9.1.14"
+    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION="9.2.9"
+    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION="9.3.5"
+    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION="9.4.0"
+    - TRAVIS_FLAVOR=rabbitmq
+    - TRAVIS_FLAVOR=redis FLAVOR_VERSION="2.4"
+    - TRAVIS_FLAVOR=redis FLAVOR_VERSION="2.6"
+    - TRAVIS_FLAVOR=redis FLAVOR_VERSION="2.8"
+    - TRAVIS_FLAVOR=snmpd
+    - TRAVIS_FLAVOR=ssh
+    - TRAVIS_FLAVOR=supervisord
+    - TRAVIS_FLAVOR=sysstat
+    - TRAVIS_FLAVOR=tomcat # JMX testing machine / need the other ones before
 
 # Override travis defaults with empty jobs
 before_install: echo "OVERRIDING TRAVIS STEPS"
@@ -73,14 +73,12 @@ before_script: echo "OVERRIDING TRAVIS STEPS"
 
 script:
   - bundle install
-  - 'ls -al $HOME/embedded'
+  - mkdir -p $INTEGRATIONS_DIR
+  - ls -al $INTEGRATIONS_DIR
   - 'rake ci:run'
+  - ls -al $INTEGRATIONS_DIR
 
 after_failure:
-  - echo "Logs from installation process come here / DEBUG LOGS"
-  - cat /tmp/ci.log
-
-after_error:
   - echo "Logs from installation process come here / DEBUG LOGS"
   - cat /tmp/ci.log
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem 'colorize'
 gem 'rake'
+gem 'addressable'

--- a/Rakefile
+++ b/Rakefile
@@ -33,11 +33,11 @@ CLOBBER.include '**/*.pyc'
 
 # Travis-like environment for local use
 
-unless ENV['IS_TRAVIS']
+unless ENV['TRAVIS']
   rakefile_dir = File.dirname(__FILE__)
   ENV['TRAVIS_BUILD_DIR'] = rakefile_dir
   ENV['INTEGRATIONS_DIR'] = File.join(rakefile_dir, 'embedded')
-  ENV['PIP_CACHE'] = File.join(rakefile_dir, '.pip-cache')
+  ENV['PIP_CACHE'] = File.join(rakefile_dir, '.cache/pip')
   ENV['VOLATILE_DIR'] = '/tmp/dd-agent-testing'
   ENV['CONCURRENCY'] = ENV['CONCURRENCY'] || '2'
   ENV['NOSE_FILTER'] = 'not windows'

--- a/checks.d/pgbouncer.py
+++ b/checks.d/pgbouncer.py
@@ -7,7 +7,8 @@ from checks import AgentCheck, CheckException
 import psycopg2 as pg
 
 
-class ShouldRestartException(Exception): pass
+class ShouldRestartException(Exception):
+    pass
 
 
 class PgBouncer(AgentCheck):
@@ -117,16 +118,15 @@ class PgBouncer(AgentCheck):
         elif host != "" and user != "":
             try:
 
-
                 if host == 'localhost' and password == '':
                     # Use ident method
                     connection = pg.connect("user=%s dbname=%s" % (user, self.DB_NAME))
                 elif port != '':
                     connection = pg.connect(host=host, port=port, user=user,
-                        password=password, database=self.DB_NAME)
+                                            password=password, database=self.DB_NAME)
                 else:
                     connection = pg.connect(host=host, user=user, password=password,
-                        database=self.DB_NAME)
+                                            database=self.DB_NAME)
 
                 connection.set_isolation_level(pg.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
                 self.log.debug('pgbouncer status: %s' % AgentCheck.OK)
@@ -134,7 +134,8 @@ class PgBouncer(AgentCheck):
             except Exception:
                 message = u'Cannot establish connection to pgbouncer://%s:%s/%s' % (host, port, self.DB_NAME)
                 self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                    tags=self._get_service_checks_tags(host, port), message=message)
+                                   tags=self._get_service_checks_tags(host, port),
+                                   message=message)
                 self.log.debug('pgbouncer status: %s' % AgentCheck.CRITICAL)
                 pass
         else:
@@ -142,7 +143,6 @@ class PgBouncer(AgentCheck):
                 raise CheckException("Please specify a PgBouncer host to connect to.")
             elif not user:
                 raise CheckException("Please specify a user to connect to PgBouncer as.")
-
 
         self.dbs[key] = connection
         return connection
@@ -171,5 +171,6 @@ class PgBouncer(AgentCheck):
 
         message = u'Established connection to pgbouncer://%s:%s/%s' % (host, port, self.DB_NAME)
         self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
-            tags=self._get_service_checks_tags(host, port), message=message)
+                           tags=self._get_service_checks_tags(host, port),
+                           message=message)
         self.log.debug('pgbouncer status: %s' % AgentCheck.OK)

--- a/ci/apache.rb
+++ b/ci/apache.rb
@@ -57,6 +57,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup'] do
       sh %(#{apache_rootdir}/bin/apachectl stop)
     end
@@ -76,6 +80,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/cassandra.rb
+++ b/ci/cassandra.rb
@@ -37,6 +37,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task cleanup: ['ci:common:cleanup'] do
       # FIXME: stop cass
     end
@@ -56,6 +60,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/couchdb.rb
+++ b/ci/couchdb.rb
@@ -81,6 +81,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup'] do
       sh %(#{couchdb_rootdir}/bin/couchdb -k)
     end
@@ -100,6 +104,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/default.rb
+++ b/ci/default.rb
@@ -13,6 +13,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke('default')
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup']
 
     task :execute do
@@ -30,6 +34,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/elasticsearch.rb
+++ b/ci/elasticsearch.rb
@@ -1,7 +1,7 @@
 require './ci/common'
 
 def es_version
-  ENV['ES_VERSION'] || '1.4.2'
+  ENV['FLAVOR_VERSION'] || '1.4.2'
 end
 
 def es_rootdir
@@ -35,6 +35,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup']
     # FIXME: stop elasticsearch
 
@@ -53,6 +57,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/etcd.rb
+++ b/ci/etcd.rb
@@ -43,6 +43,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup'] do
       # This will delete the temp directory of etcd,
       # so the etcd process will kill himself quickly after that (<10s)
@@ -64,6 +68,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/fluentd.rb
+++ b/ci/fluentd.rb
@@ -22,6 +22,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup'] do
       sh %(kill `cat $VOLATILE_DIR/fluentd.pid`)
     end
@@ -41,6 +45,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/gearman.rb
+++ b/ci/gearman.rb
@@ -39,6 +39,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup']
     # FIXME: stop gearman
 
@@ -57,6 +61,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/haproxy.rb
+++ b/ci/haproxy.rb
@@ -48,6 +48,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
      task :cleanup => ['ci:common:cleanup'] do
       %w(haproxy haproxy-open).each do |name|
         sh %(kill `cat $VOLATILE_DIR/#{name}.pid`)
@@ -69,6 +73,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/lighttpd.rb
+++ b/ci/lighttpd.rb
@@ -46,6 +46,10 @@ namespace :ci do
       sh %(kill `cat $VOLATILE_DIR/lighttpd.pid`)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :execute do
       exception = nil
       begin
@@ -61,6 +65,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/memcache.rb
+++ b/ci/memcache.rb
@@ -39,6 +39,10 @@ namespace :ci do
     task :cleanup => ['ci:common:cleanup']
     # FIXME: stop memcache
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :execute do
       exception = nil
       begin
@@ -54,6 +58,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/mongo.rb
+++ b/ci/mongo.rb
@@ -66,6 +66,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup']
     # FIXME: stop both mongos
 
@@ -84,6 +88,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/mysql.rb
+++ b/ci/mysql.rb
@@ -19,6 +19,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup']
 
     task :execute do
@@ -36,6 +40,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/nginx.rb
+++ b/ci/nginx.rb
@@ -41,6 +41,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup'] do
       sh %(kill `cat $VOLATILE_DIR/nginx.pid`)
     end
@@ -60,6 +64,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/pgbouncer.rb
+++ b/ci/pgbouncer.rb
@@ -27,8 +27,9 @@ namespace :ci do
 
     task :before_script do
       Rake::Task['ci:postgres:before_script'].invoke
-      sh %(cp $TRAVIS_BUILD_DIR/ci/resources/pgbouncer/pgbouncer.ini\
-           #{pgb_rootdir}/pgbouncer.ini)
+      sh %(sed 's#USERS_TXT##{pgb_rootdir}/users.txt#'\
+           $TRAVIS_BUILD_DIR/ci/resources/pgbouncer/pgbouncer.ini\
+           > #{pgb_rootdir}/pgbouncer.ini)
       sh %(cp $TRAVIS_BUILD_DIR/ci/resources/pgbouncer/users.txt\
            #{pgb_rootdir}/users.txt)
       sh %(#{pgb_rootdir}/pgbouncer -d #{pgb_rootdir}/pgbouncer.ini)
@@ -52,8 +53,8 @@ namespace :ci do
     task :cache => ['ci:common:cache']
 
     task :cleanup do
-      sh %(rm -rf $VOLATILE_DIR/pgbouncer*)
       sh %(killall pgbouncer)
+      sh %(rm -rf $VOLATILE_DIR/pgbouncer*)
       Rake::Task['ci:postgres:cleanup'].invoke
     end
 

--- a/ci/pgbouncer.rb
+++ b/ci/pgbouncer.rb
@@ -47,6 +47,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup do
       sh %(rm -rf $VOLATILE_DIR/pgbouncer*)
       sh %(killall pgbouncer)
@@ -68,6 +72,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/phpfpm.rb
+++ b/ci/phpfpm.rb
@@ -58,6 +58,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup'] do
       sh %(kill `cat $VOLATILE_DIR/nginx.pid`)
       sh %(kill `cat $VOLATILE_DIR/php-fpm.pid`)
@@ -78,6 +82,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/postgres.rb
+++ b/ci/postgres.rb
@@ -1,7 +1,7 @@
 require './ci/common'
 
 def raw_pg_version
-  ENV['PG_VERSION'] || '9.4.0'
+  ENV['FLAVOR_VERSION'] || '9.4.0'
 end
 
 def pg_version
@@ -73,6 +73,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup'] do
       sh %(#{pg_rootdir}/bin/pg_ctl\
            -D $VOLATILE_DIR/postgres_data\
@@ -97,6 +101,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/rabbitmq.rb
+++ b/ci/rabbitmq.rb
@@ -43,6 +43,9 @@ namespace :ci do
     end
 
     task :before_cache => ['ci:common:before_cache'] do
+      # Delete the RabbitMQ RABBITMQ_MNESIA_DIR which contains the data
+      sh %(rm -rf #{rabbitmq_rootdir}/var/lib/rabbitmq/mnesia)
+    end
 
     task :cache => ['ci:common:cache']
 

--- a/ci/rabbitmq.rb
+++ b/ci/rabbitmq.rb
@@ -42,6 +42,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache'] do
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup'] do
       sh %(#{rabbitmq_rootdir}/sbin/rabbitmqctl stop)
     end
@@ -61,6 +65,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/redis.rb
+++ b/ci/redis.rb
@@ -44,6 +44,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup'] do
       # Shutdown redis
       conf_files = ["#{ENV['TRAVIS_BUILD_DIR']}/ci/resources/redis/auth.conf",
@@ -81,6 +85,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/resources/cache.rb
+++ b/ci/resources/cache.rb
@@ -1,0 +1,189 @@
+# MIT LICENSE
+
+# Copyright (c) 2013 Travis CI GmbH <contact@travis-ci.org>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# Original file:
+# https://github.com/travis-ci/travis-build/blob/d1c3be0b6aec5989872f9c534185585108125d0d/lib/travis/build/script/shared/directory_cache/s3.rb
+
+require 'shellwords'
+
+require './ci/resources/cache/aws4_signature'
+
+class Cache
+  MSGS = {
+    config_missing: 'Worker S3 config missing: %s'
+  }
+
+  VALIDATE = {
+    bucket:            'bucket name',
+    access_key_id:     'access key id',
+    secret_access_key: 'secret access key'
+  }
+
+  CURL_FORMAT = <<-EOF
+     time_namelookup:  %{time_namelookup} s
+        time_connect:  %{time_connect} s
+     time_appconnect:  %{time_appconnect} s
+    time_pretransfer:  %{time_pretransfer} s
+       time_redirect:  %{time_redirect} s
+  time_starttransfer:  %{time_starttransfer} s
+      speed_download:  %{speed_download} bytes/s
+       url_effective:  %{url_effective}
+                     ----------
+          time_total:  %{time_total} s
+  EOF
+
+  KeyPair = Struct.new(:id, :secret)
+
+  Location = Struct.new(:scheme, :region, :bucket, :path) do
+    def hostname
+      "#{bucket}.#{region == 'us-east-1' ? 's3' : "s3-#{region}"}.amazonaws.com"
+    end
+  end
+
+  CASHER_URL = 'https://raw.githubusercontent.com/DataDog/casher/%s/bin/casher'
+  USE_RUBY   = '1.9.3'
+  BIN_PATH   = '$DD_CASHER_DIR/bin/casher'
+
+  attr_reader :data, :slug, :start, :msgs
+  attr_accessor :directories
+
+  def initialize(data, start = Time.now)
+    @data = data
+    @start = start
+    @msgs = []
+    @slug = ENV['TRAVIS_FLAVOR'] || (0...50).map { ('a'..'z').to_a[rand(26)] }.join
+    @slug += '-' + ENV['FLAVOR_VERSION'] if ENV['FLAVOR_VERSION']
+    @directories = []
+  end
+
+  def valid?
+    validate
+    msgs.empty?
+  end
+
+  def setup
+    fold 'Setting up build cache' do
+      install
+      fetch
+      directories.each { |dir| add(dir) }
+    end
+  end
+
+  def install
+    `mkdir -p $DD_CASHER_DIR/bin/`
+    `curl #{casher_url} #{debug_flags} -L -o #{BIN_PATH} -s --fail`
+    `[ $? -ne 0 ] && echo 'Failed to fetch casher from GitHub, disabling cache.' && echo > #{BIN_PATH}`
+
+    `chmod +x #{BIN_PATH}`
+  end
+
+  def add(path)
+    run('add', path) if path
+  end
+
+  def fetch
+    urls = [Shellwords.escape(fetch_url.to_s)]
+    run('fetch', urls)
+  end
+
+  def push
+    run('push', Shellwords.escape(push_url.to_s), assert: false)
+  end
+
+  def fetch_url(branch = 'master')
+    url('GET', prefixed(branch), expires: fetch_timeout)
+  end
+
+  def push_url(branch = 'master')
+    url('PUT', prefixed(branch), expires: push_timeout)
+  end
+
+  def fold(message = nil)
+    @fold_count ||= 0
+    @fold_count  += 1
+
+    puts `echo #{message}` if message
+    yield
+  end
+
+  private
+
+  def validate
+    VALIDATE.each { |key, msg| msgs << msg unless s3_options[key] }
+    system "echo " + MSGS[:config_missing] % msgs.join(', '), ansi: :red unless msgs.empty?
+  end
+
+  def run(command, args, options = {})
+    puts `rvm #{USE_RUBY} --fuzzy do #{BIN_PATH} #{command} #{Array(args).join(' ')}`
+  end
+
+  def fetch_timeout
+    options[:fetch_timeout] || 60
+  end
+
+  def push_timeout
+    options[:push_timeout] || 600
+  end
+
+  def location(path)
+    Location.new(
+      s3_options.fetch(:scheme, 'https'),
+      s3_options.fetch(:region, 'us-east-1'),
+      s3_options.fetch(:bucket),
+      path
+    )
+  end
+
+  def prefixed(branch)
+    args = [branch, slug].compact
+    args.map! { |arg| arg.to_s.gsub(/[^\w\.\_\-]+/, '') }
+    '/' << args.join('/') << '.tbz'
+  end
+
+  def url(verb, path, options = {})
+    AWS4Signature.new(key_pair, verb, location(path), options[:expires], start).to_uri.to_s.untaint
+  end
+
+  def key_pair
+    KeyPair.new(s3_options[:access_key_id], s3_options[:secret_access_key])
+  end
+
+  def s3_options
+    options[:s3] || {}
+  end
+
+  def options
+    data || {}
+  end
+
+  def casher_url
+    CASHER_URL % casher_branch
+  end
+
+  def casher_branch
+    'production'
+  end
+
+  def debug_flags
+    "-v -w '#{CURL_FORMAT}'" if data[:debug]
+  end
+end

--- a/ci/resources/cache/aws4_signature.rb
+++ b/ci/resources/cache/aws4_signature.rb
@@ -1,0 +1,116 @@
+# MIT LICENSE
+
+# Copyright (c) 2013 Travis CI GmbH <contact@travis-ci.org>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+# Original file:
+# https://github.com/travis-ci/travis-build/blob/d1c3be0b6aec5989872f9c534185585108125d0d/lib/travis/build/script/shared/directory_cache/s3/aws4_signature.rb
+
+require 'uri'
+require 'addressable/uri'
+require 'digest/sha1'
+require 'openssl'
+
+class Cache
+  class AWS4Signature
+    def initialize(key_pair, verb, location, expires, timestamp = Time.now)
+      @key_pair = key_pair
+      @verb = verb
+      @location = location
+      @expires = expires
+      @timestamp = timestamp
+    end
+
+    def to_uri
+      query = canonical_query_params.dup
+      query['X-Amz-Signature'] = OpenSSL::HMAC.hexdigest('sha256', signing_key, string_to_sign)
+
+      Addressable::URI.new(
+        scheme: @location.scheme,
+        host: @location.hostname,
+        path: @location.path,
+        query_values: query
+      )
+    end
+
+    private
+
+    def date
+      @timestamp.utc.strftime('%Y%m%d')
+    end
+
+    def timestamp
+      @timestamp.utc.strftime('%Y%m%dT%H%M%SZ')
+    end
+
+    def query_string
+      canonical_query_params.map do |key, value|
+        "#{URI.encode(key.to_s, /[^~a-zA-Z0-9_.-]/)}=#{URI.encode(value.to_s, /[^~a-zA-Z0-9_.-]/)}"
+      end.join('&')
+    end
+
+    def request_sha
+      OpenSSL::Digest::SHA256.hexdigest(
+        [
+          @verb,
+          @location.path,
+          query_string,
+          "host:#{@location.hostname}\n",
+          'host',
+          'UNSIGNED-PAYLOAD'
+        ].join("\n")
+      )
+    end
+
+    def canonical_query_params
+      @canonical_query_params ||= {
+        'X-Amz-Algorithm' => 'AWS4-HMAC-SHA256',
+        'X-Amz-Credential' => "#{@key_pair.id}/#{date}/#{@location.region}/s3/aws4_request",
+        'X-Amz-Date' => timestamp,
+        'X-Amz-Expires' => @expires,
+        'X-Amz-SignedHeaders' => 'host'
+      }
+    end
+
+    def string_to_sign
+      [
+        'AWS4-HMAC-SHA256',
+        timestamp,
+        "#{date}/#{@location.region}/s3/aws4_request",
+        request_sha
+      ].join("\n")
+    end
+
+    def signing_key
+      @signing_key ||= recursive_hmac(
+        "AWS4#{@key_pair.secret}",
+        date,
+        @location.region,
+        's3',
+        'aws4_request'
+      )
+    end
+
+    def recursive_hmac(*args)
+      args.reduce { |key, data| OpenSSL::HMAC.digest('sha256', key, data) }
+    end
+  end
+end

--- a/ci/resources/pgbouncer/pgbouncer.ini
+++ b/ci/resources/pgbouncer/pgbouncer.ini
@@ -5,7 +5,8 @@ datadog_test = host=127.0.0.1 port=15432 dbname=datadog_test
 listen_port = 15433
 listen_addr = *
 auth_type = md5
-auth_file = embedded/pgbouncer/users.txt
+auth_file = USERS_TXT
 admin_users = datadog
 logfile = /tmp/pgbouncer.log
 pidfile = /tmp/pgbouncer.pid
+logfile = /tmp/pgbouncer.log

--- a/ci/resources/supervisord/program_0.sh
+++ b/ci/resources/supervisord/program_0.sh
@@ -1,0 +1,3 @@
+# dummy program that runs for 10 seconds and dies
+
+sleep 10

--- a/ci/resources/supervisord/program_1.sh
+++ b/ci/resources/supervisord/program_1.sh
@@ -1,3 +1,3 @@
-# dummy program that runs for 30 seconds and dies
+# dummy program that runs for 20 seconds and dies
 
-sleep 30
+sleep 20

--- a/ci/resources/supervisord/program_2.sh
+++ b/ci/resources/supervisord/program_2.sh
@@ -1,3 +1,3 @@
-# dummy program that runs for 60 seconds and dies
+# dummy program that runs for 30 seconds and dies
 
-sleep 60
+sleep 30

--- a/ci/resources/supervisord/program_3.sh
+++ b/ci/resources/supervisord/program_3.sh
@@ -1,3 +1,0 @@
-# dummy program that runs for 90 seconds and dies
-
-sleep 90

--- a/ci/resources/supervisord/supervisord.conf
+++ b/ci/resources/supervisord/supervisord.conf
@@ -5,27 +5,27 @@ file=VOLATILE_DIR/supervisor.sock
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix://VOLATILE_DIR//supervisor.sock
+serverurl=unix://VOLATILE_DIR/supervisor/supervisor.sock
 
 [supervisord]
-logfile=VOLATILE_DIR/supervisord.log
+logfile=VOLATILE_DIR/supervisor/supervisord.log
 logfile_maxbytes=50MB
 logfile_backups=10
 loglevel=info
-pidfile=VOLATILE_DIR/supervisord.pid
-childlogdir=VOLATILE_DIR
+pidfile=VOLATILE_DIR/supervisor/supervisord.pid
+childlogdir=VOLATILE_DIR/supervisor
+
+[program:program_0]
+command=/bin/sh VOLATILE_DIR/supervisor/program_0.sh
+autostart=true
+autorestart=false
 
 [program:program_1]
-command=/bin/sh VOLATILE_DIR/program_1.sh
+command=/bin/sh VOLATILE_DIR/supervisor/program_1.sh
 autostart=true
 autorestart=false
 
 [program:program_2]
-command=/bin/sh VOLATILE_DIR/program_2.sh
-autostart=true
-autorestart=false
-
-[program:program_3]
-command=/bin/sh VOLATILE_DIR/program_3.sh
+command=/bin/sh VOLATILE_DIR/supervisor/program_2.sh
 autostart=true
 autorestart=false

--- a/ci/skeleton.rb
+++ b/ci/skeleton.rb
@@ -15,6 +15,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup']
 
     task :execute do
@@ -32,6 +36,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/snmpd.rb
+++ b/ci/snmpd.rb
@@ -38,6 +38,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup'] do
       sh %(kill `cat $VOLATILE_DIR/snmpd.pid`)
     end
@@ -57,6 +61,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/ssh.rb
+++ b/ci/ssh.rb
@@ -15,6 +15,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup']
 
     task :execute do
@@ -32,6 +36,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/supervisord.rb
+++ b/ci/supervisord.rb
@@ -30,6 +30,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(['supervisord'])
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup'] do
       sh %(rm -f $VOLATILE_DIR/supervisord.conf)
       sh %(rm -f $VOLATILE_DIR/supervisord.yaml)
@@ -58,6 +62,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/supervisord.rb
+++ b/ci/supervisord.rb
@@ -1,29 +1,42 @@
 require './ci/common'
 
+def supervisor_version
+  ENV['FLAVOR_VERSION'] || '3.1.3'
+end
+
+def supervisor_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/supervisor_#{supervisor_version}_#{ENV['TRAVIS_PYTHON_VERSION']}"
+end
+
 namespace :ci do
   namespace :supervisord do |flavor|
     task :before_install => ['ci:common:before_install']
 
     task :install => ['ci:common:install'] do
-        sh %(pip install supervisor)
+      unless Dir.exist? File.expand_path(supervisor_rootdir)
+        sh %(pip install supervisor==#{supervisor_version} --ignore-installed\
+             --install-option="--prefix=#{supervisor_rootdir}")
+      end
     end
 
     task :before_script => ['ci:common:before_script'] do
-      sh %(cp $TRAVIS_BUILD_DIR/ci/resources/supervisord/supervisord.conf $VOLATILE_DIR/)
-      sh %(sed -i -- 's/VOLATILE_DIR/#{ENV['VOLATILE_DIR'].gsub '/','\/'}/g' $VOLATILE_DIR/supervisord.conf)
+      sh %(mkdir -p $VOLATILE_DIR/supervisor)
+      %w(supervisord.conf supervisord.yaml).each do |conf|
+        sh %(cp $TRAVIS_BUILD_DIR/ci/resources/supervisord/#{conf}\
+             $VOLATILE_DIR/supervisor/)
+        sh %(sed -i -- 's/VOLATILE_DIR/#{ENV['VOLATILE_DIR'].gsub '/','\/'}/g'\
+           $VOLATILE_DIR/supervisor/#{conf})
+      end
 
-      sh %(cp $TRAVIS_BUILD_DIR/ci/resources/supervisord/supervisord.yaml $VOLATILE_DIR/)
-      sh %(sed -i -- 's/VOLATILE_DIR/#{ENV['VOLATILE_DIR'].gsub '/','\/'}/g' $VOLATILE_DIR/supervisord.yaml)
+      3.times do |i|
+        sh %(cp $TRAVIS_BUILD_DIR/ci/resources/supervisord/program_#{i}.sh\
+             $VOLATILE_DIR/supervisor/)
+      end
+      sh %(chmod a+x $VOLATILE_DIR/supervisor/program_*.sh)
 
-      sh %(cp $TRAVIS_BUILD_DIR/ci/resources/supervisord/program_1.sh $VOLATILE_DIR/)
-      sh %(cp $TRAVIS_BUILD_DIR/ci/resources/supervisord/program_2.sh $VOLATILE_DIR/)
-      sh %(cp $TRAVIS_BUILD_DIR/ci/resources/supervisord/program_3.sh $VOLATILE_DIR/)
-      sh %(chmod a+x $VOLATILE_DIR/program_*.sh)
-
-      sh %(supervisord -c $VOLATILE_DIR/supervisord.conf)
-      sh %(sed -i -- 's/VOLATILE_DIR/#{ENV['VOLATILE_DIR'].gsub '/','\/'}/g' $VOLATILE_DIR/supervisord.conf)
-
-      sleep_for 10
+      sh %(#{supervisor_rootdir}/bin/supervisord\
+           -c $VOLATILE_DIR/supervisor/supervisord.conf)
+      sleep_for 3
     end
 
     task :script => ['ci:common:script'] do
@@ -35,16 +48,8 @@ namespace :ci do
     task :cache => ['ci:common:cache']
 
     task :cleanup => ['ci:common:cleanup'] do
-      sh %(rm -f $VOLATILE_DIR/supervisord.conf)
-      sh %(rm -f $VOLATILE_DIR/supervisord.yaml)
-      sh %(rm -f $VOLATILE_DIR/program*.sh)
-      sh %(rm -f $VOLATILE_DIR/supervisord.conf)
-      sh %(rm -f $VOLATILE_DIR/supervisord.log)
-      sh %(rm -f $VOLATILE_DIR/supervisord.pid)
-      sh %(rm -f $VOLATILE_DIR/program*.log)
-      sh %(rm -f $VOLATILE_DIR/ci.log)
-
-      sh %(unlink $VOLATILE_DIR/supervisor.sock)
+      sh %(kill `cat $VOLATILE_DIR/supervisor/supervisord.pid`)
+      sh %(rm -rf $VOLATILE_DIR/supervisor)
     end
 
     task :execute do

--- a/ci/sysstat.rb
+++ b/ci/sysstat.rb
@@ -44,6 +44,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup']
 
     task :execute do
@@ -61,6 +65,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/ci/tomcat.rb
+++ b/ci/tomcat.rb
@@ -39,6 +39,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup'] do
       sh %(#{tomcat_rootdir}/bin/shutdown.sh)
     end
@@ -58,6 +62,11 @@ namespace :ci do
       else
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
       end
       fail exception if exception
     end

--- a/tests/test_pgbouncer.py
+++ b/tests/test_pgbouncer.py
@@ -1,9 +1,10 @@
-from tests.common import load_check, AgentCheckTest
+from tests.common import AgentCheckTest
 
 import time
 import psycopg2 as pg
 from nose.plugins.attrib import attr
 from checks import AgentCheck
+
 
 @attr(requires='pgbouncer')
 class TestPgbouncer(AgentCheckTest):
@@ -14,10 +15,10 @@ class TestPgbouncer(AgentCheckTest):
             'init_config': {},
             'instances': [
                 {
-                'host': 'localhost',
-                'port': 15433,
-                'username': 'datadog',
-                'password': 'datadog'
+                    'host': 'localhost',
+                    'port': 15433,
+                    'username': 'datadog',
+                    'password': 'datadog'
                 }
             ]
         }
@@ -66,6 +67,3 @@ class TestPgbouncer(AgentCheckTest):
             status=AgentCheck.OK,
             tags=['host:localhost', 'port:15433', 'db:pgbouncer'],
             count=service_checks_count)
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_supervisord.py
+++ b/tests/test_supervisord.py
@@ -11,6 +11,7 @@ import xmlrpclib
 from checks import AgentCheck
 from tests.common import get_check
 
+
 class TestSupervisordCheck(unittest.TestCase):
 
     TEST_CASES = [{
@@ -180,7 +181,7 @@ instances:
     def tearDown(self):
         self.patcher.stop()
 
-    ### Integration Test #####################################################
+    # Integration Test #####################################################
 
     def test_check(self):
         """Integration test for supervisord check. Using a mocked supervisord."""
@@ -214,14 +215,13 @@ instances:
         """Integration test for supervisord check. Using a supervisord on Travis."""
 
         # Load yaml config
-        config_str = open(os.environ['VOLATILE_DIR'] + '/supervisord.yaml', 'r').read()
+        config_str = open(os.environ['VOLATILE_DIR'] + '/supervisor/supervisord.yaml', 'r').read()
         ok_(config_str is not None and len(config_str) > 0, msg=config_str)
 
         # init the check and get the instances
         check, instances = get_check('supervisord', config_str)
         ok_(check is not None, msg=check)
         eq_(len(instances), 1)
-
 
         # Supervisord should run 3 programs for 30, 60 and 90 seconds
         # respectively. The tests below will ensure that the process count
@@ -243,10 +243,9 @@ instances:
                             down = value
                 eq_(up, 3 - i)
                 eq_(down, i)
-                sleep(30)
+                sleep(10)
 
-
-    ### Unit Tests ###########################################################
+    # Unit Tests ###########################################################
 
     def test_build_message(self):
         """Unit test supervisord build service check message."""
@@ -281,7 +280,7 @@ Stop time: \nExit Status: 0"""
         check, _ = get_check('supervisord', self.TEST_CASES[0]['yaml'])
         eq_(expected_message, check._build_message(process))
 
-    ### Helper Methods #######################################################
+    # Helper Methods #######################################################
 
     @staticmethod
     def mock_server(url):


### PR DESCRIPTION
Wiki: https://github.com/DataDog/dd-agent/wiki/Cache-on-Travis

* python cache (ie dependencies):
  * use Travis to cache _libs_ directly
  * remove the useless and time-consuming `pip install .`
  * replace deprecated --download-cache by --cache-dir
  * remove deprecated --use-mirrors
* other programs cache (postgresql, mysql, etc):
  * use a S3 cache based on the Travis one
    (https://github.com/travis-ci/travis-build/blob/d1c3be0b6aec5989872f9c534185585108125d0d/lib/travis/build/script/shared/directory_cache/s3.rb)
  * use our own `casher` to avoir conflicts during runtime -
  https://github.com/Datadog/casher
  * this cache use TRAVIS_FLAVOR & FLAVOR_VERSION (changed) to determine
  what file to upload/download
  * add `BEFORE_CACHE` and `CACHE` steps to clean before cache and then
  cache on Travis

An also:
* A-Z for TRAVIS_FLAVOR (except default, still first)
* remove inexistent `after_error`in .travis.yaml