### PR TITLE
[flake8-monday] enable F401 (unused import)

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -9,24 +9,23 @@
     (C) Boxed Ice 2010 all rights reserved
     (C) Datadog, Inc. 2010-2014 all rights reserved
 '''
-
 # set up logging before importing any other components
 from config import get_version, initialize_logging
 initialize_logging('collector')
 
-import os
-os.umask(022)
-
-# Core modules
+# stdlib
 import logging
+import os
 import signal
 import sys
 import time
 
-# Custom modules
-from checks.collector import Collector
+# For pickle & PID files, see issue 293
+os.umask(022)
+
+# project
 from checks.check_status import CollectorStatus
-from utils.profile import pretty_statistics
+from checks.collector import Collector
 from config import (
     get_confd_path,
     get_config,
@@ -43,8 +42,8 @@ from util import (
     get_os,
     Watchdog,
 )
-from utils.pidfile import PidFile
 from utils.flare import configcheck, Flare
+from utils.pidfile import PidFile
 from utils.profile import AgentProfiler
 
 # Constants

--- a/aggregator.py
+++ b/aggregator.py
@@ -1,8 +1,9 @@
+# stdlib
 import logging
 from time import time
 
+# project
 from checks.metric_types import MetricTypes
-from config import get_histogram_aggregates, get_histogram_percentiles
 
 log = logging.getLogger(__name__)
 

--- a/checks.d/agent_metrics.py
+++ b/checks.d/agent_metrics.py
@@ -1,4 +1,4 @@
-import os
+# stdlib
 import threading
 
 # 3p

--- a/checks.d/couchbase.py
+++ b/checks.d/couchbase.py
@@ -1,18 +1,18 @@
 # stdlib
 import re
-import sys
 
 # project
 from util import headers
 from checks import AgentCheck
 
 # 3rd party
-import simplejson as json
 import requests
 
-#Constants
+# Constants
 COUCHBASE_STATS_PATH = '/pools/default'
 DEFAULT_TIMEOUT = 10
+
+
 class Couchbase(AgentCheck):
     """Extracts stats from Couchbase via its REST API
     http://docs.couchbase.com/couchbase-manual-2.0/#using-the-rest-api

--- a/checks.d/gunicorn.py
+++ b/checks.d/gunicorn.py
@@ -3,16 +3,15 @@ Collects metrics from the gunicorn web server.
 
 http://gunicorn.org/
 """
-# project
-from checks import AgentCheck
-
 # stdlib
-import os
-import sys
 import time
 
 # 3rd party
 import psutil
+
+# project
+from checks import AgentCheck
+
 
 class GUnicornCheck(AgentCheck):
 

--- a/checks.d/jenkins.py
+++ b/checks.d/jenkins.py
@@ -1,14 +1,13 @@
 # stdlib
+from collections import defaultdict
+from glob import glob
 import os
 import time
-from collections import defaultdict
-from datetime import datetime
-from glob import glob
 from xml.etree.ElementTree import ElementTree
 
 # project
-from util import get_hostname
 from checks import AgentCheck
+from util import get_hostname
 
 
 class Skip(Exception):

--- a/checks.d/mesos.py
+++ b/checks.d/mesos.py
@@ -1,14 +1,13 @@
 # stdlib
-import time
 from hashlib import md5
+import time
 
 # project
 from checks import AgentCheck
-from util import headers
 
 # 3rd party
-import simplejson as json
 import requests
+
 
 class Mesos(AgentCheck):
     SERVICE_CHECK_NAME = "mesos.can_connect"

--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -1,16 +1,16 @@
 # stdlib
-import re
-import types
 import time
+import types
+
+# 3p
+import pymongo
 
 # project
 from checks import AgentCheck
 from util import get_hostname
 
-# 3rd party
-import pymongo
-
 DEFAULT_TIMEOUT = 10
+
 
 class MongoDb(AgentCheck):
     SERVICE_CHECK_NAME = 'mongodb.can_connect'

--- a/checks.d/network.py
+++ b/checks.d/network.py
@@ -2,10 +2,8 @@
 Collects network metrics.
 """
 # stdlib
-import platform
-import subprocess
-import sys
 import re
+import subprocess
 
 # project
 from checks import AgentCheck
@@ -22,6 +20,7 @@ SOLARIS_TCP_METRICS = [
     (re.compile("\s*tcpOutDataSegs\s*=\s*(\d+)\s*"), 'system.net.tcp.in_segs'),
     (re.compile("\s*tcpInSegs\s*=\s*(\d+)\s*"), 'system.net.tcp.out_segs')
 ]
+
 
 class Network(AgentCheck):
 

--- a/checks.d/ntp.py
+++ b/checks.d/ntp.py
@@ -1,17 +1,15 @@
-# stdlib
-import time
+# 3p
+import ntplib
 
 # project
 from checks import AgentCheck
 from utils.ntp import get_ntp_datadog_host
 
-# 3rd party
-import ntplib
-
 DEFAULT_OFFSET_THRESHOLD = 60 # in seconds
 DEFAULT_NTP_VERSION = 3
 DEFAULT_TIMEOUT = 1 # in seconds
 DEFAULT_PORT = "ntp"
+
 
 class NtpCheck(AgentCheck):
 

--- a/checks.d/rabbitmq.py
+++ b/checks.d/rabbitmq.py
@@ -2,15 +2,13 @@
 import urlparse
 import time
 import re
-import pprint
 import urllib
+
+# 3p
+import requests
 
 # project
 from checks import AgentCheck
-
-# 3rd party
-import simplejson as json
-import requests
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'rabbitmq'
 QUEUE_TYPE = 'queues'

--- a/checks.d/ssh_check.py
+++ b/checks.d/ssh_check.py
@@ -1,11 +1,13 @@
 # stdlib
+from collections import namedtuple
 import time
-import socket
+
 # 3p
 import paramiko
-from collections import namedtuple
+
 # project
 from checks import AgentCheck
+
 
 class CheckSSH(AgentCheck):
 

--- a/checks.d/supervisord.py
+++ b/checks.d/supervisord.py
@@ -1,12 +1,14 @@
+# stdlib
 from collections import defaultdict
-import errno
 import socket
 import time
 import xmlrpclib
 
-from checks import AgentCheck
-
+# 3p
 import supervisor.xmlrpc
+
+# project
+from checks import AgentCheck
 
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = '9001'
@@ -37,6 +39,7 @@ FORMAT_TIME = lambda x: time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(x))
 
 SERVER_SERVICE_CHECK = 'supervisord.can_connect'
 PROCESS_SERVICE_CHECK = 'supervisord.process.status'
+
 
 class SupervisordCheck(AgentCheck):
 

--- a/checks.d/tokumx.py
+++ b/checks.d/tokumx.py
@@ -1,16 +1,21 @@
 # stdlib
-import re
-import types
 import time
+import types
 
 # project
 from checks import AgentCheck
 from util import get_hostname
 
-# 3rd party
-from pymongo import uri_parser, MongoClient, ReadPreference, version as py_version
+# 3p
+from pymongo import (
+    MongoClient,
+    ReadPreference,
+    uri_parser,
+    version as py_version,
+)
 
 DEFAULT_TIMEOUT = 10
+
 
 class LocalRate:
     """ To be used for metrics that should be sent as rates but that we want to send as histograms"""

--- a/checks.d/vsphere.py
+++ b/checks.d/vsphere.py
@@ -2,25 +2,23 @@
 from copy import deepcopy
 from datetime import datetime, timedelta
 from hashlib import md5
+from Queue import Queue, Empty
 import re
 import time
 import traceback
-from Queue import Queue, Empty
+
+# 3p
+from pyVim import connect
+from pyVmomi import vim
 
 # project
 from checks import AgentCheck
-from util import Timer
 from checks.libs.thread_pool import Pool
 from checks.libs.vmware.basic_metrics import BASIC_METRICS
-from checks.libs.vmware.all_metrics import ALL_METRICS
-
-# 3rd party
-from pyVim import connect
-# This drives travis-ci pylint crazy!
-from pyVmomi import vim # pylint: disable=E0611
+from util import Timer
 
 SOURCE_TYPE = 'vsphere'
-REAL_TIME_INTERVAL = 20 # Default vCenter sampling interval
+REAL_TIME_INTERVAL = 20  # Default vCenter sampling interval
 
 # The size of the ThreadPool used to process the request queue
 DEFAULT_SIZE_POOL = 4
@@ -60,6 +58,7 @@ MORLIST = 'morlist'
 METRICS_METADATA = 'metrics_metadata'
 LAST = 'last'
 INTERVAL = 'interval'
+
 
 class VSphereEvent(object):
     UNKNOWN = 'unknown'

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -3,33 +3,29 @@
 If you are writing your own checks you should subclass the AgentCheck class.
 The Check class is being deprecated so don't write new checks with it.
 """
-
+# stdlib
+from collections import defaultdict
+import copy
 import logging
 import numbers
-import re
-import socket
-import time
-from types import ListType, TupleType
 import os
-import sys
-import traceback
-import copy
+import re
+import time
 import timeit
-from pprint import pprint
-from collections import defaultdict
+import traceback
+from types import ListType, TupleType
 
-from util import LaconicFilter, get_os, get_hostname, get_next_id, yLoader
-from config import get_confd_path
-from checks import check_status
-from utils.profile import pretty_statistics
-
-# 3rd party
-import yaml
-
+# 3p
 try:
     import psutil
 except ImportError:
     psutil = None
+import yaml
+
+# project
+from checks import check_status
+from util import LaconicFilter, get_hostname, get_next_id, yLoader
+from utils.profile import pretty_statistics
 
 log = logging.getLogger(__name__)
 

--- a/checks/agent_metrics.py
+++ b/checks/agent_metrics.py
@@ -1,4 +1,7 @@
+# stdlib
 import threading
+
+# project
 from checks import Check
 
 

--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -2,31 +2,28 @@
 This module contains classes which are used to occasionally persist the status
 of checks.
 """
-
 # stdlib
+from collections import defaultdict
+import cPickle as pickle
 import datetime
 import logging
 import os
-import cPickle as pickle
 import platform
 import sys
 import tempfile
 import time
-from collections import defaultdict
-import os.path
 
-# 3rd party
+# 3p
 import ntplib
 import yaml
 
 # project
 import config
 from config import get_config, get_jmx_status_path, _windows_commondata_path
-
-from util import get_os, plural
+from util import plural
 from utils.ntp import get_ntp_datadog_host
-from utils.platform import Platform
 from utils.pidfile import PidFile
+from utils.platform import Platform
 from utils.profile import pretty_statistics
 
 

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -1,26 +1,35 @@
-# Core modules
-import os
-import re
+# stdlib
+import logging
+import pprint
+import socket
+import subprocess
 import sys
 import time
-import socket
-import logging
-import datetime
-import subprocess
-import pprint
 
-import modules
-
-from config import get_version, get_system_stats, get_config
-from util import get_os, get_uuid, md5, Timer, get_hostname, EC2, GCE
-
-import jmxfetch
+# project
+from checks import AgentCheck, AGENT_METRICS_CHECK_NAME, create_service_check
+from checks.check_status import (
+    CheckStatus,
+    CollectorStatus,
+    EmitterStatus,
+    STATUS_OK,
+    STATUS_ERROR,
+)
+from checks.datadog import Dogstreams, DdForwarder
+from checks.ganglia import Ganglia
 import checks.system.unix as u
 import checks.system.win32 as w32
-from checks import create_service_check, AgentCheck, AGENT_METRICS_CHECK_NAME
-from checks.ganglia import Ganglia
-from checks.datadog import Dogstreams, DdForwarder
-from checks.check_status import CheckStatus, CollectorStatus, EmitterStatus, STATUS_OK, STATUS_ERROR
+from config import get_system_stats, get_version
+from util import (
+    EC2,
+    GCE,
+    get_hostname,
+    get_os,
+    get_uuid,
+    Timer,
+)
+import jmxfetch
+import modules
 from resources.processes import Processes as ResProcesses
 
 
@@ -30,6 +39,7 @@ log = logging.getLogger(__name__)
 FLUSH_LOGGING_PERIOD = 10
 FLUSH_LOGGING_INITIAL = 5
 DD_CHECK_TAG = 'dd_check:{0}'
+
 
 class Collector(object):
     """

--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -1,21 +1,18 @@
 """
 Unix system checks.
 """
-
 # stdlib
 import operator
 import platform
 import re
 import subprocess as sp
 import sys
-import tempfile
 import time
 
 # project
 from checks import Check
 from util import get_hostname
 from utils.platform import Platform
-from utils.subprocess_output import get_subprocess_output
 
 # locale-resilient float converter
 to_float = lambda s: float(s.replace(",", "."))

--- a/ddagent.py
+++ b/ddagent.py
@@ -9,48 +9,53 @@
     (C) Boxed Ice 2010 all rights reserved
     (C) Datadog, Inc. 2010-2013 all rights reserved
 '''
-
 # set up logging before importing any other components
 from config import initialize_logging
 initialize_logging('forwarder')
-from config import get_logging_config
 
-import os
-os.umask(022)
-
-# Standard imports
+# stdlib
 from datetime import timedelta
 import logging
+import os
 from Queue import Full, Queue
 from socket import gaierror, error as socket_error
 import sys
 import threading
 import zlib
 
-# Tornado
-from tornado.escape import json_decode
-import tornado.httpserver
-import tornado.ioloop
-from tornado.options import define, parse_command_line, options
-import tornado.web
+# For pickle & PID files, see issue 293
+os.umask(022)
 
-# agent import
-from checks.check_status import ForwarderStatus
-from config import (
-    get_config,
-    get_url_endpoint,
-    get_version
-)
-from util import Watchdog, get_uuid, get_hostname, json, get_tornado_ioloop
-from transaction import Transaction, TransactionManager
-import modules
-
-# 3rd party
+# 3p
 try:
     import pycurl
 except ImportError:
     # For the source install, pycurl might not be installed
     pycurl = None
+from tornado.escape import json_decode
+import tornado.httpclient
+import tornado.httpserver
+import tornado.ioloop
+from tornado.options import define, parse_command_line, options
+import tornado.web
+
+# project
+from checks.check_status import ForwarderStatus
+from config import (
+    get_config,
+    get_logging_config,
+    get_url_endpoint,
+    get_version
+)
+import modules
+from util import (
+    get_uuid,
+    get_hostname,
+    get_tornado_ioloop,
+    json,
+    Watchdog,
+)
+from transaction import Transaction, TransactionManager
 
 log = logging.getLogger('forwarder')
 log.setLevel(get_logging_config()['log_level'] or logging.INFO)
@@ -551,7 +556,6 @@ def main():
 
     # If we don't have any arguments, run the server.
     if not args:
-        import tornado.httpclient
         app = init(skip_ssl_validation, use_simple_http_client=use_simple_http_client)
         try:
             app.run()

--- a/emitter.py
+++ b/emitter.py
@@ -3,10 +3,9 @@ from hashlib import md5
 import logging
 import os
 import re
-import sys
 import zlib
 
-# 3rd party
+# 3p
 import requests
 import simplejson as json
 
@@ -28,8 +27,10 @@ requests_log.propagate = True
 control_chars = ''.join(map(unichr, range(0,32) + range(127,160)))
 control_char_re = re.compile('[%s]' % re.escape(control_chars))
 
+
 def remove_control_chars(s):
     return control_char_re.sub('', s)
+
 
 def http_emitter(message, log, agentConfig):
     "Send payload"

--- a/resources/processes.py
+++ b/resources/processes.py
@@ -1,11 +1,15 @@
-
-
+# stdlib
 import subprocess
-import sys
-import traceback
 
-from resources import ResourcePlugin, SnapshotDescriptor, SnapshotField, agg
+# project
 from collections import namedtuple
+from resources import (
+    agg,
+    ResourcePlugin,
+    SnapshotDescriptor,
+    SnapshotField,
+)
+
 
 class Processes(ResourcePlugin):
 

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,10 @@
-import platform
+# stdlib
+from setuptools import setup, find_packages
 import sys
+
+# project
 from config import get_version
 from jmxfetch import JMX_FETCH_JAR_NAME
-
-try:
-    from setuptools import setup, find_packages
-
-    # required to build the cython extensions
-    from distutils.extension import Extension  # pylint: disable=no-name-in-module
-
-except ImportError:
-    from ez_setup import use_setuptools
-    use_setuptools()
-    from setuptools import setup, find_packages
 
 # Extra arguments to pass to the setup function
 extra_args = {}
@@ -25,10 +17,11 @@ install_requires = []
 
 if sys.platform == 'win32':
     from glob import glob
-    import py2exe
-    import pysnmp_mibs
-    import pyVim
-    import pyVmomi
+    # noqa for flake8, these imports are probably here to force packaging of these modules
+    import py2exe  # noqa
+    import pysnmp_mibs  # noqa
+    import pyVim  # noqa
+    import pyVmomi  # noqa
 
     # That's just a copy/paste of requirements.txt
     for reqfile in ('requirements.txt', 'requirements-opt.txt'):

--- a/tests/checks/integration/test_cassandra.py
+++ b/tests/checks/integration/test_cassandra.py
@@ -12,7 +12,6 @@ from aggregator import MetricsAggregator
 from dogstatsd import Server
 from jmxfetch import JMXFetch
 from tests.checks.common import Fixtures
-from util import PidFile
 
 STATSD_PORT = 8121
 

--- a/tests/checks/integration/test_etcd.py
+++ b/tests/checks/integration/test_etcd.py
@@ -1,9 +1,5 @@
-# stdlib
-import unittest
-
 # 3p
 from nose.plugins.attrib import attr
-from requests.exceptions import Timeout
 
 # project
 from tests.checks.common import AgentCheckTest

--- a/tests/checks/integration/test_mcache.py
+++ b/tests/checks/integration/test_mcache.py
@@ -1,16 +1,15 @@
-import unittest
-from nose.plugins.attrib import attr
+# stdlib
 import os
 import time
 from subprocess import Popen, PIPE
 
-from tests.checks.common import AgentCheckTest
-
-from checks import AgentCheck
-
-# 3rd party
+# 3p
 import memcache
+from nose.plugins.attrib import attr
 
+# project
+from checks import AgentCheck
+from tests.checks.common import AgentCheckTest
 
 GAUGES = [
     "total_items",

--- a/tests/checks/integration/test_php_fpm.py
+++ b/tests/checks/integration/test_php_fpm.py
@@ -1,6 +1,3 @@
-# stdlib
-import time
-
 # 3p
 from nose.plugins.attrib import attr
 

--- a/tests/checks/integration/test_postgres.py
+++ b/tests/checks/integration/test_postgres.py
@@ -1,6 +1,3 @@
-# stdlib
-import time
-
 # 3p
 from nose.plugins.attrib import attr
 

--- a/tests/checks/mock/test_ganglia.py
+++ b/tests/checks/mock/test_ganglia.py
@@ -1,11 +1,6 @@
 # stdlib
 from cStringIO import StringIO
 import logging
-try:
-    import cProfile as profile
-except ImportError:
-    import profile
-import pstats
 import subprocess
 import tempfile
 import time

--- a/tests/checks/mock/test_java_jmx.py
+++ b/tests/checks/mock/test_java_jmx.py
@@ -6,17 +6,16 @@ import time
 from types import ListType
 import unittest
 
-# 3rd party
+# 3p
 from mock import patch
 from nose.plugins.attrib import attr
 import yaml
 
-# datadog
+# project
 from aggregator import MetricsAggregator
 from dogstatsd import Server
 from jmxfetch import JMXFetch
 from tests.checks.common import AgentCheckTest
-from utils.pidfile import PidFile
 
 STATSD_PORT = 8129
 

--- a/tests/checks/mock/test_sysstat.py
+++ b/tests/checks/mock/test_sysstat.py
@@ -1,11 +1,9 @@
-import unittest
+# stdlib
 import logging
-import re
 import sys
+import unittest
 
-logging.basicConfig(level=logging.DEBUG)
-logger = logging.getLogger(__file__)
-
+# project
 from checks.system.unix import (
     IO,
     Load,
@@ -15,6 +13,9 @@ from checks.system.unix import (
 from config import get_system_stats
 from tests.checks.common import get_check
 from utils.platform import Platform
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__file__)
 
 
 class TestSystem(unittest.TestCase):

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -5,7 +5,6 @@ import time
 import unittest
 
 # 3p
-from nose.plugins.attrib import attr
 from nose.plugins.skip import SkipTest
 
 # project
@@ -225,7 +224,6 @@ class TestCore(unittest.TestCase):
         (See: https://github.com/kennethreitz/requests/pull/945 )
         """
         from requests.utils import get_environ_proxies
-        import dogstatsd
         from os import environ as env
 
         env["http_proxy"] = "http://localhost:3128"

--- a/tests/core/test_dogstatsd.py
+++ b/tests/core/test_dogstatsd.py
@@ -839,7 +839,6 @@ class TestUnitDogStatsd(unittest.TestCase):
         (See: https://github.com/kennethreitz/requests/pull/945 )
         """
         from requests.utils import get_environ_proxies
-        import dogstatsd
         from os import environ as env
 
         env["http_proxy"] = "http://localhost:3128"

--- a/tests/core/test_service_checks.py
+++ b/tests/core/test_service_checks.py
@@ -1,16 +1,15 @@
 # stdlib
-import logging
 from Queue import Empty
 import time
-import unittest
 
-# 3rd party
+# 3p
 from nose.plugins.attrib import attr
 
 # project
 from config import AGENT_VERSION
-from tests.checks.common import AgentCheckTest, load_check
+from tests.checks.common import AgentCheckTest
 from util import headers as agent_headers
+
 
 @attr(requires='core_integration')
 class ServiceCheckTestCase(AgentCheckTest):

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
 exclude = venv/*,embedded/*,.git/*
 max-line-length = 700
-ignore = E127,E128,E203,E221,E226,E231,E241,E251,E261,E265,E302,E303,E701,F401,F841
+ignore = E127,E128,E203,E221,E226,E231,E241,E251,E261,E265,E302,E303,E701,F841

--- a/util.py
+++ b/util.py
@@ -15,24 +15,22 @@ import types
 import urllib2
 import uuid
 
-# Tornado
+# 3p
+import yaml  # noqa, let's guess, probably imported somewhere
 from tornado import ioloop
-
-# yaml
-import yaml
 try:
     from yaml import CLoader as yLoader
     from yaml import CDumper as yDumper
 except ImportError:
     # On source install C Extensions might have not been built
-    from yaml import Loader as yLoader
-    from yaml import Dumper as yDumper
+    from yaml import Loader as yLoader  # noqa, imported from here elsewhere
+    from yaml import Dumper as yDumper  # noqa, imported from here elsewhere
 
 # These classes are now in utils/, they are just here for compatibility reasons,
 # if a user actually uses them in a custom check
 # If you're this user, please use utils.pidfile or utils.platform instead
 # FIXME: remove them at a point (6.x)
-from utils.pidfile import PidFile
+from utils.pidfile import PidFile  # noqa, see ^^^
 from utils.platform import Platform
 
 

--- a/utils/ntp.py
+++ b/utils/ntp.py
@@ -1,4 +1,6 @@
+# stdlib
 import random
+
 
 def get_ntp_datadog_host(subpool=None):
     """

--- a/utils/profile.py
+++ b/utils/profile.py
@@ -1,10 +1,11 @@
-import os
-import logging
+# stdlib
 import cProfile
-import pstats
 from cStringIO import StringIO
+import logging
+import pstats
 
 log = logging.getLogger('collector')
+
 
 class AgentProfiler(object):
     PSTATS_LIMIT = 20

--- a/win32/agent.py
+++ b/win32/agent.py
@@ -5,22 +5,18 @@ import multiprocessing
 from optparse import Values
 import servicemanager
 import sys
-import threading
 import time
-import tornado.httpclient
 from win32.common import handle_exe_click
 import win32event
-import win32evtlogutil
 import win32service
 import win32serviceutil
 
-# DD
+# project
 from checks.collector import Collector
 from config import (
     get_config,
     get_confd_path,
     get_system_stats,
-    get_win32service_file,
     load_check_directory,
     set_win32_cert_path,
     PathNotFound,

--- a/win32/gui.py
+++ b/win32/gui.py
@@ -8,10 +8,8 @@
 import sys
 import os
 import os.path as osp
-import webbrowser
-import thread # To manage the windows process asynchronously
+import thread  # To manage the windows process asynchronously
 import logging
-import pickle
 import platform
 import win32serviceutil
 import win32service
@@ -20,7 +18,7 @@ import win32service
 from guidata.qt.QtGui import (QWidget, QVBoxLayout, QSplitter, QFont,
                               QListWidget, QPushButton, QLabel, QGroupBox,
                               QHBoxLayout, QMessageBox, QInputDialog,
-                              QSystemTrayIcon, QIcon, QMenu, QTextEdit, QTextDocument)
+                              QSystemTrayIcon, QMenu, QTextEdit)
 from guidata.qt.QtCore import SIGNAL, Qt, QSize, QPoint, QTimer
 
 from guidata.configtools import get_icon, get_family, MONOSPACE


### PR DESCRIPTION
And some cleaning.

Flake8 doesn't detect when a module gets reimported somewhere else, so I commented these lines with `# noqa`. (it should only be the case for `util.py`, we'll see if something is broken with the CI)