### PR TITLE
Fix docker check when a container has no name

### DIFF
--- a/checks.d/docker.py
+++ b/checks.d/docker.py
@@ -186,9 +186,15 @@ class Docker(AgentCheck):
         # The index of the names is used to generate and format events
         ids_to_names = {}
         for container in all_containers:
-            ids_to_names[container['Id']] = container['Names'][0].lstrip("/")
+            ids_to_names[container['Id']] = self._get_container_name(container)
 
         return running_containers, ids_to_names
+
+    def _get_container_name(self, container):
+        # Use either the first container name or the container ID to name the container in our events
+        if container.get('Names', []):
+            return container['Names'][0].lstrip("/")
+        return container['Id'][:11]
 
     def _prepare_filters(self, instance):
         # The reasoning is to check exclude first, so we can skip if there is no exclude


### PR DESCRIPTION
Fix a bug when a Docker container has no name.
That's uncommon (since usually Docker assign at least a random name), but that's possible.
