### PR TITLE
ignore rdsadmin database in postgres check to avoid permission error

### DIFF
--- a/checks.d/postgres.py
+++ b/checks.d/postgres.py
@@ -36,6 +36,7 @@ SELECT datname,
   FROM pg_stat_database
  WHERE datname not ilike 'template%%'
    AND datname not ilike 'postgres'
+   AND datname not ilike 'rdsadmin'
 """,
         'relation': False,
     }


### PR DESCRIPTION
When polling an RDS instance the rdsadmin database should be ignored. This is an internal database used for RDS and it's not accessible to normal users and probably doesn't have any interesting information for anyone but Amazon.

This is what happens when `rdsadmin` is not ignored:

```
2015-05-02 01:08:48 UTC | WARNING | dd.collector | checks.postgres(postgres.py:419) | Not all metrics may be available: ('ERROR', '42501', 'permission denied for database rdsadmin')
2015-05-02 01:08:48 UTC | WARNING | dd.collector | checks.postgres(postgres.py:419) | Not all metrics may be available: ('ERROR', '25P02', 'current transaction is aborted, commands ignored until end of transaction block')
```

Works fine after this patch. Should not affect anyone that isn't using a table with this name for their own purposes.