### PR TITLE
[http_check] Fix status type err. in service check

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -47,7 +47,7 @@ class HTTPCheck(NetworkCheck):
         tags = instance.get('tags', [])
         username = instance.get('username')
         password = instance.get('password')
-        http_response_status_code = instance.get('http_response_status_code', "(1|2|3)\d\d")
+        http_response_status_code = str(instance.get('http_response_status_code', "(1|2|3)\d\d"))
         timeout = int(instance.get('timeout', 10))
         config_headers = instance.get('headers', {})
         headers = agent_headers(self.agentConfig)

--- a/conf.d/http_check.yaml.example
+++ b/conf.d/http_check.yaml.example
@@ -27,7 +27,8 @@ instances:
     # password: pass
 
     # The (optional) http_response_status_code parameter will instruct the check
-    # to look for a particular HTTP response status code.
+    # to look for a particular HTTP response status code or a Regex identifying
+    # a set of possible status codes.
     # The check will report as DOWN if status code returned differs.
     # This defaults to 1xx, 2xx and 3xx HTTP status code: (1|2|3)\d\d.
     # http_response_status_code: 401


### PR DESCRIPTION
PyYaml was returning an int for the expected status code when
"http_response_status_code: 200" (for instance) was used in the yaml
config while a Regex (and therefore an string) is expected. I added a
cast to avoid that from happening again. I also added some doc to tell 
our customers about the possibility to use a Regex for this parameter.