### PR TITLE
[ci] increase default wait timeout to 10s

### DIFF
--- a/ci/common.rb
+++ b/ci/common.rb
@@ -19,7 +19,7 @@ def section(name)
 end
 
 class Wait
-  DEFAULT_TIMEOUT = 5
+  DEFAULT_TIMEOUT = 10
 
   def self.check_port(port)
     Timeout.timeout(0.5) do

--- a/ci/elasticsearch.rb
+++ b/ci/elasticsearch.rb
@@ -30,7 +30,7 @@ namespace :ci do
       Process.detach(pid)
       sh %(echo #{pid} > $VOLATILE_DIR/elasticsearch.pid)
       # Waiting for elaticsearch to start
-      Wait.for 'http://localhost:9200', 10
+      Wait.for 'http://localhost:9200', 15
     end
 
     task script: ['ci:common:script'] do

--- a/ci/supervisord.rb
+++ b/ci/supervisord.rb
@@ -37,6 +37,9 @@ namespace :ci do
       sh %(#{supervisor_rootdir}/bin/supervisord\
            -c $VOLATILE_DIR/supervisor/supervisord.conf)
       3.times { |i| Wait.for "#{ENV['VOLATILE_DIR']}/supervisor/started_#{i}" }
+      # And we still have to sleep a little, because sometimes supervisor
+      # doesn't immediately realize that its processes are running
+      sleep_for 1
     end
 
     task script: ['ci:common:script'] do


### PR DESCRIPTION
Because when Travis is slow, we get a lot of false negative because the
program takes too much time to start.
For the same reason:
* increase timeout for elasticsearch to 15s
* sleep for 1s after the Wait for supervisor