### PR TITLE
Add basic mandrill agent check

### DIFF
--- a/checks.d/mandrill_check.py
+++ b/checks.d/mandrill_check.py
@@ -1,0 +1,134 @@
+# std library
+import urlparse
+
+# third party imports
+import mandrill
+
+# dd-agent imports
+from checks import AgentCheck
+
+
+class MandrillCheck(AgentCheck):
+    """
+    Mandrill agent check
+
+    Fetches some basic stats from your Mandrill account via their api
+    """
+    TAG_GROUPS = ('last_30_days', 'last_60_days', 'last_7_days',
+                  'last_90_days', 'today')
+    TAG_STATS = ('clicks', 'complaints', 'hard_bounces', 'opens',
+                 'rejects', 'reputation', 'sent', 'soft_bounces',
+                 'unique_clicks', 'unique_opens', 'unsubs')
+
+    USER_GROUPS = ('all_time', 'last_30_days', 'last_60_days',
+                   'last_7_days', 'last_90_days', 'today')
+    USER_STATS = ('clicks', 'complaints', 'hard_bounces', 'opens',
+                  'rejects', 'sent', 'soft_bounces', 'unique_clicks',
+                  'unique_opens', 'unsubs')
+
+    URL_STATS = ('click', 'sent', 'unique_clicks')
+
+    def parse_domain(self, url):
+        """
+        Helper method to grab the domain from a url
+        """
+        parts = urlparse.urlparse(url)
+        return parts.netloc
+
+    def check(self, instance):
+        """
+        Main method called for each check run
+        """
+        if 'api_key' not in instance:
+            raise Exception('Missing "api_key" from Mandrill config')
+        api_key = instance['api_key']
+        client = mandrill.Mandrill(api_key)
+
+        self.fetch_user_stats(client)
+        self.fetch_url_stats(client)
+        self.fetch_tag_stats(client)
+
+    def fetch_user_stats(self, client):
+        """
+        Fetch and emit metrics about the current api user
+        """
+        info = client.users.info()
+        if not info:
+            return
+
+        tags = [
+            'username:%s' % (info['username'], ),
+            'public_id:%s' % (info['public_id'], ),
+        ]
+
+        self.gauge('mandrill.users.backlog', info.get('backlog', 0), tags=tags)
+        self.gauge('mandrill.users.hourly_quota', info.get('hourly_quota', 0), tags=tags)
+        self.gauge('mandrill.users.reputation', info.get('reputation', 0), tags=tags)
+
+        stats = info.get('stats', {})
+        for group_name in self.USER_GROUPS:
+            group = stats.get(group_name, {})
+            for stat_name in self.USER_STATS:
+                stat = group.get(stat_name, 0)
+                metric = 'mandrill.users.%s.%s' % (stat_name, group_name)
+                self.gauge(metric, stat, tags=tags)
+
+    def fetch_url_stats(self, client):
+        """
+        Fetch and emit metrics about all urls
+        """
+        all_data = client.urls.list()
+        if not all_data:
+            return
+
+        for url_data in all_data:
+            domain = self.parse_domain(url_data.get('url', ''))
+            tags = ['domain:%s' % (domain, )]
+            for stat_name in self.URL_STATS:
+                stat = url_data.get(stat_name, 0)
+                metric = 'mandrill.urls.%s' % (stat_name, )
+                # Use a histogram here since we will probably have an overlap
+                # in `domain:<url-domain>` tags
+                self.histogram(metric, stat, tags=tags)
+
+    def fetch_tag_stats(self, client):
+        """
+        Fetch and emit metrics about all tags
+        """
+        tags_data = client.tags.list()
+        if not tags_data:
+            return
+
+        tag_names = set(data['tag'] for data in tags_data if 'tag' in data)
+        for tag_name in tag_names:
+            tags = ['tag_name:%s' % (tag_name, )]
+
+            tag_data = client.tags.info(tag=tag_name)
+            tag_name = tag_data.get('tag', '')
+            for stat_name in self.TAG_STATS:
+                stat = tag_data.get(stat_name, 0)
+                metric = 'mandrill.tags.%s.current' % (stat_name, )
+                self.gauge(metric, stat, tags)
+
+            stats = tag_data.get('stats', {})
+            for group_name in self.TAG_GROUPS:
+                group = stats.get(group_name, {})
+                for stat_name in self.TAG_STATS:
+                    stat = group.get(stat_name, 0)
+                    metric = 'mandrill.tags.%s.%s' % (stat_name, group_name)
+                    self.gauge(metric, stat, tags)
+
+
+if __name__ == '__main__':
+    import os.path
+
+    config_file = os.path.join(os.path.dirname(__file__), '../conf.d/mandrill_check.yml')
+    check, instances = MandrillCheck.from_yaml(os.path.realpath(config_file))
+    for instance in instances:
+        print '\nRunning the check for api_key: %s' % (instance['api_key'], )
+        check.check(instance)
+
+        print 'Events:'
+        print check.get_events()
+        print 'Metrics:'
+        print check.get_metrics()

--- a/conf.d/mandrill_check.yaml.example
+++ b/conf.d/mandrill_check.yaml.example
@@ -1,0 +1,13 @@
+init_config:
+  # The mandrill api already aggregates some metrics together so you probably
+  # do not need to call the api every 15 seconds so you can optionally set
+  # `min_collection_interval: <seconds>` here to limit how often metrics are fetched
+  # https://github.com/DataDog/dd-agent/blob/2498cd6c45fc88a841e189a8de0d59cecfd38631/checks/__init__.py#L539-L544
+  # Only fetch metrics once every 10 minutes
+  # min_collection_interval: 600
+
+instances:
+  # The `api_key` should be for the user you want to get the stats of
+  # You can find your api keys here: https://mandrillapp.com/settings
+  # Your api user will need `users:info`, `tags:list`, `tags:info` and `urls:list` permissions
+  - api_key: API_KEY_HERE

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ###########################################################
 # These modules are the deps needed by the
-# agent core, meaning every module that is 
+# agent core, meaning every module that is
 # not a check
 # They're installed in the CI and when doing
 # a source install
@@ -57,3 +57,6 @@ pyvmomi==5.5.0.2014.1.1
 
 # checks.d/hdfs.py
 snakebite==1.3.11
+
+# checks.d/mandrill_check.py
+mandrill==1.0.57

--- a/tests/checks/mock/test_mandrill_check.py
+++ b/tests/checks/mock/test_mandrill_check.py
@@ -1,0 +1,141 @@
+# third party imports
+import mock
+
+# dd-agent imports
+from tests.checks.common import AgentCheckTest
+
+
+class TestMandrillCheck(AgentCheckTest):
+    CHECK_NAME = 'mandrill_check'
+
+    USER_STATS = {
+        'backlog': 5,
+        'hourly_quota': 50,
+        'reputation': 100,
+        'username': 'test_user',
+        'public_id': 'public_id',
+        'stats': {
+            'all_time': {
+                'clicks': 10000,
+            },
+            'last_30_days': {
+                'clicks': 5,
+            },
+            'last_60_days': {
+                'clicks': 10,
+            },
+            'last_90_days': {
+                'clicks': 30,
+            },
+            'last_7_days': {
+                'clicks': 2,
+            },
+            'today': {
+                'clicks': 0,
+            },
+        }
+    }
+
+    URL_STATS = [
+        {
+            'url': 'http://app.datadoghq.com/some-url/here',
+            'click': 30,
+            'sent': 1,
+            'unique_clicks': 5,
+        }
+    ]
+
+    TAGS = [
+        {
+            'tag': 'tag1',
+        },
+    ]
+    TAG_STATS = {
+        'tag1': {
+            'stats': {
+                'last_30_days': {
+                    'clicks': 5,
+                },
+                'last_60_days': {
+                    'clicks': 10,
+                },
+                'last_90_days': {
+                    'clicks': 30,
+                },
+                'last_7_days': {
+                    'clicks': 2,
+                },
+                'today': {
+                    'clicks': 0,
+                },
+            },
+        },
+    }
+
+    def _get_mock_client(self):
+        """
+        Helper method used to get mocked `mandrill.Mandrill` client
+        """
+
+        # `mandrill.Mandrill.tags.info` helper
+        def tags_info(tag):
+            return self.TAG_STATS.get(tag, {})
+
+        client = mock.MagicMock()
+        # these are the api calls that the check makes
+        client.users.info.return_value = self.USER_STATS
+        client.urls.list.return_value = self.URL_STATS
+        client.tags.list.return_value = self.TAGS
+        client.tags.info.side_effect = tags_info
+        return client
+
+    def _assert_user_stats(self):
+        """
+        Helper method to assert that the user metrics were properly sent
+        """
+        self.assertMetric('mandrill.users.backlog', 5, tags=('username:test_user', 'public_id:public_id'))
+        self.assertMetric('mandrill.users.hourly_quota', 50, tags=('username:test_user', 'public_id:public_id'))
+        self.assertMetric('mandrill.users.reputation', 100, tags=('username:test_user', 'public_id:public_id'))
+
+        self.assertMetric('mandrill.users.clicks.last_30_days', 5, tags=('username:test_user', 'public_id:public_id'))
+        self.assertMetric('mandrill.users.clicks.last_60_days', 10, tags=('username:test_user', 'public_id:public_id'))
+        self.assertMetric('mandrill.users.clicks.last_90_days', 30, tags=('username:test_user', 'public_id:public_id'))
+        self.assertMetric('mandrill.users.clicks.last_7_days', 2, tags=('username:test_user', 'public_id:public_id'))
+        self.assertMetric('mandrill.users.clicks.today', 0, tags=('username:test_user', 'public_id:public_id'))
+        self.assertMetric('mandrill.users.clicks.all_time', 10000, tags=('username:test_user', 'public_id:public_id'))
+
+    def _assert_url_stats(self):
+        """
+        Helper method to assert that the url metrics were properly sent
+        """
+        self.assertMetric('mandrill.urls.click.max', 30, tags=('domain:app.datadoghq.com', ))
+        self.assertMetric('mandrill.urls.sent.max', 1, tags=('domain:app.datadoghq.com', ))
+        self.assertMetric('mandrill.urls.unique_clicks.max', 5, tags=('domain:app.datadoghq.com', ))
+
+    def _assert_tag_stats(self):
+        """
+        Helper method to assert that the tag metrics were properly sent
+        """
+        self.assertMetric('mandrill.tags.clicks.last_30_days', 5, tags=('tag_name:tag1', ))
+        self.assertMetric('mandrill.tags.clicks.last_60_days', 10, tags=('tag_name:tag1', ))
+        self.assertMetric('mandrill.tags.clicks.last_90_days', 30, tags=('tag_name:tag1', ))
+        self.assertMetric('mandrill.tags.clicks.last_7_days', 2, tags=('tag_name:tag1', ))
+        self.assertMetric('mandrill.tags.clicks.today', 0, tags=('tag_name:tag1', ))
+
+    def test_check(self):
+        """
+        Test that a normal api call emits the correct metrics
+        """
+        config = {
+            'instances': [{
+                'api_key': 'EXAMPLE_KEY',
+            }]
+        }
+
+        with mock.patch('mandrill.Mandrill') as mandrill:
+            mandrill.return_value = self._get_mock_client()
+
+            self.run_check(config)
+            self._assert_user_stats()
+            self._assert_url_stats()
+            self._assert_tag_stats()


### PR DESCRIPTION
This PR adds a new agent check for mandrill. If you give it an api key it will go and fetch some basic information from the mandrill api about your account for the api's user, for tags and urls.