### PR TITLE
Small mistake fixed in check for Redis.

### DIFF
--- a/checks.d/redisdb.py
+++ b/checks.d/redisdb.py
@@ -288,7 +288,7 @@ class Redis(AgentCheck):
                     .format(MAX_SLOW_ENTRIES_KEY, DEFAULT_MAX_SLOW_ENTRIES))
                 max_slow_entries = DEFAULT_MAX_SLOW_ENTRIES
         else:
-            max_slow_entries = int(instance.get(max_slow_entries))
+            max_slow_entries = int(instance.get(MAX_SLOW_ENTRIES_KEY))
 
 
         # Generate a unique id for this instance to be persisted across runs


### PR DESCRIPTION
A very small one but it was making it impossible to monitor redis if you set the slowlog-max-len config key in the redisdb.yaml file (as shown in redisdb.yaml.example).