### PR TITLE
[consul] add consul catalog check

### DIFF
--- a/checks.d/consul.py
+++ b/checks.d/consul.py
@@ -31,7 +31,8 @@ class ConsulCheck(AgentCheck):
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
-
+        if instances is not None and len(instances) > 1:
+            raise Exception("Consul check only supports one configured instance.")
 
         self._local_config = None
         self._last_config_fetch_time = None

--- a/checks.d/consul.py
+++ b/checks.d/consul.py
@@ -1,0 +1,201 @@
+# 3p
+import requests
+
+# stdlib
+import time
+
+# project
+from checks import AgentCheck
+
+
+class ConsulCheck(AgentCheck):
+    CONSUL_CHECK = 'consul.up'
+    HEALTH_CHECK = 'consul.check'
+
+    CONSUL_CATALOG_CHECK = 'consul.catalog'
+    CONSUL_NODE_CHECK = 'consul.node'
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+        self._last_known_leader = None
+
+    def consul_request(self, instance, endpoint):
+        url = "{0}{1}".format(instance.get('url'), endpoint)
+        try:
+            resp = requests.get(url)
+        except requests.exceptions.Timeout:
+            self.log.exception('Consul request to {0} timed out'.format(url))
+            raise
+
+        resp.raise_for_status()
+        return resp.json()
+
+    ### Consul Config Accessors
+    def _get_local_config(self, instance):
+        #TODO: Maybe store the config on `self` here so we don't have to keep retrieving it?
+        # But how do we invalidate?
+
+        return self.consul_request(instance, '/v1/agent/self')
+
+    def _get_cluster_leader(self, instance):
+        return self.consul_request(instance, '/v1/status/leader')
+
+    def _get_agent_url(self, instance):
+        self.log.debug("Starting _get_agent_url")
+        local_config = self._get_local_config(instance)
+        agent_addr = local_config.get('Config', {}).get('AdvertiseAddr')
+        agent_port = local_config.get('Config', {}).get('Ports', {}).get('Server')
+        agent_url = "{0}:{1}".format(agent_addr, agent_port)
+        self.log.debug("Agent url is %s" % agent_url)
+        return agent_url
+
+    def _get_agent_datacenter(self, instance):
+        local_config = self._get_local_config(instance)
+        agent_dc = local_config.get('Config', {}).get('Datacenter')
+        return agent_dc
+
+    ### Consul Leader Checks
+    def _is_instance_leader(self, instance):
+        try:
+            agent_url = self._get_agent_url(instance)
+            leader = self._get_cluster_leader(instance)
+            self.log.debug("Consul agent lives at %s . Consul Leader lives at %s" % (agent_url,leader))
+            return agent_url == leader
+
+        except Exception as e:
+            return False
+
+    def _check_for_leader_change(self, instance):
+        agent_dc = self._get_agent_datacenter(instance)
+        leader = self._get_cluster_leader(instance)
+        if leader != self._last_known_leader and self._last_known_leader is not None:
+            self.log.info(('Leader change from {0} to {1}. Sending new leader event').format(
+                self._last_known_leader, leader))
+
+            self.event({
+                "timestamp": int(time.time()),
+                "event_type": "consul.new_leader",
+                "api_key": self.agentConfig.get("api_key", ''),
+                "msg_title": "New Consul Leader Elected in {0}".format(agent_dc),
+                "aggregation_key": "consul.new_leader",
+                "msg_text": "The Node at {0} is the new leader of the consul cluster {1}".format(
+                    leader,
+                    agent_dc
+                ),
+                "tags": ["prev_consul_leader:{0}".format(self._last_known_leader),
+                         "curr_consul_leader:{0}".format(leader)]
+            })
+
+        self._last_known_leader = leader
+
+    ### Consul Catalog Accessors
+    def get_services_in_cluster(self, instance):
+        return self.consul_request(instance, '/v1/catalog/services')
+
+    def get_nodes_in_cluster(self, instance):
+        return self.consul_request(instance, '/v1/catalog/nodes')
+
+    def get_nodes_with_service(self, instance, service, tag=None):
+        if tag:
+            consul_request_url = '/v1/catalog/service/{0}?tag={1}'.format(service,tag)
+        else:
+            consul_request_url = '/v1/catalog/service/{0}'.format(service)
+
+        return self.consul_request(instance, consul_request_url)
+
+    def get_services_on_node(self, instance, node):
+        return self.consul_request(instance, '/v1/catalog/node/{0}'.format(node))
+
+    def check(self, instance):
+        perform_new_leader_checks = instance.get('new_leader_checks',
+                                                 self.init_config.get('new_leader_checks', False))
+        if perform_new_leader_checks:
+            self._check_for_leader_change(instance)
+
+        if not self._is_instance_leader(instance):
+            self.log.debug("This consul agent is not the cluster leader." +
+                           "Skipping service and catalog checks for this instance")
+            return
+
+        service_whitelist = instance.get('service_whitelist',
+                                         self.init_config.get('service_whitelist', []))
+
+        service_check_tags = ['consul_url:{0}'.format(instance.get('url'))]
+        perform_catalog_checks = instance.get('catalog_checks',
+                                              self.init_config.get('catalog_checks'))
+
+        try:
+            health_state = self.consul_request(instance, '/v1/health/state/any')
+
+            STATUS_SC = {
+                'passing': AgentCheck.OK,
+                'warning': AgentCheck.WARNING,
+                'critical': AgentCheck.CRITICAL,
+            }
+
+            for check in health_state:
+                status = STATUS_SC.get(check['Status'])
+                if status is None:
+                    continue
+
+                tags = ["check:{0}".format(check["CheckID"])]
+                if check["ServiceName"]:
+                    tags.append("service:{0}".format(check["ServiceName"]))
+                if check["ServiceID"]:
+                    tags.append("service-id:{0}".format(check["ServiceID"]))
+
+            services = self.get_services_in_cluster(instance)
+            self.service_check(self.HEALTH_CHECK, status, tags=tags)
+
+        except Exception as e:
+            self.service_check(self.CONSUL_CHECK, AgentCheck.CRITICAL,
+                               tags=service_check_tags)
+        else:
+            self.service_check(self.CONSUL_CHECK, AgentCheck.OK,
+                               tags=service_check_tags)
+
+        if perform_catalog_checks:
+            services = self.get_services_in_cluster(instance)
+            if service_whitelist:
+                services = [s for s in services if s in service_whitelist]
+            else:
+                #Default to polling all services
+                self.log.warn('Consul service whitelist not defined. Agent will poll for all %d services found' % len(services))
+
+            nodes = self.get_nodes_in_cluster(instance)
+
+            main_tags = []
+            agent_dc = self._get_agent_datacenter(instance)
+            if agent_dc is not None:
+                main_tags.append('consul_datacenter:{0}'.format(agent_dc))
+
+            nodes_to_services = {}
+
+            self.gauge('consul.catalog.services_up', len(services), tags=main_tags)
+            self.gauge('consul.catalog.nodes_up', len(nodes), tags=main_tags)
+
+            for service in services:
+                nodes_with_service = self.get_nodes_with_service(instance, service)
+                node_tags = ['consul_service_id:{0}'.format(service)]
+
+                self.gauge('consul.catalog.nodes_up',
+                           len(nodes_with_service),
+                           tags=node_tags)
+
+                for n in nodes_with_service:
+                    node_id = n.get('Node') or None
+
+                    if not node_id:
+                        continue
+
+                    if node_id in nodes_to_services:
+                        nodes_to_services[node_id].append(service)
+                    else:
+                        nodes_to_services[node_id] = [service]
+
+            for node, services in nodes_to_services.items():
+                tags = ['consul_node_id:{0}'.format(node)]
+                self.gauge('consul.catalog.services_up',
+                           len(services),
+                           tags=tags)

--- a/conf.d/consul.yaml.example
+++ b/conf.d/consul.yaml.example
@@ -1,0 +1,10 @@
+init_config:
+
+instances:
+    - url: http://localhost:8500
+      catalog_checks: yes
+      new_leader_checks: yes
+      service_whitelist:
+        - zookeeper
+        - consul
+        - master-db

--- a/tests/checks/mock/test_consul.py
+++ b/tests/checks/mock/test_consul.py
@@ -1,4 +1,5 @@
 import random
+
 from tests.checks.common import AgentCheckTest, load_check
 
 MOCK_CONFIG = {
@@ -27,6 +28,18 @@ MOCK_CONFIG_LEADER_CHECK = {
     }]
 }
 
+MOCK_BAD_CONFIG = {
+    'init_config': {},
+    'instances' : [{ # Multiple instances should cause it to fail
+        'url': 'http://localhost:8500',
+        'catalog_checks': True,
+        'new_leader_checks': True
+    }, {
+        'url': 'http://localhost:8501',
+        'catalog_checks': True,
+        'new_leader_checks': True
+    }]
+}
 
 class TestCheckConsul(AgentCheckTest):
     CHECK_NAME = 'consul'
@@ -54,7 +67,11 @@ class TestCheckConsul(AgentCheckTest):
         }
 
     def mock_get_n_services_in_cluster(self, n):
-        return {"service_{0}".format(k):[] for k in range(n)}
+        dct = {}
+        for i in range(n):
+            k = "service_{0}".format(i)
+            dct[k] = []
+        return dct
 
     def mock_get_local_config(self, instance):
         return {
@@ -123,6 +140,9 @@ class TestCheckConsul(AgentCheckTest):
             '_get_local_config': self.mock_get_local_config,
             '_get_cluster_leader': self.mock_get_cluster_leader_A
         }
+
+    def test_bad_config(self):
+        self.assertRaises(Exception, self.run_check, MOCK_BAD_CONFIG)
 
     def test_get_nodes_in_cluster(self):
         self.run_check(MOCK_CONFIG, mocks=self._get_consul_mocks())

--- a/tests/checks/mock/test_consul.py
+++ b/tests/checks/mock/test_consul.py
@@ -1,0 +1,144 @@
+import random
+from tests.checks.common import AgentCheckTest, load_check
+
+MOCK_CONFIG = {
+    'init_config': {},
+    'instances' : [{
+        'url': 'http://localhost:8500',
+        'catalog_checks': True,
+    }]
+}
+
+MOCK_CONFIG_LEADER_CHECK = {
+    'init_config': {},
+    'instances' : [{
+        'url': 'http://localhost:8500',
+        'catalog_checks': True,
+        'new_leader_checks': True
+    }]
+}
+
+
+class TestCheckConsul(AgentCheckTest):
+    CHECK_NAME = 'consul'
+
+    def mock_get_services_in_cluster(self, instance):
+        return {
+            "service-1": [
+                "az-us-east-1a"
+            ],
+            "service-2": [
+                "az-us-east-1a"
+            ],
+            "service-3": [
+                "az-us-east-1a"
+            ],
+            "service-4": [
+                "az-us-east-1a"
+            ],
+            "service-5": [
+                "az-us-east-1a"
+            ],
+            "service-6": [
+                "az-us-east-1a"
+            ]
+        }
+
+    def mock_get_local_config(self, instance):
+        return {
+            "Config": {
+                "AdvertiseAddr": "10.0.2.15",
+                "Datacenter": "dc1",
+                "Ports": {
+                    "DNS": 8600,
+                    "HTTP": 8500,
+                    "HTTPS": -1,
+                    "RPC": 8400,
+                    "SerfLan": 8301,
+                    "SerfWan": 8302,
+                    "Server": 8300
+                },
+            }
+        }
+
+    def mock_get_nodes_in_cluster(self, instance):
+        return [
+            {
+                "Address": "10.0.2.15",
+                "Node": "node-1"
+            },
+            {
+                "Address": "10.0.2.25",
+                "Node": "node-2"
+            },
+            {
+                "Address": "10.0.2.35",
+                "Node": "node-2"
+            },
+        ]
+
+
+    def mock_get_nodes_with_service(self, instance, service):
+        def _get_random_ip():
+            rand_int = int(15 * random.random()) + 10
+            return "10.0.2.{0}".format(rand_int)
+
+        return [
+            {
+                "Address": _get_random_ip(),
+                "Node": "node-1",
+                "ServiceAddress": "",
+                "ServiceID": service,
+                "ServiceName": service,
+                "ServicePort": 80,
+                "ServiceTags": [
+                    "az-us-east-1a"
+                ]
+            }
+        ]
+
+    def mock_get_cluster_leader_A(self, instance):
+        return '10.0.2.15:8300'
+
+    def mock_get_cluster_leader_B(self, instance):
+        return 'My New Leader'
+
+    def _get_consul_mocks(self):
+        return {
+            'get_services_in_cluster': self.mock_get_services_in_cluster,
+            'get_nodes_in_cluster': self.mock_get_nodes_in_cluster,
+            'get_nodes_with_service': self.mock_get_nodes_with_service,
+            '_get_local_config': self.mock_get_local_config,
+            '_get_cluster_leader': self.mock_get_cluster_leader_A
+        }
+
+    def test_get_nodes_in_cluster(self):
+        self.run_check(MOCK_CONFIG, mocks=self._get_consul_mocks())
+        self.assertMetric('consul.catalog.nodes_up', value=3, tags=['consul_datacenter:dc1'])
+
+    def test_get_services_in_cluster(self):
+        self.run_check(MOCK_CONFIG, mocks=self._get_consul_mocks())
+        self.assertMetric('consul.catalog.services_up', value=6, tags=['consul_datacenter:dc1'])
+
+    def test_get_nodes_with_service(self):
+        self.run_check(MOCK_CONFIG, mocks=self._get_consul_mocks())
+        self.assertMetric('consul.catalog.nodes_up', value=1, tags=['consul_service_id:service-1'])
+
+    def test_get_services_on_node(self):
+        self.run_check(MOCK_CONFIG, mocks=self._get_consul_mocks())
+        self.assertMetric('consul.catalog.services_up', value=6, tags=['consul_node_id:node-1'])
+
+    def test_new_leader_event(self):
+        self.check = load_check(self.CHECK_NAME, MOCK_CONFIG_LEADER_CHECK, self.DEFAULT_AGENT_CONFIG)
+        self.check._last_known_leader = 'My Old Leader'
+
+        mocks = self._get_consul_mocks()
+        mocks['_get_cluster_leader'] = self.mock_get_cluster_leader_B
+
+        self.run_check(MOCK_CONFIG_LEADER_CHECK, mocks=mocks)
+        self.assertEqual(len(self.events), 1)
+
+        event = self.events[0]
+        self.assertEqual(event['event_type'], 'consul.new_leader')
+        self.assertIn('prev_consul_leader:My Old Leader', event['tags'])
+        self.assertIn('curr_consul_leader:My New Leader', event['tags'])


### PR DESCRIPTION
Adds a consul AgentCheck with the following metrics:

Number of Consul Agents in the Cluter
`consul.peers`: tagged by `consul_datacenter` and `mode` (`leader | follower`) 

Consul Catalog Nodes Up by Service
`consul.catalog.nodes_up`: tagged by `consul_datacenter` and `consul_service_id`

Consul Catalog Services Up by Node
`consul.catalog.services_up`: tagged by `consul_datacenter` and `consul_node_id`

This check also sends `consul.new_leader` events when a leader change is detected.