### PR TITLE
Modified yum install line to disable all other repos and only enable the DataDog repo

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -109,7 +109,7 @@ if [ $OS = "RedHat" ]; then
             $sudo_cmd yum -y remove datadog-agent-base
         fi
     fi
-    $sudo_cmd yum -y install datadog-agent
+    $sudo_cmd yum -y --disablerepo='*' --enablerepo=datadog install datadog-agent
 elif [ $OS = "Debian" ]; then
     printf "\033[34m\n* Installing APT package sources for Datadog\n\033[0m\n"
     $sudo_cmd sh -c "echo 'deb http://apt.datadoghq.com/ stable main' > /etc/apt/sources.list.d/datadog.list"


### PR DESCRIPTION
This fixes situations where a system might have broken repos, or repos that aren't available in specific environments. An example would be a company with an internal repo which is available during a build phase, but not available in a prod environment. I personally ran into this situation :)