### PR TITLE
[haproxy] use new test class

### DIFF
--- a/ci/resources/haproxy/haproxy-open.cfg
+++ b/ci/resources/haproxy/haproxy-open.cfg
@@ -18,12 +18,11 @@ defaults
     timeout connect 1000
 
 frontend public
-    bind 127.0.0.1:3834 # DTDG
+    bind 127.0.0.1:3836 # DTDG
     default_backend datadog
 
 backend datadog
     stats uri /stats
-    stats auth datadog:isdevops
     stats refresh 5s
 
     balance roundrobin
@@ -33,7 +32,6 @@ backend datadog
 
 backend anotherbackend
     stats uri /stats
-    stats auth datadog:isdevops
     stats refresh 5s
 
     balance roundrobin

--- a/ci/resources/haproxy/haproxy.cfg
+++ b/ci/resources/haproxy/haproxy.cfg
@@ -18,11 +18,22 @@ defaults
     timeout connect 1000
 
 frontend public
-    bind 127.0.0.1:3834 # DTDG
+    bind 127.0.0.1:3835 # DTDG
     default_backend datadog
 
 backend datadog
     stats uri /stats
+    stats auth datadog:isdevops
+    stats refresh 5s
+
+    balance roundrobin
+    server singleton:8080 127.0.0.1:8080
+    server singleton:8081 127.0.0.1:8081
+    server otherserver 127.0.0.1:1234
+
+backend anotherbackend
+    stats uri /stats
+    stats auth datadog:isdevops
     stats refresh 5s
 
     balance roundrobin

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,6 +4,7 @@ import logging
 import os
 import signal
 import sys
+import time
 import traceback
 import unittest
 
@@ -118,6 +119,12 @@ class AgentCheckTest(unittest.TestCase):
             raise Exception("You must define CHECK_NAME")
 
         self.check = None
+
+    # Helper function when testing rates
+    def run_check_twice(self, config, agent_config=None, mocks=None):
+        self.run_check(config, agent_config, mocks)
+        time.sleep(1)
+        self.run_check(config, agent_config, mocks)
 
     def run_check(self, config, agent_config=None, mocks=None):
         agent_config = agent_config or self.DEFAULT_AGENT_CONFIG


### PR DESCRIPTION
- PEP8 and FLAKE8 cleaning in `haproxy.py`
- use AgentCheckTest to test haproxy (rewrite old tests to have a 100%
  metrics coverage)
- start/stop haproxy in `ci/haproxy.rb`, instead of inside the test
  itself
- add a `run_check_twice` function inside `AgentCheckTest` to avoid code
  repetition when testing rates