### PR TITLE
[swap stats] add swap in/out check to checks.d

### DIFF
--- a/checks.d/system_swap.py
+++ b/checks.d/system_swap.py
@@ -1,17 +1,9 @@
 from checks import AgentCheck
-try:
-    import psutil
-except ImportError:
-    psutil = None
-
-B2MB  = float(1048576)
+import psutil
 
 class SystemSwap(AgentCheck):
 
     def check(self, instance):
-        if not psutil:
-            return {}
-
         swap_mem = psutil.swap_memory()
-        self.gauge('system.swap.swapped_in', swap_mem.sin / B2MB)
-        self.gauge('system.swap.swapped_out', swap_mem.sout / B2MB)
+        self.rate('system.swap.swapped_in', swap_mem.sin)
+        self.rate('system.swap.swapped_out', swap_mem.sout)

--- a/checks.d/system_swap.py
+++ b/checks.d/system_swap.py
@@ -1,0 +1,17 @@
+from checks import AgentCheck
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
+B2MB  = float(1048576)
+
+class SystemSwap(AgentCheck):
+
+    def check(self, instance):
+        if not psutil:
+            return {}
+
+        swap_mem = psutil.swap_memory()
+        self.gauge('system.swap.swapped_in', swap_mem.sin / B2MB)
+        self.gauge('system.swap.swapped_out', swap_mem.sout / B2MB)

--- a/tests/test_system_swap.py
+++ b/tests/test_system_swap.py
@@ -1,0 +1,30 @@
+import mock
+import psutil
+
+from tests.common import AgentCheckTest
+
+B2MB  = float(1048576)
+
+class _PSUtilSwapStatsMock(object):
+    def __init__(self, sin, sout):
+        self.sin = sin
+        self.sout = sout
+
+MOCK_PSUTIL_SWAP_STATS = [
+    _PSUtilSwapStatsMock(115332743168, 22920884224),
+    _PSUtilSwapStatsMock(115332743170, 22920884230),
+]
+
+class SystemSwapTestCase(AgentCheckTest):
+
+    CHECK_NAME = 'system_swap'
+
+    @mock.patch('psutil.swap_memory', side_effect=MOCK_PSUTIL_SWAP_STATS)
+    def test_system_swap(self, mock_swap_stats):
+        self.run_check({"instances": [{}]})
+        self.assertMetric('system.swap.swapped_in', 115332743168 / B2MB)
+        self.assertMetric('system.swap.swapped_out', 22920884224 / B2MB)
+
+        self.run_check({"instances": [{}]})
+        self.assertMetric('system.swap.swapped_in', 115332743170 / B2MB)
+        self.assertMetric('system.swap.swapped_out', 22920884230 / B2MB)

--- a/tests/test_system_swap.py
+++ b/tests/test_system_swap.py
@@ -1,18 +1,21 @@
 import mock
-import psutil
 
 from tests.common import AgentCheckTest
-
-B2MB  = float(1048576)
 
 class _PSUtilSwapStatsMock(object):
     def __init__(self, sin, sout):
         self.sin = sin
         self.sout = sout
 
+ORIG_SWAP_IN = 115332743168
+ORIG_SWAP_OUT = 22920884224
+
+SWAP_IN_INCR = 2
+SWAP_OUT_INCR = 4
+
 MOCK_PSUTIL_SWAP_STATS = [
-    _PSUtilSwapStatsMock(115332743168, 22920884224),
-    _PSUtilSwapStatsMock(115332743170, 22920884230),
+    _PSUtilSwapStatsMock(ORIG_SWAP_IN, ORIG_SWAP_OUT),
+    _PSUtilSwapStatsMock(ORIG_SWAP_IN + SWAP_IN_INCR, ORIG_SWAP_OUT + SWAP_OUT_INCR),
 ]
 
 class SystemSwapTestCase(AgentCheckTest):
@@ -21,10 +24,6 @@ class SystemSwapTestCase(AgentCheckTest):
 
     @mock.patch('psutil.swap_memory', side_effect=MOCK_PSUTIL_SWAP_STATS)
     def test_system_swap(self, mock_swap_stats):
-        self.run_check({"instances": [{}]})
-        self.assertMetric('system.swap.swapped_in', 115332743168 / B2MB)
-        self.assertMetric('system.swap.swapped_out', 22920884224 / B2MB)
-
-        self.run_check({"instances": [{}]})
-        self.assertMetric('system.swap.swapped_in', 115332743170 / B2MB)
-        self.assertMetric('system.swap.swapped_out', 22920884230 / B2MB)
+        self.run_check_twice({"instances": [{}]}) # Run check twice, sleeping for 1 sec in between
+        self.assertMetric('system.swap.swapped_in', value=SWAP_IN_INCR, count=1)
+        self.assertMetric('system.swap.swapped_out', value=SWAP_OUT_INCR, count=1)


### PR DESCRIPTION
Uses `psutil` to collect the rate of memory swapped in and swapped out. New metrics are labelled `system.swap.swapped_in` and `system.swap.swapped_out`.

Fixes #716 