### PR TITLE
[riak] remove custom tags from service_checks_tags

### DIFF
--- a/checks.d/riak.py
+++ b/checks.d/riak.py
@@ -60,7 +60,7 @@ class Riak(AgentCheck):
         default_timeout = self.init_config.get('default_timeout', 5)
         timeout = float(instance.get('timeout', default_timeout))
         tags = instance.get('tags', [])
-        service_check_tags = tags + ['url:%s' % url]
+        service_check_tags = ['url:%s' % url]
 
         try:
             h = Http(timeout=timeout)


### PR DESCRIPTION
Since we don't support custom tags for service_checks for now.