### PR TITLE
[tests] Clean before cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ python:
 
 cache:
   directories:
-    - $HOME/virtualenv/python2.6.9/lib/python2.6/site-packages
-    - $HOME/virtualenv/python2.7.9/lib/python2.7/site-packages
+    - $HOME/virtualenv/python$TRAVIS_PYTHON_VERSION.9
 
 matrix:
   fast_finish: true

--- a/ci/apache.rb
+++ b/ci/apache.rb
@@ -66,7 +66,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
-    task :before_cache => ['ci:common:before_cache']
+    task :before_cache => ['ci:common:before_cache'] do
+      # Useless to cache the conf, as it is regenerated every time
+      sh %(rm -f #{apache_rootdir}/conf/httpd.conf)
+    end
 
     task :cache => ['ci:common:cache']
 

--- a/ci/apache.rb
+++ b/ci/apache.rb
@@ -93,7 +93,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/cassandra.rb
+++ b/ci/cassandra.rb
@@ -68,7 +68,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/cassandra.rb
+++ b/ci/cassandra.rb
@@ -42,12 +42,14 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
-    task :before_cache => ['ci:common:before_cache']
+    task :before_cache => :cleanup
 
     task :cache => ['ci:common:cache']
 
     task cleanup: ['ci:common:cleanup'] do
       sh %(kill `cat $VOLATILE_DIR/cass.pid`)
+      sleep_for 3
+      sh %(rm -rf #{cass_rootdir}/data)
     end
 
     task :execute do

--- a/ci/common.rb
+++ b/ci/common.rb
@@ -15,8 +15,9 @@ def section(name)
   puts ''
 end
 
-# Initialize cache if in travis
-if ENV['TRAVIS']
+# Initialize cache if in travis and in our repository
+# (no cache for external contributors)
+if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
   cache = Cache.new({
     debug: ENV['DEBUG_CACHE'],
     s3: {
@@ -32,7 +33,7 @@ namespace :ci do
     task :before_install do |t|
       section('BEFORE_INSTALL')
       sh %(mkdir -p $VOLATILE_DIR)
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         cache.directories = ["#{ENV['HOME']}/embedded"]
         cache.setup
       end

--- a/ci/couchdb.rb
+++ b/ci/couchdb.rb
@@ -113,7 +113,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/couchdb.rb
+++ b/ci/couchdb.rb
@@ -84,12 +84,17 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
-    task :before_cache => ['ci:common:before_cache']
+    task :before_cache => ['ci:common:before_cache'] do
+      # It's the pid file which changes eveytime,
+      # so let's actually cleanup before cache
+      Rake::Task['ci:couchdb:cleanup'].invoke
+    end
 
     task :cache => ['ci:common:cache']
 
     task :cleanup => ['ci:common:cleanup'] do
       sh %(#{couchdb_rootdir}/bin/couchdb -k)
+      sh %(rm -f #{couchdb_rootdir}/var/run/couchdb/couchdb.pid)
     end
 
     task :execute do

--- a/ci/default.rb
+++ b/ci/default.rb
@@ -35,7 +35,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/elasticsearch.rb
+++ b/ci/elasticsearch.rb
@@ -69,7 +69,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/elasticsearch.rb
+++ b/ci/elasticsearch.rb
@@ -26,7 +26,9 @@ namespace :ci do
     end
 
     task :before_script => ['ci:common:before_script'] do
-      sh %(#{es_rootdir}/bin/elasticsearch -d)
+      pid = spawn %(#{es_rootdir}/bin/elasticsearch)
+      Process.detach(pid)
+      sh %(echo #{pid} > $VOLATILE_DIR/elasticsearch.pid)
       sleep_for 10
     end
 
@@ -37,12 +39,19 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
-    task :before_cache => ['ci:common:before_cache']
+    task :before_cache => ['ci:common:before_cache'] do
+      Rake::Task['ci:elasticsearch:cleanup'].invoke
+    end
 
     task :cache => ['ci:common:cache']
 
-    task :cleanup => ['ci:common:cleanup']
-    # FIXME: stop elasticsearch
+    task :cleanup => ['ci:common:cleanup'] do
+      # FIXME: remove `|| true` when we drop support for ES 0.90.x
+      # (the only version spawning a process in background)
+      sh %(kill `cat $VOLATILE_DIR/elasticsearch.pid` || true)
+      sleep_for 1
+      sh %(rm -rf #{es_rootdir}/data || true)
+    end
 
     task :execute do
       exception = nil

--- a/ci/etcd.rb
+++ b/ci/etcd.rb
@@ -72,7 +72,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/fluentd.rb
+++ b/ci/fluentd.rb
@@ -46,7 +46,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/gearman.rb
+++ b/ci/gearman.rb
@@ -64,7 +64,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/haproxy.rb
+++ b/ci/haproxy.rb
@@ -82,7 +82,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/lighttpd.rb
+++ b/ci/lighttpd.rb
@@ -44,13 +44,16 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
+    task :before_cache => ['ci:common:before_cache'] do
+      # Conf is regenerated at every run
+      sh %(rm -f #{lighttpd_rootdir}/lighttpd.conf)
+    end
+
+    task :cache => ['ci:common:cache']
+
     task :cleanup => ['ci:common:cleanup'] do
       sh %(kill `cat $VOLATILE_DIR/lighttpd.pid`)
     end
-
-    task :before_cache => ['ci:common:before_cache']
-
-    task :cache => ['ci:common:cache']
 
     task :execute do
       exception = nil

--- a/ci/lighttpd.rb
+++ b/ci/lighttpd.rb
@@ -71,7 +71,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/memcache.rb
+++ b/ci/memcache.rb
@@ -61,7 +61,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/mongo.rb
+++ b/ci/mongo.rb
@@ -98,7 +98,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/mysql.rb
+++ b/ci/mysql.rb
@@ -41,7 +41,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/nginx.rb
+++ b/ci/nginx.rb
@@ -70,7 +70,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/nginx.rb
+++ b/ci/nginx.rb
@@ -43,7 +43,10 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
-    task :before_cache => ['ci:common:before_cache']
+    task :before_cache => ['ci:common:before_cache'] do
+      # Conf is regenerated at every run
+      sh %(rm -f #{nginx_rootdir}/conf/nginx.conf)
+    end
 
     task :cache => ['ci:common:cache']
 

--- a/ci/pgbouncer.rb
+++ b/ci/pgbouncer.rb
@@ -75,7 +75,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/phpfpm.rb
+++ b/ci/phpfpm.rb
@@ -86,7 +86,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/postgres.rb
+++ b/ci/postgres.rb
@@ -104,7 +104,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/rabbitmq.rb
+++ b/ci/rabbitmq.rb
@@ -72,7 +72,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/redis.rb
+++ b/ci/redis.rb
@@ -88,7 +88,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/skeleton.rb
+++ b/ci/skeleton.rb
@@ -37,7 +37,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/snmpd.rb
+++ b/ci/snmpd.rb
@@ -64,7 +64,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/ssh.rb
+++ b/ci/ssh.rb
@@ -37,7 +37,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/supervisord.rb
+++ b/ci/supervisord.rb
@@ -68,7 +68,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/sysstat.rb
+++ b/ci/sysstat.rb
@@ -66,7 +66,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/sysstat.rb
+++ b/ci/sysstat.rb
@@ -32,9 +32,9 @@ namespace :ci do
     end
 
     task :before_script => ['ci:common:before_script'] do
-      # FIXME: probably not the cleanest way to go
       sh %(mkdir -p $INTEGRATIONS_DIR/bin)
-      sh %(cp #{sysstat_rootdir}/bin/mpstat $INTEGRATIONS_DIR/bin)
+      sh %(rm -f $INTEGRATIONS_DIR/bin/mpstat)
+      sh %(ln -s #{sysstat_rootdir}/bin/mpstat $INTEGRATIONS_DIR/bin/mpstat)
     end
 
     task :script => ['ci:common:script'] do

--- a/ci/tomcat.rb
+++ b/ci/tomcat.rb
@@ -69,7 +69,7 @@ namespace :ci do
         puts 'Cleaning up'
         Rake::Task["#{flavor.scope.path}:cleanup"].invoke
       end
-      if ENV['TRAVIS']
+      if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
         %w(before_cache cache).each do |t|
           Rake::Task["#{flavor.scope.path}:#{t}"].invoke
         end

--- a/ci/tomcat.rb
+++ b/ci/tomcat.rb
@@ -41,7 +41,11 @@ namespace :ci do
       Rake::Task['ci:common:run_tests'].invoke(this_provides)
     end
 
-    task :before_cache => ['ci:common:before_cache']
+    task :before_cache => ['ci:common:before_cache'] do
+      # Regenerated at every run
+      sh %(rm -f #{tomcat_rootdir}/bin/setenv.sh)
+      sh %(rm -f #{tomcat_rootdir}/conf/server.xml)
+    end
 
     task :cache => ['ci:common:cache']
 


### PR DESCRIPTION
Some files are regenerated every time the test is launched, and so were
triggering the upload of a new cache.
This commit should fix this devious behaviour.
It also fixes the issue with pylint not found by Travis-caching the
python bin directory.

& Use the cache only internally
And not on forks, this was already done by Travis to protect our
"secure env variables", this commit just removes all calls to the cache
in this case (previously, it was called, but nothing happened).

Travis doc about "Secure variables":
http://docs.travis-ci.com/user/environment-variables/#Secure-Variables
