### PR TITLE
[sqlserver] fix collector hangs when a connection is failing

### DIFF
--- a/checks.d/sqlserver.py
+++ b/checks.d/sqlserver.py
@@ -44,6 +44,13 @@ VALUE_AND_BASE_QUERY = '''select cntr_value
                           order by cntr_type;'''
 
 
+class SQLConnectionError(Exception):
+    """
+    Exception raised for SQL instance connection issues
+    """
+    pass
+
+
 class SQLServer(AgentCheck):
 
     SOURCE_TYPE_NAME = 'sql server'
@@ -69,48 +76,63 @@ class SQLServer(AgentCheck):
 
         # Cache connections
         self.connections = {}
-
+        self.failed_connections = {}
         self.instances_metrics = {}
+
+        # Pre-process the list of metrics to collect
+        custom_metrics = init_config.get('custom_metrics', [])
         for instance in instances:
+            try:
+                self._make_metric_list_to_collect(instance, custom_metrics)
+            except SQLConnectionError:
+                self.log.exception("Skipping SQL Server instance")
+                continue
 
-            metrics_to_collect = []
-            for name, counter_name, instance_name in self.METRICS:
-                try:
-                    sql_type, base_name = self.get_sql_type(instance, counter_name)
-                    metrics_to_collect.append(self.typed_metric(name,
-                                                                counter_name,
-                                                                base_name,
-                                                                None,
-                                                                sql_type,
-                                                                instance_name,
-                                                                None))
-                except Exception:
-                    self.log.warning("Can't load the metric %s, ignoring", name, exc_info=True)
-                    continue
-
-            # Load any custom metrics from conf.d/sqlserver.yaml
-            for row in init_config.get('custom_metrics', []):
-                user_type = row.get('type')
-                if user_type is not None and user_type not in VALID_METRIC_TYPES:
-                    self.log.error('%s has an invalid metric type: %s' % (row['name'], user_type))
-                sql_type = None
-                try:
-                    if user_type is None:
-                        sql_type, base_name = self.get_sql_type(instance, row['counter_name'])
-                except Exception:
-                    self.log.warning("Can't load the metric %s, ignoring", name, exc_info=True)
-                    continue
-
-                metrics_to_collect.append(self.typed_metric(row['name'],
-                                                            row['counter_name'],
+    def _make_metric_list_to_collect(self, instance, custom_metrics):
+        """
+        Store the list of metrics to collect by instance_key.
+        Will also create and cache cursors to query the db.
+        """
+        metrics_to_collect = []
+        for name, counter_name, instance_name in self.METRICS:
+            try:
+                sql_type, base_name = self.get_sql_type(instance, counter_name)
+                metrics_to_collect.append(self.typed_metric(name,
+                                                            counter_name,
                                                             base_name,
-                                                            user_type,
+                                                            None,
                                                             sql_type,
-                                                            row.get('instance_name', ''),
-                                                            row.get('tag_by', None)))
+                                                            instance_name,
+                                                            None))
+            except SQLConnectionError:
+                raise
+            except Exception:
+                self.log.warning("Can't load the metric %s, ignoring", name, exc_info=True)
+                continue
 
-            instance_key = self._conn_key(instance)
-            self.instances_metrics[instance_key] = metrics_to_collect
+        # Load any custom metrics from conf.d/sqlserver.yaml
+        for row in custom_metrics:
+            user_type = row.get('type')
+            if user_type is not None and user_type not in VALID_METRIC_TYPES:
+                self.log.error('%s has an invalid metric type: %s', row['name'], user_type)
+            sql_type = None
+            try:
+                if user_type is None:
+                    sql_type, base_name = self.get_sql_type(instance, row['counter_name'])
+            except Exception:
+                self.log.warning("Can't load the metric %s, ignoring", row['name'], exc_info=True)
+                continue
+
+            metrics_to_collect.append(self.typed_metric(row['name'],
+                                                        row['counter_name'],
+                                                        base_name,
+                                                        user_type,
+                                                        sql_type,
+                                                        row.get('instance_name', ''),
+                                                        row.get('tag_by', None)))
+
+        instance_key = self._conn_key(instance)
+        self.instances_metrics[instance_key] = metrics_to_collect
 
     def typed_metric(self, dd_name, sql_name, base_name, user_type, sql_type, instance_name, tag_by):
         '''
@@ -168,7 +190,7 @@ class SQLServer(AgentCheck):
             conn_str += 'Integrated Security=SSPI;'
         return conn_str
 
-    def get_cursor(self, instance):
+    def get_cursor(self, instance, cache_failure=False):
         '''
         Return a cursor to execute query against the db
         Cursor are cached in the self.connections dict
@@ -180,6 +202,9 @@ class SQLServer(AgentCheck):
             'host:%s' % host,
             'db:%s' % database
         ]
+
+        if conn_key in self.failed_connections:
+            raise self.failed_connections[conn_key]
 
         if conn_key not in self.connections:
             try:
@@ -194,14 +219,19 @@ class SQLServer(AgentCheck):
                 cx = "%s - %s" % (host, database)
                 message = "Unable to connect to SQL Server for instance %s." % cx
                 self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                    tags=service_check_tags, message=message)
+                                   tags=service_check_tags, message=message)
 
                 password = instance.get('password')
                 tracebk = traceback.format_exc()
                 if password is not None:
                     tracebk = tracebk.replace(password, "*" * 6)
 
-                raise Exception("%s \n %s" % (message, tracebk))
+                # Avoid multiple connection timeouts (too slow):
+                # save the exception, re-raise it when needed
+                cxn_failure_exp = SQLConnectionError("%s \n %s" % (message, tracebk))
+                if cache_failure:
+                    self.failed_connections[conn_key] = cxn_failure_exp
+                raise cxn_failure_exp
 
         conn = self.connections[conn_key]
         cursor = conn.cursor()
@@ -214,7 +244,7 @@ class SQLServer(AgentCheck):
         If the sql_type is one that needs a base (PERF_RAW_LARGE_FRACTION and
         PERF_AVERAGE_BULK), the name of the base counter will also be returned
         '''
-        cursor = self.get_cursor(instance)
+        cursor = self.get_cursor(instance, cache_failure=True)
         cursor.execute(COUNTER_TYPE_QUERY, (counter_name,))
         (sql_type,) = cursor.fetchone()
         if sql_type == PERF_LARGE_RAW_BASE:
@@ -242,12 +272,15 @@ class SQLServer(AgentCheck):
         return sql_type, base_name
 
     def check(self, instance):
-        ''' Fetch the metrics from the sys.dm_os_performance_counters table
-        '''
+        """
+        Fetch the metrics from the sys.dm_os_performance_counters table
+        """
         cursor = self.get_cursor(instance)
+
         custom_tags = instance.get('tags', [])
         instance_key = self._conn_key(instance)
         metrics_to_collect = self.instances_metrics[instance_key]
+
         for metric in metrics_to_collect:
             try:
                 metric.fetch_metric(cursor, custom_tags)


### PR DESCRIPTION
SQLServer check hangs the collector when a connection is failing.
Default timeout is set to 30s, but it is raised multiple times for the same instance: after 120s, collector is restarted by the watchdog and loops back.
Solution: cache failing connections.