### PR TITLE
[Postgresql] logging bug for custom metrics

### DIFF
--- a/checks.d/postgres.py
+++ b/checks.d/postgres.py
@@ -424,9 +424,9 @@ SELECT relname,
                     continue
 
                 if scope in custom_metrics and len(results) > MAX_CUSTOM_RESULTS:
-                    self.warning(
-                        "Query: {0} returned more than {1} results ({2}). Truncating").format(
-                        query, MAX_CUSTOM_RESULTS, len(results))
+                    log_func(
+                        "Query: {0} returned more than {1} results ({2}). Truncating".format(
+                            query, MAX_CUSTOM_RESULTS, len(results)))
                     results = results[:MAX_CUSTOM_RESULTS]
 
                 # FIXME this cramps my style


### PR DESCRIPTION
This is actually a combination of two bugs:

1. If you use custom metrics and one of your queries has too many results, you will discover a typo where we attempt to log to 'self.warning', which is not a thing.

2. the brackets *on* that call to self.warning result in attempting to format the function result rather than the parameter.