### PR TITLE
[kafka_consumer] add timeout for zk/kafka connections

### DIFF
--- a/conf.d/kafka_consumer.yaml.example
+++ b/conf.d/kafka_consumer.yaml.example
@@ -1,4 +1,8 @@
 init_config:
+#  Customize the ZooKeeper connection timeout here
+#  zk_timeout: 5
+#  Customize the Kafka connection timeout here
+#  kafka_timeout: 5
 
 instances:
   # - kafka_connect_str: localhost:19092


### PR DESCRIPTION
Because the default timeouts are pretty high in the kafka-python and
kazoo library (resp. 120s and 10s), we put them at a much lower
threshold (5s) for the default cases and offer a way to override in the
YAML init_config section.

Fixes #1589.