### PR TITLE
[disk] fix empty device regex exclusion issue

### DIFF
--- a/checks.d/disk.py
+++ b/checks.d/disk.py
@@ -70,7 +70,7 @@ class Disk(AgentCheck):
                 "Using `{0}` in datadog.conf has been deprecated"
                 " in favor of `{1}` in disk.yaml".format(legacy_name, option)
             )
-            value = self.agentConfig.get(legacy_name)
+            value = self.agentConfig.get(legacy_name) or default
         setattr(self, '_{0}'.format(option), operation(value))
 
     def collect_metrics_psutil(self):

--- a/tests/checks/mock/test_disk.py
+++ b/tests/checks/mock/test_disk.py
@@ -167,3 +167,12 @@ class TestCheckDisk(AgentCheckTest):
         self.assertFalse(self.check._tag_by_filesystem)
         self.assertTrue(self.check._all_partitions)
         self.assertEqual(self.check._excluded_disk_re, re.compile('^$'))
+
+    def test_ignore_empty_regex(self):
+        """
+        Ignore empty regex as they match all strings
+        (and so exclude all disks from the check)
+        """
+        self.load_check({'instances': [{}]}, agent_config={'device_blacklist_re': ''})
+        self.check._load_conf({})
+        self.assertEqual(self.check._excluded_disk_re, re.compile('^$'))


### PR DESCRIPTION
When `device_blacklist_re` or `excluded_disk_re` were empty (let's say in
datadog.conf `device_blacklist_re: `), the disk check was failing, because all
disks were excluded.

This is fixed.