### PR TITLE
[ci] Use a bucket to download all tarballs :racehorse:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,16 @@ env:
   matrix:
     - TRAVIS_FLAVOR=default
     - TRAVIS_FLAVOR=apache
-    - TRAVIS_FLAVOR=cassandra
+    - TRAVIS_FLAVOR=cassandra FLAVOR_VERSION=2.0.13
+    - TRAVIS_FLAVOR=cassandra FLAVOR_VERSION=2.1.3
     - TRAVIS_FLAVOR=couchdb
     - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=0.90.13
     - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.0.3
     - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.1.2
     - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.2.4
     - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.3.7
-    - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.4.2
+    - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.4.4
+    - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.5.0
     - TRAVIS_FLAVOR=etcd
     - TRAVIS_FLAVOR=fluentd
     # FIXME: cannot enable gearman on Travis right now
@@ -46,20 +48,22 @@ env:
     - TRAVIS_FLAVOR=haproxy
     - TRAVIS_FLAVOR=lighttpd
     - TRAVIS_FLAVOR=memcache
-    - TRAVIS_FLAVOR=mongo
+    - TRAVIS_FLAVOR=mongo FLAVOR_VERSION=2.6.9
+    - TRAVIS_FLAVOR=mongo FLAVOR_VERSION=3.0.1
     - TRAVIS_FLAVOR=mysql
-    - TRAVIS_FLAVOR=nginx
+    - TRAVIS_FLAVOR=nginx FLAVOR_VERSION=1.6.2
+    - TRAVIS_FLAVOR=nginx FLAVOR_VERSION=1.7.11
     - TRAVIS_FLAVOR=pgbouncer
     - TRAVIS_FLAVOR=phpfpm
-    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION="9.0.18"
-    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION="9.1.14"
-    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION="9.2.9"
-    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION="9.3.5"
-    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION="9.4.0"
+    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION=9.0.19
+    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION=9.1.15
+    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION=9.2.10
+    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION=9.3.6
+    - TRAVIS_FLAVOR=postgres FLAVOR_VERSION=9.4.1
     - TRAVIS_FLAVOR=rabbitmq
-    - TRAVIS_FLAVOR=redis FLAVOR_VERSION="2.4"
-    - TRAVIS_FLAVOR=redis FLAVOR_VERSION="2.6"
-    - TRAVIS_FLAVOR=redis FLAVOR_VERSION="2.8"
+    - TRAVIS_FLAVOR=redis FLAVOR_VERSION=2.4.18
+    - TRAVIS_FLAVOR=redis FLAVOR_VERSION=2.6.17
+    - TRAVIS_FLAVOR=redis FLAVOR_VERSION=2.8.19
     - TRAVIS_FLAVOR=snmpd
     - TRAVIS_FLAVOR=ssh
     - TRAVIS_FLAVOR=supervisord

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,9 @@ env:
     - TRAVIS_FLAVOR=ssh
     - TRAVIS_FLAVOR=supervisord
     - TRAVIS_FLAVOR=sysstat
+# FIXME: reenable, but right now cannot run on Travis because
+# hugepages are enabled
+#    - TRAVIS_FLAVOR=tokumx
     - TRAVIS_FLAVOR=tomcat # JMX testing machine / need the other ones before
 
 # Override travis defaults with empty jobs

--- a/Rakefile
+++ b/Rakefile
@@ -27,6 +27,7 @@ require './ci/snmpd'
 require './ci/sysstat'
 require './ci/ssh'
 require './ci/supervisord'
+require './ci/tokumx'
 require './ci/tomcat'
 
 CLOBBER.include '**/*.pyc'

--- a/checks.d/tokumx.py
+++ b/checks.d/tokumx.py
@@ -393,6 +393,7 @@ class TokuMX(AgentCheck):
                         continue
                     m = 'stats.db.%s' % m
                     m = self.normalize(m, 'tokumx')
+                    # FIXME: here tokumx.stats.db.* are potentially unbounded
                     self.gauge(m, v, db_tags)
                 for collname in db.collection_names(False):
                     stats = db.command('collStats', collname)
@@ -408,6 +409,7 @@ class TokuMX(AgentCheck):
                                 for k in ['queries', 'nscanned', 'nscannedObjects', 'inserts', 'deletes']:
                                     key = (dbname, collname, idx_stats['name'])
                                     self.submit_idx_rate('tokumx.statsd.idx.%s' % k, idx_stats[k], tags=db_tags, key=key)
+                        # FIXME: here tokumx.stats.coll.* are potentially unbounded
                         elif type(v) in (types.IntType, types.LongType, types.FloatType):
                             self.histogram('tokumx.stats.coll.%s' % m, v, db_tags)
 

--- a/ci/apache.rb
+++ b/ci/apache.rb
@@ -51,6 +51,7 @@ namespace :ci do
       sh %(sed -i -e "s@%VOLATILE_DIR%@$VOLATILE_DIR@"\
             #{apache_rootdir}/conf/httpd.conf)
       sh %(#{apache_rootdir}/bin/apachectl start)
+      sleep_for 2
       # Simulate activity to populate metrics
       100.times do
         sh %(curl --silent http://localhost:8080 > /dev/null)

--- a/ci/apache.rb
+++ b/ci/apache.rb
@@ -1,7 +1,7 @@
 require './ci/common'
 
 def apache_version
-  ENV['APACHE_VERSION'] || '2.4.10'
+  ENV['FLAVOR_VERSION'] || '2.4.12'
 end
 
 def apache_rootdir
@@ -14,15 +14,18 @@ namespace :ci do
 
     task :install => ['ci:common:install'] do
       unless Dir.exist? File.expand_path(apache_rootdir)
+        # Downloads:
+        # http://httpd.apache.org/download.cgi#apache24
+        # apr/apr-util on any apache mirror https://www.apache.org/mirrors/
         sh %(curl -s -L\
              -o $VOLATILE_DIR/httpd-#{apache_version}.tar.bz2\
-             http://mirror.cc.columbia.edu/pub/software/apache/httpd/httpd-#{apache_version}.tar.bz2)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/httpd-#{apache_version}.tar.bz2)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/apr.tar.bz2\
-             http://mirror.cc.columbia.edu/pub/software/apache/apr/apr-1.5.1.tar.bz2)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/apr-1.5.1.tar.bz2)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/apr-util.tar.bz2\
-             http://mirror.cc.columbia.edu/pub/software/apache/apr/apr-util-1.5.4.tar.bz2)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/apr-util-1.5.4.tar.bz2)
         sh %(mkdir -p #{apache_rootdir})
         sh %(mkdir -p $VOLATILE_DIR/apache)
         sh %(tar jxf $VOLATILE_DIR/httpd-#{apache_version}.tar.bz2\

--- a/ci/cassandra.rb
+++ b/ci/cassandra.rb
@@ -2,7 +2,7 @@ require './ci/common'
 
 # TODO: make this available in the matrix
 def cass_version
-  ENV['FLAVOR_VERSION'] || '2.1.13'
+  ENV['FLAVOR_VERSION'] || '2.1.3'
 end
 
 def cass_rootdir
@@ -27,7 +27,10 @@ namespace :ci do
     end
 
     task :before_script => ['ci:common:before_script'] do
-      sh %(#{cass_rootdir}/bin/cassandra)
+      sh %(cp $TRAVIS_BUILD_DIR/ci/resources/cassandra/cassandra_#{cass_version.split('.')[0..1].join('.')}.yaml #{cass_rootdir}/conf/cassandra.yaml)
+      sh %(#{cass_rootdir}/bin/cassandra -p $VOLATILE_DIR/cass.pid)
+      # Create temp cassandra workdir
+      sh %(mkdir -p $VOLATILE_DIR/cassandra)
       # Wait for cassandra to init
       sleep_for 10
     end
@@ -44,7 +47,7 @@ namespace :ci do
     task :cache => ['ci:common:cache']
 
     task cleanup: ['ci:common:cleanup'] do
-      # FIXME: stop cass
+      sh %(kill `cat $VOLATILE_DIR/cass.pid`)
     end
 
     task :execute do

--- a/ci/cassandra.rb
+++ b/ci/cassandra.rb
@@ -2,7 +2,7 @@ require './ci/common'
 
 # TODO: make this available in the matrix
 def cass_version
-  ENV['CASS_VERSION'] || '2.1.1'
+  ENV['FLAVOR_VERSION'] || '2.1.13'
 end
 
 def cass_rootdir
@@ -15,9 +15,11 @@ namespace :ci do
 
     task :install => ['ci:common:install'] do
       unless Dir.exist? File.expand_path(cass_rootdir)
+        # Downloads
+        # http://cassandra.apache.org/download/
         sh %(curl -s -L\
              -o $VOLATILE_DIR/apache-cassandra-#{cass_version}-bin.tar.gz\
-              http://apache.petsads.us/cassandra/#{cass_version}/apache-cassandra-#{cass_version}-bin.tar.gz)
+              https://s3.amazonaws.com/dd-agent-tarball-mirror/apache-cassandra-#{cass_version}-bin.tar.gz)
         sh %(mkdir -p #{cass_rootdir})
         sh %(tar zxf $VOLATILE_DIR/apache-cassandra-#{cass_version}-bin.tar.gz\
              -C #{cass_rootdir} --strip-components=1)

--- a/ci/common.rb
+++ b/ci/common.rb
@@ -41,6 +41,7 @@ namespace :ci do
 
     task :install do |t|
       section('INSTALL')
+      sh %(pip install --upgrade pip setuptools)
       sh %(pip install\
            -r requirements.txt\
            --cache-dir $PIP_CACHE\

--- a/ci/couchdb.rb
+++ b/ci/couchdb.rb
@@ -1,9 +1,7 @@
 require './ci/common'
 
-# FIXME: use our own brew of couchdb
-
 def couchdb_version
-  ENV['COUCHDB_VERSION']  || '1.6.1'
+  ENV['FLAVOR_VERSION']  || '1.6.1'
 end
 
 def couchdb_rootdir
@@ -16,18 +14,23 @@ namespace :ci do
 
     task :install => ['ci:common:install'] do
       unless Dir.exist? File.expand_path(couchdb_rootdir)
+        # Downloads
+        # http://www.erlang.org/download/otp_src_17.4.tar.gz
+        # http://mirrors.gigenet.com/apache/couchdb/source/#{couchdb_version}/apache-couchdb-#{couchdb_version}.tar.gz
+        # http://ftp.mozilla.org/pub/mozilla.org/js/js185-1.0.0.tar.gz
+        # http://download.icu-project.org/files/icu4c/54.1/icu4c-54_1-src.tgz
         sh %(curl -s -L\
              -o $VOLATILE_DIR/erlang.tar.gz\
-             http://www.erlang.org/download/otp_src_17.4.tar.gz)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/otp_src_17.4.tar.gz)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/couchdb-#{couchdb_version}.tar.gz\
-             http://mirrors.gigenet.com/apache/couchdb/source/#{couchdb_version}/apache-couchdb-#{couchdb_version}.tar.gz)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/apache-couchdb-#{couchdb_version}.tar.gz)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/js185.tar.gz\
-             http://ftp.mozilla.org/pub/mozilla.org/js/js185-1.0.0.tar.gz)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/js185-1.0.0.tar.gz)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/icu.tar.gz\
-             http://download.icu-project.org/files/icu4c/54.1/icu4c-54_1-src.tgz)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/icu4c-54_1-src.tgz)
         sh %(mkdir -p $VOLATILE_DIR/couchdb)
         sh %(mkdir -p $VOLATILE_DIR/js185)
         sh %(mkdir -p $VOLATILE_DIR/icu)

--- a/ci/elasticsearch.rb
+++ b/ci/elasticsearch.rb
@@ -14,9 +14,11 @@ namespace :ci do
 
     task :install => ['ci:common:install'] do
       unless Dir.exist? File.expand_path(es_rootdir)
+        # Downloads
+        # https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-#{es_version}.tar.gz
         sh %(curl -s -L\
              -o $VOLATILE_DIR/elasticsearch-#{es_version}.tar.gz\
-             https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-#{es_version}.tar.gz)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/elasticsearch-#{es_version}.tar.gz)
         sh %(mkdir -p #{es_rootdir})
         sh %(tar zxf $VOLATILE_DIR/elasticsearch-#{es_version}.tar.gz\
              -C #{es_rootdir} --strip-components=1)

--- a/ci/etcd.rb
+++ b/ci/etcd.rb
@@ -1,7 +1,7 @@
 require './ci/common'
 
 def etcd_version
-  ENV['ETCD_VERSION'] || '2.0.3'
+  ENV['FLAVOR_VERSION'] || '2.0.5'
 end
 
 def etcd_rootdir
@@ -14,15 +14,18 @@ namespace :ci do
 
     task :install => ['ci:common:install'] do
       unless Dir.exist? File.expand_path(etcd_rootdir)
+        # Downloads:
+        # https://github.com/coreos/etcd/releases/download/v#{etcd_version}/etcd-v#{etcd_version}-darwin-amd64.zip
+        # https://github.com/coreos/etcd/releases/download/v#{etcd_version}/etcd-v#{etcd_version}-linux-amd64.tar.gz
         if `uname -s`.strip.downcase == 'darwin'
           sh %(curl -s -L -o $VOLATILE_DIR/etcd.zip\
-                https://github.com/coreos/etcd/releases/download/v#{etcd_version}/etcd-v#{etcd_version}-darwin-amd64.zip)
+                https://s3.amazonaws.com/dd-agent-tarball-mirror/etcd-v#{etcd_version}-darwin-amd64.zip)
           sh %(mkdir -p #{etcd_rootdir})
           sh %(unzip -d $VOLATILE_DIR/ -x $VOLATILE_DIR/etcd.zip)
           sh %(mv -f $VOLATILE_DIR/etcd-*/* #{etcd_rootdir})
         else
           sh %(curl -s -L -o $VOLATILE_DIR/etcd.tar.gz\
-                https://github.com/coreos/etcd/releases/download/v#{etcd_version}/etcd-v#{etcd_version}-linux-amd64.tar.gz)
+                https://s3.amazonaws.com/dd-agent-tarball-mirror/etcd-v#{etcd_version}-linux-amd64.tar.gz)
           sh %(mkdir -p #{etcd_rootdir})
           sh %(tar xzvf $VOLATILE_DIR/etcd.tar.gz\
                         -C #{etcd_rootdir}\

--- a/ci/gearman.rb
+++ b/ci/gearman.rb
@@ -14,9 +14,11 @@ namespace :ci do
 
     task :install => ['ci:common:install'] do
       unless Dir.exist? File.expand_path(gearman_rootdir)
+        # Downloads
+        # https://launchpad.net/gearmand/#{gearman_version[0..2]}/#{gearman_version}/+download/gearmand-#{gearman_version}.tar.gz
         sh %(curl -s -L\
              -o $VOLATILE_DIR/gearman-#{gearman_version}.tar.gz\
-             https://launchpad.net/gearmand/#{gearman_version[0..2]}/#{gearman_version}/+download/gearmand-#{gearman_version}.tar.gz)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/gearmand-#{gearman_version}.tar.gz)
         sh %(mkdir -p $VOLATILE_DIR/gearman)
         sh %(tar zxf $VOLATILE_DIR/gearman-#{gearman_version}.tar.gz\
              -C $VOLATILE_DIR/gearman --strip-components=1)

--- a/ci/haproxy.rb
+++ b/ci/haproxy.rb
@@ -23,8 +23,14 @@ namespace :ci do
         sh %(mkdir -p $VOLATILE_DIR/haproxy)
         sh %(tar zxf $VOLATILE_DIR/haproxy-#{haproxy_version}.tar.gz\
              -C $VOLATILE_DIR/haproxy --strip-components=1)
+
+        if `uname`.strip == 'Darwin'
+          target = 'mac'
+        else
+          target = 'linux2628'
+        end
         sh %(cd $VOLATILE_DIR/haproxy\
-             && make -j $CONCURRENCY TARGET=linux2628 USE_PCRE=1 USE_OPENSSL=1 USE_ZLIB=1)
+             && make -j $CONCURRENCY TARGET=#{target} USE_PCRE=1 USE_OPENSSL=1 USE_ZLIB=1)
         sh %(cp $VOLATILE_DIR/haproxy/haproxy #{haproxy_rootdir})
         # FIXME: use that we don't start haproxy in the tests
         sh %(mkdir -p #{ENV['INTEGRATIONS_DIR']}/bin)

--- a/ci/haproxy.rb
+++ b/ci/haproxy.rb
@@ -1,7 +1,7 @@
 require './ci/common'
 
 def haproxy_version
-  ENV['HAPROXY_VERSION'] || '1.5.10'
+  ENV['FLAVOR_VERSION'] || '1.5.11'
 end
 
 def haproxy_rootdir
@@ -14,9 +14,11 @@ namespace :ci do
 
     task :install => ['ci:common:install'] do
       unless Dir.exist? File.expand_path(haproxy_rootdir)
+        # Downloads
+        # http://www.haproxy.org/download/#{haproxy_version[0..2]}/src/haproxy-#{haproxy_version}.tar.gz
         sh %(curl -s -L\
              -o $VOLATILE_DIR/haproxy-#{haproxy_version}.tar.gz\
-             http://www.haproxy.org/download/#{haproxy_version[0..2]}/src/haproxy-#{haproxy_version}.tar.gz)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/haproxy-#{haproxy_version}.tar.gz)
         sh %(mkdir -p #{haproxy_rootdir})
         sh %(mkdir -p $VOLATILE_DIR/haproxy)
         sh %(tar zxf $VOLATILE_DIR/haproxy-#{haproxy_version}.tar.gz\

--- a/ci/lighttpd.rb
+++ b/ci/lighttpd.rb
@@ -1,7 +1,7 @@
 require './ci/common'
 
 def lighttpd_version
-  ENV['LIGHTTPD_VERSION'] || '1.4.35'
+  ENV['FLAVOR_VERSION'] || '1.4.35'
 end
 
 def lighttpd_rootdir
@@ -14,9 +14,11 @@ namespace :ci do
 
     task :install => ['ci:common:install'] do
       unless Dir.exist? File.expand_path(lighttpd_rootdir)
+        # Downloads
+        # http://download.lighttpd.net/lighttpd/releases-#{lighttpd_version[0..2]}.x/lighttpd-#{lighttpd_version}.tar.gz
         sh %(curl -s -L\
              -o $VOLATILE_DIR/lighttpd-#{lighttpd_version}.tar.gz\
-             http://download.lighttpd.net/lighttpd/releases-#{lighttpd_version[0..2]}.x/lighttpd-#{lighttpd_version}.tar.gz)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/lighttpd-#{lighttpd_version}.tar.gz)
         sh %(mkdir -p #{lighttpd_rootdir})
         sh %(mkdir -p $VOLATILE_DIR/lighttpd)
         sh %(tar zxf $VOLATILE_DIR/lighttpd-#{lighttpd_version}.tar.gz\

--- a/ci/memcache.rb
+++ b/ci/memcache.rb
@@ -15,9 +15,11 @@ namespace :ci do
 
     task :install => ['ci:common:install'] do
       unless Dir.exist? File.expand_path(memcache_rootdir)
+        # Downloads
+        # http://memcached.org/files/memcached-#{memcache_version}.tar.gz
         sh %(curl -s -L\
              -o $VOLATILE_DIR/memcached-#{memcache_version}.tar.gz\
-              http://memcached.org/files/memcached-#{memcache_version}.tar.gz)
+              https://s3.amazonaws.com/dd-agent-tarball-mirror/memcached-#{memcache_version}.tar.gz)
         sh %(mkdir -p #{memcache_rootdir})
         sh %(tar zxf $VOLATILE_DIR/memcached-#{memcache_version}.tar.gz\
              -C #{memcache_rootdir} --strip-components=1)

--- a/ci/mongo.rb
+++ b/ci/mongo.rb
@@ -1,8 +1,7 @@
 require './ci/common'
 
-# TODO: make this available in the matrix
 def mongo_version
-  '2.6.6'
+  ENV['FLAVOR_VERSION'] || '3.0.1'
 end
 
 def mongo_rootdir
@@ -15,11 +14,13 @@ namespace :ci do
 
     task :install => ['ci:common:install'] do
       unless Dir.exist? File.expand_path(mongo_rootdir)
+        # Downloads
+        # https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-#{mongo_version}.tgz
         sh %(curl -s -L\
-             -o $VOLATILE_DIR/mongodb-linux-x86_64-2.6.6.tgz\
-             https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-2.6.6.tgz)
+             -o $VOLATILE_DIR/mongodb-linux-x86_64-#{mongo_version}.tgz\
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/mongodb-linux-x86_64-#{mongo_version}.tgz)
         sh %(mkdir -p #{mongo_rootdir})
-        sh %(tar zxf $VOLATILE_DIR/mongodb-linux-x86_64-2.6.6.tgz\
+        sh %(tar zxf $VOLATILE_DIR/mongodb-linux-x86_64-#{mongo_version}.tgz\
              -C #{mongo_rootdir} --strip-components=1)
       end
     end

--- a/ci/nginx.rb
+++ b/ci/nginx.rb
@@ -1,7 +1,7 @@
 require './ci/common'
 
 def nginx_version
-  ENV['NGINX_VERSION'] || '1.7.9'
+  ENV['FLAVOR_VERSION'] || '1.7.11'
 end
 
 def nginx_rootdir
@@ -13,10 +13,12 @@ namespace :ci do
     task :before_install => ['ci:common:before_install']
 
     task :install => ['ci:common:install'] do
+      # Downloads
+      # http://nginx.org/download/nginx-#{nginx_version}.tar.gz
       unless Dir.exist? File.expand_path(nginx_rootdir)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/nginx-#{nginx_version}.tar.gz\
-             http://nginx.org/download/nginx-#{nginx_version}.tar.gz)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/nginx-#{nginx_version}.tar.gz)
         sh %(mkdir -p #{nginx_rootdir})
         sh %(mkdir -p $VOLATILE_DIR/nginx)
         sh %(tar zxf $VOLATILE_DIR/nginx-#{nginx_version}.tar.gz\

--- a/ci/pgbouncer.rb
+++ b/ci/pgbouncer.rb
@@ -12,9 +12,10 @@ namespace :ci do
     task :install do
       Rake::Task['ci:postgres:install'].invoke
       unless Dir.exist? File.expand_path(pgb_rootdir)
-        sh %(wget -O $VOLATILE_DIR/pgbouncer-1.5.4.tar.gz https://s3.amazonaws.com/dd-agent-tarball-mirror/pgbouncer-1.5.4.tar.gz)
+        # upstream link: https://github.com/markokr/pgbouncer-dev/archive/pgbouncer_1_5_4.tar.gz
+        sh %(wget -O $VOLATILE_DIR/pgbouncer_1_5_4.tar.gz https://s3.amazonaws.com/dd-agent-tarball-mirror/pgbouncer_1_5_4.tar.gz)
         sh %(mkdir -p $VOLATILE_DIR/pgbouncer)
-        sh %(tar xzf $VOLATILE_DIR/pgbouncer-1.5.4.tar.gz\
+        sh %(tar xzf $VOLATILE_DIR/pgbouncer_1_5_4.tar.gz\
              -C $VOLATILE_DIR/pgbouncer --strip-components=1)
         sh %(mkdir -p #{pgb_rootdir})
         sh %(cd $VOLATILE_DIR/pgbouncer\

--- a/ci/pgbouncer.rb
+++ b/ci/pgbouncer.rb
@@ -13,12 +13,13 @@ namespace :ci do
       Rake::Task['ci:postgres:install'].invoke
       unless Dir.exist? File.expand_path(pgb_rootdir)
         # upstream link: https://github.com/markokr/pgbouncer-dev/archive/pgbouncer_1_5_4.tar.gz
-        sh %(wget -O $VOLATILE_DIR/pgbouncer_1_5_4.tar.gz https://s3.amazonaws.com/dd-agent-tarball-mirror/pgbouncer_1_5_4.tar.gz)
-        sh %(mkdir -p $VOLATILE_DIR/pgbouncer)
-        sh %(tar xzf $VOLATILE_DIR/pgbouncer_1_5_4.tar.gz\
-             -C $VOLATILE_DIR/pgbouncer --strip-components=1)
         sh %(mkdir -p #{pgb_rootdir})
+        sh %(git clone https://github.com/markokr/pgbouncer-dev $VOLATILE_DIR/pgbouncer)
         sh %(cd $VOLATILE_DIR/pgbouncer\
+             && git checkout pgbouncer_1_5_4\
+             && git submodule init\
+             && git submodule update\
+             && ./autogen.sh\
              && ./configure --prefix=#{pgb_rootdir}\
              && make\
              && cp pgbouncer #{pgb_rootdir})

--- a/ci/pgbouncer.rb
+++ b/ci/pgbouncer.rb
@@ -5,7 +5,6 @@ def pgb_rootdir
   "#{ENV['INTEGRATIONS_DIR']}/pgbouncer"
 end
 
-
 namespace :ci do
   namespace :pgbouncer do |flavor|
     task :before_install => ['ci:common:before_install']
@@ -13,7 +12,7 @@ namespace :ci do
     task :install do
       Rake::Task['ci:postgres:install'].invoke
       unless Dir.exist? File.expand_path(pgb_rootdir)
-        sh %(wget -O $VOLATILE_DIR/pgbouncer-1.5.4.tar.gz https://s3.amazonaws.com/travis-archive/pgbouncer-1.5.4.tar.gz)
+        sh %(wget -O $VOLATILE_DIR/pgbouncer-1.5.4.tar.gz https://s3.amazonaws.com/dd-agent-tarball-mirror/pgbouncer-1.5.4.tar.gz)
         sh %(mkdir -p $VOLATILE_DIR/pgbouncer)
         sh %(tar xzf $VOLATILE_DIR/pgbouncer-1.5.4.tar.gz\
              -C $VOLATILE_DIR/pgbouncer --strip-components=1)

--- a/ci/phpfpm.rb
+++ b/ci/phpfpm.rb
@@ -1,11 +1,11 @@
 require './ci/common'
 
 def nginx_version
-  ENV['NGINX_VERSION'] || '1.7.9'
+  ENV['NGINX_VERSION'] || '1.7.11'
 end
 
 def php_version
-  ENV['PHP_VERSION'] || '5.6.6'
+  ENV['PHP_VERSION'] || '5.6.7'
 end
 
 def phpfpm_rootdir
@@ -17,10 +17,13 @@ namespace :ci do
     task :before_install => ['ci:common:before_install']
 
     task :install => ['ci:common:install'] do
+      # Downloads
+      # http://nginx.org/download/nginx-#{nginx_version}.tar.gz
+      # http://us1.php.net/get/php-#{php_version}.tar.bz2/from/this/mirror
       unless Dir.exist? File.expand_path(phpfpm_rootdir)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/nginx-#{nginx_version}.tar.gz\
-             http://nginx.org/download/nginx-#{nginx_version}.tar.gz)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/nginx-#{nginx_version}.tar.gz)
         sh %(mkdir -p #{phpfpm_rootdir})
         sh %(mkdir -p $VOLATILE_DIR/nginx)
         sh %(tar zxf $VOLATILE_DIR/nginx-#{nginx_version}.tar.gz\
@@ -31,7 +34,7 @@ namespace :ci do
              && make install)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/php-#{php_version}.tar.bz2\
-             http://us1.php.net/get/php-#{php_version}.tar.bz2/from/this/mirror)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/php-#{php_version}.tar.bz2)
         sh %(mkdir -p $VOLATILE_DIR/php)
         sh %(tar jxf $VOLATILE_DIR/php-#{php_version}.tar.bz2\
              -C $VOLATILE_DIR/php --strip-components=1)

--- a/ci/postgres.rb
+++ b/ci/postgres.rb
@@ -1,7 +1,7 @@
 require './ci/common'
 
 def raw_pg_version
-  ENV['FLAVOR_VERSION'] || '9.4.0'
+  ENV['FLAVOR_VERSION'] || '9.4.1'
 end
 
 def pg_version
@@ -17,10 +17,12 @@ namespace :ci do
     task :before_install => ['ci:common:before_install']
 
     task :install => ['ci:common:install'] do
+      # Downloads
+      # https://github.com/postgres/postgres/archive/#{pg_version}.tar.gz
       unless Dir.exist? File.expand_path(pg_rootdir)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/postgres-#{pg_version}.tar.gz\
-             https://github.com/postgres/postgres/archive/#{pg_version}.tar.gz)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/#{pg_version}.tar.gz)
         sh %(mkdir -p $VOLATILE_DIR/postgres)
         sh %(tar zxf $VOLATILE_DIR/postgres-#{pg_version}.tar.gz\
              -C $VOLATILE_DIR/postgres --strip-components=1)

--- a/ci/rabbitmq.rb
+++ b/ci/rabbitmq.rb
@@ -2,7 +2,7 @@ require './ci/common'
 
 # TODO: make this available in the matrix
 def rabbitmq_version
-  '3.4.3'
+  '3.5.0'
 end
 
 def rabbitmq_rootdir
@@ -14,12 +14,14 @@ namespace :ci do
     task :before_install => ['ci:common:before_install']
 
     task :install => ['ci:common:install'] do
+      # Downloads
+      # http://www.rabbitmq.com/releases/rabbitmq-server/v#{mongo_version}/rabbitmq-server-generic-unix-#{mongo_version}.tar.gz
       unless Dir.exist? File.expand_path(rabbitmq_rootdir)
         sh %(curl -s -L\
-             -o $VOLATILE_DIR/rabbitmq-server-generic-unix-3.4.3.tar.gz\
-             http://www.rabbitmq.com/releases/rabbitmq-server/v3.4.3/rabbitmq-server-generic-unix-3.4.3.tar.gz)
+             -o $VOLATILE_DIR/rabbitmq-server-generic-unix-#{rabbitmq_version}.tar.gz\
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/rabbitmq-server-generic-unix-#{rabbitmq_version}.tar.gz)
         sh %(mkdir -p #{rabbitmq_rootdir})
-        sh %(tar zxf $VOLATILE_DIR/rabbitmq-server-generic-unix-3.4.3.tar.gz\
+        sh %(tar zxf $VOLATILE_DIR/rabbitmq-server-generic-unix-#{rabbitmq_version}.tar.gz\
              -C #{rabbitmq_rootdir} --strip-components=1)
       end
     end

--- a/ci/redis.rb
+++ b/ci/redis.rb
@@ -1,7 +1,7 @@
 require './ci/common'
 
 def redis_version
-  ENV['REDIS_VERSION'] || '2.8'
+  ENV['FLAVOR_VERSION'] || '2.8.19'
 end
 
 def redis_rootdir
@@ -13,10 +13,12 @@ namespace :ci do
     task :before_install => ['ci:common:before_install']
 
     task :install => ['ci:common:install'] do
+      # Downloads
+      # https://github.com/antirez/redis/archive/#{redis_version}.zip
       unless Dir.exist? File.expand_path(redis_rootdir)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/redis.zip\
-             https://github.com/antirez/redis/archive/#{redis_version}.zip)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/redis-#{redis_version}.zip)
         sh %(mkdir -p #{redis_rootdir})
         sh %(mkdir -p $VOLATILE_DIR/redis)
         sh %(unzip -x $VOLATILE_DIR/redis.zip -d $VOLATILE_DIR/)

--- a/ci/resources/cache.rb
+++ b/ci/resources/cache.rb
@@ -23,6 +23,7 @@
 # Original file:
 # https://github.com/travis-ci/travis-build/blob/d1c3be0b6aec5989872f9c534185585108125d0d/lib/travis/build/script/shared/directory_cache/s3.rb
 
+require 'digest/md5'
 require 'shellwords'
 
 require './ci/resources/cache/aws4_signature'
@@ -70,9 +71,13 @@ class Cache
     @data = data
     @start = start
     @msgs = []
-    @slug = ENV['TRAVIS_FLAVOR'] || (0...50).map { ('a'..'z').to_a[rand(26)] }.join
+    @slug = ENV['TRAVIS_FLAVOR']
     @slug += '-' + ENV['FLAVOR_VERSION'] if ENV['FLAVOR_VERSION']
+    # the cached artifacts depend on the CI file version
+    @slug += '-' + Digest::MD5.hexdigest(File.read("#{ENV['TRAVIS_BUILD_DIR']}/ci/#{ENV['TRAVIS_FLAVOR']}.rb"))
     @directories = []
+
+    puts "SLUG #{@slug}"
   end
 
   def valid?

--- a/ci/resources/cassandra/cassandra_2.0.yaml
+++ b/ci/resources/cassandra/cassandra_2.0.yaml
@@ -1,0 +1,709 @@
+# Cassandra storage config YAML 
+
+# NOTE:
+#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   full explanations of configuration directives
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+cluster_name: 'Test Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+#
+# If you leave this unspecified, Cassandra will use the default of 1 token for legacy compatibility,
+# and will use the initial_token as described below.
+#
+# Specifying initial_token will override this setting on the node's initial start,
+# on subsequent starts, this setting will apply even if initial token is set.
+#
+# If you already have a cluster with 1 token per node, and wish to migrate to 
+# multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
+num_tokens: 256
+
+# initial_token allows you to specify tokens manually.  While you can use # it with
+# vnodes (num_tokens > 1, above) -- in which case you should provide a 
+# comma-separated list -- it's primarily used when adding nodes # to legacy clusters 
+# that do not have vnodes enabled.
+# initial_token:
+
+# May either be "true" or "false" to enable globally, or contain a list
+# of data centers to enable per-datacenter.
+# hinted_handoff_enabled: DC1,DC2
+# See http://wiki.apache.org/cassandra/HintedHandoff
+hinted_handoff_enabled: true
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+max_hint_window_in_ms: 10800000 # 3 hours
+# Maximum throttle in KBs per second, per delivery thread.  This will be
+# reduced proportionally to the number of nodes in the cluster.  (If there
+# are two nodes in the cluster, each delivery thread will use the maximum
+# rate; if there are three, each will throttle to half of the maximum,
+# since we expect two nodes to be delivering hints simultaneously.)
+hinted_handoff_throttle_in_kb: 1024
+# Number of threads with which to deliver hints;
+# Consider increasing this number when you have multi-dc deployments, since
+# cross-dc handoff tends to be slower
+max_hints_delivery_threads: 2
+
+# Maximum throttle in KBs per second, total. This will be
+# reduced proportionally to the number of nodes in the cluster.
+batchlog_replay_throttle_in_kb: 1024
+
+# Authentication backend, implementing IAuthenticator; used to identify users
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+authenticator: AllowAllAuthenticator
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+authorizer: AllowAllAuthorizer
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+permissions_validity_in_ms: 2000
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 1000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Besides Murmur3Partitioner, partitioners included for backwards
+# compatibility include RandomPartitioner, ByteOrderedPartitioner, and
+# OrderPreservingPartitioner.
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Directories where Cassandra should store data on disk.  Cassandra
+# will spread data evenly across them, subject to the granularity of
+# the configured compaction strategy.
+data_file_directories:
+    - /tmp/cassandra/data
+
+# commit log
+commitlog_directory: /tmp/cassandra/commitlog
+
+# policy for data disk failures:
+# stop_paranoid: shut down gossip and Thrift even for single-sstable errors.
+# stop: shut down gossip and Thrift, leaving the node effectively dead, but
+#       can still be inspected via JMX.
+# best_effort: stop using the failed disk and respond to requests based on
+#              remaining available sstables.  This means you WILL see obsolete
+#              data at CL.ONE!
+# ignore: ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
+disk_failure_policy: stop
+
+# policy for commit disk failures:
+# stop: shut down gossip and Thrift, leaving the node effectively dead, but
+#       can still be inspected via JMX.
+# stop_commit: shutdown the commit log, letting writes collect but 
+#              continuing to service reads, as in pre-2.0.5 Cassandra
+# ignore: ignore fatal errors and let the batches fail
+commit_failure_policy: stop
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must contain the entire row,
+# so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
+key_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the key cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 14400 or 4 hours.
+key_cache_save_period: 14400
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# key_cache_keys_to_save: 100
+
+# Maximum size of the row cache in memory.
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is 0, to disable row caching.
+row_cache_size_in_mb: 0
+
+# Duration in seconds after which Cassandra should
+# safe the row cache. Caches are saved to saved_caches_directory as specified
+# in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
+row_cache_save_period: 0
+
+# Number of keys from the row cache to save
+# Disabled by default, meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+
+# The off-heap memory allocator.  Affects storage engine metadata as
+# well as caches.  Experiments show that JEMAlloc saves some memory
+# than the native GCC allocator (i.e., JEMalloc is more
+# fragmentation-resistant).
+# 
+# Supported values are: NativeAllocator, JEMallocAllocator
+#
+# If you intend to use JEMallocAllocator you have to install JEMalloc as library and
+# modify cassandra-env.sh as directed in the file.
+#
+# Defaults to NativeAllocator
+# memory_allocator: NativeAllocator
+
+# saved caches
+saved_caches_directory: /tmp/cassandra/saved_caches
+
+# commitlog_sync may be either "periodic" or "batch." 
+# When in batch mode, Cassandra won't ack writes until the commit log
+# has been fsynced to disk.  It will wait up to
+# commitlog_sync_batch_window_in_ms milliseconds for other writes, before
+# performing the sync.
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 50
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.  By default this allows 1024*(CPU cores) pending
+# entries on the commitlog queue.  If you are writing very large blobs,
+# you should reduce that; 16*cores works reasonably well for 1MB blobs.
+# It should be at least as large as the concurrent_writes setting.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+# commitlog_periodic_queue_size:
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.  
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+commitlog_segment_size_in_mb: 32
+
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
+seed_provider:
+    # Addresses of hosts that are deemed contact points. 
+    # Cassandra nodes use this list of hosts to find each other and learn
+    # the topology of the ring.  You must change this if you are running
+    # multiple nodes!
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          # seeds is actually a comma-delimited list of addresses.
+          # Ex: "<ip1>,<ip2>,<ip3>"
+          - seeds: "127.0.0.1"
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_reads: 32
+concurrent_writes: 32
+
+# Total memory to use for sstable-reading buffers.  Defaults to
+# the smaller of 1/4 of heap or 512MB.
+# file_cache_size_in_mb: 512
+
+# Total memory to use for memtables.  Cassandra will flush the largest
+# memtable when this much memory is used.
+# If omitted, Cassandra will set it to 1/4 of the heap.
+# memtable_total_space_in_mb: 2048
+
+# Total space to use for commitlogs.  Since commitlog segments are
+# mmapped, and hence use up address space, the default size is 32
+# on 32-bit JVMs, and 1024 on 64-bit JVMs.
+#
+# If space gets above this value (it will round up to the next nearest
+# segment multiple), Cassandra will flush every dirty CF in the oldest
+# segment and remove it.  So a small total commitlog space will tend
+# to cause more flush activity on less-active columnfamilies.
+# commitlog_total_space_in_mb: 4096
+
+# This sets the amount of memtable flush writer threads.  These will
+# be blocked by disk io, and each one will hold a memtable in memory
+# while blocked. If you have a large heap and many data directories,
+# you can increase this value for better flush performance.
+# By default this will be set to the amount of data directories defined.
+#memtable_flush_writers: 1
+
+# the number of full memtables to allow pending flush, that is,
+# waiting for a writer thread.  At a minimum, this should be set to
+# the maximum number of secondary indexes created on a single CF.
+memtable_flush_queue_size: 4
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSDs; not
+# necessarily on platters.
+trickle_fsync: false
+trickle_fsync_interval_in_kb: 10240
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+storage_port: 7000
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+ssl_storage_port: 7001
+
+# Address to bind to and tell other Cassandra nodes to connect to. You
+# _must_ change this if you want multiple nodes to be able to
+# communicate!
+# 
+# Leaving it blank leaves it up to InetAddress.getLocalHost(). This
+# will always do the Right Thing _if_ the node is properly configured
+# (hostname, name resolution, etc), and the Right Thing is to use the
+# address associated with the hostname (it might not be).
+#
+# Setting this to 0.0.0.0 is always wrong.
+listen_address: localhost
+
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+# Internode authentication backend, implementing IInternodeAuthenticator;
+# used to allow/disallow connections from peer nodes.
+# internode_authenticator: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+start_native_transport: true
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+native_transport_port: 9042
+# The maximum threads for handling requests when the native transport is used.
+# This is similar to rpc_max_threads though the default differs slightly (and
+# there is no native_transport_min_threads, idle threads will always be stopped
+# after 30 seconds).
+# native_transport_max_threads: 128
+#
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB.
+# native_transport_max_frame_size_in_mb: 256
+
+# Whether to start the thrift rpc server.
+start_rpc: true
+
+# The address to bind the Thrift RPC service and native transport
+# server -- clients connect here.
+#
+# Leaving this blank has the same effect it does for ListenAddress,
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike ListenAddress above, it is allowed to specify 0.0.0.0
+# here if you want to listen on all interfaces, but that will break clients 
+# that rely on node auto-discovery.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+rpc_address: localhost
+# port for Thrift to listen for clients on
+rpc_port: 9160
+
+# enable or disable keepalive on rpc/native connections
+rpc_keepalive: true
+
+# Cassandra provides two out-of-the-box options for the RPC Server:
+#
+# sync  -> One thread per thrift connection. For a very large number of clients, memory
+#          will be your limiting factor. On a 64 bit JVM, 180KB is the minimum stack size
+#          per thread, and that will correspond to your use of virtual memory (but physical memory
+#          may be limited depending on use of stack space).
+#
+# hsha  -> Stands for "half synchronous, half asynchronous." All thrift clients are handled
+#          asynchronously using a small number of threads that does not vary with the amount
+#          of thrift clients (and thus scales well to many clients). The rpc requests are still
+#          synchronous (one thread per active request). If hsha is selected then it is essential
+#          that rpc_max_threads is changed from the default value of unlimited.
+#
+# The default is sync because on Windows hsha is about 30% slower.  On Linux,
+# sync/hsha performance is about the same, with hsha of course using less memory.
+#
+# Alternatively,  can provide your own RPC server by providing the fully-qualified class name
+# of an o.a.c.t.TServerFactory that can create an instance of it.
+rpc_server_type: sync
+
+# Uncomment rpc_min|max_thread to set request pool size limits.
+#
+# Regardless of your choice of RPC server (see above), the number of maximum requests in the
+# RPC thread pool dictates how many concurrent requests are possible (but if you are using the sync
+# RPC server, it also dictates the number of clients that can be connected at all).
+#
+# The default is unlimited and thus provides no protection against clients overwhelming the server. You are
+# encouraged to set a maximum that makes sense for you in production, but do keep in mind that
+# rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
+#
+# rpc_min_threads: 16
+# rpc_max_threads: 2048
+
+# uncomment to set socket buffer sizes on rpc connections
+# rpc_send_buff_size_in_bytes:
+# rpc_recv_buff_size_in_bytes:
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# See:
+# /proc/sys/net/core/wmem_max
+# /proc/sys/net/core/rmem_max
+# /proc/sys/net/ipv4/tcp_wmem
+# /proc/sys/net/ipv4/tcp_wmem
+# and: man tcp
+# internode_send_buff_size_in_bytes:
+# internode_recv_buff_size_in_bytes:
+
+# Frame size for thrift (maximum message length).
+thrift_framed_transport_size_in_mb: 15
+
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Cassandra won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true 
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: true
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+tombstone_warn_threshold: 1000
+tombstone_failure_threshold: 100000
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#   1) a smaller granularity means more index entries are generated
+#      and looking up rows withing the partition by collation column
+#      is faster
+#   2) but, Cassandra will keep the collation index in memory for hot
+#      rows (as part of the key cache), so a larger granularity means
+#      you can cache more hot rows
+column_index_size_in_kb: 64
+
+
+# Log WARN on any batch size exceeding this value. 5kb per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 5
+
+# Size limit for rows being compacted in memory.  Larger rows will spill
+# over to disk and use a slower two-pass compaction process.  A message
+# will be logged specifying the row key.
+in_memory_compaction_limit_in_mb: 64
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput_mb_per_sec first.
+#
+# concurrent_compactors defaults to the number of cores.
+# Uncomment to make compaction mono-threaded, the pre-0.8 default.
+#concurrent_compactors: 1
+
+# Multi-threaded compaction. When enabled, each compaction will use
+# up to one thread per core, plus one thread per sstable being merged.
+# This is usually only useful for SSD-based hardware: otherwise, 
+# your concern is usually to get compaction to do LESS i/o (see:
+# compaction_throughput_mb_per_sec), not more.
+multithreaded_compaction: false
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this account for all types
+# of compaction, including validation compaction.
+compaction_throughput_mb_per_sec: 16
+
+# Track cached row keys during compaction, and re-cache their new
+# positions in the compacted sstable.  Disable if you use really large
+# key caches.
+compaction_preheat_key_cache: true
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 200 Mbps or 25 MB/s.
+# stream_throughput_outbound_megabits_per_sec: 200
+
+# Throttles all streaming file transfer between the datacenters,
+# this setting allows users to throttle inter dc stream throughput in addition
+# to throttling all network stream traffic as configured with
+# stream_throughput_outbound_megabits_per_sec
+# inter_dc_stream_throughput_outbound_megabits_per_sec:
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+# How long the coordinator should wait for seq or index scans to complete
+range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+request_timeout_in_ms: 10000
+
+# Enable operation timeout information exchange between nodes to accurately
+# measure request timeouts.  If disabled, replicas will assume that requests
+# were forwarded to them instantly by the coordinator, which means that
+# under overload conditions we will waste that much extra time processing 
+# already-timed-out requests.
+#
+# Warning: before enabling this property make sure to ntp is installed
+# and the times are synchronized between the nodes.
+cross_node_timeout: false
+
+# Enable socket timeout for streaming operation.
+# When a timeout occurs during streaming, streaming is retried from the start
+# of the current file. This _can_ involve re-streaming an important amount of
+# data, so you should avoid setting the value too low.
+# Default value is 0, which never timeout streams.
+# streaming_socket_timeout_in_ms: 0
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# endpoint_snitch -- Set this to a class that implements
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Cassandra enough about your network topology to route
+#   requests efficiently
+# - it allows Cassandra to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Cassandra will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
+# Out of the box, Cassandra provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#  - GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Cassandra will switch to the private IP after
+#    establishing a connection.)
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: SimpleSnitch
+
+# controls how often to perform the more expensive part of host score
+# calculation
+dynamic_snitch_update_interval_in_ms: 100 
+# controls how often to reset all host scores, allowing a bad host to
+# possibly recover
+dynamic_snitch_reset_interval_in_ms: 600000
+# if set greater than zero and read_repair_chance is < 1.0, this will allow
+# 'pinning' of replicas to hosts in order to increase cache capacity.
+# The badness threshold will control how much worse the pinned host has to be
+# before the dynamic snitch will prefer other replicas over it.  This is
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+dynamic_snitch_badness_threshold: 0.1
+
+# request_scheduler -- Set this to a class that implements
+# RequestScheduler, which will schedule incoming client requests
+# according to the specific policy. This is useful for multi-tenancy
+# with a single Cassandra cluster.
+# NOTE: This is specifically for requests from the client and does
+# not affect inter node communication.
+# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
+# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
+# client requests to a node with a separate queue for each
+# request_scheduler_id. The scheduler is further customized by
+# request_scheduler_options as described below.
+request_scheduler: org.apache.cassandra.scheduler.NoScheduler
+
+# Scheduler Options vary based on the type of scheduler
+# NoScheduler - Has no options
+# RoundRobin
+#  - throttle_limit -- The throttle_limit is the number of in-flight
+#                      requests per client.  Requests beyond 
+#                      that limit are queued up until
+#                      running requests can complete.
+#                      The value of 80 here is twice the number of
+#                      concurrent_reads + concurrent_writes.
+#  - default_weight -- default_weight is optional and allows for
+#                      overriding the default which is 1.
+#  - weights -- Weights are optional and will default to 1 or the
+#               overridden default_weight. The weight translates into how
+#               many requests are handled during each turn of the
+#               RoundRobin, based on the scheduler id.
+#
+# request_scheduler_options:
+#    throttle_limit: 80
+#    default_weight: 5
+#    weights:
+#      Keyspace1: 1
+#      Keyspace2: 5
+
+# request_scheduler_id -- An identifier based on which to perform
+# the request scheduling. Currently the only valid option is keyspace.
+# request_scheduler_id: keyspace
+
+# Enable or disable inter-node encryption
+# Default settings are TLS v1, RSA 1024-bit keys (it is imperative that
+# users generate their own keys) TLS_RSA_WITH_AES_128_CBC_SHA as the cipher
+# suite for authentication, key exchange and encryption of the actual data transfers.
+# Use the DHE/ECDHE ciphers if running in FIPS 140 compliant mode.
+# NOTE: No custom encryption options are enabled at the moment
+# The available internode options are : all, none, dc, rack
+#
+# If set to dc cassandra will encrypt the traffic between the DCs
+# If set to rack cassandra will encrypt the traffic between the racks
+#
+# The passwords used in these options must match the passwords used when generating
+# the keystore and truststore.  For instructions on generating these files, see:
+# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+#
+server_encryption_options:
+    internode_encryption: none
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    truststore: conf/.truststore
+    truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+    # require_client_auth: false
+
+# enable or disable client/server encryption.
+client_encryption_options:
+    enabled: false
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    # require_client_auth: false
+    # Set trustore and truststore_password if require_client_auth is true
+    # truststore: conf/.truststore
+    # truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# can be:  all  - all traffic is compressed
+#          dc   - traffic between different datacenters is compressed
+#          none - nothing is compressed.
+internode_compression: all
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+inter_dc_tcp_nodelay: false
+
+# Enable or disable kernel page cache preheating from contents of the key cache after compaction.
+# When enabled it would preheat only first "page" (4KB) of each row to optimize
+# for sequential access. Note: This could be harmful for fat rows, see CASSANDRA-4937
+# for further details on that topic.
+preheat_kernel_page_cache: false

--- a/ci/resources/cassandra/cassandra_2.1.yaml
+++ b/ci/resources/cassandra/cassandra_2.1.yaml
@@ -1,0 +1,768 @@
+# Cassandra storage config YAML 
+
+# NOTE:
+#   See http://wiki.apache.org/cassandra/StorageConfiguration for
+#   full explanations of configuration directives
+# /NOTE
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+cluster_name: 'Test Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+#
+# If you leave this unspecified, Cassandra will use the default of 1 token for legacy compatibility,
+# and will use the initial_token as described below.
+#
+# Specifying initial_token will override this setting on the node's initial start,
+# on subsequent starts, this setting will apply even if initial token is set.
+#
+# If you already have a cluster with 1 token per node, and wish to migrate to 
+# multiple tokens per node, see http://wiki.apache.org/cassandra/Operations
+num_tokens: 256
+
+# initial_token allows you to specify tokens manually.  While you can use # it with
+# vnodes (num_tokens > 1, above) -- in which case you should provide a 
+# comma-separated list -- it's primarily used when adding nodes # to legacy clusters 
+# that do not have vnodes enabled.
+# initial_token:
+
+# See http://wiki.apache.org/cassandra/HintedHandoff
+# May either be "true" or "false" to enable globally, or contain a list
+# of data centers to enable per-datacenter.
+# hinted_handoff_enabled: DC1,DC2
+hinted_handoff_enabled: true
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+max_hint_window_in_ms: 10800000 # 3 hours
+# Maximum throttle in KBs per second, per delivery thread.  This will be
+# reduced proportionally to the number of nodes in the cluster.  (If there
+# are two nodes in the cluster, each delivery thread will use the maximum
+# rate; if there are three, each will throttle to half of the maximum,
+# since we expect two nodes to be delivering hints simultaneously.)
+hinted_handoff_throttle_in_kb: 1024
+# Number of threads with which to deliver hints;
+# Consider increasing this number when you have multi-dc deployments, since
+# cross-dc handoff tends to be slower
+max_hints_delivery_threads: 2
+
+# Maximum throttle in KBs per second, total. This will be
+# reduced proportionally to the number of nodes in the cluster.
+batchlog_replay_throttle_in_kb: 1024
+
+# Authentication backend, implementing IAuthenticator; used to identify users
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+authenticator: AllowAllAuthenticator
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Cassandra provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+authorizer: AllowAllAuthorizer
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 2000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+permissions_validity_in_ms: 2000
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this must be
+# also.
+# Defaults to the same value as permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 1000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Besides Murmur3Partitioner, partitioners included for backwards
+# compatibility include RandomPartitioner, ByteOrderedPartitioner, and
+# OrderPreservingPartitioner.
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Directories where Cassandra should store data on disk.  Cassandra
+# will spread data evenly across them, subject to the granularity of
+# the configured compaction strategy.
+# If not set, the default directory is $CASSANDRA_HOME/data/data.
+# data_file_directories:
+#     - /var/lib/cassandra/data
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# If not set, the default directory is $CASSANDRA_HOME/data/commitlog.
+# commitlog_directory: /var/lib/cassandra/commitlog
+
+# policy for data disk failures:
+# die: shut down gossip and Thrift and kill the JVM for any fs errors or
+#      single-sstable errors, so the node can be replaced.
+# stop_paranoid: shut down gossip and Thrift even for single-sstable errors.
+# stop: shut down gossip and Thrift, leaving the node effectively dead, but
+#       can still be inspected via JMX.
+# best_effort: stop using the failed disk and respond to requests based on
+#              remaining available sstables.  This means you WILL see obsolete
+#              data at CL.ONE!
+# ignore: ignore fatal errors and let requests fail, as in pre-1.2 Cassandra
+disk_failure_policy: stop
+
+# policy for commit disk failures:
+# die: shut down gossip and Thrift and kill the JVM, so the node can be replaced.
+# stop: shut down gossip and Thrift, leaving the node effectively dead, but
+#       can still be inspected via JMX.
+# stop_commit: shutdown the commit log, letting writes collect but
+#              continuing to service reads, as in pre-2.0.5 Cassandra
+# ignore: ignore fatal errors and let the batches fail
+commit_failure_policy: stop
+
+# Maximum size of the key cache in memory.
+#
+# Each key cache hit saves 1 seek and each row cache hit saves 2 seeks at the
+# minimum, sometimes more. The key cache is fairly tiny for the amount of
+# time it saves, so it's worthwhile to use it at large numbers.
+# The row cache saves even more time, but must contain the entire row,
+# so it is extremely space-intensive. It's best to only use the
+# row cache if you have hot rows or static rows.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(5% of Heap (in MB), 100MB)). Set to 0 to disable key cache.
+key_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the key cache. Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 14400 or 4 hours.
+key_cache_save_period: 14400
+
+# Number of keys from the key cache to save
+# Disabled by default, meaning all keys are going to be saved
+# key_cache_keys_to_save: 100
+
+# Maximum size of the row cache in memory.
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is 0, to disable row caching.
+row_cache_size_in_mb: 0
+
+# Duration in seconds after which Cassandra should
+# save the row cache. Caches are saved to saved_caches_directory as specified
+# in this configuration file.
+#
+# Saved caches greatly improve cold-start speeds, and is relatively cheap in
+# terms of I/O for the key cache. Row cache saving is much more expensive and
+# has limited use.
+#
+# Default is 0 to disable saving the row cache.
+row_cache_save_period: 0
+
+# Number of keys from the row cache to save
+# Disabled by default, meaning all keys are going to be saved
+# row_cache_keys_to_save: 100
+
+# Maximum size of the counter cache in memory.
+#
+# Counter cache helps to reduce counter locks' contention for hot counter cells.
+# In case of RF = 1 a counter cache hit will cause Cassandra to skip the read before
+# write entirely. With RF > 1 a counter cache hit will still help to reduce the duration
+# of the lock hold, helping with hot counter cell updates, but will not allow skipping
+# the read entirely. Only the local (clock, count) tuple of a counter cell is kept
+# in memory, not the whole counter, so it's relatively cheap.
+#
+# NOTE: if you reduce the size, you may not get you hottest keys loaded on startup.
+#
+# Default value is empty to make it "auto" (min(2.5% of Heap (in MB), 50MB)). Set to 0 to disable counter cache.
+# NOTE: if you perform counter deletes and rely on low gcgs, you should disable the counter cache.
+counter_cache_size_in_mb:
+
+# Duration in seconds after which Cassandra should
+# save the counter cache (keys only). Caches are saved to saved_caches_directory as
+# specified in this configuration file.
+#
+# Default is 7200 or 2 hours.
+counter_cache_save_period: 7200
+
+# Number of keys from the counter cache to save
+# Disabled by default, meaning all keys are going to be saved
+# counter_cache_keys_to_save: 100
+
+# The off-heap memory allocator.  Affects storage engine metadata as
+# well as caches.  Experiments show that JEMAlloc saves some memory
+# than the native GCC allocator (i.e., JEMalloc is more
+# fragmentation-resistant).
+# 
+# Supported values are: NativeAllocator, JEMallocAllocator
+#
+# If you intend to use JEMallocAllocator you have to install JEMalloc as library and
+# modify cassandra-env.sh as directed in the file.
+#
+# Defaults to NativeAllocator
+# memory_allocator: NativeAllocator
+
+# saved caches
+# If not set, the default directory is $CASSANDRA_HOME/data/saved_caches.
+# saved_caches_directory: /var/lib/cassandra/saved_caches
+
+# commitlog_sync may be either "periodic" or "batch." 
+# When in batch mode, Cassandra won't ack writes until the commit log
+# has been fsynced to disk.  It will wait up to
+# commitlog_sync_batch_window_in_ms milliseconds for other writes, before
+# performing the sync.
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 50
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds. 
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.  
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+commitlog_segment_size_in_mb: 32
+
+# any class that implements the SeedProvider interface and has a
+# constructor that takes a Map<String, String> of parameters will do.
+seed_provider:
+    # Addresses of hosts that are deemed contact points. 
+    # Cassandra nodes use this list of hosts to find each other and learn
+    # the topology of the ring.  You must change this if you are running
+    # multiple nodes!
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          # seeds is actually a comma-delimited list of addresses.
+          # Ex: "<ip1>,<ip2>,<ip3>"
+          - seeds: "127.0.0.1"
+
+# For workloads with more data than can fit in memory, Cassandra's
+# bottleneck will be reads that need to fetch data from
+# disk. "concurrent_reads" should be set to (16 * number_of_drives) in
+# order to allow the operations to enqueue low enough in the stack
+# that the OS and drives can reorder them. Same applies to
+# "concurrent_counter_writes", since counter writes read the current
+# values before incrementing and writing them back.
+#
+# On the other hand, since writes are almost never IO bound, the ideal
+# number of "concurrent_writes" is dependent on the number of cores in
+# your system; (8 * number_of_cores) is a good rule of thumb.
+concurrent_reads: 32
+concurrent_writes: 32
+concurrent_counter_writes: 32
+
+# Total memory to use for sstable-reading buffers.  Defaults to
+# the smaller of 1/4 of heap or 512MB.
+# file_cache_size_in_mb: 512
+
+# Total permitted memory to use for memtables. Cassandra will stop 
+# accepting writes when the limit is exceeded until a flush completes,
+# and will trigger a flush based on memtable_cleanup_threshold
+# If omitted, Cassandra will set both to 1/4 the size of the heap.
+# memtable_heap_space_in_mb: 2048
+# memtable_offheap_space_in_mb: 2048
+
+# Ratio of occupied non-flushing memtable size to total permitted size
+# that will trigger a flush of the largest memtable.  Lager mct will
+# mean larger flushes and hence less compaction, but also less concurrent
+# flush activity which can make it difficult to keep your disks fed
+# under heavy write load.
+#
+# memtable_cleanup_threshold defaults to 1 / (memtable_flush_writers + 1)
+# memtable_cleanup_threshold: 0.11
+
+# Specify the way Cassandra allocates and manages memtable memory.
+# Options are:
+#   heap_buffers:    on heap nio buffers
+#   offheap_buffers: off heap (direct) nio buffers
+#   offheap_objects: native memory, eliminating nio buffer heap overhead
+memtable_allocation_type: heap_buffers
+
+# Total space to use for commitlogs.  Since commitlog segments are
+# mmapped, and hence use up address space, the default size is 32
+# on 32-bit JVMs, and 8192 on 64-bit JVMs.
+#
+# If space gets above this value (it will round up to the next nearest
+# segment multiple), Cassandra will flush every dirty CF in the oldest
+# segment and remove it.  So a small total commitlog space will tend
+# to cause more flush activity on less-active columnfamilies.
+# commitlog_total_space_in_mb: 8192
+
+# This sets the amount of memtable flush writer threads.  These will
+# be blocked by disk io, and each one will hold a memtable in memory
+# while blocked. 
+#
+# memtable_flush_writers defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+# 
+# If your data directories are backed by SSD, you should increase this
+# to the number of cores.
+#memtable_flush_writers: 8
+
+# A fixed memory pool size in MB for for SSTable index summaries. If left
+# empty, this will default to 5% of the heap size. If the memory usage of
+# all index summaries exceeds this limit, SSTables with low read rates will
+# shrink their index summaries in order to meet this limit.  However, this
+# is a best-effort process. In extreme conditions Cassandra may need to use
+# more than this amount of memory.
+index_summary_capacity_in_mb:
+
+# How frequently index summaries should be resampled.  This is done
+# periodically to redistribute memory from the fixed-size pool to sstables
+# proportional their recent read rates.  Setting to -1 will disable this
+# process, leaving existing index summaries at their current sampling level.
+index_summary_resize_interval_in_minutes: 60
+
+# Whether to, when doing sequential writing, fsync() at intervals in
+# order to force the operating system to flush the dirty
+# buffers. Enable this to avoid sudden dirty buffer flushing from
+# impacting read latencies. Almost always a good idea on SSDs; not
+# necessarily on platters.
+trickle_fsync: false
+trickle_fsync_interval_in_kb: 10240
+
+# TCP port, for commands and data
+storage_port: 7000
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+ssl_storage_port: 7001
+
+# Address or interface to bind to and tell other Cassandra nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# Set listen_address OR listen_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+#
+# Leaving it blank leaves it up to InetAddress.getLocalHost(). This
+# will always do the Right Thing _if_ the node is properly configured
+# (hostname, name resolution, etc), and the Right Thing is to use the
+# address associated with the hostname (it might not be).
+#
+# Setting listen_address to 0.0.0.0 is always wrong.
+listen_address: localhost
+# listen_interface: eth0
+
+# Address to broadcast to other Cassandra nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+# Internode authentication backend, implementing IInternodeAuthenticator;
+# used to allow/disallow connections from peer nodes.
+# internode_authenticator: org.apache.cassandra.auth.AllowAllInternodeAuthenticator
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+start_native_transport: true
+# port for the CQL native transport to listen for clients on
+native_transport_port: 9042
+# The maximum threads for handling requests when the native transport is used.
+# This is similar to rpc_max_threads though the default differs slightly (and
+# there is no native_transport_min_threads, idle threads will always be stopped
+# after 30 seconds).
+# native_transport_max_threads: 128
+#
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB.
+# native_transport_max_frame_size_in_mb: 256
+
+# Whether to start the thrift rpc server.
+start_rpc: true
+
+# The address or interface to bind the Thrift RPC service and native transport
+# server to.
+#
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+rpc_address: localhost
+# rpc_interface: eth1
+
+# port for Thrift to listen for clients on
+rpc_port: 9160
+
+# RPC address to broadcast to drivers and other Cassandra nodes. This cannot
+# be set to 0.0.0.0. If left blank, this will be set to the value of
+# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+# be set.
+# broadcast_rpc_address: 1.2.3.4
+
+# enable or disable keepalive on rpc/native connections
+rpc_keepalive: true
+
+# Cassandra provides two out-of-the-box options for the RPC Server:
+#
+# sync  -> One thread per thrift connection. For a very large number of clients, memory
+#          will be your limiting factor. On a 64 bit JVM, 180KB is the minimum stack size
+#          per thread, and that will correspond to your use of virtual memory (but physical memory
+#          may be limited depending on use of stack space).
+#
+# hsha  -> Stands for "half synchronous, half asynchronous." All thrift clients are handled
+#          asynchronously using a small number of threads that does not vary with the amount
+#          of thrift clients (and thus scales well to many clients). The rpc requests are still
+#          synchronous (one thread per active request). If hsha is selected then it is essential
+#          that rpc_max_threads is changed from the default value of unlimited.
+#
+# The default is sync because on Windows hsha is about 30% slower.  On Linux,
+# sync/hsha performance is about the same, with hsha of course using less memory.
+#
+# Alternatively,  can provide your own RPC server by providing the fully-qualified class name
+# of an o.a.c.t.TServerFactory that can create an instance of it.
+rpc_server_type: sync
+
+# Uncomment rpc_min|max_thread to set request pool size limits.
+#
+# Regardless of your choice of RPC server (see above), the number of maximum requests in the
+# RPC thread pool dictates how many concurrent requests are possible (but if you are using the sync
+# RPC server, it also dictates the number of clients that can be connected at all).
+#
+# The default is unlimited and thus provides no protection against clients overwhelming the server. You are
+# encouraged to set a maximum that makes sense for you in production, but do keep in mind that
+# rpc_max_threads represents the maximum number of client requests this server may execute concurrently.
+#
+# rpc_min_threads: 16
+# rpc_max_threads: 2048
+
+# uncomment to set socket buffer sizes on rpc connections
+# rpc_send_buff_size_in_bytes:
+# rpc_recv_buff_size_in_bytes:
+
+# Uncomment to set socket buffer size for internode communication
+# Note that when setting this, the buffer size is limited by net.core.wmem_max
+# and when not setting it it is defined by net.ipv4.tcp_wmem
+# See:
+# /proc/sys/net/core/wmem_max
+# /proc/sys/net/core/rmem_max
+# /proc/sys/net/ipv4/tcp_wmem
+# /proc/sys/net/ipv4/tcp_wmem
+# and: man tcp
+# internode_send_buff_size_in_bytes:
+# internode_recv_buff_size_in_bytes:
+
+# Frame size for thrift (maximum message length).
+thrift_framed_transport_size_in_mb: 15
+
+# Set to true to have Cassandra create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Cassandra won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true 
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+auto_snapshot: true
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+tombstone_warn_threshold: 1000
+tombstone_failure_threshold: 100000
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#   1) a smaller granularity means more index entries are generated
+#      and looking up rows withing the partition by collation column
+#      is faster
+#   2) but, Cassandra will keep the collation index in memory for hot
+#      rows (as part of the key cache), so a larger granularity means
+#      you can cache more hot rows
+column_index_size_in_kb: 64
+
+
+# Log WARN on any batch size exceeding this value. 5kb per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 5
+
+# Number of simultaneous compactions to allow, NOT including
+# validation "compactions" for anti-entropy repair.  Simultaneous
+# compactions can help preserve read performance in a mixed read/write
+# workload, by mitigating the tendency of small sstables to accumulate
+# during a single long running compactions. The default is usually
+# fine and if you experience problems with compaction running too
+# slowly or too fast, you should look at
+# compaction_throughput_mb_per_sec first.
+#
+# concurrent_compactors defaults to the smaller of (number of disks,
+# number of cores), with a minimum of 2 and a maximum of 8.
+# 
+# If your data directories are backed by SSD, you should increase this
+# to the number of cores.
+#concurrent_compactors: 1
+
+# Throttles compaction to the given total throughput across the entire
+# system. The faster you insert data, the faster you need to compact in
+# order to keep the sstable count down, but in general, setting this to
+# 16 to 32 times the rate you are inserting data is more than sufficient.
+# Setting this to 0 disables throttling. Note that this account for all types
+# of compaction, including validation compaction.
+compaction_throughput_mb_per_sec: 16
+
+# When compacting, the replacement sstable(s) can be opened before they
+# are completely written, and used in place of the prior sstables for
+# any range that has been written. This helps to smoothly transfer reads 
+# between the sstables, reducing page cache churn and keeping hot rows hot
+sstable_preemptive_open_interval_in_mb: 50
+
+# Throttles all outbound streaming file transfers on this node to the
+# given total throughput in Mbps. This is necessary because Cassandra does
+# mostly sequential IO when streaming data during bootstrap or repair, which
+# can lead to saturating the network connection and degrading rpc performance.
+# When unset, the default is 200 Mbps or 25 MB/s.
+# stream_throughput_outbound_megabits_per_sec: 200
+
+# Throttles all streaming file transfer between the datacenters,
+# this setting allows users to throttle inter dc stream throughput in addition
+# to throttling all network stream traffic as configured with
+# stream_throughput_outbound_megabits_per_sec
+# inter_dc_stream_throughput_outbound_megabits_per_sec:
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+# How long the coordinator should wait for seq or index scans to complete
+range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# How long the coordinator should wait for counter writes to complete
+counter_write_request_timeout_in_ms: 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+request_timeout_in_ms: 10000
+
+# Enable operation timeout information exchange between nodes to accurately
+# measure request timeouts.  If disabled, replicas will assume that requests
+# were forwarded to them instantly by the coordinator, which means that
+# under overload conditions we will waste that much extra time processing 
+# already-timed-out requests.
+#
+# Warning: before enabling this property make sure to ntp is installed
+# and the times are synchronized between the nodes.
+cross_node_timeout: false
+
+# Enable socket timeout for streaming operation.
+# When a timeout occurs during streaming, streaming is retried from the start
+# of the current file. This _can_ involve re-streaming an important amount of
+# data, so you should avoid setting the value too low.
+# Default value is 0, which never timeout streams.
+# streaming_socket_timeout_in_ms: 0
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# endpoint_snitch -- Set this to a class that implements
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Cassandra enough about your network topology to route
+#   requests efficiently
+# - it allows Cassandra to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Cassandra will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
+# Out of the box, Cassandra provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#  - GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Cassandra will switch to the private IP after
+#    establishing a connection.)
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: SimpleSnitch
+
+# controls how often to perform the more expensive part of host score
+# calculation
+dynamic_snitch_update_interval_in_ms: 100 
+# controls how often to reset all host scores, allowing a bad host to
+# possibly recover
+dynamic_snitch_reset_interval_in_ms: 600000
+# if set greater than zero and read_repair_chance is < 1.0, this will allow
+# 'pinning' of replicas to hosts in order to increase cache capacity.
+# The badness threshold will control how much worse the pinned host has to be
+# before the dynamic snitch will prefer other replicas over it.  This is
+# expressed as a double which represents a percentage.  Thus, a value of
+# 0.2 means Cassandra would continue to prefer the static snitch values
+# until the pinned host was 20% worse than the fastest.
+dynamic_snitch_badness_threshold: 0.1
+
+# request_scheduler -- Set this to a class that implements
+# RequestScheduler, which will schedule incoming client requests
+# according to the specific policy. This is useful for multi-tenancy
+# with a single Cassandra cluster.
+# NOTE: This is specifically for requests from the client and does
+# not affect inter node communication.
+# org.apache.cassandra.scheduler.NoScheduler - No scheduling takes place
+# org.apache.cassandra.scheduler.RoundRobinScheduler - Round robin of
+# client requests to a node with a separate queue for each
+# request_scheduler_id. The scheduler is further customized by
+# request_scheduler_options as described below.
+request_scheduler: org.apache.cassandra.scheduler.NoScheduler
+
+# Scheduler Options vary based on the type of scheduler
+# NoScheduler - Has no options
+# RoundRobin
+#  - throttle_limit -- The throttle_limit is the number of in-flight
+#                      requests per client.  Requests beyond 
+#                      that limit are queued up until
+#                      running requests can complete.
+#                      The value of 80 here is twice the number of
+#                      concurrent_reads + concurrent_writes.
+#  - default_weight -- default_weight is optional and allows for
+#                      overriding the default which is 1.
+#  - weights -- Weights are optional and will default to 1 or the
+#               overridden default_weight. The weight translates into how
+#               many requests are handled during each turn of the
+#               RoundRobin, based on the scheduler id.
+#
+# request_scheduler_options:
+#    throttle_limit: 80
+#    default_weight: 5
+#    weights:
+#      Keyspace1: 1
+#      Keyspace2: 5
+
+# request_scheduler_id -- An identifier based on which to perform
+# the request scheduling. Currently the only valid option is keyspace.
+# request_scheduler_id: keyspace
+
+# Enable or disable inter-node encryption
+# Default settings are TLS v1, RSA 1024-bit keys (it is imperative that
+# users generate their own keys) TLS_RSA_WITH_AES_128_CBC_SHA as the cipher
+# suite for authentication, key exchange and encryption of the actual data transfers.
+# Use the DHE/ECDHE ciphers if running in FIPS 140 compliant mode.
+# NOTE: No custom encryption options are enabled at the moment
+# The available internode options are : all, none, dc, rack
+#
+# If set to dc cassandra will encrypt the traffic between the DCs
+# If set to rack cassandra will encrypt the traffic between the racks
+#
+# The passwords used in these options must match the passwords used when generating
+# the keystore and truststore.  For instructions on generating these files, see:
+# http://download.oracle.com/javase/6/docs/technotes/guides/security/jsse/JSSERefGuide.html#CreateKeystore
+#
+server_encryption_options:
+    internode_encryption: none
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    truststore: conf/.truststore
+    truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+    # require_client_auth: false
+
+# enable or disable client/server encryption.
+client_encryption_options:
+    enabled: false
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    # require_client_auth: false
+    # Set trustore and truststore_password if require_client_auth is true
+    # truststore: conf/.truststore
+    # truststore_password: cassandra
+    # More advanced defaults below:
+    # protocol: TLS
+    # algorithm: SunX509
+    # store_type: JKS
+    # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA]
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# can be:  all  - all traffic is compressed
+#          dc   - traffic between different datacenters is compressed
+#          none - nothing is compressed.
+internode_compression: all
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+inter_dc_tcp_nodelay: false

--- a/ci/resources/haproxy/haproxy-open.cfg
+++ b/ci/resources/haproxy/haproxy-open.cfg
@@ -2,7 +2,7 @@
 global
     log 127.0.0.1 local0
     maxconn 4096
-    stats socket /tmp/haproxy
+    stats socket ${VOLATILE_DIR}/haproxy_open_sock_stats
 
 defaults
     log     global

--- a/ci/resources/haproxy/haproxy.cfg
+++ b/ci/resources/haproxy/haproxy.cfg
@@ -2,7 +2,7 @@
 global
     log 127.0.0.1 local0
     maxconn 4096
-    stats socket /tmp/haproxy
+    stats socket ${VOLATILE_DIR}/haproxy_sock_stats
 
 defaults
     log     global

--- a/ci/snmpd.rb
+++ b/ci/snmpd.rb
@@ -9,10 +9,12 @@ namespace :ci do
     task :before_install => ['ci:common:before_install']
 
     task :install => ['ci:common:install'] do
+      # Downloads
+      # http://sourceforge.net/projects/net-snmp/files/net-snmp/5.7.3/net-snmp-5.7.3.tar.gz/download
       unless Dir.exist? File.expand_path(snmpd_rootdir)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/snmpd.tar.gz\
-             http://sourceforge.net/projects/net-snmp/files/net-snmp/5.7.3/net-snmp-5.7.3.tar.gz/download)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/net-snmp-5.7.3.tar.gz)
         sh %(mkdir -p $VOLATILE_DIR/snmpd)
         sh %(mkdir -p #{snmpd_rootdir})
         sh %(tar zxf $VOLATILE_DIR/snmpd.tar.gz\

--- a/ci/sysstat.rb
+++ b/ci/sysstat.rb
@@ -18,7 +18,7 @@ namespace :ci do
       unless Dir.exist? File.expand_path(sysstat_rootdir)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/sysstat-#{sysstat_version}.tar.xz\
-             https://s3.amazonaws.com/travis-archive/sysstat-11.0.1.tar.xz)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/sysstat-11.0.1.tar.xz)
         sh %(mkdir -p $VOLATILE_DIR/sysstat)
         sh %(mkdir -p #{sysstat_rootdir})
         sh %(mkdir -p #{sysstat_rootdir}/var/log/sa)

--- a/ci/tokumx.rb
+++ b/ci/tokumx.rb
@@ -1,0 +1,80 @@
+require './ci/common'
+
+def tokumx_version
+  ENV['FLAVOR_VERSION'] || '2.0.1'
+end
+
+def tokumx_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/tokumx_#{tokumx_version}"
+end
+
+namespace :ci do
+  namespace :tokumx do |flavor|
+    task :before_install => ['ci:common:before_install']
+
+    task :install => ['ci:common:install'] do
+      unless Dir.exist? File.expand_path(tokumx_rootdir)
+        # Downloads
+        # http://www.tokutek.com/tokumx-for-mongodb/download-community/
+        sh %(curl -s -L\
+             -o $VOLATILE_DIR/tokumx-#{tokumx_version}.tgz\
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/tokumx-#{tokumx_version}-linux-x86_64-main.tar.gz)
+        sh %(mkdir -p #{tokumx_rootdir})
+        sh %(tar zxf $VOLATILE_DIR/tokumx-#{tokumx_version}.tgz\
+             -C #{tokumx_rootdir} --strip-components=1)
+      end
+    end
+
+    task :before_script => ['ci:common:before_script'] do
+      sh %(mkdir -p $VOLATILE_DIR/tokumxd1)
+      hostname = `hostname`.strip
+      sh %(#{tokumx_rootdir}/bin/mongod --port 37017\
+           --pidfilepath $VOLATILE_DIR/tokumxd1/tokumx.pid\
+           --dbpath $VOLATILE_DIR/tokumxd1\
+           --logpath $VOLATILE_DIR/tokumxd1/tokumx.log\
+           --noprealloc --rest --fork)
+
+      sh %(#{tokumx_rootdir}/bin/mongo\
+           --eval "printjson(db.serverStatus())" 'localhost:37017')
+    end
+
+    task :script => ['ci:common:script'] do
+      this_provides = [
+        'tokumx'
+      ]
+      Rake::Task['ci:common:run_tests'].invoke(this_provides)
+    end
+
+    task :before_cache => ['ci:common:before_cache']
+
+    task :cache => ['ci:common:cache']
+
+    task :cleanup => ['ci:common:cleanup'] do
+      sh %(kill `cat $VOLATILE_DIR/tokumxd1/tokumx.pid`)
+    end
+
+    task :execute do
+      exception = nil
+      begin
+        %w(before_install install before_script script).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
+      rescue => e
+        exception = e
+        puts "Failed task: #{e.class} #{e.message}".red
+      end
+      if ENV['SKIP_CLEANUP']
+        puts 'Skipping cleanup, disposable environments are great'.yellow
+      else
+        puts 'Cleaning up'
+        Rake::Task["#{flavor.scope.path}:cleanup"].invoke
+      end
+      if ENV['TRAVIS']
+        %w(before_cache cache).each do |t|
+          Rake::Task["#{flavor.scope.path}:#{t}"].invoke
+        end
+      end
+      fail exception if exception
+    end
+  end
+end

--- a/ci/tomcat.rb
+++ b/ci/tomcat.rb
@@ -12,10 +12,12 @@ namespace :ci do
     task :before_install => ['ci:common:before_install']
 
     task :install => ['ci:common:install'] do
+      # Downloads
+      # http://mirror.sdunix.com/apache/tomcat/tomcat-6/v6.0.43/bin/apache-tomcat-6.0.43.tar.gz
       unless Dir.exist? File.expand_path(tomcat_rootdir)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/apache-tomcat-6.0.43.tar.gz\
-             http://mirror.sdunix.com/apache/tomcat/tomcat-6/v6.0.43/bin/apache-tomcat-6.0.43.tar.gz)
+             https://s3.amazonaws.com/dd-agent-tarball-mirror/apache-tomcat-6.0.43.tar.gz)
         sh %(mkdir -p #{tomcat_rootdir})
         sh %(tar zxf $VOLATILE_DIR/apache-tomcat-6.0.43.tar.gz\
              -C #{tomcat_rootdir} --strip-components=1)

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -10,11 +10,11 @@ from pprint import pprint
 
 # postgres version: (expected metrics, expected tagged metrics per database)
 METRICS = {
-    '9.4.0': (40, 26),
-    '9.3.5': (40, 26),
-    '9.2.9': (40, 26),
-    '9.1.14': (35, 23),
-    '9.0.18': (34, 23),
+    '9.4.1': (40, 26),
+    '9.3.6': (40, 26),
+    '9.2.10': (40, 26),
+    '9.1.15': (35, 23),
+    '9.0.19': (34, 23),
 }
 
 @attr(requires='postgres')

--- a/tests/test_tokumx.py
+++ b/tests/test_tokumx.py
@@ -1,90 +1,227 @@
-import unittest
+# 3p
 from nose.plugins.attrib import attr
-import time
 
-import pymongo
+# project
+from checks import AgentCheck
+from tests.common import AgentCheckTest
 
-from tests.common import load_check
 
-PORT1 = 37017
-PORT2 = 37018
-MAX_WAIT = 150
+GAUGES = [
+# FIXME: For some reason these metrics are not always available
+#    'tokumx.indexCounters.btree.missRatio',
+#    'tokumx.globalLock.ratio',
+#    'tokumx.mem.mapped',
+#    'tokumx.replSet.health',
+#    'tokumx.replSet.state',
+#    'tokumx.replSet.replicationLag',
+#    'tokumx.metrics.repl.buffer.maxSizeBytes',
+    'tokumx.connections.available',
+    'tokumx.connections.current',
+    'tokumx.cursors.timedOut',
+    'tokumx.cursors.totalOpen',
+    'tokumx.ft.alerts.checkpointFailures',
+    'tokumx.ft.alerts.locktreeRequestsPending',
+    'tokumx.ft.cachetable.size.current',
+    'tokumx.ft.cachetable.size.limit',
+    'tokumx.ft.cachetable.size.writing',
+    'tokumx.ft.checkpoint.lastComplete.time',
+    'tokumx.ft.compressionRatio.leaf',
+    'tokumx.ft.compressionRatio.nonleaf',
+    'tokumx.ft.compressionRatio.overall',
+    'tokumx.ft.locktree.size.current',
+    'tokumx.ft.locktree.size.limit',
+    'tokumx.mem.resident',
+    'tokumx.mem.virtual',
+    'tokumx.metrics.repl.buffer.count',
+    'tokumx.metrics.repl.buffer.sizeBytes',
+    'tokumx.stats.dataSize',
+    'tokumx.stats.indexSize',
+    'tokumx.stats.indexes',
+    'tokumx.stats.objects',
+    'tokumx.stats.storageSize',
+    'tokumx.uptime',
+]
 
-@attr(requires='mongo')
-class TestTokuMX(unittest.TestCase):
+
+RATES = [
+# FIXME: For some reason these metrics are not available
+#    'tokumx.indexCounters.btree.missRatio',
+#    'tokumx.indexCounters.btree.accessesps',
+#    'tokumx.indexCounters.btree.hitsps',
+#    'tokumx.indexCounters.btree.missesps',
+#    'tokumx.metrics.operation.fastmodps',
+#    'tokumx.metrics.record.movesps',
+    'tokumx.asserts.msgps',
+    'tokumx.asserts.regularps',
+    'tokumx.asserts.rolloversps',
+    'tokumx.asserts.userps',
+    'tokumx.asserts.warningps',
+    'tokumx.ft.alerts.longWaitEvents.cachePressure.countps',
+    'tokumx.ft.alerts.longWaitEvents.cachePressure.timeps',
+    'tokumx.ft.alerts.longWaitEvents.checkpointBegin.countps',
+    'tokumx.ft.alerts.longWaitEvents.checkpointBegin.timeps',
+    'tokumx.ft.alerts.longWaitEvents.fsync.countps',
+    'tokumx.ft.alerts.longWaitEvents.fsync.timeps',
+    'tokumx.ft.alerts.longWaitEvents.locktreeWait.countps',
+    'tokumx.ft.alerts.longWaitEvents.locktreeWait.timeps',
+    'tokumx.ft.alerts.longWaitEvents.locktreeWaitEscalation.countps',
+    'tokumx.ft.alerts.longWaitEvents.locktreeWaitEscalation.timeps',
+    'tokumx.ft.alerts.longWaitEvents.logBufferWaitps',
+    'tokumx.ft.cachetable.evictions.full.leaf.clean.bytesps',
+    'tokumx.ft.cachetable.evictions.full.leaf.clean.countps',
+    'tokumx.ft.cachetable.evictions.full.leaf.dirty.bytesps',
+    'tokumx.ft.cachetable.evictions.full.leaf.dirty.countps',
+    'tokumx.ft.cachetable.evictions.full.leaf.dirty.timeps',
+    'tokumx.ft.cachetable.evictions.full.nonleaf.clean.bytesps',
+    'tokumx.ft.cachetable.evictions.full.nonleaf.clean.countps',
+    'tokumx.ft.cachetable.evictions.full.nonleaf.dirty.bytesps',
+    'tokumx.ft.cachetable.evictions.full.nonleaf.dirty.countps',
+    'tokumx.ft.cachetable.evictions.full.nonleaf.dirty.timeps',
+    'tokumx.ft.cachetable.evictions.partial.leaf.clean.bytesps',
+    'tokumx.ft.cachetable.evictions.partial.leaf.clean.countps',
+    'tokumx.ft.cachetable.evictions.partial.nonleaf.clean.bytesps',
+    'tokumx.ft.cachetable.evictions.partial.nonleaf.clean.countps',
+    'tokumx.ft.cachetable.miss.countps',
+    'tokumx.ft.cachetable.miss.full.countps',
+    'tokumx.ft.cachetable.miss.full.timeps',
+    'tokumx.ft.cachetable.miss.partial.countps',
+    'tokumx.ft.cachetable.miss.partial.timeps',
+    'tokumx.ft.cachetable.miss.timeps',
+    'tokumx.ft.checkpoint.begin.timeps',
+    'tokumx.ft.checkpoint.countps',
+    'tokumx.ft.checkpoint.timeps',
+    'tokumx.ft.checkpoint.write.leaf.bytes.compressedps',
+    'tokumx.ft.checkpoint.write.leaf.bytes.uncompressedps',
+    'tokumx.ft.checkpoint.write.leaf.countps',
+    'tokumx.ft.checkpoint.write.leaf.timeps',
+    'tokumx.ft.checkpoint.write.nonleaf.bytes.compressedps',
+    'tokumx.ft.checkpoint.write.nonleaf.bytes.uncompressedps',
+    'tokumx.ft.checkpoint.write.nonleaf.countps',
+    'tokumx.ft.checkpoint.write.nonleaf.timeps',
+    'tokumx.ft.fsync.countps',
+    'tokumx.ft.fsync.timeps',
+    'tokumx.ft.log.bytesps',
+    'tokumx.ft.log.countps',
+    'tokumx.ft.log.timeps',
+    'tokumx.ft.serializeTime.leaf.compressps',
+    'tokumx.ft.serializeTime.leaf.decompressps',
+    'tokumx.ft.serializeTime.leaf.deserializeps',
+    'tokumx.ft.serializeTime.leaf.serializeps',
+    'tokumx.ft.serializeTime.nonleaf.compressps',
+    'tokumx.ft.serializeTime.nonleaf.decompressps',
+    'tokumx.ft.serializeTime.nonleaf.deserializeps',
+    'tokumx.ft.serializeTime.nonleaf.serializeps',
+    'tokumx.metrics.document.deletedps',
+    'tokumx.metrics.document.insertedps',
+    'tokumx.metrics.document.returnedps',
+    'tokumx.metrics.document.updatedps',
+    'tokumx.metrics.getLastError.wtime.numps',
+    'tokumx.metrics.getLastError.wtime.totalMillisps',
+    'tokumx.metrics.getLastError.wtimeoutsps',
+    'tokumx.metrics.operation.idhackps',
+    'tokumx.metrics.operation.scanAndOrderps',
+    'tokumx.metrics.queryExecutor.scannedps',
+    'tokumx.metrics.repl.apply.batches.numps',
+    'tokumx.metrics.repl.apply.batches.totalMillisps',
+    'tokumx.metrics.repl.apply.opsps',
+    'tokumx.metrics.repl.network.bytesps',
+    'tokumx.metrics.repl.network.getmores.numps',
+    'tokumx.metrics.repl.network.getmores.totalMillisps',
+    'tokumx.metrics.repl.network.opsps',
+    'tokumx.metrics.repl.network.readersCreatedps',
+    'tokumx.metrics.repl.oplog.insert.numps',
+    'tokumx.metrics.repl.oplog.insert.totalMillisps',
+    'tokumx.metrics.repl.oplog.insertBytesps',
+    'tokumx.metrics.ttl.deletedDocumentsps',
+    'tokumx.metrics.ttl.passesps',
+    'tokumx.opcounters.commandps',
+    'tokumx.opcounters.deleteps',
+    'tokumx.opcounters.getmoreps',
+    'tokumx.opcounters.insertps',
+    'tokumx.opcounters.queryps',
+    'tokumx.opcounters.updateps',
+    'tokumx.opcountersRepl.commandps',
+    'tokumx.opcountersRepl.deleteps',
+    'tokumx.opcountersRepl.getmoreps',
+    'tokumx.opcountersRepl.insertps',
+    'tokumx.opcountersRepl.queryps',
+    'tokumx.opcountersRepl.updateps',
+]
+
+
+IDX_HISTS = [
+    'size',
+    'count',
+    'avgObjSize',
+    'storageSize',
+]
+
+
+# LocalRates are computed as rates but sent as histograms
+# FIXME ['nscanned', 'nscannedObjects', 'inserts', 'deletes'] are N/A
+IDX_LCL_RATES = ['queries']
+
+
+COLL_HISTS = [
+    'totalIndexSize',
+    'nindexes',
+    'size',
+    'count',
+    'nindexesbeingbuilt',
+    'totalIndexStorageSize',
+    'storageSize',
+]
+
+
+DB_STATS = [
+    'avgObjSize',
+    'collections',
+    'dataSize',
+    'indexSize',
+    'indexStorageSize',
+    'indexes',
+    'objects',
+    'storageSize'
+]
+
+
+HIST_SUFFIXES = ['avg', 'max', 'count', '95percentile', 'median']
+
+
+@attr(requires='tokumx')
+class TestTokuMXTest(AgentCheckTest):
+    CHECK_NAME = 'tokumx'
+
     def testTokuMXCheck(self):
-        self.agentConfig = {
-            'version': '0.1',
-            'api_key': 'toto'
-        }
-
-        self.config = {
+        mongo_server = 'mongodb://localhost:37017/test'
+        config = {
             'instances': [{
-                'server': "mongodb://localhost:%s/test" % PORT1
-            },
-            {
-                'server': "mongodb://localhost:%s/test" % PORT2
+                'server': mongo_server
             }]
         }
 
-        # Test mongodb with checks.d
-        self.check = load_check('tokumx', self.config, self.agentConfig)
+        server_tag = 'server:%s' % mongo_server
 
-        # Run the check against our running server
-        self.check.check(self.config['instances'][0])
-        # Sleep for 1 second so the rate interval >=1
-        time.sleep(1)
-        # Run the check again so we get the rates
-        self.check.check(self.config['instances'][0])
+        self.run_check_twice(config)
 
-        # Metric assertions
-        metrics = self.check.get_metrics()
-        assert metrics
-        self.assertTrue(type(metrics) == type([]))
-        self.assertTrue(len(metrics) > 0)
+        # TODO: assert more tags
+        for mname in GAUGES:
+            self.assertMetric(mname, count=1, tags=[server_tag])
+        for mname in RATES:
+            self.assertMetric(mname, count=1)
+        for msuff in IDX_HISTS:
+            for hsuff in HIST_SUFFIXES:
+                self.assertMetric('tokumx.stats.idx.%s.%s' % (msuff, hsuff), count=1)
+        for msuff in IDX_LCL_RATES:
+            for hsuff in HIST_SUFFIXES:
+                self.assertMetric('tokumx.statsd.idx.%s.%s' % (msuff, hsuff), count=1)
+        for msuff in COLL_HISTS:
+            for hsuff in HIST_SUFFIXES:
+                self.assertMetric('tokumx.stats.coll.%s.%s' % (msuff, hsuff), count=1)
+        for msuff in DB_STATS:
+            for dbname in ('admin', 'local', 'test'):
+                self.assertMetric('tokumx.stats.db.%s' % (msuff), count=1, tags=[server_tag, 'db:%s' % dbname])
 
-        metric_val_checks = {
-            'mongodb.connections.current': lambda x: x >= 1,
-            'mongodb.connections.available': lambda x: x >= 1,
-            'mongodb.uptime': lambda x: x >= 0,
-            'mongodb.ft.cachetable.size.current': lambda x: x > 0,
-            'mongodb.ft.cachetable.size.limit': lambda x: x > 0,
-        }
+        self.assertServiceCheck('tokumx.can_connect', count=1, status=AgentCheck.OK, tags=['db:test', 'host:localhost', 'port:37017'])
 
-        for m in metrics:
-            metric_name = m[0]
-            if metric_name in metric_val_checks:
-                self.assertTrue( metric_val_checks[metric_name]( m[2] ) )
-
-        # Run the check against our running server
-        self.check.check(self.config['instances'][1])
-        # Sleep for 1 second so the rate interval >=1
-        time.sleep(1)
-        # Run the check again so we get the rates
-        self.check.check(self.config['instances'][1])
-
-        # Service checks
-        service_checks = self.check.get_service_checks()
-        print service_checks
-        service_checks_count = len(service_checks)
-        self.assertTrue(type(service_checks) == type([]))
-        self.assertTrue(service_checks_count > 0)
-        self.assertEquals(len([sc for sc in service_checks if sc['check'] == self.check.SERVICE_CHECK_NAME]), 4, service_checks)
-        # Assert that all service checks have the proper tags: host and port
-        self.assertEquals(len([sc for sc in service_checks if "host:localhost" in sc['tags']]), service_checks_count, service_checks)
-        self.assertEquals(len([sc for sc in service_checks if "port:%s" % PORT1 in sc['tags'] or "port:%s" % PORT2 in sc['tags']]), service_checks_count, service_checks)
-        self.assertEquals(len([sc for sc in service_checks if "db:test" in sc['tags']]), service_checks_count, service_checks)
-
-        # Metric assertions
-        metrics = self.check.get_metrics()
-        assert metrics
-        self.assertTrue(type(metrics) == type([]))
-        self.assertTrue(len(metrics) > 0)
-
-        for m in metrics:
-            metric_name = m[0]
-            if metric_name in metric_val_checks:
-                self.assertTrue( metric_val_checks[metric_name]( m[2] ) )
-
-if __name__ == '__main__':
-    unittest.main()
+        self.coverage_report()


### PR DESCRIPTION
This shouldn't be used too often because we have another layer of
caching (depending on dd-agent-travis-cache).
Although, when we really have to download the source and recompile it's
often when SourceForge or GitHub have an outage. By placing every egg in
the same basket we ensure that it's *our fault* if things go wrong.