### PR TITLE
[flake8] ignore git files

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
-exclude = venv/*,embedded/*
+exclude = venv/*,embedded/*,.git/*
 max-line-length = 700
 ignore = E121,E125,E126,E127,E128,E202,E203,E211,E221,E222,E226,E231,E241,E251,E261,E262,E265,E271,E272,E301,E302,E303,E701,E702,E711,F401,F811,F841,W291,W292,W391


### PR DESCRIPTION
As some of them can be named *.py and thus fail flake8.