### PR TITLE
[systemd] Package updated to be systemd compliant

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -5,7 +5,7 @@ logfile="ddagent-install.log"
 gist_request=/tmp/agent-gist-request.tmp
 gist_response=/tmp/agent-gist-response.tmp
 
-if [ $(which curl) ]; then
+if [ $(command -v curl) ]; then
     dl_cmd="curl -f"
 else
     dl_cmd="wget --quiet"
@@ -144,7 +144,11 @@ else
 fi
 
 printf "\033[34m* Starting the Agent...\n\033[0m\n"
-$sudo_cmd /etc/init.d/datadog-agent restart
+if command -v invoke-rc.d >/dev/null 2>&1; then
+    $sudo_cmd invoke-rc.d datadog-agent restart
+else
+    $sudo_cmd /etc/init.d/datadog-agent restart
+fi
 
 # Wait for metrics to be submitted by the forwarder
 printf "\033[32m

--- a/packaging/debian/datadog-agent.service
+++ b/packaging/debian/datadog-agent.service
@@ -1,0 +1,11 @@
+[Unit]
+Description="Datadog Agent"
+After=network.target
+
+[Service]
+Type=forking
+ExecStart=/opt/datadog-agent/bin/start_agent.sh
+ExecStop=/opt/datadog-agent/bin/supervisorctl -c /etc/dd-agent/supervisor.conf shutdown
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/debian/start_agent.sh
+++ b/packaging/debian/start_agent.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+PATH=/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:$PATH
+
+exec /opt/datadog-agent/bin/supervisord -c /etc/dd-agent/supervisor.conf --pidfile /var/run/datadog-supervisord.pid


### PR DESCRIPTION
The install script has been modified (it uses updated-rc.d to restart
the agent, which will implicitly call systemd if available) and the
datadog-agent.service systemd descriptor has been added as part of the
package (so that omnibus puts it in the .deb packages).

This service declaration is basically pluging supervisord into systemd,
nothing more (as shown here
https://gist.github.com/tonyseek/ddc7e3a89f0d78e685d6 for instance)

The supervisord start call has been ut in a separate script.
It allows us to have access to the PATH (/bin/sh is called to run the
script) while keeping a one-level forking scheme thanks to exec (/bin/sh
gets replaced by supervisord that will then fork and launch the
different components of our agent. Being a direct child of systemd, the
forked processes are too).