### PR TITLE
[gohai] Writing gohai errors to collector's log

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -450,10 +450,12 @@ class Collector(object):
                     command = "gohai"
                 else:
                     command = "gohai\gohai.exe"
-                gohai_metadata = subprocess.Popen(
-                    [command], stdout=subprocess.PIPE
-                ).communicate()[0]
+                gohai_metadata, gohai_log = subprocess.Popen(
+                    [command], stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                ).communicate()
                 payload['gohai'] = gohai_metadata
+                if gohai_log:
+                    log.warning("GOHAI LOG | {0}".format(gohai_log))
             except OSError as e:
                 if e.errno == 2:  # file not found, expected when install from source
                     log.info("gohai file not found")


### PR DESCRIPTION
From now on, everything gohai prints on its stderr (that is to say the
logs) is written to the collector.log file. It makes it easier for us to
pinpoint gohai related errors such as the "No IPV6" bug we just found.