### PR TITLE
Add HAProxy timer metrics

### DIFF
--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -59,6 +59,10 @@ class HAProxy(AgentCheck):
         "hrsp_4xx": ("rate", "response.4xx"),
         "hrsp_5xx": ("rate", "response.5xx"),
         "hrsp_other": ("rate", "response.other"),
+        "qtime": ("gauge", "queue.time"),  # HA Proxy 1.5 and higher
+        "ctime": ("gauge", "connect.time"),  # HA Proxy 1.5 and higher
+        "rtime": ("gauge", "response.time"),  # HA Proxy 1.5 and higher
+        "ttime": ("gauge", "session.time"),  # HA Proxy 1.5 and higher
     }
 
     SERVICE_CHECK_NAME = 'haproxy.backend_up'

--- a/tests/checks/integration/test_haproxy.py
+++ b/tests/checks/integration/test_haproxy.py
@@ -22,6 +22,10 @@ class HaproxyTest(AgentCheckTest):
     BACKEND_CHECK_GAUGES = [
         'haproxy.backend.queue.current',
         'haproxy.backend.session.current',
+        'haproxy.backend.queue.time',
+        'haproxy.backend.connect.time',
+        'haproxy.backend.response.time',
+        'haproxy.backend.session.time',
     ]
 
     FRONTEND_CHECK_RATES = [


### PR DESCRIPTION
There are useful to see backend performance.  They are new in HAProxy 1.5, but the collector should still work with older versions.

From http://cbonte.github.io/haproxy-dconv/configuration-1.5.html#9.1:
```
 58. qtime [..BS]: the average queue time in ms over the 1024 last requests
 59. ctime [..BS]: the average connect time in ms over the 1024 last requests
 60. rtime [..BS]: the average response time in ms over the 1024 last requests
     (0 for TCP)
 61. ttime [..BS]: the average total session time in ms over the 1024 last
     requests
```