### PR TITLE
update requests library, per CVE-2015-2296

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ if sys.platform == 'win32':
         'pyvmomi==5.5.0.2014.1.1',
         'pywin32==217',
         'redis==2.10.3',
-        'requests==2.4.3',
+        'requests==2.6.0',
         'simplejson==3.6.4',
         'tornado==3.2.2',
         'wmi==1.4.9',


### PR DESCRIPTION
Versions prior to 2.6.0 are vulnerable to a specific session hijack
attack. Since we don't necessarily set cookies on Agent-based calls to
the data intake, a session-based hijacking is unlikely, but we should
still try to keep up with security patches.

More details: http://www.openwall.com/lists/oss-security/2015/03/14/4