### PR TITLE
[disk] AgentCheck for Disk metrics :tada:

### DIFF
--- a/checks.d/disk.py
+++ b/checks.d/disk.py
@@ -1,0 +1,232 @@
+# stdlib
+import os
+import re
+
+# 3p
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
+# project
+from checks import AgentCheck
+from config import _is_affirmative
+from util import Platform
+import utils.subprocess_output
+
+
+class Disk(AgentCheck):
+    """ Collects metrics about the machine's disks. """
+    # -T for filesystem info
+    DF_COMMAND = ['df', '-T']
+    FAKE_DEVICES = ['udev', 'sysfs', 'rpc_pipefs', 'proc', 'devpts']
+    METRIC_DISK = 'system.disk.{0}'
+    METRIC_INODE = 'system.fs.inodes.{0}'
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        if instances is not None and len(instances) > 1:
+            raise Exception("Disk check only supports one configured instance.")
+        AgentCheck.__init__(self, name, init_config,
+                            agentConfig, instances=instances)
+        # Get the configuration once for all
+        self._load_conf(instances[0])
+
+    def check(self, instance):
+        """Get disk space/inode stats"""
+        # Windows and Mac will always have psutil
+        # (we have packaged for both of them)
+        if self._psutil():
+            self.collect_metrics_psutil()
+        else:
+            self.collect_metrics_manually()
+
+    @classmethod
+    def _psutil(cls):
+        return psutil is not None
+
+    def _load_conf(self, instance):
+        self._excluded_filesystems = instance.get('excluded_filesystems', [])
+        self._excluded_disks = instance.get('excluded_disks', [])
+        self._tag_by_filesystem = _is_affirmative(
+            instance.get('tag_by_filesystem', False))
+        self._all_partitions = _is_affirmative(
+            instance.get('all_partitions', True))
+
+        # FIXME: 6.x, drop use_mount option in datadog.conf
+        self._load_legacy_option(instance, 'use_mount', False,
+                                 operation=_is_affirmative)
+        # FIXME: 6.x, drop device_blacklist_re option in datadog.conf
+        self._load_legacy_option(instance, 'excluded_disk_re', '^$',
+                                 legacy_name='device_blacklist_re',
+                                 operation=re.compile)
+
+    def _load_legacy_option(self, instance, option, default,
+                            legacy_name=None, operation=lambda l: l):
+        value = instance.get(option, default)
+        legacy_name = legacy_name or option
+
+        if value == default and legacy_name in self.agentConfig:
+            self.log.warn(
+                "Using `{0}` in datadog.conf has been deprecated"
+                " in favor of `{1}` in disk.yaml".format(legacy_name, option)
+            )
+            value = self.agentConfig.get(legacy_name)
+        setattr(self, '_{0}'.format(option), operation(value))
+
+    def collect_metrics_psutil(self):
+        self._valid_disks = {}
+        for part in psutil.disk_partitions(all=self._all_partitions):
+            # we check all exclude conditions
+            if self._exclude_disk_psutil(part):
+                continue
+            # For later, latency metrics
+            self._valid_disks[part.device] = (part.fstype, part.mountpoint)
+            self.log.debug('Passed: {0}'.format(part.device))
+
+            tags = [part.fstype] if self._tag_by_filesystem else []
+            device_name = part.mountpoint if self._use_mount else part.device
+            for metric_name, metric_value in self._collect_part_metrics(part).iteritems():
+                self.gauge(metric_name, metric_value,
+                           tags=tags, device_name=device_name)
+        # And finally, latency metrics, a legacy gift from the old Windows Check
+        self.collect_latency_metrics()
+
+    def _exclude_disk_psutil(self, part):
+        # skip cd-rom drives with no disk in it; they may raise
+        # ENOENT, pop-up a Windows GUI error for a non-ready
+        # partition or just hang;
+        # and all the other excluded disks
+        return ((Platform.is_win32() and ('cdrom' in part.opts or
+                                          part.fstype == '')) or
+                self._exclude_disk(part.device, part.fstype))
+
+    # We don't want all those incorrect devices
+    def _exclude_disk(self, name, filesystem):
+        return (name in self.FAKE_DEVICES or
+                name in self._excluded_disks or
+                self._excluded_disk_re.match(name) or
+                filesystem in self._excluded_filesystems)
+
+    def _collect_part_metrics(self, part):
+        usage = psutil.disk_usage(part.mountpoint)
+        metrics = {}
+        for name in ['total', 'used', 'free']:
+            # For legacy reasons,  the standard unit it kB
+            metrics[self.METRIC_DISK.format(name)] = getattr(usage, name) / 1024.0
+        # FIXME: 6.x, use percent, a lot more logical than in_use
+        metrics[self.METRIC_DISK.format('in_use')] = usage.percent / 100.0
+        if Platform.is_unix():
+            metrics.update(self._collect_inodes_metrics(part.mountpoint))
+
+        return metrics
+
+    def _collect_inodes_metrics(self, mountpoint):
+        metrics = {}
+        inodes = os.statvfs(mountpoint)
+        if inodes.f_files != 0:
+            total = inodes.f_files
+            free = inodes.f_ffree
+            metrics[self.METRIC_INODE.format('total')] = total
+            metrics[self.METRIC_INODE.format('free')] = free
+            metrics[self.METRIC_INODE.format('used')] = total - free
+            # FIXME: 6.x, use percent, a lot more logical than in_use
+            metrics[self.METRIC_INODE.format('in_use')] = \
+                (total - free) / float(total)
+        return metrics
+
+    def collect_latency_metrics(self):
+        for disk_name, disk in psutil.disk_io_counters(True).iteritems():
+            # disk_name is sda1, _valid_disks contains /dev/sda1
+            match_disks = [d for d in self._valid_disks
+                           if re.match('^(/dev/)?{0}$'.format(disk_name), d)]
+            if not match_disks:
+                continue
+
+            device = match_disks[0]
+            fstype, mountpoint = self._valid_disks[device]
+            self.log.debug('Passed: {0} -> {1}'.format(disk_name, device))
+            tags = []
+            if self._tag_by_filesystem:
+                tags = [fstype]
+            device_name = mountpoint if self._use_mount else device
+
+            # x100 to have it as a percentage,
+            # /1000 as psutil returns the value in ms
+            read_time_pct = disk.read_time * 100.0 / 1000.0
+            write_time_pct = disk.write_time * 100.0 / 1000.0
+            self.gauge(self.METRIC_DISK.format('read_time_pct'),
+                       read_time_pct, device_name=device_name, tags=tags)
+            self.gauge(self.METRIC_DISK.format('write_time_pct'),
+                       write_time_pct, device_name=device_name, tags=tags)
+
+    # no psutil, let's use df
+    def collect_metrics_manually(self):
+        df_out = utils.subprocess_output.get_subprocess_output(
+            self.DF_COMMAND + ['-k'], self.log
+        )
+        self.log.debug(df_out)
+        for device in self._list_devices(df_out):
+            self.log.debug("Passed: {0}".format(device))
+            tags = [device[1]] if self._tag_by_filesystem else []
+            device_name = device[-1] if self._use_mount else device[0]
+            for metric_name, value in self._collect_metrics_manually(device).iteritems():
+                self.gauge(metric_name, value, tags=tags,
+                           device_name=device_name)
+
+    def _collect_metrics_manually(self, device):
+        result = {}
+        # device is
+        # ["/dev/sda1", "ext4", 524288,  171642,  352646, "33%", "/"]
+        result[self.METRIC_DISK.format('total')] = float(device[2])
+        result[self.METRIC_DISK.format('used')] = float(device[3])
+        result[self.METRIC_DISK.format('free')] = float(device[4])
+        if len(device[5]) > 1 and device[5][-1] == '%':
+            result[self.METRIC_DISK.format('in_use')] = \
+                float(device[5][:-1]) / 100.0
+
+        result.update(self._collect_inodes_metrics(device[-1]))
+        return result
+
+    def _keep_device(self, device):
+        # device is for Unix
+        # [/dev/disk0s2, ext4, 244277768, 88767396, 155254372, 37%, /]
+        # First, skip empty lines.
+        # then filter our fake hosts like 'map -hosts'.
+        #    Filesystem    Type   1024-blocks     Used Available Capacity  Mounted on
+        #    /dev/disk0s2  ext4     244277768 88767396 155254372    37%    /
+        #    map -hosts    tmpfs            0        0         0   100%    /net
+        # and finally filter out fake devices
+        return (device and len(device) > 1 and
+                device[2].isdigit() and
+                not self._exclude_disk(device[0], device[1]))
+
+    def _flatten_devices(self, devices):
+        # Some volumes are stored on their own line. Rejoin them here.
+        previous = None
+        for parts in devices:
+            if len(parts) == 1:
+                previous = parts[0]
+            elif previous and self._is_number(parts[0]):
+                # collate with previous line
+                parts.insert(0, previous)
+                previous = None
+            else:
+                previous = None
+        return devices
+
+    def _list_devices(self, df_output):
+        """
+        Given raw output for the df command, transform it into a normalized
+        list devices. A 'device' is a list with fields corresponding to the
+        output of df output on each platform.
+        """
+        all_devices = [l.strip().split() for l in df_output.splitlines()]
+
+        # Skip the header row and empty lines.
+        raw_devices = [l for l in all_devices[1:] if l]
+
+        # Flatten the disks that appear in the mulitple lines.
+        flattened_devices = self._flatten_devices(raw_devices)
+
+        # Filter fake or unwanteddisks.
+        return [d for d in flattened_devices if self._keep_device(d)]

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -181,10 +181,10 @@ class Collector(object):
             # Unix system checks
             sys_checks = self._unix_system_checks
 
-            diskUsage = sys_checks['disk'].check(self.agentConfig)
-            if diskUsage and len(diskUsage) == 2:
-                payload["diskUsage"] = diskUsage[0]
-                payload["inodes"] = diskUsage[1]
+            # diskUsage = sys_checks['disk'].check(self.agentConfig)
+            # if diskUsage and len(diskUsage) == 2:
+            #     payload["diskUsage"] = diskUsage[0]
+            #     payload["inodes"] = diskUsage[1]
 
             load = sys_checks['load'].check(self.agentConfig)
             payload.update(load)

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -75,7 +75,6 @@ class Collector(object):
 
         # Unix System Checks
         self._unix_system_checks = {
-            'disk': u.Disk(log),
             'io': u.IO(log),
             'load': u.Load(log),
             'memory': u.Memory(log),
@@ -86,7 +85,6 @@ class Collector(object):
 
         # Win32 System `Checks
         self._win32_system_checks = {
-            'disk': w32.Disk(log),
             'io': w32.IO(log),
             'proc': w32.Processes(log),
             'memory': w32.Memory(log),
@@ -180,11 +178,6 @@ class Collector(object):
         else:
             # Unix system checks
             sys_checks = self._unix_system_checks
-
-            # diskUsage = sys_checks['disk'].check(self.agentConfig)
-            # if diskUsage and len(diskUsage) == 2:
-            #     payload["diskUsage"] = diskUsage[0]
-            #     payload["inodes"] = diskUsage[1]
 
             load = sys_checks['load'].check(self.agentConfig)
             payload.update(load)

--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -21,157 +21,6 @@ from utils.subprocess_output import get_subprocess_output
 to_float = lambda s: float(s.replace(",", "."))
 
 
-class Disk(Check):
-    """ Collects metrics about the machine's disks. """
-
-    def check(self, agentConfig):
-        """Get disk space/inode stats"""
-        # First get the configuration.
-        use_mount = agentConfig.get("use_mount", False)
-        blacklist_re = agentConfig.get('device_blacklist_re', None)
-        platform_name = sys.platform
-
-        try:
-            dfk_out = get_subprocess_output(['df', '-k'], self.logger)
-            disks = self.parse_df_output(
-                dfk_out,
-                platform_name,
-                use_mount=use_mount,
-                blacklist_re=blacklist_re
-            )
-
-            # Collect inode metrics.
-            dfi_out = get_subprocess_output(['df', '-i'], self.logger)
-            inodes = self.parse_df_output(
-                dfi_out,
-                platform_name,
-                inodes=True,
-                use_mount=use_mount,
-                blacklist_re=blacklist_re
-            )
-            return (disks, inodes)
-
-        except Exception:
-            self.logger.exception('Error collecting disk stats')
-            return False
-
-    def parse_df_output(self, df_output, platform_name, inodes=False, use_mount=False, blacklist_re=None):
-        """
-        Parse the output of the df command. If use_volume is true the volume
-        is used to anchor the metric, otherwise false the mount
-        point is used. Returns a tuple of (disk, inode).
-        """
-        usage_data = []
-
-        # Transform the raw output into tuples of the df data.
-        devices = self._transform_df_output(df_output, blacklist_re)
-
-        # If we want to use the mount point, replace the volume name on each
-        # line.
-        for parts in devices:
-            try:
-                if use_mount:
-                    parts[0] = parts[-1]
-                if inodes:
-                    if Platform.is_darwin(platform_name):
-                        # Filesystem 512-blocks Used Available Capacity iused ifree %iused  Mounted
-                        # Inodes are in position 5, 6 and we need to compute the total
-                        # Total
-                        parts[1] = int(parts[5]) + int(parts[6])  # Total
-                        parts[2] = int(parts[5])  # Used
-                        parts[3] = int(parts[6])  # Available
-                    elif Platform.is_freebsd(platform_name):
-                        # Filesystem 1K-blocks Used Avail Capacity iused ifree %iused Mounted
-                        # Inodes are in position 5, 6 and we need to compute the total
-                        parts[1] = int(parts[5]) + int(parts[6])  # Total
-                        parts[2] = int(parts[5])  # Used
-                        parts[3] = int(parts[6])  # Available
-                    else:
-                        parts[1] = int(parts[1])  # Total
-                        parts[2] = int(parts[2])  # Used
-                        parts[3] = int(parts[3])  # Available
-                else:
-                    parts[1] = int(parts[1])  # Total
-                    parts[2] = int(parts[2])  # Used
-                    parts[3] = int(parts[3])  # Available
-            except IndexError:
-                self.logger.exception("Cannot parse %s" % (parts,))
-
-            usage_data.append(parts)
-
-        return usage_data
-
-    @staticmethod
-    def _is_number(a_string):
-        try:
-            float(a_string)
-        except ValueError:
-            return False
-        return True
-
-    def _is_real_device(self, device):
-        """
-        Return true if we should track the given device name and false otherwise.
-        """
-        # First, skip empty lines.
-        if not device or len(device) <= 1:
-            return False
-
-        # Filter out fake devices.
-        device_name = device[0]
-        if device_name == 'none':
-            return False
-
-        # Now filter our fake hosts like 'map -hosts'. For example:
-        #       Filesystem    1024-blocks     Used Available Capacity  Mounted on
-        #       /dev/disk0s2    244277768 88767396 155254372    37%    /
-        #       map -hosts              0        0         0   100%    /net
-        blocks = device[1]
-        if not self._is_number(blocks):
-            return False
-        return True
-
-    def _flatten_devices(self, devices):
-        # Some volumes are stored on their own line. Rejoin them here.
-        previous = None
-        for parts in devices:
-            if len(parts) == 1:
-                previous = parts[0]
-            elif previous and self._is_number(parts[0]):
-                # collate with previous line
-                parts.insert(0, previous)
-                previous = None
-            else:
-                previous = None
-        return devices
-
-    def _transform_df_output(self, df_output, blacklist_re):
-        """
-        Given raw output for the df command, transform it into a normalized
-        list devices. A 'device' is a list with fields corresponding to the
-        output of df output on each platform.
-        """
-        all_devices = [l.strip().split() for l in df_output.split("\n")]
-
-        # Skip the header row and empty lines.
-        raw_devices = [l for l in all_devices[1:] if l]
-
-        # Flatten the disks that appear in the mulitple lines.
-        flattened_devices = self._flatten_devices(raw_devices)
-
-        # Filter fake disks.
-        def keep_device(device):
-            if not self._is_real_device(device):
-                return False
-            if blacklist_re and blacklist_re.match(device[0]):
-                return False
-            return True
-
-        devices = filter(keep_device, flattened_devices)
-
-        return devices
-
-
 class IO(Check):
 
     def __init__(self, logger):
@@ -912,7 +761,6 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG, format='%(asctime)-15s %(message)s')
     log = logging.getLogger()
     cpu = Cpu(log)
-    disk = Disk(log)
     io = IO(log)
     load = Load(log)
     mem = Memory(log)
@@ -923,8 +771,6 @@ if __name__ == '__main__':
         print("=" * 10)
         print("--- IO ---")
         print(io.check(config))
-        print("--- Disk ---")
-        print(disk.check(config))
         print("--- CPU ---")
         print(cpu.check(config))
         print("--- Load ---")

--- a/conf.d/disk.yaml.default
+++ b/conf.d/disk.yaml.default
@@ -1,0 +1,29 @@
+init_config:
+
+instances:
+  # The use_mount parameter will instruct the check to collect disk
+  # and fs metrics using mount points instead of volumes
+  - use_mount: no
+    # The (optional) excluded_filesystems parameter will instruct the check to
+    # ignore disks using these filesystems
+    excluded_filesystems:
+      - tmpfs
+
+    # The (optional) excluded_disks parameter will instruct the check to
+    # ignore this list of disks
+    # excluded_disks:
+    #   - /dev/sda1
+    #   - /dev/sda2
+    #
+    # The (optional) excluded_disk_re parameter will instruct the check to
+    # ignore all disks matching this regex
+    # excluded_disk_re: /dev/sde*
+    #
+    # The (optional) tag_by_filesystem parameter will instruct the check to
+    # tag all disks with their filesystem (for ex: filesystem:nfs)
+    # tag_by_filesystem: no
+    #
+    # The (optional) all_partitions parameter will instruct the check to
+    # only get metrics for physical disks if set to no
+    # all_partitions: yes
+

--- a/config.py
+++ b/config.py
@@ -765,6 +765,7 @@ def check_yaml(conf_path):
     finally:
         f.close()
 
+
 def load_check_directory(agentConfig, hostname):
     ''' Return the initialized checks from checks.d, and a mapping of checks that failed to
     initialize. Only checks that have a configuration
@@ -827,18 +828,17 @@ def load_check_directory(agentConfig, hostname):
             conf_exists = True
 
         if conf_exists:
-            f = open(conf_path)
             try:
                 check_config = check_yaml(conf_path)
             except Exception, e:
                 log.exception("Unable to parse yaml config in %s" % conf_path)
                 traceback_message = traceback.format_exc()
-                init_failed_checks[check_name] = {'error':str(e), 'traceback':traceback_message}
+                init_failed_checks[check_name] = {'error': str(e), 'traceback': traceback_message}
                 continue
         else:
             # Compatibility code for the Nagios checks if it's still configured
             # in datadog.conf
-            # fixme: Should be removed in ulterior major version
+            # FIXME: 6.x, should be removed
             if check_name == 'nagios':
                 if any([nagios_key in agentConfig for nagios_key in NAGIOS_OLD_CONF_KEYS]):
                     log.warning("Configuring Nagios in datadog.conf is deprecated "

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -110,7 +110,6 @@ def get_check(name, config_str):
 
 
 class Fixtures(object):
-
     @staticmethod
     def integration_name():
         for stack in inspect.stack():
@@ -153,6 +152,10 @@ class AgentCheckTest(unittest.TestCase):
     def is_travis(self):
         return "TRAVIS" in os.environ
 
+    def load_check(self, config, agent_config=None):
+        agent_config = agent_config or self.DEFAULT_AGENT_CONFIG
+        self.check = load_check(self.CHECK_NAME, config, agent_config)
+
     # Helper function when testing rates
     def run_check_twice(self, config, agent_config=None, mocks=None,
                         force_reload=False):
@@ -161,12 +164,9 @@ class AgentCheckTest(unittest.TestCase):
         self.run_check(config, agent_config, mocks)
 
     def run_check(self, config, agent_config=None, mocks=None, force_reload=False):
-        agent_config = agent_config or self.DEFAULT_AGENT_CONFIG
-
         # If not loaded already, do it!
         if self.check is None or force_reload:
-            self.check = load_check(self.CHECK_NAME, config, agent_config)
-
+            self.load_check(config, agent_config=agent_config)
         if mocks is not None:
             for func_name, mock in mocks.iteritems():
                 if not hasattr(self.check, func_name):

--- a/tests/checks/fixtures/disk/debian-df-Tk
+++ b/tests/checks/fixtures/disk/debian-df-Tk
@@ -1,0 +1,6 @@
+Filesystem                              Type     1K-blocks      Used Available Use% Mounted on
+/dev/sda1                               ext4      		 5   	   4  		 1  80% /
+udev                                    devtmpfs   2020720         8   2020712   1% /dev
+tmpfs                                   tmpfs       404968       328    404640   1% /run
+none                                    tmpfs         5120         0      5120   0% /run/lock
+none                                    tmpfs      2024828         0   2024828   0% /run/shm

--- a/tests/checks/fixtures/disk/freebsd-df-Tk
+++ b/tests/checks/fixtures/disk/freebsd-df-Tk
@@ -1,0 +1,20 @@
+Filesystem                 Type  1024-blocks    Used   Avail Capacity  Mounted on
+zroot                      zfs             5       4       1    80%    /
+devfs                      devfs           1       1       0   100%    /dev
+zroot/tmp                  zfs       6013913      88 6013825     0%    /tmp
+zroot/usr                  zfs       7317053 1303228 6013825    18%    /usr
+zroot/usr/home             zfs       6013857      32 6013825     0%    /usr/home
+zroot/usr/home/vagrant     zfs       6077010   63185 6013825     1%    /usr/home/vagrant
+zroot/usr/ports            zfs       6013858      33 6013825     0%    /usr/ports
+zroot/usr/ports/distfiles  zfs       6013856      31 6013825     0%    /usr/ports/distfiles
+zroot/usr/ports/packages   zfs       6013856      31 6013825     0%    /usr/ports/packages
+zroot/usr/src              zfs       6013856      31 6013825     0%    /usr/src
+zroot/var                  zfs       6159848  146023 6013825     2%    /var
+zroot/var/crash            zfs       6013856      31 6013825     0%    /var/crash
+zroot/var/db               zfs       6013910      85 6013825     0%    /var/db
+zroot/var/db/pkg           zfs       6038024   24199 6013825     0%    /var/db/pkg
+zroot/var/empty            zfs       6013856      31 6013825     0%    /var/empty
+zroot/var/log              zfs       6013882      57 6013825     0%    /var/log
+zroot/var/mail             zfs       6013856      31 6013825     0%    /var/mail
+zroot/var/run              zfs       6013882      57 6013825     0%    /var/run
+zroot/var/tmp              zfs       6013857      32 6013825     0%    /var/tmp

--- a/tests/checks/integration/test_disk.py
+++ b/tests/checks/integration/test_disk.py
@@ -1,0 +1,41 @@
+# 3p
+from nose.plugins.attrib import attr
+
+# project
+from tests.checks.common import AgentCheckTest
+
+
+@attr(requires='sysstat')
+class TestCheckDisk(AgentCheckTest):
+    CHECK_NAME = 'disk'
+
+    DISK_GAUGES = [
+        'system.disk.total',
+        'system.disk.used',
+        'system.disk.free',
+        'system.disk.in_use',
+        'system.disk.read_time_pct',
+        'system.disk.write_time_pct'
+    ]
+
+    INODE_GAUGES = [
+        'system.fs.inodes.total',
+        'system.fs.inodes.used',
+        'system.fs.inodes.free',
+        'system.fs.inodes.in_use'
+    ]
+
+    # Really a basic check to see if all metrics are there
+    def test_check(self):
+        self.run_check({'instances': [{'use_mount': 'no'}]})
+
+        # Assert metrics
+        for metric in self.DISK_GAUGES + self.INODE_GAUGES:
+            self.assertMetric(metric, tags=[])
+
+        self.coverage_report()
+
+    # Test two instances
+    def test_bad_config(self):
+        self.assertRaises(Exception,
+                          lambda: self.run_check({'instances': [{}, {}]}))

--- a/tests/checks/integration/test_pgbouncer.py
+++ b/tests/checks/integration/test_pgbouncer.py
@@ -1,11 +1,16 @@
+# stdlib
 import time
 from types import ListType
 
-import psycopg2 as pg
+# 3p
 from nose.plugins.attrib import attr
+try:
+    import psycopg2 as pg
+except ImportError:
+    pg = None
 
+# project
 from tests.checks.common import AgentCheckTest
-from checks import AgentCheck
 
 
 @attr(requires='pgbouncer')
@@ -64,8 +69,7 @@ class TestPgbouncer(AgentCheckTest):
         service_checks_count = len(self.service_checks)
         self.assertTrue(isinstance(self.service_checks, ListType))
         self.assertTrue(service_checks_count > 0)
-        self.assertServiceCheck(
+        self.assertServiceCheckOK(
             'pgbouncer.can_connect',
-            status=AgentCheck.OK,
             tags=['host:localhost', 'port:15433', 'db:pgbouncer'],
             count=service_checks_count)

--- a/tests/checks/mock/test_disk.py
+++ b/tests/checks/mock/test_disk.py
@@ -1,0 +1,169 @@
+# stdlib
+import mock
+import re
+
+# project
+from tests.checks.common import AgentCheckTest, Fixtures
+
+
+DEFAULT_DEVICE_NAME = '/dev/sda1'
+
+
+class MockPart(object):
+    def __init__(self, device=DEFAULT_DEVICE_NAME, fstype='ext4',
+                 mountpoint='/'):
+        self.device = device
+        self.fstype = fstype
+        self.mountpoint = mountpoint
+
+
+class MockDiskMetrics(object):
+    def __init__(self):
+        self.total = 5 * 1024
+        self.used = 4 * 1024
+        self.free = 1 * 1024
+        self.percent = 80
+
+
+class MockInodesMetrics(object):
+    def __init__(self):
+        self.f_files = 10
+        self.f_ffree = 9
+
+
+class MockIoCountersMetrics(object):
+    def __init__(self):
+        self.read_time = 15
+        self.write_time = 25
+
+
+class TestCheckDisk(AgentCheckTest):
+    CHECK_NAME = 'disk'
+
+    GAUGES_VALUES = {
+        'system.disk.total': 5,
+        'system.disk.used': 4,
+        'system.disk.free': 1,
+        'system.disk.in_use': .80,
+        'system.fs.inodes.total': 10,
+        'system.fs.inodes.used': 1,
+        'system.fs.inodes.free': 9,
+        'system.fs.inodes.in_use': .10
+    }
+
+    GAUGES_VALUES_PSUTIL = {
+        'system.disk.read_time_pct': 1.5,
+        'system.disk.write_time_pct': 2.5,
+    }
+
+    def test_device_exclusion_logic(self):
+        self.run_check({'instances': [{'use_mount': 'no',
+                                       'excluded_filesystems': ['aaaaaa'],
+                                       'excluded_disks': ['bbbbbb'],
+                                       'excluded_disk_re': '^tev+$'}]},
+                       mocks={'collect_metrics': lambda: None})
+        # should pass, default mock is a normal disk
+        exclude_disk = self.check._exclude_disk_psutil
+        self.assertFalse(exclude_disk(MockPart()))
+
+        # standard fake devices
+        self.assertTrue(exclude_disk(MockPart(device='udev')))
+
+        # excluded filesystems list
+        self.assertTrue(exclude_disk(MockPart(fstype='aaaaaa')))
+        self.assertFalse(exclude_disk(MockPart(fstype='a')))
+
+        # excluded devices list
+        self.assertTrue(exclude_disk(MockPart(device='bbbbbb')))
+        self.assertFalse(exclude_disk(MockPart(device='b')))
+
+        # excluded devices regex
+        self.assertTrue(exclude_disk(MockPart(device='tevvv')))
+        self.assertFalse(exclude_disk(MockPart(device='tevvs')))
+
+    @mock.patch('psutil.disk_partitions', return_value=[MockPart()])
+    @mock.patch('psutil.disk_usage', return_value=MockDiskMetrics())
+    @mock.patch('psutil.disk_io_counters',
+                return_value={'sda1': MockIoCountersMetrics()})
+    @mock.patch('os.statvfs', return_value=MockInodesMetrics())
+    def test_psutil(self, mock_partitions, mock_usage,
+                    mock_io_counters, mock_inodes):
+        for tag_by in ['yes', 'no']:
+            self.run_check({'instances': [{'tag_by_filesystem': tag_by}]},
+                           force_reload=True)
+
+            # Assert metrics
+            tags = ['ext4'] if tag_by == 'yes' else []
+            self.GAUGES_VALUES_PSUTIL.update(self.GAUGES_VALUES)
+            for metric, value in self.GAUGES_VALUES_PSUTIL.iteritems():
+                self.assertMetric(metric, value=value, tags=tags,
+                                  device_name=DEFAULT_DEVICE_NAME)
+
+            self.coverage_report()
+
+    @mock.patch('psutil.disk_partitions', return_value=[MockPart()])
+    @mock.patch('psutil.disk_usage', return_value=MockDiskMetrics())
+    @mock.patch('psutil.disk_io_counters',
+                return_value={'sda1': MockIoCountersMetrics()})
+    @mock.patch('os.statvfs', return_value=MockInodesMetrics())
+    def test_use_mount(self, mock_partitions, mock_usage,
+                       mock_io_counters, mock_inodes):
+        self.run_check({'instances': [{'use_mount': 'yes'}]})
+
+        # Assert metrics
+        self.GAUGES_VALUES_PSUTIL.update(self.GAUGES_VALUES)
+        for metric, value in self.GAUGES_VALUES_PSUTIL.iteritems():
+            self.assertMetric(metric, value=value, tags=[],
+                              device_name='/')
+
+        self.coverage_report()
+
+    @mock.patch('utils.subprocess_output.get_subprocess_output',
+                return_value=Fixtures.read_file('debian-df-Tk'))
+    @mock.patch('os.statvfs', return_value=MockInodesMetrics())
+    def test_no_psutil_debian(self, mock_df_output, mock_statvfs):
+        self.run_check({'instances': [{'use_mount': 'no',
+                                       'excluded_filesystems': ['tmpfs']}]},
+                       mocks={'_psutil': lambda: False})
+
+        for metric, value in self.GAUGES_VALUES.iteritems():
+            self.assertMetric(metric, value=value, tags=[],
+                              device_name=DEFAULT_DEVICE_NAME)
+
+        self.coverage_report()
+
+    @mock.patch('utils.subprocess_output.get_subprocess_output',
+                return_value=Fixtures.read_file('freebsd-df-Tk'))
+    @mock.patch('os.statvfs', return_value=MockInodesMetrics())
+    def test_no_psutil_freebsd(self, mock_df_output, mock_statvfs):
+        self.run_check({'instances': [{'use_mount': 'no',
+                                       'excluded_filesystems': ['devfs'],
+                                       'excluded_disk_re': 'zroot/.+'}]},
+                       mocks={'_psutil': lambda: False})
+
+        for metric, value in self.GAUGES_VALUES.iteritems():
+            self.assertMetric(metric, value=value, tags=[],
+                              device_name='zroot')
+
+        self.coverage_report()
+
+    def test_legacy_option(self):
+        # First, let's check that it actually retrieves from the agent config
+        self.load_check({'instances': [{}]}, agent_config={'use_mount': 'yes'})
+        self.assertTrue(self.check._use_mount)
+
+        # Then let's check that check option overrides datadog.cong
+        self.load_check({'instances': [{'use_mount': 'no'}]},
+                        agent_config={'use_mount': 'yes'})
+        self.assertFalse(self.check._use_mount)
+
+    def test_default_options(self):
+        self.load_check({'instances': [{}]})
+        self.check._load_conf({})
+
+        self.assertFalse(self.check._use_mount)
+        self.assertEqual(self.check._excluded_filesystems, [])
+        self.assertEqual(self.check._excluded_disks, [])
+        self.assertFalse(self.check._tag_by_filesystem)
+        self.assertTrue(self.check._all_partitions)
+        self.assertEqual(self.check._excluded_disk_re, re.compile('^$'))

--- a/tests/checks/mock/test_sysstat.py
+++ b/tests/checks/mock/test_sysstat.py
@@ -7,7 +7,6 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__file__)
 
 from checks.system.unix import (
-    Disk,
     IO,
     Load,
     Memory,
@@ -41,111 +40,6 @@ class TestSystem(unittest.TestCase):
         res = load.check({})
         assert 'system.load.1' in res
         assert 'system.load.norm.1' not in res
-
-    lion_df_i = """Filesystem                        512-blocks      Used Available Capacity  iused    ifree %iused  Mounted onto
-/dev/disk1                         487932936 220080040 267340896    46% 27574003 33417612   45%   /
-devfs                                    374       374         0   100%      648        0  100%   /dev
-map -hosts                                 0         0         0   100%        0        0  100%   /net
-map auto_home                              0         0         0   100%        0        0  100%   /home
-localhost:/KJDS7Bgpbp1QglL9lBwOe6  487932936 487932936         0   100%        0        0  100%   /Volumes/MobileBackups
-/dev/disk2s1                        62309376   5013120  57296256     9%        0        0  100%   /Volumes/NO name"""
-
-    lion_df_k = """Filesystem                        1024-blocks      Used Available Capacity  Mounted onto
-/dev/disk1                          243966468 110040020 133670448    46%    /
-devfs                                     187       187         0   100%    /dev
-map -hosts                                  0         0         0   100%    /net
-map auto_home                               0         0         0   100%    /home
-localhost:/KJDS7Bgpbp1QglL9lBwOe6   243966468 243966468         0   100%    /Volumes/MobileBackups
-/dev/disk2s1                         31154688   2506560  28648128     9%    /Volumes/NO NAME"""
-
-    linux_df_k = """Filesystem           1K-blocks      Used Available Use% Mounted on
-/dev/sda1              8256952   5600592   2236932  72% /
-none                   3802316       124   3802192   1% /dev
-none                   3943856         0   3943856   0% /dev/shm
-none                   3943856       148   3943708   1% /var/run
-none                   3943856         0   3943856   0% /var/lock
-none                   3943856         0   3943856   0% /lib/init/rw
-/dev/sdb             433455904    305360 411132240   1% /mnt
-/dev/sdf              52403200  40909112  11494088  79% /data
-nfs:/abc/def/ghi/jkl/mno/pqr
-                      52403200  40909112  11494088  79% /data2
-/dev/sdg              52403200  40909112  11494088  79% /data3
-tmpfs           14039440       256  14039184   1% /run
-/dev/xvdf1     209612800 144149992  65462808  69% /var/lib/postgresql/9.1/main
-/dev/xvdf2     209612800   2294024 207318776   2% /var/lib/postgresql/9.1/main/pg_xlog
-/dev/xvdf3       2086912   1764240    322672  85% /var/lib/postgresql/9.1/user_influence_history
-/dev/xvdf4      41922560  12262780  29659780  30% /var/lib/postgresql/9.1/entity_love
-/dev/xvdf5      10475520   3943856   6531664  38% /var/lib/postgresql/9.1/user_profile
-/dev/xvdf6      10475520   5903964   4571556  57% /var/lib/postgresql/9.1/entity_love_history
-/dev/xvdf7       8378368     33288   8345080   1% /var/lib/postgresql/9.1/_user_profile_queue
-/dev/xvdf8      41922560   6784964  35137596  17% /var/lib/postgresql/9.1/entity_entity
-/dev/xvdf9       2086912     33480   2053432   2% /var/lib/postgresql/9.1/event_framework_event_handler_queue
-/dev/xvdi1       2086912     33488   2053424   2% /var/lib/postgresql/9.1/user_communication_queue
-/dev/xvdi2      52403200   9960744  42442456  20% /var/lib/postgresql/9.1/affiliate_click_tracking
-/dev/xvdi3      31441920   9841092  21600828  32% /var/lib/postgresql/9.1/index01
-/dev/xvdi4      31441920  10719884  20722036  35% /var/lib/postgresql/9.1/index02
-/dev/xvdi5      31441920   9096476  22345444  29% /var/lib/postgresql/9.1/index03
-/dev/xvdi6      31441920   6473916  24968004  21% /var/lib/postgresql/9.1/index04
-/dev/xvdi7      31441920   3519356  27922564  12% /var/lib/postgresql/9.1/index05
-"""
-
-    linux_df_i = """Filesystem            Inodes   IUsed   IFree IUse% Mounted on
-/dev/sda1             524288  171642  352646   33% /
-none                  950579    2019  948560    1% /dev
-none                  985964       1  985963    1% /dev/shm
-none                  985964      66  985898    1% /var/run
-none                  985964       3  985961    1% /var/lock
-none                  985964       1  985963    1% /lib/init/rw
-/dev/sdb             27525120     147 27524973    1% /mnt
-/dev/sdf             46474080  478386 45995694    2% /data
-"""
-
-    def testDfParser(self):
-        global logger
-        disk = Disk(logger)
-
-        res = disk.parse_df_output(TestSystem.lion_df_k, 'darwin')
-        assert res[0][:4] == ["/dev/disk1", 243966468, 110040020, 133670448], res[0]
-        assert res[3][:4] == ["/dev/disk2s1", 31154688, 2506560, 28648128], res[3]
-
-        res = disk.parse_df_output(TestSystem.lion_df_i, 'darwin', inodes=True)
-        assert res[0][:4] == ["/dev/disk1", 60991615, 27574003, 33417612], res[0]
-
-        # Test parsing linux output.
-        res = disk.parse_df_output(TestSystem.linux_df_k, 'linux2')
-        assert len(res) == 22
-        assert res[0][:4] == ["/dev/sda1", 8256952, 5600592,  2236932], res[0]
-        assert res[2][:4] == ["/dev/sdf", 52403200, 40909112, 11494088], res[2]
-        assert res[3][:4] == ["nfs:/abc/def/ghi/jkl/mno/pqr", 52403200, 40909112, 11494088], res[3]
-        assert res[4][:4] == ["/dev/sdg", 52403200, 40909112, 11494088], res[4]
-
-        # Test parsing linux output but filter some of the nodes.
-        blacklist_re = re.compile('/dev/xvdi.*')
-        res = disk.parse_df_output(TestSystem.linux_df_k, 'linux2', blacklist_re=blacklist_re)
-        assert res[0][:4] == ["/dev/sda1", 8256952, 5600592,  2236932], res[0]
-        assert len(res) == 15, len(res)
-
-        res = disk.parse_df_output(TestSystem.linux_df_i, 'linux2', inodes = True)
-        assert res[0][:4] == ["/dev/sda1", 524288, 171642, 352646], res[0]
-        assert res[1][:4] == ["/dev/sdb", 27525120, 147, 27524973], res[1]
-        assert res[2][:4] == ["/dev/sdf", 46474080, 478386, 45995694], res[2]
-
-        res = disk.parse_df_output(TestSystem.linux_df_k, 'linux2', use_mount = True)
-        assert res[0][:4] == ["/", 8256952, 5600592,  2236932], res[0]
-        assert res[2][:4] == ["/data", 52403200, 40909112, 11494088], res[2]
-        assert res[3][:4] == ["/data2", 52403200, 40909112, 11494088], res[3]
-        assert res[4][:4] == ["/data3", 52403200, 40909112, 11494088], res[4]
-        assert res[-1][:4] == ["/var/lib/postgresql/9.1/index05", 31441920, 3519356, 27922564], res[-1]
-
-    def test_collecting_disk_metrics(self):
-        """Testing disk stats gathering"""
-        if Platform.is_unix():
-            disk = Disk(logger)
-            res = disk.check({})
-            # Assert we have disk & inode stats
-            assert len(res) == 2
-            assert res[0]
-            assert res[1]
 
     def testMemory(self):
         global logger

--- a/utils/subprocess_output.py
+++ b/utils/subprocess_output.py
@@ -1,0 +1,23 @@
+# stdlib
+import subprocess
+import tempfile
+
+
+# FIXME: python 2.7 has a far better way to do this
+def get_subprocess_output(command, log):
+    """
+    Run the given subprocess command and return it's output. Raise an Exception
+    if an error occurs.
+    """
+    with tempfile.TemporaryFile('rw') as stdout_f:
+        proc = subprocess.Popen(command, close_fds=True,
+                                stdout=stdout_f, stderr=subprocess.PIPE)
+        proc.wait()
+        err = proc.stderr.read()
+        if err:
+            log.debug("Error while running {0} : {1}".format(" ".join(command),
+                                                             err))
+
+        stdout_f.seek(0)
+        output = stdout_f.read()
+    return output


### PR DESCRIPTION
This commit is the first step towards the annihilation of the old `Check`
hidden in `checks/system/{unix,win32}.py`!
It's time to launch the final assault of `Check`. `AgentCheck` shall triumph!

Add a `checks.d/disk.py` checks, which uses psutil when available to get
disk metrics (same than the previous `disk` checks), and otherwise
get the same metrics with `df`.
It has a small integration test, just to check that metrics exist, and
more precise mock tests.
This new check is enabled by default, and the old `disk` checks are
deleted.

Fix https://github.com/DataDog/dd-agent/issues/568