### PR TITLE
Add ssl support for etcd plugin

### DIFF
--- a/checks.d/etcd.py
+++ b/checks.d/etcd.py
@@ -70,6 +70,7 @@ class Etcd(AgentCheck):
         url = instance['url']
         instance_tags = instance.get('tags', [])
 
+        # Load the ssl configuration
         ssl_params = {
             'ssl': _is_affirmative(instance.get('ssl', False)),
             'ssl_keyfile': instance.get('ssl_keyfile', None),
@@ -157,7 +158,8 @@ class Etcd(AgentCheck):
     def _get_json(self, url, ssl_params, timeout):
         try:
             if ssl_params['ssl']:
-                r = requests.get(url, verify=ssl_params['ssl_cert_reqs'], cert=(ssl_params['ssl_certfile'], ssl_params['ssl_keyfile']), timeout=timeout, headers=headers(self.agentConfig))
+                certificate = (ssl_params['ssl_certfile'], ssl_params['ssl_keyfile']) if 'ssl_certfile' in ssl_params and 'ssl_keyfile' in ssl_params else None
+                r = requests.get(url, verify=ssl_params['ssl_cert_reqs'], cert=certificate, timeout=timeout, headers=headers(self.agentConfig))
             else:
                 r = requests.get(url, timeout=timeout, headers=headers(self.agentConfig))
         except requests.exceptions.Timeout:

--- a/checks.d/etcd.py
+++ b/checks.d/etcd.py
@@ -159,7 +159,7 @@ class Etcd(AgentCheck):
             if ssl_params['ssl']:
                 r = requests.get(url, verify=ssl_params['ssl_cert_reqs'], cert=(ssl_params['ssl_certfile'], ssl_params['ssl_keyfile']), timeout=timeout, headers=headers(self.agentConfig))
             else:
-                r = requests.get(url, timeout=timeout, headers=headers(self.agentConfig))                
+                r = requests.get(url, timeout=timeout, headers=headers(self.agentConfig))
         except requests.exceptions.Timeout:
             # If there's a timeout
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,

--- a/checks.d/etcd.py
+++ b/checks.d/etcd.py
@@ -1,5 +1,6 @@
 # project
 from checks import AgentCheck
+from config import _is_affirmative
 from util import headers
 
 # 3rd party
@@ -70,7 +71,7 @@ class Etcd(AgentCheck):
         instance_tags = instance.get('tags', [])
 
         ssl_params = {
-            'ssl': instance.get('ssl', False),
+            'ssl': _is_affirmative(instance.get('ssl', False)),
             'ssl_keyfile': instance.get('ssl_keyfile', None),
             'ssl_certfile': instance.get('ssl_certfile', None),
             'ssl_cert_reqs':  instance.get('ssl_cert_reqs', True)

--- a/checks.d/etcd.py
+++ b/checks.d/etcd.py
@@ -70,7 +70,7 @@ class Etcd(AgentCheck):
         instance_tags = instance.get('tags', [])
 
         ssl_params = {
-            'ssl': instance.get('ssl', None),
+            'ssl': instance.get('ssl', False),
             'ssl_keyfile': instance.get('ssl_keyfile', None),
             'ssl_certfile': instance.get('ssl_certfile', None),
             'ssl_cert_reqs':  instance.get('ssl_cert_reqs', True)

--- a/conf.d/etcd.yaml.example
+++ b/conf.d/etcd.yaml.example
@@ -5,3 +5,12 @@ instances:
 #    - url: "https://server:port"
 # timeout: time to wait on a etcd API request
 #      timeout: 5
+# ssl: etcd requires ssl certificate & key (default: false)
+#      ssl: true
+# ssl_keyfile: path to the key file used to communicate with etcd
+#      ssl_keyfile: /path/to/key/file
+# ssl_certfile: path to the certificate file used to communicate with etcd
+#      ssl_certfile: /path/to/certificate/file
+# ssl_cert_reqs: require verification SSL certificates for HTTPS requests (default: true), will take in the CA file if needed (choose one)
+#      ssl_cert_reqs: true
+#      ssl_cert_reqs: /path/to/CA/certificate/file

--- a/tests/checks/integration/test_etcd.py
+++ b/tests/checks/integration/test_etcd.py
@@ -85,7 +85,7 @@ class CheckEtcdTest(AgentCheckTest):
         }
 
         mocks = {
-            '_get_leader_metrics': lambda u, t: mock
+            '_get_leader_metrics': lambda url, ssl, timeout: mock
         }
 
         self.run_check_twice(self.config, mocks=mocks)


### PR DESCRIPTION
Added in optional support etcd ssl configuration.
Users have to opt in to use the ssl monitoring.
Modified the example etcd.yaml.example to reflect the changes.