### PR TITLE
[core] Collector and Checks metrics Governor

### DIFF
--- a/checks.d/nagios.py
+++ b/checks.d/nagios.py
@@ -4,8 +4,8 @@ import re
 from collections import namedtuple
 
 # project
-from checks.utils import TailFile
 from checks import AgentCheck
+from checks.tail import TailFile
 
 # fields order for each event type, as named tuples
 EVENT_FIELDS = {

--- a/checks/datadog.py
+++ b/checks/datadog.py
@@ -10,7 +10,7 @@ from itertools import groupby # >= python 2.4
 # project
 import modules
 from checks import LaconicFilter
-from checks.utils import TailFile
+from checks.tail import TailFile
 from util import windows_friendly_colon_split
 
 if hasattr('some string', 'partition'):

--- a/checks/tail.py
+++ b/checks/tail.py
@@ -7,17 +7,6 @@ SEEK_END = 2
 from stat import *
 import binascii
 
-def median(vals):
-    vals = sorted(vals)
-    if not vals:
-        raise ValueError(vals)
-    elif len(vals) % 2 == 0:
-        i1 = int(len(vals) / 2)
-        i2 = i1 - 1
-        return float(vals[i1] + vals[i2]) / 2.
-    else:
-        return vals[int(len(vals) / 2)]
-
 
 class TailFile(object):
 
@@ -31,7 +20,7 @@ class TailFile(object):
         self._crc = None
         self._log = logger
         self._callback = callback
-   
+
     def _open_file(self, move_end=False, pos=False):
 
         already_open = False

--- a/tests/test_governor.py
+++ b/tests/test_governor.py
@@ -1,0 +1,388 @@
+import copy
+import unittest
+from functools import partial
+from mock import patch
+
+from utils.governor import (
+    CheckGovernor,
+    ExpiringSelection,
+    Governor,
+    Limiter,
+    LimiterParser,
+    LimiterConfigError)
+from aggregator import MetricsAggregator
+
+
+class HybridGovernor(Governor):
+    """
+    HybridGovernor for tests purpose
+    """
+    def __init__(self):
+        super(HybridGovernor, self).__init__()
+        self._limiters = copy.deepcopy(self._CHECK_LIMITERS + self._AGENT_LIMITERS)
+
+
+class MockMetricAggregator(MetricsAggregator):
+    """a MockClass for tests"""
+    def __init__(self):
+        self.governor = CheckGovernor()
+        super(MockMetricAggregator, self).__init__("", governor=self.governor)
+
+    def get_governor(self):
+        return self.governor
+
+    def submit_metric(self, name, value=42, mtype='g', tags=None, hostname=None,
+                      device_name=None, timestamp=None, sample_rate=1):
+        return True
+
+
+class MockLimiter(Limiter):
+    """
+    MockLimiter
+    """
+    _ATOMS = frozenset(['key1', 'key2', 'key3', 'key4', 'key5'])
+
+
+class GovernorTestCase(unittest.TestCase):
+    LIMIT_METRIC_NB = {
+        'limiters': [{
+            'scope': 'check',
+            'selection': 'name',
+            'limit': 1
+        }]
+    }
+
+    NO_LIMIT = {}
+
+    METRIC_PAYLOAD = [
+        ('metric_name1', 123456, 42, {"tags": ["tag1", "tag2"]}),
+        ('metric_name2', 123456, 42, {"tags": ["tag1", "tag2"]}),
+        ('metric_name1', 123456, 42, {"tags": ["tag3"]}),
+    ]
+
+    def setUp(self):
+        # Simplify `Governor.init` function for tests
+        Governor.init = partial(Governor.init, agent_config={}, hostname="my_hostname")
+
+    ##########
+    # Common #
+    ##########
+
+    def test_empty_conf(self):
+        """
+        Always accept when no rule is specified
+        """
+        Governor.init(self.NO_LIMIT)
+
+        m1 = MockMetricAggregator()
+
+        for x in xrange(1, 100):
+            self.assertTrue(m1.submit_metric(name='my_metric'))
+
+    def test_name_args(self):
+        """
+        Properly name arguments
+        """
+        def myfunction(self, arg1, arg2, arg3):
+            pass
+        m_governor = CheckGovernor()
+        m_governor.set(myfunction)
+
+        # Synchronous
+        self.assertTrue(
+            m_governor._name_args([1, 2, 3], {}) == {'arg1': 1, 'arg2': 2, 'arg3': 3})
+        self.assertTrue(
+            m_governor._name_args([1], {'arg2': 2, 'arg3': 3}) == {'arg1': 1, 'arg2': 2, 'arg3': 3})
+
+        # Asynchronous
+        self.assertTrue(
+            m_governor._name_args(
+                [1, 2, 3], {}, asynchronous=True) == {'name': 1, 'timestamp': 2, 'value': 3})
+        self.assertTrue(
+            m_governor._name_args(
+                [1],
+                {'arg2': 2, 'arg3': 3}, asynchronous=True) == {'name': 1, 'arg2': 2, 'arg3': 3})
+
+    def test_flush(self):
+        """
+        Getting governor status should flush limiters when explicitely asked
+        """
+        Governor.init(self.LIMIT_METRIC_NB)
+        Governor._CONTEXTS_TTL = 0  # Reset active contexts at each governor iteration
+
+        aggr = MockMetricAggregator()
+        governor = aggr.get_governor()
+
+        self.assertTrue(aggr.submit_metric('my_metric'))
+        self.assertFalse(aggr.submit_metric('another_metric'))    # Blocked !
+
+        # Get governor status
+        statuses = governor.get_status(flush=True)
+
+        self.assertTrue(len(statuses) == 1)
+        mstatus = statuses[0]
+        self.assertTrue(mstatus['trace']['overflow_metrics'] == 1)
+        self.assertTrue(mstatus['trace']['max_selection_cardinal'] == 1)
+
+        # Get it again
+        statuses = governor.get_status()
+
+        self.assertTrue(len(statuses) == 1)
+        mstatus = statuses[0]
+        self.assertTrue(mstatus['trace']['overflow_metrics'] == 0)
+        self.assertTrue(mstatus['trace']['max_selection_cardinal'] == 0)
+
+    ########################################
+    # Governor for `asynchronous` analysis #
+    ########################################
+
+    @patch('utils.governor.Governor._report_to_datadog')
+    def test_process(self, mock_post_warning):
+        """
+        Hitting the governor limit should trigger a post warning
+        """
+        Governor.init(self.LIMIT_METRIC_NB)
+        governor = HybridGovernor()
+
+        # Do not hit the limit
+        governor.process(self.METRIC_PAYLOAD[0:1], report=True)
+
+        self.assertFalse(mock_post_warning.called)
+
+        # Hit the limit
+        governor.process(self.METRIC_PAYLOAD, report=True)
+        self.assertTrue(mock_post_warning.called)
+
+    #####################################################
+    # Governor as a decorator  for `real-time` analysis #
+    #####################################################
+
+    def test_aggregators_contamination(self):
+        """
+        No cross contamination between != metric aggregators
+        """
+        Governor.init(self.LIMIT_METRIC_NB)
+
+        self.assertTrue(len(Governor.get_all_limiters()) == 1)
+
+        m1 = MockMetricAggregator()
+        m2 = MockMetricAggregator()
+
+        self.assertTrue(m1.submit_metric('my_metric'))
+        self.assertFalse(m1.submit_metric('another_metric'))    # Blocked !
+        self.assertTrue(m1.submit_metric('my_metric'))          # Not blocked !
+
+        self.assertTrue(m2.submit_metric('another_metric'))     # Not blocke
+
+
+class LimiterTestCase(unittest.TestCase):
+    @staticmethod
+    def generate_metric(v1, v2):
+        """
+        Helper to return a metric with
+        """
+        return {
+            'key1': v1,
+            'key2': v2,
+        }
+
+    def test_limit(self):
+        """
+        Check incoming metrics against the limit set
+        """
+        limiter = MockLimiter('key1', 'key2', 1)
+        limiter.check = partial(limiter.check, 0)
+
+        # Check limiter task
+        self.assertTrue(limiter.check(self.generate_metric("scope1", "selection1")))
+        self.assertFalse(limiter.check(self.generate_metric("scope1", "selection2")))
+        self.assertTrue(limiter.check(self.generate_metric("scope1", "selection1")))
+
+        # Check trace
+        self.assertTrue(limiter._overflow_metrics == 1)
+
+    def test_no_limit(self):
+        """
+        Always accept metrics when no limit is set
+        """
+        limiter = MockLimiter('key1', 'key2')
+        limiter.check = partial(limiter.check, 0)
+
+        for x in xrange(10000):
+            self.assertTrue(limiter.check(
+                self.generate_metric("scope1", "selection_" + str(x))))
+
+    def test_limiter_trace(self):
+        """
+        Generate a trace from submitted metrics
+        """
+
+        limiter = MockLimiter('key1', 'key2', 3)
+        limiter.check = partial(limiter.check, 0)
+
+        # Check trace definition
+        definition = limiter.get_status()['definition']
+        self.assertTrue(definition['scope'] == ('key1',))
+        self.assertTrue(definition['selection'] == ('key2',))
+        self.assertTrue(definition['limit'] == 3)
+
+        # Submit metrics
+        limiter.check(self.generate_metric("scope1", "selection1"))
+        limiter.check(self.generate_metric("scope1", "selection2"))
+        limiter.check(self.generate_metric("scope1", "selection3"))  # We reached the max
+        limiter.check(self.generate_metric("scope1", "selection4"))  # Blocked !
+        limiter.check(self.generate_metric("scope1", "selection2"))  # Has no effect
+
+        limiter.check(self.generate_metric("scope2", "selection1"))
+        limiter.check(self.generate_metric("scope2", "selection2"))
+
+        # Check trace
+        trace = limiter.get_status()['trace']
+        self.assertTrue(trace['scope_cardinal'] == 2)
+        self.assertTrue(trace['overflow_metrics'] == 1)
+        self.assertTrue(trace['scope_overflow_cardinal'] == 1)
+        self.assertTrue(trace['max_selection_scope'] == ("scope1",))
+        self.assertTrue(trace['max_selection_cardinal'] == 3)
+
+    def test_key_extractor(self):
+        """
+        Extract scope and selection keys from metrics
+        """
+        limiter1 = MockLimiter(('key1', 'key3'), ('key4', 'key5'), 1)
+        limiter2 = MockLimiter('key1', 'key4', 1)
+
+        metric = {
+            'key1': 'value1',
+            'key2': 'value2',
+            'key3': 'value3',
+            'key4': 'value4',
+            'key5': 'value5'
+        }
+
+        # Test _to_scope_key
+        scope_value1, limit_value1 = limiter1._extract_metric_keys(metric)
+        self.assertTrue(scope_value1 == ('value1', 'value3'))
+        self.assertTrue(limit_value1 == ('value4', 'value5'))
+
+        scope_value2, limit_value2 = limiter2._extract_metric_keys(metric)
+        self.assertTrue(scope_value2 == ('value1',))
+        self.assertTrue(limit_value2 == ('value4',))
+
+    def test_hashable_value(self):
+        """
+        Selection values should always be hashable
+        """
+        metric = {
+            'key1': 'scope_value',
+            'key2': ["v1", "v2"],
+        }
+
+        limiter = MockLimiter('key1', 'key2', 1)
+        _, limit_value = limiter._extract_metric_keys(metric)
+        self.assertTrue(limit_value == (("v1", "v2"),), limit_value)
+
+
+class ExpiringSelectionTestCase(unittest.TestCase):
+    def test_active_selection(self):
+        """
+        Count number of active selections
+        """
+        expiring_selection = ExpiringSelection()
+
+        expiring_selection.add('selection1', 1)  # New selection
+        expiring_selection.add('selection2', 1)  # New selection
+        expiring_selection.add('selection1', 2)  # Active selection
+
+        self.assertTrue(len(expiring_selection), 2)
+
+    def test_flush(self):
+        """
+        Expired selections are flushed
+        """
+        expiring_selection = ExpiringSelection()
+        expiring_selection.add('selection1', 1)
+        expiring_selection.add('selection2', 1)
+        expiring_selection.add('selection1', 2)
+
+        self.assertTrue(len(expiring_selection), 2)
+        expiring_selection.flush(1)
+        self.assertTrue(len(expiring_selection), 1)
+
+
+class LimiterParserTestCase(unittest.TestCase):
+    LIMIT_CONFIG = {
+        'limiters': [
+            {
+                'scope': 'name',
+                'selection': 'tags',
+                'limit': 3
+            },
+            {
+                'scope': ('name', 'check'),
+                'selection': 'tags',
+                'limit': 5
+            },
+            {
+                'scope': 'check',
+                'selection': 'tags',
+                'limit': 10
+            },
+            {
+                'scope': 'check',
+                'selection': 'name',
+                'limit': 10
+            }
+        ]
+    }
+
+    NO_SCOPE_CONFIG = {
+        'limiters': [
+            {
+                'selection': 'tags',
+                'limit': 3
+            }
+        ]
+    }
+
+    NO_LIMIT_CONFIG = {
+        'limiters': [
+            {
+                'scope': 'check',
+                'selection': 'tags',
+            }
+        ]
+    }
+
+    UNKOWN_SCOPE_CONFIG = {
+        'limiters': [
+            {
+                'scope': ('name', 'unknown_scope'),
+                'selection': 'tags',
+                'limit': 3
+            }
+        ]
+    }
+
+    NO_CONFIG = {}
+
+    def test_rule_parser(self):
+        """
+        Parse limiters
+        """
+        # Incorrect config
+        self.assertRaises(LimiterConfigError, LimiterParser.parse_limiters,
+                          self.NO_SCOPE_CONFIG)
+        self.assertRaises(LimiterConfigError, LimiterParser.parse_limiters,
+                          self.UNKOWN_SCOPE_CONFIG)
+
+        # Correct config
+        check_limiters, agent_limiters = LimiterParser.parse_limiters(self.LIMIT_CONFIG)
+        self.assertTrue(len(check_limiters) == 3)
+        self.assertTrue(len(agent_limiters) == 1)
+
+        # No config is a correct config
+        self.assertTrue(LimiterParser.parse_limiters(self.NO_CONFIG) == ([], []))
+
+        # No limit is a correct config
+        check_limiters, _ = LimiterParser.parse_limiters(self.NO_LIMIT_CONFIG)
+        self.assertTrue(len(check_limiters) == 1)

--- a/tests/test_tail.py
+++ b/tests/test_tail.py
@@ -21,39 +21,39 @@ class TestTail(unittest.TestCase):
 
     def _trigger_logrotate(self):
         subprocess.check_call([
-            'logrotate', 
+            'logrotate',
             '-v', # Verbose logging
             '-f', # Force the rotation even though the file isn't old
             # Create a state file that you have file permissions for
-            '-s', self.logrotate_state_file.name, 
+            '-s', self.logrotate_state_file.name,
             self.logrotate_config.name
-        ])    
-    
+        ])
+
     def test_logrotate_copytruncate(self):
-        from checks.utils import TailFile
-        
+        from checks.tail import TailFile
+
         def line_parser(l):
             self.last_line = l
-        
+
         tail = TailFile(logging.getLogger(), self.log_file.name, line_parser)
         self.assertEquals(tail._size, 0)
-        
+
         # Write some data to the log file
         init_string = "hey there, I am a log\n"
         self.log_file.write(init_string)
         self.log_file.flush()
-        
+
         # Consume from the tail
         gen = tail.tail(line_by_line=False, move_end=True)
         gen.next()
-        
+
         # Verify that the tail consumed the data I wrote
         self.assertEquals(tail._size, len(init_string))
-        
+
         try:
             # Trigger a copytruncate logrotation on the log file
             self._trigger_logrotate()
-            
+
             # Write a new line to the log file
             new_string = "I am shorter\n"
             self.log_file.write(new_string)
@@ -64,7 +64,7 @@ class TestTail(unittest.TestCase):
             self.assertEquals(self.last_line, new_string[:-1], self.last_line)
         except OSError:
             "logrotate is not present"
-        
+
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.DEBUG)
     logging.getLogger().addHandler(logging.StreamHandler())

--- a/utils/governor.py
+++ b/utils/governor.py
@@ -1,0 +1,413 @@
+# stdlib
+from collections import defaultdict, deque
+import copy
+import inspect
+import logging
+import requests
+
+# project
+from config import _is_affirmative, format_proxy_settings, get_proxy, get_url_endpoint
+
+log = logging.getLogger('governor')
+
+
+class LimiterConfigError(Exception):
+    """
+    Error when parsing limiter
+    """
+    pass
+
+
+class Governor(object):
+    """
+    Abstract Governor class
+    """
+
+    # Defines what's an 'active' context
+    # i.e. number of iterations for which a context (not encountered anymore)
+    # is kept stored before being flushed.
+    _CONTEXTS_TTL = 3
+
+    # Collector payload's metric format
+    _METRIC_FORMAT = ['name', 'timestamp', 'value', 'attributes']
+
+    # Governor report endpoint
+    DATADOG_REPORT_GOVERNOR_URL = 'agent_governor/report'
+
+    # Governor agent-specific static variables
+    _CHECK_LIMITERS, _AGENT_LIMITERS = None, None
+    _HOSTNAME = None
+    _DD_URL = None
+    _API_KEY = None
+
+    @classmethod
+    def init(cls, governor_config, agent_config, hostname):
+        """
+        Set Governor agent-specific variables
+        """
+        if not _is_affirmative(agent_config.get('use_governor', True)):
+            return
+
+        cls._CHECK_LIMITERS, cls._AGENT_LIMITERS = LimiterParser.parse_limiters(governor_config)
+        cls._HOSTNAME = hostname
+        cls._API_KEY = agent_config.get('api_key')
+
+        # Set Governor report URL and proxy settings
+        cls._GOVERNOR_URL = "{0}/{1}".format(
+            get_url_endpoint(agent_config.get('dd_url', ""), endpoint_type='governor'),
+            cls.DATADOG_REPORT_GOVERNOR_URL)
+        cls._PROXY = format_proxy_settings(get_proxy(agent_config))
+
+    @classmethod
+    def get_agent_limiters(cls):
+        return cls._AGENT_LIMITERS
+
+    @classmethod
+    def get_check_limiters(cls):
+        return cls._CHECK_LIMITERS
+
+    @classmethod
+    def get_all_limiters(cls):
+        return cls.get_agent_limiters() + cls.get_check_limiters()
+
+    def __init__(self):
+        self._iteration = 0
+
+    def process(self, metrics, flush=False, report=False):
+        """
+        Asynchronous metric payload analysis
+        """
+        for m in metrics:
+            named_args = self._name_args(m[0:3], m[3], asynchronous=True)
+            self._check(named_args)
+
+        statuses = self.get_status(flush=flush)
+
+        # Report to Datadog when Governor limit is hit
+        overflow_statuses = filter(lambda s: s['trace']['overflow_metrics'], statuses)
+        if report and overflow_statuses:
+            self._report_to_datadog(overflow_statuses)
+
+        return statuses
+
+    def _report_to_datadog(self, status):
+        """
+        Agent hit the active contexts limit set by the Governor.
+        Send a warning email to Datadog team.
+        """
+        log.warning("Agent hit the active contexts limit set by the Governor."
+                    "Sending a warning to Datadog team")
+
+        try:
+            # FIXME set actual data, once endpoint is ready
+            data = ""
+            log.debug("Performing post {0} to url {1}".format(data, self._GOVERNOR_URL))
+
+            r = requests.post(self._GOVERNOR_URL, data=data, proxies=self._PROXY)
+            r.raise_for_status()
+        except (requests.ConnectionError, requests.exceptions.Timeout):
+            log.exception("Unable to connect to url {0}".format(self._GOVERNOR_URL))
+        except requests.exceptions.HTTPError as e:
+            log.exception("HTTP error {0}. Something went wrong.".format(e.response.status_code))
+
+    def get_status(self, flush=False):
+        """
+        Return limiter statuses and flush limiters
+        """
+        try:
+            statuses = [l.get_status() for l in self._limiters]
+        except TypeError:
+            log.exception("Governor instantiated before being set.")
+            return []
+
+        # Flush limiters
+        if flush:
+            for l in self._limiters:
+                l.flush(self._iteration - self._CONTEXTS_TTL)
+            self._iteration += 1
+
+        return statuses
+
+    def _name_args(self, arg_list, kwargs, asynchronous=False):
+        """
+        Name `arg_list` items and merge with `kwargs`
+        """
+        named_args = kwargs.copy()
+        for i, arg_value in enumerate(arg_list):
+            if asynchronous:
+                arg_name = self._METRIC_FORMAT[i]
+            else:
+                arg_name = self._submit_metric_arg_names[i + 1]
+            named_args[arg_name] = arg_value
+        return named_args
+
+    def _check(self, args):
+        """
+        Check metric against all limiters
+        """
+        try:
+            return all(r.check(self._iteration, args) for r in self._limiters)
+        except TypeError:
+            log.exception("Governor instantiated before being set.")
+            return True
+
+
+class CheckGovernor(Governor):
+    """
+    Monitor check's metric payload
+    """
+    def __init__(self):
+        super(CheckGovernor, self).__init__()
+        self._limiters = copy.deepcopy(self._CHECK_LIMITERS)
+
+    def process(self, metrics):
+        """
+        Asynchronous check's metric payload analysis. Do not report on anomalies.
+        """
+        return super(CheckGovernor, self).process(metrics, flush=False, report=False)
+
+    #####################################################
+    # Governor as a decorator  for `real-time` analysis #
+    #####################################################
+    # Deprecated: will be removed once confirmed #
+    ##############################################
+    def set(self, func):
+        """
+        Set governor to run as a decorator
+        """
+        self._submit_metric = func
+        self._submit_metric_arg_names = inspect.getargspec(func)[0]
+
+    def __call__(self, *args, **kw):
+        """
+        Decorator purpose around `submit_metric` method for 'real-time' analysis
+        """
+        # Shortcut when no rules are defined
+        if not self._limiters:
+            return self._submit_metric(*args, **kw)
+
+        # FIXME really dirty trick -> to improve
+        named_args = self._name_args(args, kw)
+
+        # Extract argument dict
+        if self._check(named_args):
+            return self._submit_metric(*args, **kw)
+
+
+class AgentGovernor(Governor):
+    """
+    Monitor entire collector's metric payload
+    """
+    def __init__(self):
+        super(AgentGovernor, self).__init__()
+        self._limiters = copy.deepcopy(self._AGENT_LIMITERS)
+
+    def process(self, metrics):
+        """
+        Asynchronous agent's metric payload analysis. Report on anomalies.
+        """
+        # FIXME keep `report` to False for now, until endpoint is ready
+        return super(AgentGovernor, self).process(metrics, flush=True, report=False)
+
+
+class LimiterParser(object):
+    """
+    Limiter parser
+    """
+    @staticmethod
+    def parse_limiters(config):
+        """
+        Parse limiter config to limiters
+        :param config: agent configuration
+        :type config: dictionnary
+        """
+        limiters = [Limiter(r.get('scope'), r.get('selection'), r.get('limit'))
+                    for r in config.get('limiters', [])]
+
+        # Split limiters in two categories:
+        # * Check limiters monitor check's metrics payload individually
+        # * Agent limiters monitor the entire collector payload
+        check_limiters = []
+        agent_limiters = []
+
+        for l in limiters:
+            if 'check' in l._scope:
+                check_limiters.append(l)
+            else:
+                agent_limiters.append(l)
+
+        return check_limiters, agent_limiters
+
+
+class Limiter(object):
+    """
+    A generic limiter
+    """
+    _ATOMS = frozenset(['name', 'agent', 'check', 'tags'])
+
+    def __init__(self, scope, selection, limit=None):
+        # Definition
+        self._scope, self._selection = self._make_scope_and_selection(scope, selection)
+        self._limit_cardinal = limit or "inf"
+
+        # Metric values extractor
+        self._extract_metric_keys = self._extract_to_keys(self._scope, self._selection)
+
+        # Limiter data structure
+        self._active_selections_by_scope = defaultdict(ExpiringSelection)
+
+        # Trace
+        self._overflow_metrics = 0
+
+    @classmethod
+    def _make_scope_and_selection(cls, scope, selection):
+        """
+        Check limiter `scope` and `selection` settings. Cast as a tuple and returns.
+
+        :param scope: scope where the rule applies
+        :type scope: string tuple or singleton
+
+        :param selection: selection where the rule applies
+        :type selection: string tuple or singleton
+        """
+        if not scope or not selection:
+            raise LimiterConfigError("Limiters must contain a `scope` and a `selection`.")
+
+        scope = scope if isinstance(scope, tuple) else (scope,)
+        selection = selection if isinstance(selection, tuple) else (selection,)
+
+        for s in scope:
+            if s not in cls._ATOMS:
+                raise LimiterConfigError("Unrecognized `{0}` within `scope`. `scope` must"
+                                         " be a subset of {1}".format(s, cls._ATOMS))
+        for s in selection:
+            if s not in cls._ATOMS:
+                raise LimiterConfigError("Unrecognized `{0}` within `selection`. `selection` must"
+                                         " be a subset of {1}".format(s, cls._ATOMS))
+
+        return scope, selection
+
+    @classmethod
+    def _extract_to_keys(cls, scope, selection):
+        """
+        Return a function that extracts scope and selection values from a metric
+
+        :param scope: scope where the rule applies
+        :type scope: string tuple or singleton
+
+        :param selection: selection where the rule applies
+        :type selection: string tuple or singleton
+        """
+        def get(d, k):
+            """
+            Return hashable d.get(k)
+            """
+            v = d.get(k)
+            if isinstance(v, list):
+                v = tuple(v)
+            return v
+
+        return lambda x: (tuple(get(x, k) for k in scope), tuple(get(x, k) for k in selection))
+
+    def check(self, ts, metric):
+        """
+        Limiter main task.
+        Check incoming metrics against the limit set, and returns a boolean
+
+        :param ts: metric timestamp (i.e. governor iteration)
+        :param metric: metric named parameters
+        """
+        scope_value, selection_value = self._extract_metric_keys(metric)
+
+        active_scope_selections = self._active_selections_by_scope[scope_value]
+
+        if selection_value in active_scope_selections:
+            active_scope_selections.add(selection_value, 1)
+            return True
+        else:
+            if len(active_scope_selections) >= self._limit_cardinal:
+                self._overflow_metrics += 1
+                log.warning("Metric overflow {0}. {1} hit the {2} limit set."
+                            .format(self._overflow_metrics, metric, self._limit_cardinal))
+                return False
+            active_scope_selections.add(selection_value, ts)
+            return True
+
+    def flush(self, max_timestamp):
+        """
+        Flush every scope's active selections
+        :param max_timestamp: cut off timestamp
+        """
+        for _, active_selections in self._active_selections_by_scope.iteritems():
+            active_selections.flush(max_timestamp)
+        self._overflow_metrics = 0
+
+    def get_status(self):
+        """
+        Return limiter trace:
+        `scope_cardinal`            -> Number of scopes registred
+        `overflow_metrics`          -> Number of overflow metrics
+        `scope_overflow_cardinal`   -> Number of scope with selection overflows
+        `max_selection_scope`       -> Scope with the maximum of selections registred
+        `max_selection_cardinal`    -> Maximum number of selections registred for a scope
+        """
+        scope_cardinal = len(self._active_selections_by_scope)
+        scope_overflow_cardinal = 0
+        max_selection_scope = None
+        max_selection_cardinal = 0
+
+        for scope, selections in self._active_selections_by_scope.iteritems():
+            if max_selection_cardinal < len(selections):
+                max_selection_cardinal = len(selections)
+                max_selection_scope = scope
+            if len(selections) >= self._limit_cardinal:
+                scope_overflow_cardinal += 1
+
+        return {
+            'definition': {
+                'scope': self._scope,
+                'selection': self._selection,
+                'limit': self._limit_cardinal
+            },
+            'trace': {
+                'scope_cardinal': scope_cardinal,
+                'overflow_metrics': self._overflow_metrics,
+                'scope_overflow_cardinal': scope_overflow_cardinal,
+                'max_selection_scope': max_selection_scope,
+                'max_selection_cardinal': max_selection_cardinal
+            }
+        }
+
+
+class ExpiringSelection(object):
+    """
+    Active selections storage
+    """
+    def __init__(self):
+        self._timestamp_by_selection = {}   # Active selections
+        self._selection_queue = deque()     # Selection timestamps window
+
+    def __len__(self):
+        """
+        Return unique not-expired selections cardinal
+        """
+        return len(self._timestamp_by_selection)
+
+    def __contains__(self, selection):
+        return selection in self._timestamp_by_selection
+
+    def add(self, selection, timestamp):
+        """
+        Add selection
+        """
+        self._timestamp_by_selection[selection] = timestamp
+        self._selection_queue.append((timestamp, selection))
+
+    def flush(self, max_timestamp):
+        """
+        Remove expired selections
+        """
+        while self._selection_queue and self._selection_queue[0][0] <= max_timestamp:
+            expiry, key = self._selection_queue.popleft()
+            if self._timestamp_by_selection.get(key) == expiry:
+                del self._timestamp_by_selection[key]


### PR DESCRIPTION
Collector and Checks metrics Governor is ready for review !

## What is a Limiter ?

A limiter is a rule set to monitor the metric stream.

It is defined by:
* a `scope`: scope where the rule applies
* a `selection`: selection where the rule applies
* an optional `limit`:  limit of selections per scope. 

`scope` and `selection` are defined as subset of `['name', 'agent', 'check', 'tags']` and allow to define 
custom rules. 
For instance
`'scope' = ('name', 'check') selection = 'tags'` monitors number of tags per (metric name, check)
`'scope' = 'agent'` `selection = 'name'` monitors globally the number of metrics names


Limiters keep tracks of 'active' selections (see point below), i.e. metrics's met selections on a sliding window, and count the number of metrics exceeding the limit set. 


## What an 'active' selection ?

A selection is considered as 'active', if it has been met at least once during the last `X` metrics stream batch processing, where `X` is a settable parameter. 


## What is a Governor ? 

A Governor supervises multiple limiters: submitting metric stream batches for checks, and reporting when an anomaly is detected.

Governors are split in two categories 
* CheckGovernor. 
Supervise `check` scoped limiters. 

* AgentGovernor.
Supervise wide scoped limiters. 
When a limiter hit the active selections limit, a warning is post to Datadog.

## Notes
For now the Governor is ready-only and does not alterate any payload.

### TO-DO
- [ ] Choose where to get Governor settings from (hardcoded for now)
- [ ] Define Governor settings
- [ ] Enable Governor report endpoint
- [ ] Add a Governor for Dogstatsd metrics