### PR TITLE
[apptags] Added apptag support to dd-agent

### DIFF
--- a/config.py
+++ b/config.py
@@ -426,8 +426,12 @@ def get_config(parse_args=True, cfg_path=None, options=None):
                 agentConfig[key] = config.get('Main', key)
             else:
                 agentConfig[key] = value
+        
+        # Create app:xxx tags based on monitored apps
+        agentConfig['create_dd_check_tags'] = config.has_option('Main', 'create_dd_check_tags')\
+                and _is_affirmative(config.get('Main', 'create_dd_check_tags'))
 
-        #Forwarding to external statsd server
+        # Forwarding to external statsd server
         if config.has_option('Main', 'statsd_forward_host'):
             agentConfig['statsd_forward_host'] = config.get('Main', 'statsd_forward_host')
             if config.has_option('Main', 'statsd_forward_port'):

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -384,6 +384,20 @@ class JMXFetch(object):
                                 "jmxfetch", JMX_FETCH_JAR_NAME))
 
 
+def _get_jmx_appnames():
+    """ 
+    Retrieves the running JMX checks based on the {tmp}/jmx_status.yaml file 
+    updated by JMXFetch (and the only communication channel between JMXFetch
+    and the collector since JMXFetch).
+    """
+    check_names = []
+    jmx_status_path = os.path.join(get_jmx_status_path(), "jmx_status.yaml")
+    if os.path.exists(jmx_status_path):
+        jmx_checks = yaml.load(file(jmx_status_path)).get('checks', {})
+        check_names = [name for name in jmx_checks.get('initialized_checks', {}).iterkeys()]
+    return check_names
+        
+
 def init(config_path=None):
     agentConfig = get_config(parse_args=False, cfg_path=config_path)
     osname = get_os()


### PR DESCRIPTION
The agent now sends one "dd_check:appname" tag to dogweb for each
running check (including the JMX checks) if the user enables the
create_dd_check_tags option. This enables slice/dice by app in the
backend. The apptags are sent at regular intervals (every ten minutes by
default)

The running JMX apps list is retrieved from the {tmp}/jmx_status.yaml
file. Indeed, these tags have to be sent from the collectors side, along
with host-tags and this file happens to be the only communication
channel between JMXFetch.jar and the agent.

A test had been added to our test suite specifically for this new
feature (checking that the apptag is sent).