### PR TITLE
[tests] use AgentCheckTest for couch.py

### DIFF
--- a/checks.d/couch.py
+++ b/checks.d/couch.py
@@ -2,13 +2,11 @@
 from urlparse import urljoin
 
 # 3rd party
-import simplejson as json
 import requests
 
 # project
 from checks import AgentCheck
 from util import headers
-
 
 
 class CouchDb(AgentCheck):

--- a/ci/couchdb.rb
+++ b/ci/couchdb.rb
@@ -60,11 +60,18 @@ namespace :ci do
              && ./configure --prefix=#{couchdb_rootdir} --with-js-lib=#{couchdb_rootdir}/lib --with-js-include=#{couchdb_rootdir}/include/js\
              && make -j $CONCURRENCY\
              && make install)
+      else
+        # Still needed to start
+        ENV['PATH'] = "#{couchdb_rootdir}/bin:#{ENV['PATH']}"
+        ENV['LD_LIBRARY_PATH'] = "#{couchdb_rootdir}/lib:#{ENV['LD_LIBRARY_PATH']}"
+        ENV['DYLD_LIBRARY_PATH'] = "#{couchdb_rootdir}/lib:#{ENV['DYLD_LIBRARY_PATH']}"
       end
     end
 
     task :before_script => ['ci:common:before_script'] do
       sh %(#{couchdb_rootdir}/bin/couchdb -b)
+      # Couch takes some time to start
+      sleep_for 2
     end
 
     task :script => ['ci:common:script'] do

--- a/tests/test_couch.py
+++ b/tests/test_couch.py
@@ -1,54 +1,43 @@
-import unittest
-from tests.common import load_check
+from tests.common import AgentCheckTest
 from nose.plugins.attrib import attr
 from checks import AgentCheck
 
+
 @attr(requires='couchdb')
-class CouchDBTestCase(unittest.TestCase):
+class CouchTestCase(AgentCheckTest):
 
-    def test_metrics(self):
-        config = {
-            'instances': [{
-                'server': 'http://localhost:5984',
-            }]
-        }
-        agentConfig = {
-            'version': '0.1',
-            'api_key': 'toto'
-        }
+    CHECK_NAME = 'couch'
+    DB_NAMES = ['_users', '_replicator']
+    CHECK_GAUGES = [
+        'couchdb.by_db.disk_size',
+        'couchdb.by_db.doc_count',
+    ]
 
-        self.check = load_check('couch', config, agentConfig)
+    def __init__(self, *args, **kwargs):
+        AgentCheckTest.__init__(self, *args, **kwargs)
+        self.config = {"instances": [{"server": "http://localhost:5984"}]}
 
-        self.check.check(config['instances'][0])
+    def test_couch(self):
+        self.run_check(self.config)
+        for db_name in self.DB_NAMES:
+            tags = ['instance:http://localhost:5984', 'db:{0}'.format(db_name)]
+            for gauge in self.CHECK_GAUGES:
+                self.assertMetric(gauge, tags=tags, count=1)
 
-        metrics = self.check.get_metrics()
-        self.assertTrue(type(metrics) == type([]), metrics)
-        self.assertTrue(len(metrics) > 3)
-        self.assertTrue(len([k for k in metrics if "instance:http://localhost:5984" in k[3]['tags']]) > 3)
+        self.assertServiceCheck(self.check.SERVICE_CHECK_NAME,
+                                status=AgentCheck.OK,
+                                tags=['instance:http://localhost:5984'],
+                                count=1)
 
-    def test_service_checks(self):
-        config = {
-            'instances': [
-                {'server': 'http://localhost:5984'},
-                {'server': 'http://localhost:5985'}]
-        }
-        agentConfig = {
-            'version': '0.1',
-            'api_key': 'toto'
-        }
+        self.coverage_report()
 
-        self.check = load_check('couch', config, agentConfig)
-        self.check.check(config['instances'][0])
-        self.assertRaises(Exception, self.check.check, config['instances'][1])
+    def test_bad_config(self):
+        self.assertRaises(
+            Exception,
+            lambda: self.run_check({"instances": [{"server": "http://localhost:5985"}]})
+        )
 
-        service_checks = self.check.get_service_checks()
-        self.assertEqual(len(service_checks), 2)
-
-        ok_svc_check = service_checks[0]
-        self.assertEqual(ok_svc_check['check'], self.check.SERVICE_CHECK_NAME)
-        self.assertEqual(ok_svc_check['status'], AgentCheck.OK)
-
-        cr_svc_check = service_checks[1]
-        self.assertEqual(cr_svc_check['check'], self.check.SERVICE_CHECK_NAME)
-        self.assertEqual(cr_svc_check['status'], AgentCheck.CRITICAL)
-
+        self.assertServiceCheck(self.check.SERVICE_CHECK_NAME,
+                                status=AgentCheck.CRITICAL,
+                                tags=['instance:http://localhost:5985'],
+                                count=1)


### PR DESCRIPTION
Couch test can now be run using the cache (previously it wasn't possible because
of missing environment variables)