### PR TITLE
[elasticsearch] Get information about `pending_tasks`

### DIFF
--- a/tests/checks/integration/test_elastic.py
+++ b/tests/checks/integration/test_elastic.py
@@ -221,8 +221,7 @@ class TestElastic(AgentCheckTest):
                                 count=1)
 
 
-        status = AgentCheck.OK if os.environ.get("TRAVIS")\
-            else AgentCheck.CRITICAL
+        status = AgentCheck.OK
         # Travis doesn't have any shards in the cluster and consider this as green
         self.assertServiceCheck('elasticsearch.cluster_health',
                                 status=status, tags=good_sc_tags,


### PR DESCRIPTION
Adding new elasticsearch metrics
- [x] pending_task_total - total number of pending tasks
- [x] pending_tasks_priority_high - number of high priority pending tasks
- [x] pending_tasks_priority_urgent - number of urgent priority pending tasks