### PR TITLE
Fix small bug in vSphere integration check

### DIFF
--- a/checks.d/vsphere.py
+++ b/checks.d/vsphere.py
@@ -447,7 +447,7 @@ class VSphereCheck(AgentCheck):
 
         # Test if the connection is working
         try:
-            server_instance.RetrieveContent()
+            self.server_instances[i_key].RetrieveContent()
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
                     tags=service_check_tags)
         except Exception as e:


### PR DESCRIPTION
Fix bug in retrieving open connections to vCenter instances
(previously, `server_instance` was only defined for new connections).