### PR TITLE
[jmx] invalid_checks cast bug :bug:

### DIFF
--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -165,7 +165,7 @@ class JMXFetch(object):
                             tools_jar_path = check_tools_jar_path
                 except InvalidJMXConfiguration, e:
                     log.error("%s check does not have a valid JMX configuration: %s" % (check_name, e))
-                    invalid_checks[check_name] = e
+                    invalid_checks[check_name] = str(e)
 
         return (jmx_checks, invalid_checks, java_bin_path, java_options, tools_jar_path)
 


### PR DESCRIPTION
Save exception as a string, not a Python object

### Before
jmx_status_python.yaml
```
invalid_checks:
  jmx: !!python/object/apply:__main__.InvalidJMXConfiguration [A numeric port must
      be specified]
timestamp: 1429048613.553269
```
Printing agent info was raising an exception:
```
ConstructorError: while constructing a Python object
cannot find 'InvalidJMXConfiguration' in the module '__main__'
  in "/tmp/jmx_status_python.yaml", line 2, column 8
```

### After
jmx_status_python.yaml
```
invalid_checks: {jmx: A numeric port must be specified}
timestamp: 1429050253.38898
```