### PR TITLE
[source] log properly (package style) & cleanup

### DIFF
--- a/packaging/datadog-agent/osx/com.datadoghq.Agent.plist.example
+++ b/packaging/datadog-agent/osx/com.datadoghq.Agent.plist.example
@@ -15,6 +15,6 @@
   <key>WorkingDirectory</key>
   <string>AGENT_BASE</string>
   <key>StandardErrorPath</key>
-  <string>AGENT_BASE/launchd/logs/launchd.log</string>
+  <string>AGENT_BASE/logs/launchd.log</string>
 </dict>
 </plist>

--- a/packaging/datadog-agent/source/agent
+++ b/packaging/datadog-agent/source/agent
@@ -5,7 +5,7 @@ cd "$BASEDIR/.."
 PATH=$BASEDIR/../venv/bin:$PATH
 
 SUPERVISOR_NOT_RUNNING="Supervisor is not running"
-SUPERVISOR_CONF_FILE='supervisord/supervisord.conf'
+SUPERVISOR_CONF_FILE='agent/supervisor.conf'
 SOCK_FILE='supervisord/agent-supervisor.sock'
 PID_FILE='supervisord/supervisord.pid'
 action=$1

--- a/packaging/datadog-agent/source/info
+++ b/packaging/datadog-agent/source/info
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-BASEDIR=$(dirname $0)
-/usr/bin/env sh "$BASEDIR/agent" info $@
-

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -406,35 +406,39 @@ else
     if [ "$(uname)" = "SunOS" ]; then
         $SED_CMD -i "s/# log_to_syslog: yes/log_to_syslog: no/" "$DD_HOME/agent/datadog.conf"
     fi
-    echo "disable_file_logging: True" >> "$DD_HOME/agent/datadog.conf"
+    # Setting up logging
+    # Needed to avoid "unknown var $prog_log_file"
+    log_suffix="_log_file"
+    for prog in collector forwarder dogstatsd jmxfetch; do
+      echo "$prog$log_suffix: $DD_HOME/logs/$prog.log" >> "$DD_HOME/agent/datadog.conf"
+    done
 fi
 print_done
 
 print_console "* Setting up init scripts"
 mkdir -p "$DD_HOME/bin"
 cp "$DD_HOME/agent/packaging/datadog-agent/source/agent" "$DD_HOME/bin/agent"
-cp "$DD_HOME/agent/packaging/datadog-agent/source/info" "$DD_HOME/bin/info"
 chmod +x "$DD_HOME/bin/agent"
-chmod +x "$DD_HOME/bin/info"
 if [ "$(uname)" = "SunOS" ]; then
     cp "$DD_HOME/agent/packaging/datadog-agent/smartos/dd-agent" "$DD_HOME/bin/dd-agent"
     chmod +x "$DD_HOME/bin/dd-agent"
 fi
 print_done
 
-print_console "* Setting up supervisord (or launchd on OSX)"
-if [ "$(uname)" = "Darwin" ]; then
-    mkdir -p "$DD_HOME/launchd/logs"
-    touch "$DD_HOME/launchd/logs/launchd.log"
-    $SED_CMD "s|AGENT_BASE|$DD_HOME|; s|USER_NAME|$(whoami)|" "$DD_HOME/agent/packaging/datadog-agent/osx/com.datadoghq.Agent.plist.example" > "$DD_HOME/launchd/com.datadoghq.Agent.plist"
-    ln -s "$DD_HOME/launchd/logs" "$DD_HOME/logs"
-else
-    mkdir -p "$DD_HOME/supervisord/logs"
-    $VENV_PIP_CMD install "supervisor==$SUPERVISOR_VERSION"
-    cp "$DD_HOME/agent/packaging/datadog-agent/source/supervisord.conf" "$DD_HOME/supervisord/supervisord.conf"
-    ln -s "$DD_HOME/supervisord/logs" "$DD_HOME/logs"
-fi
+print_console "* Setting up supervisord"
+  mkdir -p "$DD_HOME/logs"
+  mkdir -p "$DD_HOME/supervisord"
+  $VENV_PIP_CMD install "supervisor==$SUPERVISOR_VERSION"
+  cp "$DD_HOME/agent/packaging/datadog-agent/source/supervisor.conf" "$DD_HOME/agent/supervisor.conf"
 print_done
+
+if [ "$(uname)" = "Darwin" ]; then
+  print_console "* Setting up launchd"
+  mkdir -p "$DD_HOME/launchd"
+  touch "$DD_HOME/logs/launchd.log"
+  $SED_CMD "s|AGENT_BASE|$DD_HOME|; s|USER_NAME|$(whoami)|" "$DD_HOME/agent/packaging/datadog-agent/osx/com.datadoghq.Agent.plist.example" > "$DD_HOME/launchd/com.datadoghq.Agent.plist"
+  print_done
+fi
 
 print_console "* Starting the agent"
 if [ "$DD_START_AGENT" = "0" ]; then
@@ -462,7 +466,7 @@ fi
 
 # supervisord.conf uses relative paths so need to chdir
 cd "$DD_HOME"
-supervisord -c supervisord/supervisord.conf &
+supervisord -c agent/supervisor.conf &
 cd -
 AGENT_PID=$!
 sleep 1

--- a/packaging/datadog-agent/source/supervisor.conf
+++ b/packaging/datadog-agent/source/supervisor.conf
@@ -1,9 +1,9 @@
 [supervisord]
-logfile = supervisord/logs/supervisord.log
+logfile = logs/supervisord.log
 logfile_maxbytes = 50MB
 loglevel = info
 nodaemon = true
-identifier = supervisor
+identifier = supervisord
 nocleanup = true
 pidfile = supervisord/supervisord.pid
 directory= supervisord
@@ -20,7 +20,6 @@ serverurl = unix://supervisord/agent-supervisor.sock
 
 [program:collector]
 command=python agent/agent.py foreground --use-local-forwarder
-stdout_logfile=supervisord/logs/collector.log
 redirect_stderr=true
 priority=999
 startsecs=2
@@ -28,21 +27,18 @@ environment=LANG=POSIX,PYTHONPATH='agent/checks/libs:$PYTHONPATH'
 
 [program:forwarder]
 command=python agent/ddagent.py --use_simple_http_client=1
-stdout_logfile=supervisord/logs/forwarder.log
 redirect_stderr=true
 priority=998
 startsecs=3
 
 [program:dogstatsd]
 command=python agent/dogstatsd.py --use-local-forwarder
-stdout_logfile=supervisord/logs/dogstatsd.log
 redirect_stderr=true
 priority=998
 startsecs=3
 
 [program:jmxfetch]
 command=python agent/jmxfetch.py
-stdout_logfile=supervisord/logs/jmxfetch.log
 redirect_stderr=true
 priority=999
 startsecs=0

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -282,7 +282,7 @@ class Flare(object):
         if not os.path.isfile(supervisor_conf):
             supervisor_conf = os.path.join(
                 os.path.dirname(os.path.realpath(__file__)),
-                '../../supervisord/supervisord.conf'
+                '../../agent/supervisor.conf'
             )
         return supervisor_conf
 


### PR DESCRIPTION
Previsouly logging was done using supervisor & stdout, totally different
from the package logging. There are options in the configuration to
change the log location, so let's use them instead of doing this trick!

In order to do this, this changes were made:
* remove supervisor processes logging (except `supervisor` itself)
* add a step to configure log location in the source install script

In order to clean weird conf location & others:
* move `supervisor.conf` from `supervisord/` to `agent/` with
`datadog.conf`
* update `bin/agent` to reflect this change
* remove `bin/info` as it is handled in `bin/agent` now (was probably
still here for _legacy_ reasons)
* put launchd logs in the same directory as other logs (`logs/`)
* update the source install script to reflect this change

And to fix the Mac install:
* install supervisor & launchd conf on Mac