### PR TITLE
[ci] replace sleep_for by a function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,9 @@ env:
     - TRAVIS_FLAVOR=etcd
     - TRAVIS_FLAVOR=fluentd
     - TRAVIS_FLAVOR=go_expvar
-    # FIXME: cannot enable gearman on Travis right now
-    # because it needs boost
-    # - TRAVIS_FLAVOR=gearman
+# FIXME: cannot enable gearman on Travis right now
+# because it needs boost
+#   - TRAVIS_FLAVOR=gearman
     - TRAVIS_FLAVOR=haproxy
     - TRAVIS_FLAVOR=lighttpd
     - TRAVIS_FLAVOR=memcache
@@ -64,8 +64,8 @@ env:
     - TRAVIS_FLAVOR=redis FLAVOR_VERSION=2.4.18
     - TRAVIS_FLAVOR=redis FLAVOR_VERSION=2.6.17
     - TRAVIS_FLAVOR=redis FLAVOR_VERSION=2.8.19
-    # Compilation takes too much time on Travis
-    # - TRAVIS_FLAVOR=riak
+# Compilation takes too much time on Travis
+#   - TRAVIS_FLAVOR=riak
     - TRAVIS_FLAVOR=snmpd
     - TRAVIS_FLAVOR=ssh
     - TRAVIS_FLAVOR=supervisord

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
-gem 'colorize'
-gem 'rake'
 gem 'addressable'
+gem 'colorize'
+gem 'httparty'
+gem 'rake'

--- a/ci/apache.rb
+++ b/ci/apache.rb
@@ -51,7 +51,8 @@ namespace :ci do
       sh %(sed -i -e "s@%VOLATILE_DIR%@$VOLATILE_DIR@"\
             #{apache_rootdir}/conf/httpd.conf)
       sh %(#{apache_rootdir}/bin/apachectl start)
-      sleep_for 2
+      # Wait for Apache to start
+      Wait.for 'http://localhost:8080'
       # Simulate activity to populate metrics
       100.times do
         sh %(curl --silent http://localhost:8080 > /dev/null)

--- a/ci/cassandra.rb
+++ b/ci/cassandra.rb
@@ -28,11 +28,11 @@ namespace :ci do
 
     task :before_script => ['ci:common:before_script'] do
       sh %(cp $TRAVIS_BUILD_DIR/ci/resources/cassandra/cassandra_#{cass_version.split('.')[0..1].join('.')}.yaml #{cass_rootdir}/conf/cassandra.yaml)
-      sh %(#{cass_rootdir}/bin/cassandra -p $VOLATILE_DIR/cass.pid)
+      sh %(#{cass_rootdir}/bin/cassandra -p $VOLATILE_DIR/cass.pid > /dev/null)
       # Create temp cassandra workdir
       sh %(mkdir -p $VOLATILE_DIR/cassandra)
       # Wait for cassandra to init
-      sleep_for 10
+      Wait.for 7000, 10
     end
 
     task :script => ['ci:common:script'] do

--- a/ci/common.rb
+++ b/ci/common.rb
@@ -1,5 +1,8 @@
 require 'colorize'
+require 'httparty'
+require 'socket'
 require 'time'
+require 'timeout'
 
 require './ci/resources/cache'
 
@@ -15,17 +18,84 @@ def section(name)
   puts ''
 end
 
+class Wait
+  DEFAULT_TIMEOUT = 5
+
+  def self.check_port(port)
+    begin
+      Timeout.timeout(0.5) do
+        begin
+          s = TCPSocket.new('localhost', port)
+          s.close
+          return true
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+          return false
+        end
+      end
+    rescue Timeout::Error
+      return false
+    end
+  end
+
+  def self.check_url(url)
+    begin
+      Timeout.timeout(0.5) do
+        begin
+          r = HTTParty.get(url)
+          return (200...300).include? r.code
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+          return false
+        end
+      end
+    rescue Timeout::Error
+      return false
+    end
+  end
+
+  def self.check_file(file_path)
+    File.exist?(file_path)
+  end
+
+  def self.check(smth)
+    if smth.is_a? Integer
+      check_port smth
+    elsif smth.include? 'http'
+      check_url smth
+    else
+      check_file smth
+    end
+  end
+
+  def self.for(smth, max_timeout = DEFAULT_TIMEOUT)
+    start_time = Time.now
+    status = false
+    n = 1
+    puts "Trying #{smth}"
+    loop do
+      puts n.to_s
+      status = check(smth)
+      break if status || Time.now > start_time + max_timeout
+      n += 1
+      sleep 0.25
+    end
+    if status
+      puts 'Found!'
+    else
+      fail "Still not up after #{max_timeout}s"
+    end
+    status
+  end
+end
+
 # Initialize cache if in travis and in our repository
 # (no cache for external contributors)
 if ENV['TRAVIS'] && ENV['AWS_SECRET_ACCESS_KEY']
-  cache = Cache.new({
-    debug: ENV['DEBUG_CACHE'],
-    s3: {
-      bucket: 'dd-agent-travis-cache',
-      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
-    }
-  })
+  cache = Cache.new(debug: ENV['DEBUG_CACHE'],
+                    s3: {
+                      bucket: 'dd-agent-travis-cache',
+                      access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+                      secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+                    })
 end
 
 namespace :ci do
@@ -72,7 +142,7 @@ namespace :ci do
       t.reenable
     end
 
-    task :cache do |t|
+    task :cache do |_t|
       section('CACHE')
       cache.push
     end
@@ -97,6 +167,6 @@ namespace :ci do
       t.reenable
     end
 
-    task :execute => [:before_install, :install, :before_script, :script]
+    task execute: [:before_install, :install, :before_script, :script]
   end
 end

--- a/ci/couchdb.rb
+++ b/ci/couchdb.rb
@@ -74,7 +74,7 @@ namespace :ci do
     task :before_script => ['ci:common:before_script'] do
       sh %(#{couchdb_rootdir}/bin/couchdb -b)
       # Couch takes some time to start
-      sleep_for 2
+      Wait.for 5984
     end
 
     task :script => ['ci:common:script'] do

--- a/ci/elasticsearch.rb
+++ b/ci/elasticsearch.rb
@@ -1,7 +1,7 @@
 require './ci/common'
 
 def es_version
-  ENV['FLAVOR_VERSION'] || '1.4.2'
+  ENV['FLAVOR_VERSION'] || '1.4.4'
 end
 
 def es_rootdir
@@ -29,7 +29,8 @@ namespace :ci do
       pid = spawn %(#{es_rootdir}/bin/elasticsearch)
       Process.detach(pid)
       sh %(echo #{pid} > $VOLATILE_DIR/elasticsearch.pid)
-      sleep_for 10
+      # Waiting for elaticsearch to start
+      Wait.for 'http://localhost:9200', 10
     end
 
     task :script => ['ci:common:script'] do

--- a/ci/etcd.rb
+++ b/ci/etcd.rb
@@ -36,7 +36,14 @@ namespace :ci do
 
     task :before_script => ['ci:common:before_script'] do
       sh %(cd $VOLATILE_DIR && #{etcd_rootdir}/etcd >/dev/null &)
-      sleep_for 10
+      # Waiting for etcd to start
+      Wait.for 'http://localhost:4001/v2/stats/self'
+      Wait.for 'http://localhost:4001/v2/stats/store'
+      10.times do
+        sh %(curl -s http://127.0.0.1:2379/v2/keys/message\
+             -XPUT -d value="Hello world" >/dev/null)
+        sh %(curl -s http://127.0.0.1:2379/v2/keys/message > /dev/null)
+      end
     end
 
     task :script => ['ci:common:script'] do

--- a/ci/fluentd.rb
+++ b/ci/fluentd.rb
@@ -12,7 +12,8 @@ namespace :ci do
       pid = spawn %(fluentd -c $TRAVIS_BUILD_DIR/ci/resources/fluentd/td-agent.conf)
       Process.detach(pid)
       sh %(echo #{pid} > $VOLATILE_DIR/fluentd.pid)
-      sleep_for 10
+      # Waiting for fluentd to start
+      Wait.for 24220
     end
 
     task :script => ['ci:common:script'] do

--- a/ci/gearman.rb
+++ b/ci/gearman.rb
@@ -32,6 +32,8 @@ namespace :ci do
 
     task :before_script => ['ci:common:before_script'] do
       sh %(#{gearman_rootdir}/sbin/gearmand -d -l $VOLATILE_DIR/gearmand.log)
+      # FIXME: wait for gearman start
+      # Wait.for ??
     end
 
     task :script => ['ci:common:script'] do

--- a/ci/go_expvar.rb
+++ b/ci/go_expvar.rb
@@ -10,7 +10,7 @@ namespace :ci do
       pid = spawn %(go run $TRAVIS_BUILD_DIR/ci/resources/go_expvar/test_expvar.go)
       Process.detach(pid)
       sh %(echo #{pid} > $VOLATILE_DIR/go_expvar.pid)
-      sleep_for 2
+      Wait.for 8079
       2.times do
         sh %(curl -s http://localhost:8079?user=123456)
       end

--- a/ci/haproxy.rb
+++ b/ci/haproxy.rb
@@ -46,7 +46,8 @@ namespace :ci do
         Process.detach(pid)
         sh %(echo #{pid} > $VOLATILE_DIR/#{name}.pid)
       end
-      sleep_for 2
+      # Waiting for haproxy to start
+      Wait.for 3836
     end
 
     task :script => ['ci:common:script'] do

--- a/ci/mongo.rb
+++ b/ci/mongo.rb
@@ -48,7 +48,8 @@ namespace :ci do
           --noprealloc --rest --fork)
 
       # Set up the replica set + print some debug info
-      sleep_for 15
+      Wait.for 37017, 10
+      Wait.for 37018
       sh %(#{mongo_rootdir}/bin/mongo\
            --eval "printjson(db.serverStatus())" 'localhost:37017'\
            >> $VOLATILE_DIR/mongo.log)

--- a/ci/pgbouncer.rb
+++ b/ci/pgbouncer.rb
@@ -34,12 +34,13 @@ namespace :ci do
       sh %(cp $TRAVIS_BUILD_DIR/ci/resources/pgbouncer/users.txt\
            #{pgb_rootdir}/users.txt)
       sh %(#{pgb_rootdir}/pgbouncer -d #{pgb_rootdir}/pgbouncer.ini)
-      sleep_for 3
+      # Wait for pgbouncer to start
+      Wait.for 15433
       sh %(PGPASSWORD=datadog #{pg_rootdir}/bin/psql\
            -h localhost -p 15433 -U datadog -w\
            -c "SELECT * FROM persons"\
            datadog_test)
-      sleep_for 3
+      sleep_for 5
     end
 
     task :script do

--- a/ci/postgres.rb
+++ b/ci/postgres.rb
@@ -43,7 +43,7 @@ namespace :ci do
            -l $VOLATILE_DIR/postgres.log\
            -o "-p 15432"\
            start)
-      sleep_for 5
+      Wait.for 15432
       sh %(#{pg_rootdir}/bin/psql\
            -p 15432 -U $USER\
            postgres < $TRAVIS_BUILD_DIR/ci/resources/postgres/postgres.sql)

--- a/ci/rabbitmq.rb
+++ b/ci/rabbitmq.rb
@@ -28,7 +28,7 @@ namespace :ci do
 
     task :before_script => ['ci:common:before_script'] do
       sh %(#{rabbitmq_rootdir}/sbin/rabbitmq-server -detached)
-      sleep_for 5
+      Wait.for 5672, 10
       sh %(#{rabbitmq_rootdir}/sbin/rabbitmq-plugins enable rabbitmq_management)
       sh %(#{rabbitmq_rootdir}/sbin/rabbitmq-plugins enable rabbitmq_management)
       %w(test1 test5 tralala).each do |q|

--- a/ci/resources/supervisord/program_0.sh
+++ b/ci/resources/supervisord/program_0.sh
@@ -1,3 +1,3 @@
 # dummy program that runs for 10 seconds and dies
-
+echo 'test' >> $VOLATILE_DIR/supervisor/started_0
 sleep 10

--- a/ci/resources/supervisord/program_1.sh
+++ b/ci/resources/supervisord/program_1.sh
@@ -1,3 +1,3 @@
 # dummy program that runs for 20 seconds and dies
-
+echo 'test' >> $VOLATILE_DIR/supervisor/started_1
 sleep 20

--- a/ci/resources/supervisord/program_2.sh
+++ b/ci/resources/supervisord/program_2.sh
@@ -1,3 +1,3 @@
 # dummy program that runs for 30 seconds and dies
-
+echo 'test' >> $VOLATILE_DIR/supervisor/started_2
 sleep 30

--- a/ci/skeleton.rb
+++ b/ci/skeleton.rb
@@ -7,6 +7,8 @@ namespace :ci do
     task :install => ['ci:common:install']
 
     task :before_script => ['ci:common:before_script']
+    # If you need to wait on a start of a progran, please use Wait.for,
+    # see https://github.com/DataDog/dd-agent/pull/1547
 
     task :script => ['ci:common:script'] do
       this_provides = [

--- a/ci/supervisord.rb
+++ b/ci/supervisord.rb
@@ -36,7 +36,7 @@ namespace :ci do
 
       sh %(#{supervisor_rootdir}/bin/supervisord\
            -c $VOLATILE_DIR/supervisor/supervisord.conf)
-      sleep_for 3
+      3.times { |i| Wait.for "#{ENV['VOLATILE_DIR']}/supervisor/started_#{i}" }
     end
 
     task :script => ['ci:common:script'] do

--- a/ci/tomcat.rb
+++ b/ci/tomcat.rb
@@ -31,7 +31,7 @@ namespace :ci do
       sh %(cp $TRAVIS_BUILD_DIR/ci/resources/tomcat/tomcat.yaml $VOLATILE_DIR/jmx_yaml/)
       sh %(cp $TRAVIS_BUILD_DIR/ci/resources/tomcat/jmx.yaml $VOLATILE_DIR/jmx_yaml/)
       sh %(#{tomcat_rootdir}/bin/startup.sh)
-      sleep_for 5
+      Wait.for 'http://localhost:8080'
     end
 
     task :script => ['ci:common:script'] do

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -309,7 +309,7 @@ WARNINGS
             for cmtuple in candidates:
                 if mtuple == cmtuple:
                     mtuple[3]['tested'] = True
-        log.debug("FOUND !")
+        log.debug("{0} FOUND !".format(metric_name))
 
     def assertMetricTagPrefix(self, metric_name, tag_prefix, count=None, at_least=1):
         log.debug("Looking for a tag starting with `{0}:` on metric {1}"
@@ -339,7 +339,7 @@ WARNINGS
             for cmtuple in candidates:
                 if mtuple == cmtuple:
                     mtuple[3]['tested'] = True
-        log.debug("FOUND !")
+        log.debug("{0} FOUND !".format(metric_name))
 
     def assertMetricTag(self, metric_name, tag, count=None, at_least=1):
         log.debug("Looking for tag {0} on metric {1}".format(tag, metric_name))
@@ -368,7 +368,7 @@ WARNINGS
             for cmtuple in candidates:
                 if mtuple == cmtuple:
                     mtuple[3]['tested'] = True
-        log.debug("FOUND !")
+        log.debug("{0} FOUND !".format(metric_name))
 
     def assertServiceCheck(self, service_check_name, status=None, tags=None,
         count=None, at_least=1):
@@ -403,7 +403,7 @@ WARNINGS
             for csc in candidates:
                 if sc == csc:
                     sc['tested'] = True
-        log.debug("FOUND !")
+        log.debug("{0} FOUND !".format(service_check_name))
 
     def assertServiceCheckOK(self, service_check_name, tags=None, count=None, at_least=1):
         self.assertServiceCheck(service_check_name,

--- a/tests/checks/integration/test_elastic.py
+++ b/tests/checks/integration/test_elastic.py
@@ -142,7 +142,7 @@ CLUSTER_HEALTH_METRICS = {
 def get_es_version():
     version = os.environ.get("FLAVOR_VERSION")
     if version is None:
-        return [1, 4, 2]
+        return [1, 4, 4]
     return [int(k) for k in version.split(".")]
 
 

--- a/tests/checks/integration/test_pgbouncer.py
+++ b/tests/checks/integration/test_pgbouncer.py
@@ -52,7 +52,7 @@ class TestPgbouncer(AgentCheckTest):
             cur.execute('SELECT * FROM persons;')
         except Exception:
             pass
-        time.sleep(5)
+        time.sleep(1)
         self.run_check(config)
         self.assertMetric('pgbouncer.stats.requests_per_second')
         self.assertMetric('pgbouncer.stats.bytes_received_per_second')


### PR DESCRIPTION
`Wait.for` can receive either:
- a port (`Wait.for 7199`), and will return when the port is open
- an url (`Wait.for 'http://localhost:8080'`), and will return when
  receiving a 2xx response code
- a file (`Wait.for '/tmp/started'`), and will return when the file
  exists

It has a default timeout of 5s, which can be configured as its second
parameter: `Wait.for 'http://localhost:8080', 10`