### PR TITLE
[phpfpm] Use monotonic counts instead of counters

### DIFF
--- a/checks.d/php_fpm.py
+++ b/checks.d/php_fpm.py
@@ -22,13 +22,10 @@ class PHPFPMCheck(AgentCheck):
         'total processes': 'php_fpm.processes.total',
     }
 
-    RATES = {
-        'max children reached': 'php_fpm.processes.max_reached'
-    }
-
-    COUNTERS = {
+    MONOTONIC_COUNTS = {
         'accepted conn': 'php_fpm.requests.accepted',
-        'slow requests': 'php_fpm.requests.slow'
+        'max children reached': 'php_fpm.processes.max_reached',
+        'slow requests': 'php_fpm.requests.slow',
     }
 
     def check(self, instance):
@@ -86,17 +83,11 @@ class PHPFPMCheck(AgentCheck):
                 continue
             self.gauge(mname, int(data[key]), tags=metric_tags)
 
-        for key, mname in self.RATES.iteritems():
-            if key not in data:
-                self.log.warn("Rate metric {0} is missing from FPM status".format(key))
-                continue
-            self.rate(mname, int(data[key]), tags=metric_tags)
-
-        for key, mname in self.COUNTERS.iteritems():
+        for key, mname in self.MONOTONIC_COUNTS.iteritems():
             if key not in data:
                 self.log.warn("Counter metric {0} is missing from FPM status".format(key))
                 continue
-            self.increment(mname, int(data[key]), tags=metric_tags)
+            self.monotonic_count(mname, int(data[key]), tags=metric_tags)
 
         # return pool, to tag the service check with it if we have one
         return pool_name

--- a/tests/test_php_fpm.py
+++ b/tests/test_php_fpm.py
@@ -62,7 +62,7 @@ class PHPFPMCheckTest(AgentCheckTest):
             'tags': ['cluster:forums']
         }
 
-        self.run_check({'instances': [instance]})
+        self.run_check_twice({'instances': [instance]})
 
         metrics = [
             'php_fpm.listen_queue.size',
@@ -83,8 +83,5 @@ class PHPFPMCheckTest(AgentCheckTest):
 
         self.assertServiceCheck('php_fpm.can_ping', status=AgentCheck.OK,
                                 count=1)
-        time.sleep(1)
 
-        # Run check second time to get the rate
-        self.run_check({'instances': [instance]})
         self.assertMetric('php_fpm.processes.max_reached', count=1)


### PR DESCRIPTION
Otherwise it doesn't produce the expected results, with an increment the
graph will have a monotonically increasing curve whereas with a
monotonic count it will only report the difference since the last flush
which is what we want because the value given by FPM is never reset.