### PR TITLE
[Multi] Fix service check tags

### DIFF
--- a/checks.d/docker.py
+++ b/checks.d/docker.py
@@ -166,9 +166,9 @@ class Docker(AgentCheck):
             all_containers = self._get_containers(instance, get_all=True)
         except (socket.timeout, urllib2.URLError), e:
             self.service_check(service_check_name, AgentCheck.CRITICAL,
-                message="Unable to list Docker containers: {0}".format(e), tags=tags)
+                message="Unable to list Docker containers: {0}".format(e))
             raise Exception("Failed to collect the list of containers. Exception: {0}".format(e))
-        self.service_check(service_check_name, AgentCheck.OK, tags=tags)
+        self.service_check(service_check_name, AgentCheck.OK)
 
         running_containers_ids = set([container['Id'] for container in running_containers])
 

--- a/checks.d/etcd.py
+++ b/checks.d/etcd.py
@@ -91,7 +91,8 @@ class Etcd(AgentCheck):
                     self.log.warn("Missing key {0} in stats.".format(key))
 
         if self_response is not None and store_response is not None:
-            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=instance_tags)
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
+                               tags=["url:{0}".format(url)])
 
     def get_self_metrics(self, url, timeout):
         return self.get_json(url + "/v2/stats/self", timeout)

--- a/checks.d/kyototycoon.py
+++ b/checks.d/kyototycoon.py
@@ -76,7 +76,8 @@ class KyotoTycoonCheck(AgentCheck):
                 tags=service_check_tags, message=str(e))
             raise
         else:
-            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK)
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
+                tags=service_check_tags)
 
         body = r.content
 

--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -63,18 +63,18 @@ class Marathon(AgentCheck):
             # If there's a timeout
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
                 message='%s timed out after %s seconds.' % (url, timeout),
-                tags = ["url:{}".format(url)])
+                tags = ["url:{0}".format(url)])
             raise Exception("Timeout when hitting %s" % url)
 
         except requests.exceptions.HTTPError:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
                 message='%s returned a status of %s' % (url, r.status_code),
-                tags = ["url:{}".format(url)])
+                tags = ["url:{0}".format(url)])
             raise Exception("Got %s when hitting %s" % (r.status_code, url))
 
         else:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
-                tags = ["url:{}".format(url)]
+                tags = ["url:{0}".format(url)]
             )
 
         return r.json()

--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -101,6 +101,10 @@ class MySql(AgentCheck):
                     user=user,
                     passwd=password
                 )
+                service_check_tags = [
+                    'host:%s' % mysql_sock,
+                    'port:unix_socket'
+                ]
             elif port:
                 db = pymysql.connect(
                     host=host,

--- a/checks.d/php_fpm.py
+++ b/checks.d/php_fpm.py
@@ -93,9 +93,7 @@ class PHPFPMCheck(AgentCheck):
         return pool_name
 
     def _process_ping(self, ping_url, auth, tags, pool_name):
-        sc_tags = tags[:]
-        if pool_name is not None:
-            sc_tags.append("pool:{0}".format(pool_name))
+        sc_tags = ["ping_url:{0}".format(ping_url)]
 
         try:
             # TODO: adding the 'full' parameter gets you per-process detailed

--- a/checks.d/redisdb.py
+++ b/checks.d/redisdb.py
@@ -140,12 +140,15 @@ class Redis(AgentCheck):
         tags = set(custom_tags or [])
 
         if 'unix_socket_path' in instance:
-            tags_to_add = ["unix_socket_path:%s" % instance.get("unix_socket_path")]
+            tags_to_add = [
+                "redis_host:%s" % instance.get("unix_socket_path"),
+                "redis_port:unix_socket",
+            ]
         else:
-            tags_to_add = ["redis_host:%s" % instance.get('host'), "redis_port:%s" % instance.get('port')]
-
-        if instance.get('db') is not None:
-            tags_to_add.append("db:%s" % instance.get('db'))
+            tags_to_add = [
+                "redis_host:%s" % instance.get('host'),
+                "redis_port:%s" % instance.get('port')
+            ]
 
         tags = sorted(tags.union(tags_to_add))
 
@@ -278,7 +281,7 @@ class Redis(AgentCheck):
         
         conn = self._get_conn(instance)
 
-        tags, tags_to_add = self._get_tags(custom_tags, instance)
+        tags, _ = self._get_tags(custom_tags, instance)
 
         if not instance.get(MAX_SLOW_ENTRIES_KEY):
             max_slow_entries = int(conn.config_get(MAX_SLOW_ENTRIES_KEY)[MAX_SLOW_ENTRIES_KEY])

--- a/checks.d/zk.py
+++ b/checks.d/zk.py
@@ -50,6 +50,7 @@ class ZookeeperCheck(AgentCheck):
         expected_mode = (instance.get('expected_mode') or '').strip()
         tags = instance.get('tags', [])
         cx_args = (host, port, timeout)
+        sc_tags = ["host:{0}".format(host), "port:{0}".format(port)]
 
         # Send a service check based on the `ruok` response.
         try:
@@ -67,7 +68,8 @@ class ZookeeperCheck(AgentCheck):
             else:
                 status = AgentCheck.WARNING
             message = u'Response from the server: %s' % ruok
-        self.service_check('zookeeper.ruok', status, message=message)
+        self.service_check('zookeeper.ruok', status, message=message,
+                           tags=sc_tags)
 
         # Read metrics from the `stat` output.
         try:
@@ -91,7 +93,8 @@ class ZookeeperCheck(AgentCheck):
                     status = AgentCheck.CRITICAL
                     message = u"Server is in %s mode but check expects %s mode"\
                               % (mode, expected_mode)
-                self.service_check('zookeeper.mode', status, message=message)
+                self.service_check('zookeeper.mode', status, message=message,
+                                   tags=sc_tags)
 
     def _send_command(self, command, host, port, timeout):
         sock = socket.socket()

--- a/tests/test_etcd.py
+++ b/tests/test_etcd.py
@@ -27,7 +27,7 @@ class EtcdTest(AgentCheckTest):
         self.assertEqual(len(self.service_checks), 1, self.service_checks)
         self.assertServiceCheck(self.check.SERVICE_CHECK_NAME,
                                 status=AgentCheck.OK,
-                                tags=['url:http://localhost:4001', 'etcd_state:leader'])
+                                tags=['url:http://localhost:4001'])
 
     def test_bad_config(self):
         self.assertRaises(Exception,

--- a/tests/test_php_fpm.py
+++ b/tests/test_php_fpm.py
@@ -49,7 +49,7 @@ class PHPFPMCheckTest(AgentCheckTest):
         self.assertServiceCheck(
             'php_fpm.can_ping',
             status=AgentCheck.CRITICAL,
-            tags=['expectedbroken'],
+            tags=['ping_url:http://localhost:9001/status'],
             count=1
         )
 
@@ -82,6 +82,7 @@ class PHPFPMCheckTest(AgentCheckTest):
         self.assertMetric('php_fpm.processes.total', count=1, value=2)
 
         self.assertServiceCheck('php_fpm.can_ping', status=AgentCheck.OK,
-                                count=1)
+                                count=1,
+                                tags=['ping_url:http://localhost:42424/ping'])
 
         self.assertMetric('php_fpm.processes.max_reached', count=1)


### PR DESCRIPTION
- etc: do not use custom tags
- Docker: Remove custom tags
- kyototycoon: add missing tags on status OK
- Marathon: Remove python2.6 incompatible code
- Mysql: Add support for socket connection
- PHP-FPM: Remove custom tags
- Redis: Use only one set of tags
- Zookeeper: Add tags to service check

--
This will likely break the CI and i'll try to add a few tests so this is not ready to merge yet.

cc: @conorbranagan , @LeoCavaille 