### PR TITLE
[core] run supervisor as dd-agent

### DIFF
--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -102,7 +102,7 @@ start() {
     # no need to test for status before daemon,
     # the daemon function does the right thing
     echo -n "Starting Datadog Agent (using supervisord):"
-    daemon --pidfile=$SUPERVISOR_PIDFILE $SUPERVISORD_PATH -c $SUPERVISOR_CONF > /dev/null
+    daemon --user=$AGENTUSER --pidfile=$SUPERVISOR_PIDFILE $SUPERVISORD_PATH -c $SUPERVISOR_CONF > /dev/null
     # check if the agent is running once per second for 10 seconds
     retries=10
     while [ $retries -gt 1 ]; do

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -88,7 +88,7 @@ case "$1" in
 
 
         log_daemon_msg "Starting $DESC (using supervisord)" "$NAME"
-        PATH=$SYSTEM_PATH start-stop-daemon --start --quiet --oknodo --exec $SUPERVISORD_PATH -- -c $SUPERVISOR_FILE --pidfile $SUPERVISOR_PIDFILE
+        PATH=$SYSTEM_PATH start-stop-daemon --chuid $AGENTUSER --start --quiet --oknodo --exec $SUPERVISORD_PATH -- -c $SUPERVISOR_FILE --pidfile $SUPERVISOR_PIDFILE
         if [ $? -ne 0 ]; then
             log_end_msg 1
         fi
@@ -114,7 +114,7 @@ case "$1" in
     stop)
 
         log_daemon_msg "Stopping $DESC (stopping supervisord)" "$NAME"
-        start-stop-daemon --stop --retry 30 --quiet --oknodo --pidfile $SUPERVISOR_PIDFILE
+        start-stop-daemon --chuid $AGENTUSER --stop --retry 30 --quiet --oknodo --pidfile $SUPERVISOR_PIDFILE
 
         log_end_msg $?
 

--- a/packaging/debian/datadog-agent.service
+++ b/packaging/debian/datadog-agent.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
+User=dd-agent
 ExecStart=/opt/datadog-agent/bin/start_agent.sh
 ExecStop=/opt/datadog-agent/bin/supervisorctl -c /etc/dd-agent/supervisor.conf shutdown
 

--- a/packaging/debian/start_agent.sh
+++ b/packaging/debian/start_agent.sh
@@ -2,4 +2,4 @@
 
 PATH=/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:$PATH
 
-exec /opt/datadog-agent/bin/supervisord -c /etc/dd-agent/supervisor.conf --pidfile /var/run/datadog-supervisord.pid
+exec /opt/datadog-agent/bin/supervisord -c /etc/dd-agent/supervisor.conf

--- a/packaging/supervisor.conf
+++ b/packaging/supervisor.conf
@@ -17,6 +17,7 @@ logfile_maxbytes = 50MB
 nodaemon = false
 pidfile = /opt/datadog-agent/run/datadog-supervisord.pid
 logfile_backups = 10
+user=dd-agent
 environment=PYTHONPATH=/opt/datadog-agent/agent:/opt/datadog-agent/agent/checks,LANG=POSIX
 
 [program:collector]


### PR DESCRIPTION
We don't need to run supervisor as root anymore.

Tested on:
- [x] debian 
- [ ] wheezy
- [ ] centos

Will launch a `dd-agent-testing` on them.