### PR TITLE
[core] service metadata collection

### DIFF
--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -225,9 +225,6 @@ class ESCheck(AgentCheck):
         health_url, nodes_url, stats_url, pending_tasks_url, stats_metrics\
             = self._define_params(version, config.is_external)
 
-        # Collect metadata
-        self._collect_metadata(version)
-
         # Load stats data.
         stats_url = urlparse.urljoin(config.url, stats_url)
         stats_data = self._get_data(stats_url, config)
@@ -264,6 +261,7 @@ class ESCheck(AgentCheck):
             )
             version = [1, 0, 0]
 
+        self.service_metadata('version', version)
         self.log.debug("Elasticsearch version is %s" % version)
         return version
 
@@ -544,7 +542,3 @@ class ESCheck(AgentCheck):
             'event_object': hostname,
             'tags': tags
         }
-
-    def _collect_metadata(self, version):
-        metadata_dict = {'version': version}
-        self.svc_metadata(metadata_dict)

--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -225,6 +225,9 @@ class ESCheck(AgentCheck):
         health_url, nodes_url, stats_url, pending_tasks_url, stats_metrics\
             = self._define_params(version, config.is_external)
 
+        # Collect metadata
+        self._collect_metadata(version)
+
         # Load stats data.
         stats_url = urlparse.urljoin(config.url, stats_url)
         stats_data = self._get_data(stats_url, config)
@@ -541,3 +544,7 @@ class ESCheck(AgentCheck):
             'event_object': hostname,
             'tags': tags
         }
+
+    def _collect_metadata(self, version):
+        metadata_dict = {'version': version}
+        self.svc_metadata(metadata_dict)

--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -70,6 +70,9 @@ class MySql(AgentCheck):
 
         db = self._connect(host, port, mysql_sock, user, password, defaults_file)
 
+        # Metadata collection
+        self._collect_metadata(db, host)
+
         # Metric collection
         self._collect_metrics(host, db, tags, options)
         if Platform.is_linux():
@@ -128,6 +131,11 @@ class MySql(AgentCheck):
             raise
 
         return db
+
+    def _collect_metadata(self, db, host):
+        metadata_dict = {}
+        metadata_dict['version'] = self._get_version(db, host)
+        self.svc_metadata(metadata_dict)
 
     def _collect_metrics(self, host, db, tags, options):
         cursor = db.cursor()

--- a/checks.d/redisdb.py
+++ b/checks.d/redisdb.py
@@ -334,7 +334,5 @@ class Redis(AgentCheck):
         self._check_slowlog(instance, custom_tags)
 
     def _collect_metadata(self, info):
-        metadata_dict = {}
         if info and 'redis_version' in info:
-            metadata_dict['version'] = info['redis_version']
-        self.svc_metadata(metadata_dict)
+            self.service_metadata('version', info['redis_version'])

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -316,6 +316,7 @@ class AgentCheck(object):
         self.warnings = []
         self.library_versions = None
         self.last_collection_time = defaultdict(int)
+        self.service_metadata = []
 
     def instance_count(self):
         """ Return the number of instances that are configured for this check. """
@@ -474,6 +475,14 @@ class AgentCheck(object):
                                  hostname, check_run_id, message)
         )
 
+    def svc_metadata(self, metadata):
+        """
+        Save metadata.
+
+        :param metadata: The service metadata dictionary
+        """
+        self.service_metadata.append(metadata)
+
     def has_events(self):
         """
         Check whether the check has saved any events
@@ -514,6 +523,18 @@ class AgentCheck(object):
         service_checks = self.service_checks
         self.service_checks = []
         return service_checks
+
+    def get_service_metadata(self):
+        """
+        Return a list of the metadata dictionaries saved by the check -if any-
+        and clears them out of the instance's service_checks list
+
+        @return the list of metadata saved by this check
+        @rtype list of metadata dicts
+        """
+        service_metadata = self.service_metadata
+        self.service_metadata = []
+        return service_metadata
 
     def has_warnings(self):
         """
@@ -648,7 +669,7 @@ class AgentCheck(object):
                 after = AgentCheck._collect_internal_stats()
                 self._set_internal_profiling_stats(before, after)
                 log.info("\n \t %s %s" % (self.name, pretty_statistics(self._internal_profiling_stats)))
-            except Exception: # It's fine if we can't collect stats for the run, just log and proceed
+            except Exception:  # It's fine if we can't collect stats for the run, just log and proceed
                 self.log.debug("Failed to collect Agent Stats after check {0}".format(self.name))
 
         return instance_statuses

--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -19,7 +19,7 @@ import yaml
 
 # project
 import config
-from config import get_config, get_jmx_status_path, _windows_commondata_path
+from config import get_config, get_jmx_status_path, _is_affirmative, _windows_commondata_path
 from util import plural
 from utils.ntp import get_ntp_args
 from utils.pidfile import PidFile
@@ -79,6 +79,7 @@ class Stylizer(object):
 # a small convienence method
 def style(*args):
     return Stylizer.stylize(*args)
+
 
 def logger_info():
     loggers = []
@@ -285,7 +286,7 @@ class InstanceStatus(object):
 class CheckStatus(object):
 
     def __init__(self, check_name, instance_statuses, metric_count=None,
-                 event_count=None, service_check_count=None,
+                 event_count=None, service_check_count=None, service_metadata=[],
                  init_failed_error=None, init_failed_traceback=None,
                  library_versions=None, source_type_name=None,
                  check_stats=None):
@@ -299,6 +300,7 @@ class CheckStatus(object):
         self.init_failed_traceback = init_failed_traceback
         self.library_versions = library_versions
         self.check_stats = check_stats
+        self.service_metadata = service_metadata
 
     @property
     def status(self):
@@ -340,7 +342,7 @@ class CollectorStatus(AgentStatus):
         AgentStatus.__init__(self)
         self.check_statuses = check_statuses or []
         self.emitter_statuses = emitter_statuses or []
-        self.metadata = metadata or []
+        self.host_metadata = metadata or []
 
     @property
     def status(self):
@@ -433,7 +435,6 @@ class CollectorStatus(AgentStatus):
             'instance-id'
         ]
 
-
         lines = [
             'Clocks',
             '======',
@@ -477,10 +478,10 @@ class CollectorStatus(AgentStatus):
             ''
         ]
 
-        if not self.metadata:
+        if not self.host_metadata:
             lines.append("  No host information available yet.")
         else:
-            for key, host in self.metadata.items():
+            for key, host in self.host_metadata.iteritems():
                 for whitelist_item in metadata_whitelist:
                     if whitelist_item in key:
                         lines.append("  " + key + ": " + host)
@@ -563,6 +564,41 @@ class CollectorStatus(AgentStatus):
 
                 lines += check_lines
 
+        # Metadata status
+        metadata_enabled = _is_affirmative(get_config().get('display_service_metadata', False))
+
+        if metadata_enabled:
+            lines += [
+                "",
+                "Service metadata",
+                "================",
+                ""
+            ]
+            if not check_statuses:
+                lines.append("  No checks have run yet.")
+            else:
+                meta_lines = []
+                for cs in check_statuses:
+                    # Check title
+                    check_line = [
+                        '  ' + cs.name,
+                        '  ' + '-' * len(cs.name)
+                    ]
+                    instance_lines = []
+                    for i, meta in enumerate(cs.service_metadata):
+                        if not meta:
+                            continue
+                        instance_lines += ["    - instance #%s:" % i]
+                        for k, v in meta.iteritems():
+                            instance_lines += ["        - %s: %s" % (k, v)]
+                    if instance_lines:
+                        check_line += instance_lines
+                        meta_lines += check_line
+                if meta_lines:
+                    lines += meta_lines
+                else:
+                    lines.append("  No metadata were collected.")
+
         # Emitter status
         lines += [
             "",
@@ -577,7 +613,7 @@ class CollectorStatus(AgentStatus):
                 c = 'green'
                 if es.has_error():
                     c = 'red'
-                line = "  - %s [%s]" % (es.name, style(es.status,c))
+                line = "  - %s [%s]" % (es.name, style(es.status, c))
                 if es.status != STATUS_OK:
                     line += ": %s" % es.error
                 lines.append(line)
@@ -595,8 +631,8 @@ class CollectorStatus(AgentStatus):
             'ipv4',
             'instance-id'
         ]
-        if self.metadata:
-            for key, host in self.metadata.items():
+        if self.host_metadata:
+            for key, host in self.host_metadata.iteritems():
                 for whitelist_item in metadata_whitelist:
                     if whitelist_item in key:
                         status_info['hostnames'][key] = host

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -549,6 +549,7 @@ class Collector(object):
             current_check_metrics = check.get_metrics()
             current_check_events = check.get_events()
             current_service_checks = check.get_service_checks()
+            current_service_metadata = check.get_service_metadata()
 
             check_stats = check._get_internal_profiling_stats()
 
@@ -560,6 +561,7 @@ class Collector(object):
             print "Metrics: \n{0}".format(pprint.pformat(current_check_metrics))
             print "Events: \n{0}".format(pprint.pformat(current_check_events))
             print "Service Checks: \n{0}".format(pprint.pformat(current_service_checks))
+            print "Service Metadata: \n{0}".format(pprint.pformat(current_service_metadata))
 
         except Exception:
             log.exception("Error running check %s" % check.name)

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -1,4 +1,5 @@
 # stdlib
+import collections
 import logging
 import pprint
 import socket
@@ -32,7 +33,6 @@ from util import (
 )
 from utils.subprocess_output import subprocess
 
-
 log = logging.getLogger(__name__)
 
 
@@ -41,12 +41,113 @@ FLUSH_LOGGING_INITIAL = 5
 DD_CHECK_TAG = 'dd_check:{0}'
 
 
+class AgentPayload(collections.MutableMapping):
+    """
+    AgentPayload offers a single payload interface but manages two payloads:
+    * A metadata payload
+    * A data payload that contains metrics, events, service_checks and more
+
+    Each of these payloads is automatically submited to its specific endpoint.
+    """
+    METADATA_KEYS = frozenset(['meta', 'tags', 'host-tags', 'systemStats',
+                               'agent_checks', 'gohai', 'external_host_tags'])
+
+    DUPLICATE_KEYS = frozenset(['apiKey', 'agentVersion'])
+
+    COMMON_ENDPOINT = ''
+    DATA_ENDPOINT = 'metrics'
+    METADATA_ENDPOINT = 'metadata'
+
+    def __init__(self):
+        self.data_payload = dict()
+        self.meta_payload = dict()
+
+    @property
+    def payload(self):
+        """
+        Single payload with the content of data and metadata payloads.
+        """
+        res = self.data_payload.copy()
+        res.update(self.meta_payload)
+
+        return res
+
+    def __getitem__(self, key):
+        if key in self.METADATA_KEYS:
+            return self.meta_payload[key]
+        else:
+            return self.data_payload[key]
+
+    def __setitem__(self, key, value):
+        if key in self.DUPLICATE_KEYS:
+            self.data_payload[key] = value
+            self.meta_payload[key] = value
+        elif key in self.METADATA_KEYS:
+            self.meta_payload[key] = value
+        else:
+            self.data_payload[key] = value
+
+    def __delitem__(self, key):
+        if key in self.DUPLICATE_KEYS:
+            del self.data_payload[key]
+            del self.meta_payload[key]
+        elif key in self.METADATA_KEYS:
+            del self.meta_payload[key]
+        else:
+            del self.data_payload[key]
+
+    def __iter__(self):
+        for item in self.data_payload:
+            yield item
+        for item in self.meta_payload:
+            yield item
+
+    def __len__(self):
+        return len(self.data_payload) + len(self.meta_payload)
+
+    def emit(self, log, config, emitters, continue_running, merge_payloads=True):
+        """
+        Send payloads via the emitters.
+
+        :param merge_payloads: merge data and metadata payloads in a single payload and submit it
+            to the common endpoint
+        :type merge_payloads: boolean
+
+        """
+        statuses = []
+
+        def _emit_payload(payload, endpoint):
+            """ Send the payload via the emitters. """
+            statuses = []
+            for emitter in emitters:
+                # Don't try to send to an emitter if we're stopping/
+                if not continue_running:
+                    return statuses
+                name = emitter.__name__
+                emitter_status = EmitterStatus(name)
+                try:
+                    emitter(payload, log, config, endpoint)
+                except Exception, e:
+                    log.exception("Error running emitter: %s"
+                                  % emitter.__name__)
+                    emitter_status = EmitterStatus(name, e)
+                statuses.append(emitter_status)
+            return statuses
+
+        if merge_payloads:
+            statuses.extend(_emit_payload(self.payload, self.COMMON_ENDPOINT))
+        else:
+            statuses.extend(_emit_payload(self.data_payload, self.DATA_ENDPOINT))
+            statuses.extend(_emit_payload(self.meta_payload, self.METADATA_ENDPOINT))
+
+        return statuses
+
+
 class Collector(object):
     """
     The collector is responsible for collecting data from each check and
     passing it along to the emitters, who send it to their final destination.
     """
-
     def __init__(self, agentConfig, emitters, systemStats, hostname):
         self.emit_duration = None
         self.agentConfig = agentConfig
@@ -59,12 +160,12 @@ class Collector(object):
         self.emitters = emitters
         self.check_timings = agentConfig.get('check_timings')
         self.push_times = {
-            'metadata': {
+            'host_metadata': {
                 'start': time.time(),
                 'interval': int(agentConfig.get('metadata_interval', 4 * 60 * 60))
             },
             'external_host_tags': {
-                'start': time.time() - 3 * 60, # Wait for the checks to init
+                'start': time.time() - 3 * 60,  # Wait for the checks to init
                 'interval': int(agentConfig.get('external_host_tags', 5 * 60))
             },
             'agent_checks': {
@@ -79,7 +180,7 @@ class Collector(object):
         socket.setdefaulttimeout(15)
         self.run_count = 0
         self.continue_running = True
-        self.metadata_cache = None
+        self.hostname_metadata_cache = None
         self.initialized_checks_d = []
         self.init_failed_checks_d = {}
 
@@ -124,7 +225,7 @@ class Collector(object):
 
         # Resource Checks
         self._resources_checks = [
-            ResProcesses(log,self.agentConfig)
+            ResProcesses(log, self.agentConfig)
         ]
 
     def stop(self):
@@ -156,19 +257,23 @@ class Collector(object):
         log.debug("Starting collection run #%s" % self.run_count)
 
         if checksd:
-            self.initialized_checks_d = checksd['initialized_checks'] # is a list of AgentCheck instances
-            self.init_failed_checks_d = checksd['init_failed_checks'] # is of type {check_name: {error, traceback}}
+            self.initialized_checks_d = checksd['initialized_checks']  # is a list of AgentCheck instances
+            self.init_failed_checks_d = checksd['init_failed_checks']  # is of type {check_name: {error, traceback}}
 
-            # Find the AgentMetrics check and pop it out
-            # This check must run at the end of the loop to collect info on agent performance
-            if not self._agent_metrics:
-                for check in self.initialized_checks_d:
-                    if check.name == AGENT_METRICS_CHECK_NAME:
-                        self._agent_metrics = check
-                        self.initialized_checks_d.remove(check)
-                        break
+        payload = AgentPayload()
 
-        payload = self._build_payload(start_event=start_event)
+        # Find the AgentMetrics check and pop it out
+        # This check must run at the end of the loop to collect info on agent performance
+        if not self._agent_metrics:
+            for check in self.initialized_checks_d:
+                if check.name == AGENT_METRICS_CHECK_NAME:
+                    self._agent_metrics = check
+                    self.initialized_checks_d.remove(check)
+                    break
+
+        # Initialize payload
+        self._build_payload(payload)
+
         metrics = payload['metrics']
         events = payload['events']
         service_checks = payload['service_checks']
@@ -199,16 +304,16 @@ class Collector(object):
 
             if memory:
                 payload.update({
-                    'memPhysUsed' : memory.get('physUsed'),
-                    'memPhysPctUsable' : memory.get('physPctUsable'),
-                    'memPhysFree' : memory.get('physFree'),
-                    'memPhysTotal' : memory.get('physTotal'),
-                    'memPhysUsable' : memory.get('physUsable'),
-                    'memSwapUsed' : memory.get('swapUsed'),
-                    'memSwapFree' : memory.get('swapFree'),
-                    'memSwapPctFree' : memory.get('swapPctFree'),
-                    'memSwapTotal' : memory.get('swapTotal'),
-                    'memCached' : memory.get('physCached'),
+                    'memPhysUsed': memory.get('physUsed'),
+                    'memPhysPctUsable': memory.get('physPctUsable'),
+                    'memPhysFree': memory.get('physFree'),
+                    'memPhysTotal': memory.get('physTotal'),
+                    'memPhysUsable': memory.get('physUsable'),
+                    'memSwapUsed': memory.get('swapUsed'),
+                    'memSwapFree': memory.get('swapFree'),
+                    'memSwapPctFree': memory.get('swapPctFree'),
+                    'memSwapTotal': memory.get('swapTotal'),
+                    'memCached': memory.get('physCached'),
                     'memBuffers': memory.get('physBuffers'),
                     'memShared': memory.get('physShared')
                 })
@@ -228,7 +333,6 @@ class Collector(object):
         gangliaData = self._ganglia.check(self.agentConfig)
         dogstreamData = self._dogstream.check(self.agentConfig)
         ddforwarderData = self._ddforwarder.check(self.agentConfig)
-
 
         if gangliaData is not False and gangliaData is not None:
             payload['ganglia'] = gangliaData
@@ -257,8 +361,10 @@ class Collector(object):
                 snaps = resources_check.pop_snapshots()
                 if snaps:
                     has_resource = True
-                    res_value = {'snaps': snaps,
-                                 'format_version': resources_check.get_format_version()}
+                    res_value = {
+                        'snaps': snaps,
+                        'format_version': resources_check.get_format_version()
+                    }
                     res_format = resources_check.describe_format_if_needed()
                     if res_format is not None:
                         res_value['format_description'] = res_format
@@ -298,7 +404,10 @@ class Collector(object):
                 current_check_events = check.get_events()
                 check_stats = check._get_internal_profiling_stats()
 
-                # Save them for the payload.
+                # Collect metadata
+                current_check_metadata = check.get_service_metadata()
+
+                # Save metrics & events for the payload.
                 metrics.extend(current_check_metrics)
                 if current_check_events:
                     if check.name not in events:
@@ -315,7 +424,7 @@ class Collector(object):
 
             check_status = CheckStatus(
                 check.name, instance_statuses, metric_count,
-                event_count, service_check_count,
+                event_count, service_check_count, service_metadata=current_check_metadata,
                 library_versions=check.get_library_info(),
                 source_type_name=check.SOURCE_TYPE_NAME or check.name,
                 check_stats=check_stats
@@ -358,39 +467,16 @@ class Collector(object):
 
         # Add a service check for the agent
         service_checks.append(create_service_check('datadog.agent.up', AgentCheck.OK,
-            hostname=self.hostname))
+                              hostname=self.hostname))
 
         # Store the metrics and events in the payload.
         payload['metrics'] = metrics
         payload['events'] = events
         payload['service_checks'] = service_checks
 
-        if self._should_send_additional_data('agent_checks'):
-            # Add agent checks statuses and error/warning messages
-            agent_checks = []
-            for check in check_statuses:
-                if check.instance_statuses is not None:
-                    for instance_status in check.instance_statuses:
-                        agent_checks.append(
-                            (
-                                check.name, check.source_type_name,
-                                instance_status.instance_id,
-                                instance_status.status,
-                                # put error message or list of warning messages in the same field
-                                # it will be handled by the UI
-                                instance_status.error or instance_status.warnings or ""
-                            )
-                        )
-                else:
-                    agent_checks.append(
-                        (
-                            check.name, check.source_type_name,
-                            "initialization",
-                            check.status, repr(check.init_failed_error)
-                        )
-                    )
-            payload['agent_checks'] = agent_checks
-            payload['meta'] = self.metadata_cache  # add hostname metadata
+        # Populate metadata
+        self._populate_payload_metadata(payload, check_statuses, start_event)
+
         collect_duration = timer.step()
 
         if self.os != 'windows':
@@ -422,24 +508,26 @@ class Collector(object):
                     log.info("\n AGENT STATS: \n {0}".format(Collector._stats_for_display(agent_stats)))
 
         # Let's send our payload
-        emitter_statuses = self._emit(payload)
+        emitter_statuses = payload.emit(log, self.agentConfig, self.emitters,
+                                        self.continue_running)
         self.emit_duration = timer.step()
 
         # Persist the status of the collection run.
         try:
-            CollectorStatus(check_statuses, emitter_statuses, self.metadata_cache).persist()
+            CollectorStatus(check_statuses, emitter_statuses,
+                            self.hostname_metadata_cache).persist()
         except Exception:
             log.exception("Error persisting collector status")
 
         if self.run_count <= FLUSH_LOGGING_INITIAL or self.run_count % FLUSH_LOGGING_PERIOD == 0:
             log.info("Finished run #%s. Collection time: %ss. Emit time: %ss" %
-                    (self.run_count, round(collect_duration, 2), round(self.emit_duration, 2)))
+                     (self.run_count, round(collect_duration, 2), round(self.emit_duration, 2)))
             if self.run_count == FLUSH_LOGGING_INITIAL:
-                log.info("First flushes done, next flushes will be logged every %s flushes." % FLUSH_LOGGING_PERIOD)
-
+                log.info("First flushes done, next flushes will be logged every %s flushes." %
+                         FLUSH_LOGGING_PERIOD)
         else:
             log.debug("Finished run #%s. Collection time: %ss. Emit time: %ss" %
-                    (self.run_count, round(collect_duration, 2), round(self.emit_duration, 2)))
+                      (self.run_count, round(collect_duration, 2), round(self.emit_duration, 2)))
 
         return payload
 
@@ -506,26 +594,31 @@ class Collector(object):
     def _is_first_run(self):
         return self.run_count <= 1
 
-    def _build_payload(self, start_event=True):
+    def _build_payload(self, payload):
         """
-        Return an dictionary that contains all of the generic payload data.
+        Build the payload skeleton, so it contains all of the generic payload data.
         """
         now = time.time()
-        payload = {
-            'collection_timestamp': now,
-            'os' : self.os,
-            'python': sys.version,
-            'agentVersion' : self.agentConfig['version'],
-            'apiKey': self.agentConfig['api_key'],
-            'events': {},
-            'metrics': [],
-            'service_checks': [],
-            'resources': {},
-            'internalHostname' : self.hostname,
-            'uuid' : get_uuid(),
-            'host-tags': {},
-            'external_host_tags': {}
-        }
+
+        payload['collection_timestamp'] = now
+        payload['os'] = self.os
+        payload['python'] = sys.version
+        payload['agentVersion'] = self.agentConfig['version']
+        payload['apiKey'] = self.agentConfig['api_key']
+        payload['events'] = {}
+        payload['metrics'] = []
+        payload['service_checks'] = []
+        payload['resources'] = {}
+        payload['internalHostname'] = self.hostname
+        payload['uuid'] = get_uuid()
+        payload['host-tags'] = {}
+        payload['external_host_tags'] = {}
+
+    def _populate_payload_metadata(self, payload, check_statuses, start_event=True):
+        """
+        Periodically populate the payload with metadata related to the system, host, and/or checks.
+        """
+        now = time.time()
 
         # Include system stats on first postback
         if start_event and self._is_first_run():
@@ -540,7 +633,7 @@ class Collector(object):
             }]
 
         # Periodically send the host metadata.
-        if self._should_send_additional_data('metadata'):
+        if self._should_send_additional_data('host_metadata'):
             # gather metadata with gohai
             try:
                 if get_os() != 'windows':
@@ -562,13 +655,14 @@ class Collector(object):
                 log.warning("gohai command failed with error %s" % str(e))
 
             payload['systemStats'] = get_system_stats()
-            payload['meta'] = self._get_metadata()
+            payload['meta'] = self._get_hostname_metadata()
 
-            self.metadata_cache = payload['meta']
+            self.hostname_metadata_cache = payload['meta']
             # Add static tags from the configuration file
             host_tags = []
             if self.agentConfig['tags'] is not None:
-                host_tags.extend([unicode(tag.strip()) for tag in self.agentConfig['tags'].split(",")])
+                host_tags.extend([unicode(tag.strip())
+                                 for tag in self.agentConfig['tags'].split(",")])
 
             if self.agentConfig['collect_ec2_tags']:
                 host_tags.extend(EC2.get_tags(self.agentConfig))
@@ -582,7 +676,8 @@ class Collector(object):
 
             # Log the metadata on the first run
             if self._is_first_run():
-                log.info("Hostnames: %s, tags: %s" % (repr(self.metadata_cache), payload['host-tags']))
+                log.info("Hostnames: %s, tags: %s" %
+                         (repr(self.hostname_metadata_cache), payload['host-tags']))
 
         # Periodically send extra hosts metadata (vsphere)
         # Metadata of hosts that are not the host where the agent runs, not all the checks use
@@ -600,6 +695,35 @@ class Collector(object):
         if external_host_tags:
             payload['external_host_tags'] = external_host_tags
 
+        # Periodically send agent_checks metadata
+        if self._should_send_additional_data('agent_checks'):
+            # Add agent checks statuses and error/warning messages
+            agent_checks = []
+            for check in check_statuses:
+                if check.instance_statuses is not None:
+                    for i, instance_status in enumerate(check.instance_statuses):
+                        agent_checks.append(
+                            (
+                                check.name, check.source_type_name,
+                                instance_status.instance_id,
+                                instance_status.status,
+                                # put error message or list of warning messages in the same field
+                                # it will be handled by the UI
+                                instance_status.error or instance_status.warnings or "",
+                                check.service_metadata[i]
+                            )
+                        )
+                else:
+                    agent_checks.append(
+                        (
+                            check.name, check.source_type_name,
+                            "initialization",
+                            check.status, repr(check.init_failed_error)
+                        )
+                    )
+            payload['agent_checks'] = agent_checks
+            payload['meta'] = self.hostname_metadata_cache  # add hostname metadata
+
         # If required by the user, let's create the dd_check:xxx host tags
         if self.agentConfig['create_dd_check_tags'] and \
                 self._should_send_additional_data('dd_check_tags'):
@@ -611,9 +735,10 @@ class Collector(object):
 
             payload['host-tags']['system'].extend(app_tags_list)
 
-        return payload
-
-    def _get_metadata(self):
+    def _get_hostname_metadata(self):
+        """
+        Returns a dictionnary that contains hostname metadata.
+        """
         metadata = EC2.get_metadata(self.agentConfig)
         if metadata.get('hostname'):
             metadata['ec2-hostname'] = metadata.get('hostname')

--- a/ddagent.py
+++ b/ddagent.py
@@ -320,7 +320,7 @@ class StatusHandler(tornado.web.RequestHandler):
 
 
 class AgentInputHandler(tornado.web.RequestHandler):
-    _MSG_TYPE = None
+    _MSG_TYPE = ""
 
     def post(self):
         """Read the message and forward it to the intake"""

--- a/emitter.py
+++ b/emitter.py
@@ -20,7 +20,7 @@ requests_log.setLevel(logging.WARN)
 requests_log.propagate = True
 
 # From http://stackoverflow.com/questions/92438/stripping-non-printable-characters-from-a-string-in-python
-control_chars = ''.join(map(unichr, range(0,32) + range(127,160)))
+control_chars = ''.join(map(unichr, range(0, 32) + range(127, 160)))
 control_char_re = re.compile('[%s]' % re.escape(control_chars))
 
 
@@ -28,7 +28,7 @@ def remove_control_chars(s):
     return control_char_re.sub('', s)
 
 
-def http_emitter(message, log, agentConfig):
+def http_emitter(message, log, agentConfig, endpoint):
     "Send payload"
     url = agentConfig['dd_url']
 
@@ -43,13 +43,14 @@ def http_emitter(message, log, agentConfig):
 
     zipped = zlib.compress(payload)
 
-    log.debug("payload_size=%d, compressed_size=%d, compression_ratio=%.3f" % (len(payload), len(zipped), float(len(payload))/float(len(zipped))))
+    log.debug("payload_size=%d, compressed_size=%d, compression_ratio=%.3f"
+              % (len(payload), len(zipped), float(len(payload))/float(len(zipped))))
 
     apiKey = message.get('apiKey', None)
     if not apiKey:
         raise Exception("The http emitter requires an api key")
 
-    url = "{0}/intake?api_key={1}".format(url, apiKey)
+    url = "{0}/intake/{1}?api_key={2}".format(url, endpoint, apiKey)
 
     try:
         headers = post_headers(agentConfig, zipped)

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -181,6 +181,8 @@ class AgentCheckTest(unittest.TestCase):
                 # ie the check edits the tags of the instance, problematic if
                 # run twice
                 self.check.check(copy.deepcopy(instance))
+                # FIXME: This should be called within the `run` method only
+                self.check._roll_up_instance_metadata()
             except Exception, e:
                 # Catch error before re-raising it to be able to get service_checks
                 print "Exception {0} during check".format(e)

--- a/tests/checks/integration/test_elastic.py
+++ b/tests/checks/integration/test_elastic.py
@@ -220,12 +220,14 @@ class TestElastic(AgentCheckTest):
                                 status=AgentCheck.CRITICAL, tags=bad_sc_tags,
                                 count=1)
 
-
         status = AgentCheck.OK
         # Travis doesn't have any shards in the cluster and consider this as green
         self.assertServiceCheck('elasticsearch.cluster_health',
                                 status=status, tags=good_sc_tags,
                                 count=2)
+
+        # Assert service metadata
+        self.assertServiceMetadata(['version'], count=3)
 
         self.coverage_report()
 

--- a/tests/checks/integration/test_mysql.py
+++ b/tests/checks/integration/test_mysql.py
@@ -114,6 +114,9 @@ class TestMySql(AgentCheckTest):
                       self.KEY_CACHE + self.COMMON_GAUGES + self.COMMON_RATES):
             self.assertMetric(mname, tags=self.METRIC_TAGS, count=1)
 
+        # Assert service metadata
+        self.assertServiceMetadata(['version'], count=1)
+
         # Raises when COVERAGE=true and coverage < 100%
         self.coverage_report()
 

--- a/tests/checks/integration/test_postgres.py
+++ b/tests/checks/integration/test_postgres.py
@@ -212,4 +212,7 @@ class TestPostgres(AgentCheckTest):
             tags=['host:localhost', 'port:15432', 'db:dogs']
         )
 
+        # Assert service metadata
+        self.assertServiceMetadata(['version'], count=2)
+
         self.coverage_report()

--- a/tests/checks/integration/test_redisdb.py
+++ b/tests/checks/integration/test_redisdb.py
@@ -146,6 +146,13 @@ class TestRedis(AgentCheckTest):
         keys = [m[0] for m in metrics]
         assert 'redis.net.commands' in keys
 
+        # Service metadata
+        service_metadata = r.get_service_metadata()
+        service_metadata_count = len(service_metadata)
+        self.assertTrue(service_metadata_count > 0)
+        for meta_dict in service_metadata:
+            assert meta_dict
+
     def test_redis_replication_link_metric(self):
         metric_name = 'redis.replication.master_link_down_since_seconds'
         r = load_check('redisdb', {}, {})

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -119,13 +119,6 @@ class TestCore(unittest.TestCase):
         self.assertEqual(self.ac.normalize("PauseTotalNs", "prefix", fix_case = True), "prefix.pause_total_ns")
         self.assertEqual(self.ac.normalize("Metric.wordThatShouldBeSeparated", "prefix", fix_case = True), "prefix.metric.word_that_should_be_separated")
 
-    def test_metadata(self):
-        c = Collector({"collect_instance_metadata": True}, None, {}, "foo")
-        metadata = c._get_metadata()
-        assert "hostname" in metadata
-        assert "socket-fqdn" in metadata
-        assert "socket-hostname" in metadata
-
     def test_service_check(self):
         check_name = 'test.service_check'
         status = AgentCheck.CRITICAL

--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -10,24 +10,42 @@ class TestMetadata(unittest.TestCase):
     Test the metadata collection logic.
     """
     class FakeCheck(AgentCheck):
-        """ This check will generate metadata depending on the instance """
+        """
+        This check will generate more or less metadata depending on the instance
+        """
         def check(self, instance):
-            metadata = instance.get('metadata')
-            if metadata:
-                self._collect_metadata()
+            if instance.get('metadata'):
+                self._collect_metadata(instance.get('more_meta'))
 
-        def _collect_metadata(self):
-            self.svc_metadata({'version': 1})
+        def _collect_metadata(self, more_meta):
+            self.service_metadata('foo', "bar")
+            if more_meta:
+                self.service_metadata('baz', "qux")
 
     def test_hostname_metadata(self):
         """
-        Collect hostname metadata.
+        Collect hostname metadata
         """
         c = Collector({"collect_instance_metadata": True}, None, {}, "foo")
         metadata = c._get_hostname_metadata()
         assert "hostname" in metadata
         assert "socket-fqdn" in metadata
         assert "socket-hostname" in metadata
+
+    def test_instance_metadata_rollup(self):
+        """
+        Roll-up instance metadata
+        """
+        config = {'instances': [{'metadata': True, 'more_meta': True}]}
+        instances = config.get('instances')
+        check = TestMetadata.FakeCheck("fake_check", config, {}, instances)
+        check.run()
+
+        service_metadata = check.get_service_metadata()
+        service_metadata_count = len(service_metadata)
+
+        self.assertEquals(service_metadata_count, 1)
+        self.assertEquals(service_metadata[0], {'foo': "bar", 'baz': "qux"})
 
     def test_metadata_length(self):
         """
@@ -39,10 +57,11 @@ class TestMetadata(unittest.TestCase):
         instances = config.get('instances')
         check = TestMetadata.FakeCheck("fake_check", config, {}, instances)
         check.run()
+
         service_metadata = check.get_service_metadata()
         service_metadata_count = len(service_metadata)
 
         self.assertEquals(service_metadata_count, 3)
-        self.assertEquals(service_metadata[0], {'version': 1})
+        self.assertEquals(service_metadata[0], {'foo': "bar"})
         self.assertEquals(service_metadata[1], {})
-        self.assertEquals(service_metadata[2], {'version': 1})
+        self.assertEquals(service_metadata[2], {'foo': "bar"})

--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -1,0 +1,48 @@
+import unittest
+
+# project
+from checks import AgentCheck
+from checks.collector import Collector
+
+
+class TestMetadata(unittest.TestCase):
+    """
+    Test the metadata collection logic.
+    """
+    class FakeCheck(AgentCheck):
+        """ This check will generate metadata depending on the instance """
+        def check(self, instance):
+            metadata = instance.get('metadata')
+            if metadata:
+                self._collect_metadata()
+
+        def _collect_metadata(self):
+            self.svc_metadata({'version': 1})
+
+    def test_hostname_metadata(self):
+        """
+        Collect hostname metadata.
+        """
+        c = Collector({"collect_instance_metadata": True}, None, {}, "foo")
+        metadata = c._get_hostname_metadata()
+        assert "hostname" in metadata
+        assert "socket-fqdn" in metadata
+        assert "socket-hostname" in metadata
+
+    def test_metadata_length(self):
+        """
+        Fill up checks that do not generate any metadata
+        """
+        # Instance 2 will not generate any metadata
+        config = {'instances': [{'metadata': True}, {}, {'metadata': True}]}
+
+        instances = config.get('instances')
+        check = TestMetadata.FakeCheck("fake_check", config, {}, instances)
+        check.run()
+        service_metadata = check.get_service_metadata()
+        service_metadata_count = len(service_metadata)
+
+        self.assertEquals(service_metadata_count, 3)
+        self.assertEquals(service_metadata[0], {'version': 1})
+        self.assertEquals(service_metadata[1], {})
+        self.assertEquals(service_metadata[2], {'version': 1})

--- a/tests/core/test_payload.py
+++ b/tests/core/test_payload.py
@@ -1,0 +1,109 @@
+import unittest
+
+# project
+from checks.collector import AgentPayload
+
+# 3p
+from mock import Mock
+
+
+class TestAgentPayload(unittest.TestCase):
+    """
+    Test the agent payload logic
+    """
+    def test_add_rem_elem(self):
+        """
+        Can set, read, update and delete data in the agent_payload
+        """
+        agent_payload = AgentPayload()
+
+        # Is initially empty
+        self.assertEquals(len(agent_payload), 0)
+
+        # Set a new value
+        agent_payload['something'] = "value"
+        self.assertEquals(len(agent_payload), 1)
+
+        # Can access it
+        self.assertEquals(agent_payload['something'], "value")
+
+        # Can update it
+        agent_payload['something'] = "other value"
+        self.assertEquals(len(agent_payload), 1)
+        self.assertEquals(agent_payload['something'], "other value")
+
+        # Delete it
+        del agent_payload['something']
+        self.assertEquals(len(agent_payload), 0)
+
+    def test_payload_property(self):
+        """
+        `agent_payload` property returns a single agent_payload
+        with the content of data and metadata payloads.
+        """
+        agent_payload = AgentPayload()
+        payload = {}
+
+        DATA_KEYS = ['key1', 'key2']
+        META_KEYS = list(AgentPayload.METADATA_KEYS)[:2]
+        DUP_KEYS = list(AgentPayload.DUPLICATE_KEYS)[:2]
+
+        # Addind data, meta and duplicate values to agent_payload and payload
+        for k in DATA_KEYS + META_KEYS + DUP_KEYS:
+            agent_payload[k] = "value"
+            payload[k] = "value"
+
+        self.assertEquals(agent_payload.payload, payload, agent_payload)
+
+    def test_split_metrics_and_meta(self):
+        """
+        Split data and metadata payloads. Submit to the right endpoint.
+        """
+        # Some not metadata keys
+        DATA_KEYS = ['key1', 'key2', 'key3', 'key4']
+
+        agent_payload = AgentPayload()
+
+        # Adding metadata values
+        for key in AgentPayload.METADATA_KEYS:
+            agent_payload[key] = "value"
+        len_payload1 = len(agent_payload)
+        self.assertEquals(len_payload1, len(AgentPayload.METADATA_KEYS))
+        self.assertEquals(len_payload1, len(agent_payload.meta_payload))
+        self.assertEquals(len(agent_payload.data_payload), 0)
+
+        # Adding data values
+        for key in DATA_KEYS:
+            agent_payload[key] = "value"
+        len_payload2 = len(agent_payload)
+        self.assertEquals(len_payload2, len_payload1 + len(DATA_KEYS))
+        self.assertEquals(len_payload2 - len_payload1, len(agent_payload.data_payload))
+        self.assertEquals(len(agent_payload.meta_payload), len_payload1)
+
+        # Adding common values
+        for key in AgentPayload.DUPLICATE_KEYS:
+            agent_payload[key] = "value"
+        len_payload3 = len(agent_payload)
+        self.assertEquals(len_payload3, len_payload2 + 2 * len(AgentPayload.DUPLICATE_KEYS))
+        self.assertEquals(len_payload1 + len(AgentPayload.DUPLICATE_KEYS),
+                          len(agent_payload.meta_payload))
+        self.assertEquals(len_payload2 - len_payload1 + len(AgentPayload.DUPLICATE_KEYS),
+                          len(agent_payload.data_payload))
+
+    def test_emit_payload(self):
+        """
+        Submit each payload to its specific endpoint.
+        """
+        agent_payload = AgentPayload()
+
+        fake_emitter = Mock()
+        fake_emitter.__name__ = None
+
+        # Different payloads, different endpoints
+        agent_payload.emit(None, None, [fake_emitter], True, merge_payloads=False)
+        fake_emitter.assert_any_call(agent_payload.data_payload, None, None, "metrics")
+        fake_emitter.assert_any_call(agent_payload.meta_payload, None, None, "metadata")
+
+        # One payload, one endpoint
+        agent_payload.emit(None, None, [fake_emitter], True)
+        fake_emitter.assert_any_call(agent_payload.payload, None, None, "")

--- a/tests/core/test_transaction.py
+++ b/tests/core/test_transaction.py
@@ -9,12 +9,12 @@ import requests
 import simplejson as json
 
 # project
-from transaction import Transaction, TransactionManager
+from config import get_version
 from ddagent import (
     MAX_QUEUE_SIZE, THROTTLING_DELAY,
     APIMetricTransaction, APIServiceCheckTransaction, MetricTransaction
 )
-from config import get_version
+from transaction import Transaction, TransactionManager
 
 
 class memTransaction(Transaction):
@@ -46,7 +46,7 @@ class TestTransaction(unittest.TestCase):
         """Test memory limit as well as simple flush"""
 
         # No throttling, no delay for replay
-        trManager = TransactionManager(timedelta(seconds = 0), MAX_QUEUE_SIZE, timedelta(seconds=0))
+        trManager = TransactionManager(timedelta(seconds=0), MAX_QUEUE_SIZE, timedelta(seconds=0))
 
         step = 10
         oneTrSize = (MAX_QUEUE_SIZE / step) - 1
@@ -60,7 +60,7 @@ class TestTransaction(unittest.TestCase):
         # a flush count of 1
         self.assertEqual(len(trManager._transactions), step)
         for tr in trManager._transactions:
-            self.assertEqual(tr._flush_count,1)
+            self.assertEqual(tr._flush_count, 1)
 
         # Try to add one more
         tr = memTransaction(oneTrSize + 10, trManager)
@@ -69,7 +69,7 @@ class TestTransaction(unittest.TestCase):
         # At this point, transaction one (the oldest) should have been removed from the list
         self.assertEqual(len(trManager._transactions), step)
         for tr in trManager._transactions:
-            self.assertNotEqual(tr._id,1)
+            self.assertNotEqual(tr._id, 1)
 
         trManager.flush()
         self.assertEqual(len(trManager._transactions), step)
@@ -78,9 +78,9 @@ class TestTransaction(unittest.TestCase):
             tr.is_flushable = True
             # Last transaction has been flushed only once
             if tr._id == step + 1:
-                self.assertEqual(tr._flush_count,1)
+                self.assertEqual(tr._flush_count, 1)
             else:
-                self.assertEqual(tr._flush_count,2)
+                self.assertEqual(tr._flush_count, 2)
 
         trManager.flush()
         self.assertEqual(len(trManager._transactions), 0)
@@ -89,8 +89,8 @@ class TestTransaction(unittest.TestCase):
         """Test throttling while flushing"""
 
         # No throttling, no delay for replay
-        trManager = TransactionManager(timedelta(seconds = 0), MAX_QUEUE_SIZE, THROTTLING_DELAY)
-        trManager._flush_without_ioloop = True # Use blocking API to emulate tornado ioloop
+        trManager = TransactionManager(timedelta(seconds=0), MAX_QUEUE_SIZE, THROTTLING_DELAY)
+        trManager._flush_without_ioloop = True  # Use blocking API to emulate tornado ioloop
 
         # Add 3 transactions, make sure no memory limit is in the way
         oneTrSize = MAX_QUEUE_SIZE / 10
@@ -102,8 +102,8 @@ class TestTransaction(unittest.TestCase):
         before = datetime.now()
         trManager.flush()
         after = datetime.now()
-        self.assertTrue((after-before) > 3 * THROTTLING_DELAY - timedelta(microseconds=100000),
-            "before = %s after = %s" % (before, after))
+        self.assertTrue((after - before) > 3 * THROTTLING_DELAY - timedelta(microseconds=100000),
+                        "before = %s after = %s" % (before, after))
 
     def testCustomEndpoint(self):
         MetricTransaction._endpoints = []
@@ -119,15 +119,15 @@ class TestTransaction(unittest.TestCase):
         app._agentConfig = config
         app.use_simple_http_client = True
 
-        trManager = TransactionManager(timedelta(seconds = 0), MAX_QUEUE_SIZE, THROTTLING_DELAY)
-        trManager._flush_without_ioloop = True # Use blocking API to emulate tornado ioloop
+        trManager = TransactionManager(timedelta(seconds=0), MAX_QUEUE_SIZE, THROTTLING_DELAY)
+        trManager._flush_without_ioloop = True  # Use blocking API to emulate tornado ioloop
         MetricTransaction._trManager = trManager
         MetricTransaction.set_application(app)
         MetricTransaction.set_endpoints()
 
-        transaction = MetricTransaction(None, {})
+        transaction = MetricTransaction(None, {}, "msgtype")
         endpoints = [transaction.get_url(e) for e in transaction._endpoints]
-        expected = ['https://foo.bar.com/intake?api_key=foo']
+        expected = ['https://foo.bar.com/intake/msgtype?api_key=foo']
         self.assertEqual(endpoints, expected, (endpoints, expected))
 
     def testEndpoints(self):
@@ -154,9 +154,9 @@ class TestTransaction(unittest.TestCase):
         MetricTransaction.set_application(app)
         MetricTransaction.set_endpoints()
 
-        transaction = MetricTransaction(None, {})
+        transaction = MetricTransaction(None, {}, "msgtype")
         endpoints = [transaction.get_url(e) for e in transaction._endpoints]
-        expected = ['https://{0}-app.agent.datadoghq.com/intake?api_key={1}'.format(
+        expected = ['https://{0}-app.agent.datadoghq.com/intake/msgtype?api_key={1}'.format(
             get_version().replace(".", "-"), api_key)]
         self.assertEqual(endpoints, expected, (endpoints, expected))
 


### PR DESCRIPTION
# Service metadata collection


## Update 05/18
`AgentCheck.service_metadata(metadata_name, value)` replaces `AgentCheck.svc_metadata(metadata_dict)` method.
Under the hood, metadata are stored in a list, and rolled-up to a dictionnary for every instance.
Usage:
```
self.service_metadata('foo', "bar")
```



## Changes

### AgentCheck interface

Following methods were added to `AgentCheck` interface to support service metadata collection:
```python
self.service_metadata(name, value) # Check purpose - Send metadata
self.get_service_metadata() # Collector purpose - Return a list of metadata dictionaries saved by check -if any-
							# and clears them out of the instance's service_checks list
```

To send metadata from an Agent Check, decorate it with `self.svc_metadata(...)` statements.
```python
def	check(...)
	...
	# Send integration metadata
	self.service_metadata('foo', "bar")
	...
```

### Payload refactoring

Collector payload was re-factored behind `AgentPayload` interface: it offers the same single payload style interface but manages, distinguishes two payloads:
* A metadata payload related to hostname, system and services
* A data payload that contains metrics, events, service_checks and more

Each of these payloads *can be* automatically submitted to a specific endpoint.

Before
```
payload
+------------+
|'metrics'   |
+--+---------+
|'events'    |
+------------+
|'svc_cheks' |        submit
+--+---------+          ------->     /intake
|'gohai'     |
+------------+
|'systm_stts'|
+------------+
|'meta'      |
+------------+
|'agent_chks'|
+--+---------+
|'svc_meta'  |
+--+---------+
|............|
|            |
+            +
 ............
```

Now:
```
 payload
+---------------------------------------+
| payload_data           payload_meta   |
| +------------+         +------------+ |
| |'metrics'   |         |'systm_stts'| |
| +--+---------+         +------------+ |
| |'events'    |         |'meta'      | |
| +------------+         +------------+ |
| |'svc_cheks' |         |'agent_chks'| |
| +--+---------+         +--+---------+ |
| |............|         |'svc_meta'  | |
| |            |         +--+---------+ |
| +            +         |............| |
|  ............          |            | |
| +            +         |            | |
| +------------+         +------------+ |
+-+------------+---------+------------+-+

                       submit
                        + +
                        | |
                        | |
/intake/metrics  <------+ +------->  /intake/metadata
```


### Collector

Collector `run` method was reorganised to successively populate the payload by data type (it used to be more random).

Steps are:
1. Payload skeleton
	* `self._build_payload(...)`: only builds the payload skeleton, so it contains all of the generic payload data (no metadata).
2. Data payload
	* Metrics
	* Events
	* Service checks
3. Metadata payload
	* `self._populate_payload_metadata(...)`: periodically populates the payload with metadata related to the system, host, and/or checks.


## Displaying metadata

### agent `check`command

Agent `check` command now displays collected metadata, in addition to metrics, events and service checks.


### agent `info` command

Set `display_service_metadata` to True in `datadog.conf` file.

```
...
display_service_metadata: True
...
```

A new **Service metadata** section is now displayed in the `info` command output whenever service metadata are collected.
![screenshot 2015-05-12 10 05 35](https://cloud.githubusercontent.com/assets/5708089/7594683/5b620d28-f8b0-11e4-81b1-5a9f8ffd78da.png)

## Thoughts

###  Split data and metadata ?
Currently data and metadata from the agent are part of the same payload, which is processed by a single handler in Sobotka.
Metadata are extracted, directly written to Postgres when data are forwarded to Kafka.

As the volume of metadata is growing, it would be wiser to split data and metadata processing, so that postgres operations would not slow down the agent data pipeline.

First suggestion made was to have two different Sobotka handlers specific for data and metadata:
https://docs.google.com/document/d/10LAKQ1E_ez4jgTn_czFJwDkEIghGFUFsDF03LgY8QRE

### Include host tags in the data payload ?

Host tags are now listed in the metadata payload only.
As it is possibly sent in a different packet (to a different endpoint), it may lead to a 'no tag' situation when a data payload is received before any metadata's.

A workaround would be to add/duplicate host tags in the data payload, but it breaks the Sobotka handler logic described in the section above.

## For now

### Single payload/endpoint for metrics and metadata

Let's keep it simple for now, so we can test and play with metadata support internally with the 5.4 agent release.
As the volume of metadata is still low, I can set `AgentPayload` to send a single data+metadata payload to the current `/intake` endpoint.

## TODO
- [x] Fix flaky tests
- [x] Submit only one data+metadata payload to `/intake` endpoint (c.f. 'Single endpoint for metrics and metadata' section)
- [ ] Write a RFC on why and how we would split agent data and metadata