### PR TITLE
[postgres] fix log 'truncating' custom metrics query

### DIFF
--- a/checks.d/postgres.py
+++ b/checks.d/postgres.py
@@ -425,8 +425,9 @@ SELECT relname,
 
                 if scope in custom_metrics and len(results) > MAX_CUSTOM_RESULTS:
                     self.warning(
-                        "Query: {0} returned more than {1} results ({2}). Truncating").format(
-                        query, MAX_CUSTOM_RESULTS, len(results))
+                        "Query: {0} returned more than {1} results ({2}). Truncating"
+                        .format(query, MAX_CUSTOM_RESULTS, len(results))
+                    )
                     results = results[:MAX_CUSTOM_RESULTS]
 
                 # FIXME this cramps my style


### PR DESCRIPTION
rebased version of #1633 