### PR TITLE
[flare] remove pip cache warning :bug:

### DIFF
--- a/utils/flare.py
+++ b/utils/flare.py
@@ -303,9 +303,11 @@ class Flare(object):
 
     # Run a pip freeze
     def _pip_freeze(self):
+        # pip uses a debug log file EVEN FOR FREEZE, potentially
+        # resulting in warning which we cannot remove (no option for this)
         try:
             import pip
-            pip.main(['freeze'])
+            pip.main(['freeze', '--no-cache-dir'])
         except ImportError:
             print 'Unable to import pip'
 


### PR DESCRIPTION
When unning the `flare` command, this output appear if the user has installed some modules manually in the `/opt/datadog-agent` python environment:

> 2015-03-31 23:55:36,997 | INFO | dd.collector | flare(flare.py:99) |   * pip freeze
The directory '/opt/datadog-agent/.cache/pip/log' or its parent directory is not owned by the current user and the debug log has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want the -H flag.
The directory '/opt/datadog-agent/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want the -H flag.

We cannot remove the warning about the log file (no option for this), only the cache one.
This shouldn't appear often. cc @remh 