### PR TITLE
[jmx] Fix yaml indent of example jmx configuration

### DIFF
--- a/conf.d/jmx.yaml.example
+++ b/conf.d/jmx.yaml.example
@@ -21,19 +21,19 @@ instances:
     # Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it
     # conf:
     #   - include:
-    #     domain: my_domain
-    #     bean:
-    #       - my_bean
-    #       - my_second_bean
-    #     attribute:
-    #       attribute1:
-    #         metric_type: counter
-    #         alias: jmx.my_metric_name
-    #       attribute2:
-    #         metric_type: gauge
-    #         alias: jmx.my2ndattribute
+    #       domain: my_domain
+    #       bean:
+    #         - my_bean
+    #         - my_second_bean
+    #       attribute:
+    #         attribute1:
+    #           metric_type: counter
+    #           alias: jmx.my_metric_name
+    #         attribute2:
+    #           metric_type: gauge
+    #           alias: jmx.my2ndattribute
     #   - include:
-    #     domain: 2nd_domain
+    #       domain: 2nd_domain
     #   - exclude:
-    #     bean:
-    #       - excluded_bean
+    #       bean:
+    #         - excluded_bean


### PR DESCRIPTION
Is this documentation bug??

I've run dd-agent with following `jmx.yaml`.

```yaml
init_config:

instances:
  - host: 172.17.0.9
    port: 7900
    name: jmx_instance

    conf:
      - include:
        bean_name: 'java.lang:type=GarbageCollector,name=PS Scavenge'
        attribute:
          CollectionCount:
            metric_type: counter
            alias: jmx.gc.scavenge.count
          CollectionTime:
            metric_type: gauge
            alias: jmx.gc.scavenge.spent_time
```

But an error occurred `jmx check does not have a valid JMX configuration: Each configuration must have an 'include' section.`. This reasons: python dict object after parsing above yaml is following.

```python
{
    'conf': {
        'include': None,
        'bean_name': ..snip..
    }
}
```