### PR TITLE
[Core] Do not use proxy for local connections

### DIFF
--- a/emitter.py
+++ b/emitter.py
@@ -1,6 +1,7 @@
 # stdlib
 from hashlib import md5
 import logging
+import os
 import re
 import sys
 import zlib
@@ -12,6 +13,12 @@ import simplejson as json
 # project
 from config import get_version
 
+# Starting with Agent 5.0.0, there should always be a local forwarder
+# running and all payloads should go through it. So we should make sure
+# that we pass the no_proxy environment variable that will be used by requests
+# See: https://github.com/kennethreitz/requests/pull/945
+os.environ['no_proxy'] = '127.0.0.1,localhost'
+
 # urllib3 logs a bunch of stuff at the info level
 requests_log = logging.getLogger("requests.packages.urllib3")
 requests_log.setLevel(logging.WARN)
@@ -20,13 +27,6 @@ requests_log.propagate = True
 # From http://stackoverflow.com/questions/92438/stripping-non-printable-characters-from-a-string-in-python
 control_chars = ''.join(map(unichr, range(0,32) + range(127,160)))
 control_char_re = re.compile('[%s]' % re.escape(control_chars))
-
-NO_PROXY = {
-# See https://github.com/kennethreitz/requests/issues/879
-# and https://github.com/DataDog/dd-agent/issues/1112
-    'no': 'pass',
-}
-
 
 def remove_control_chars(s):
     return control_char_re.sub('', s)
@@ -55,8 +55,8 @@ def http_emitter(message, log, agentConfig):
     url = "{0}/intake?api_key={1}".format(url, apiKey)
 
     try:
-        r = requests.post(url, data=zipped, timeout=5,
-            headers=post_headers(agentConfig, zipped), proxies=NO_PROXY)
+        headers = post_headers(agentConfig, zipped)
+        r = requests.post(url, data=zipped, timeout=5, headers=headers)
 
         r.raise_for_status()
 

--- a/tests/test_dogstatsd.py
+++ b/tests/test_dogstatsd.py
@@ -820,5 +820,43 @@ class TestUnitDogStatsd(unittest.TestCase):
         nt.assert_equals(third['metric'], 'line_ending.windows')
         nt.assert_equals(third['points'][0][1], 300)
 
+
+    def test_no_proxy(self):
+        """ Starting with Agent 5.0.0, there should always be a local forwarder
+        running and all payloads should go through it. So we should make sure
+        that we pass the no_proxy environment variable that will be used by requests
+        (See: https://github.com/kennethreitz/requests/pull/945 )
+        """
+        from requests.utils import get_environ_proxies
+        import dogstatsd
+        from os import environ as env
+        
+        env["http_proxy"] = "http://localhost:3128"
+        env["https_proxy"] = env["http_proxy"]
+        env["HTTP_PROXY"] = env["http_proxy"]
+        env["HTTPS_PROXY"] = env["http_proxy"]
+
+        self.assertTrue("no_proxy" in env)
+
+        self.assertEquals(env["no_proxy"], "127.0.0.1,localhost")
+        self.assertEquals({}, get_environ_proxies(
+            "http://localhost:17123/api/v1/series"))
+
+        expected_proxies = {
+            'http': 'http://localhost:3128',
+            'https': 'http://localhost:3128',
+            'no': '127.0.0.1,localhost'
+        }
+        environ_proxies = get_environ_proxies("https://www.google.com")
+        self.assertEquals(expected_proxies, environ_proxies,
+            (expected_proxies, environ_proxies))
+
+        # Clear the env variables set
+        del env["http_proxy"]
+        del env["https_proxy"]
+        del env["HTTP_PROXY"]
+        del env["HTTPS_PROXY"]
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Starting with Agent 5.0.0, there should always
be a local forwarder running and all payloads
should go through it.

So we should make sure that we pass the no_proxy
environment variable that will be used by requests

See: https://github.com/kennethreitz/requests/pull/945

Fix #1514