### PR TITLE
[Core+NTP] Use data dog ntp pool

### DIFF
--- a/checks.d/ntp.py
+++ b/checks.d/ntp.py
@@ -3,6 +3,7 @@ import time
 
 # project
 from checks import AgentCheck
+from utils.ntp import get_ntp_datadog_host
 
 # 3rd party
 import ntplib
@@ -10,7 +11,6 @@ import ntplib
 DEFAULT_OFFSET_THRESHOLD = 60 # in seconds
 DEFAULT_NTP_VERSION = 3
 DEFAULT_TIMEOUT = 1 # in seconds
-DEFAULT_HOST = "pool.ntp.org"
 DEFAULT_PORT = "ntp"
 
 class NtpCheck(AgentCheck):
@@ -24,8 +24,11 @@ class NtpCheck(AgentCheck):
             offset_threshold = int(offset_threshold)
         except (TypeError, ValueError):
             raise Exception('Must specify an integer value for offset_threshold. Configured value is %s' % repr(offset_threshold))
+
+        host = instance.get('host') or get_ntp_datadog_host()
+        self.log.debug("Using ntp host: {0}".format(host))
         req_args = {
-            'host':    instance.get('host', DEFAULT_HOST),
+            'host':    host,
             'port':    instance.get('port', DEFAULT_PORT),
             'version': int(instance.get('version', DEFAULT_NTP_VERSION)),
             'timeout': float(instance.get('timeout', DEFAULT_TIMEOUT)),

--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -15,15 +15,17 @@ import time
 from collections import defaultdict
 import os.path
 
+# 3rd party
+import ntplib
+import yaml
+
 # project
 import config
 from config import get_config, get_jmx_status_path, _windows_commondata_path
 from util import get_os, plural
+from utils.ntp import get_ntp_datadog_host
 from utils.platform import Platform
 from utils.pidfile import PidFile
-# 3rd party
-import ntplib
-import yaml
 
 STATUS_OK = 'OK'
 STATUS_ERROR = 'ERROR'
@@ -96,7 +98,8 @@ def logger_info():
 
 
 def get_ntp_info():
-    ntp_offset = ntplib.NTPClient().request('pool.ntp.org', version=3).offset
+    ntp_host = get_ntp_datadog_host()
+    ntp_offset = ntplib.NTPClient().request(ntp_host, version=3).offset
     if abs(ntp_offset) > NTP_OFFSET_THRESHOLD:
         ntp_styles = ['red', 'bold']
     else:

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -1,11 +1,14 @@
+# stdlib
 import logging
 import os
 import time
 import unittest
 
+# 3p
 from nose.plugins.attrib import attr
 from nose.plugins.skip import SkipTest
 
+# project
 from aggregator import MetricsAggregator
 from checks import (
     AgentCheck,
@@ -17,6 +20,7 @@ from checks import (
 from checks.collector import Collector
 from tests.checks.common import load_check
 from util import get_hostname
+from utils.ntp import get_ntp_datadog_host
 
 logger = logging.getLogger()
 
@@ -253,7 +257,7 @@ class TestCore(unittest.TestCase):
     def test_min_collection_interval(self):
         if os.environ.get('TRAVIS', False):
             raise SkipTest('ntp server times out too often on Travis')
-        config = {'instances': [{'host': '0.amazon.pool.ntp.org', 'timeout': 1}], 'init_config': {}}
+        config = {'instances': [{'host': get_ntp_datadog_host(), 'timeout': 1}], 'init_config': {}}
 
         agentConfig = {
             'version': '0.1',
@@ -287,7 +291,7 @@ class TestCore(unittest.TestCase):
         metrics = check.get_metrics()
         self.assertTrue(len(metrics) > 0, metrics)
 
-        config = {'instances': [{'host': '0.amazon.pool.ntp.org', 'timeout': 1, 'min_collection_interval':3}], 'init_config': {}}
+        config = {'instances': [{'host': get_ntp_datadog_host(), 'timeout': 1, 'min_collection_interval':3}], 'init_config': {}}
         check = load_check('ntp', config, agentConfig)
         check.run()
         metrics = check.get_metrics()
@@ -300,7 +304,7 @@ class TestCore(unittest.TestCase):
         metrics = check.get_metrics()
         self.assertTrue(len(metrics) > 0, metrics)
 
-        config = {'instances': [{'host': '0.amazon.pool.ntp.org', 'timeout': 1, 'min_collection_interval': 12}], 'init_config': {'min_collection_interval':3}}
+        config = {'instances': [{'host': get_ntp_datadog_host(), 'timeout': 1, 'min_collection_interval': 12}], 'init_config': {'min_collection_interval':3}}
         check = load_check('ntp', config, agentConfig)
         check.run()
         metrics = check.get_metrics()

--- a/utils/ntp.py
+++ b/utils/ntp.py
@@ -1,0 +1,9 @@
+import random
+
+def get_ntp_datadog_host(subpool=None):
+    """
+    Returns randomly a NTP hostname of our vendor pool. Or
+    a given subpool if given in input.
+    """
+    subpool = subpool or random.randint(0, 3)
+    return "{0}.datadog.pool.ntp.org".format(subpool)


### PR DESCRIPTION
Using directly pool.ntp.org is not recommended and must be avoided.

We set up our own vendor pool zone and we have the following hostnames:

```
0.datadog.pool.ntp.org
1.datadog.pool.ntp.org
2.datadog.pool.ntp.org
3.datadog.pool.ntp.org
```