### PR TITLE
[mesos] cast error message to string

### DIFF
--- a/checks.d/mesos.py
+++ b/checks.d/mesos.py
@@ -90,7 +90,7 @@ class Mesos(AgentCheck):
             msg = "%s seconds timeout when hitting %s" % (timeout, url)
             status = AgentCheck.CRITICAL
         except Exception as e:
-            msg = e.message
+            msg = str(e)
             status = AgentCheck.CRITICAL
         finally:
             self.service_check(self.SERVICE_CHECK_NAME, status, tags=tags, message=msg)


### PR DESCRIPTION
`AgentCheck.service_check` expect a string message. Otherwise it breaks the
emitter `json.dumps()`.