### PR TITLE
[core][windows] restore 'run_check' from 'checks'

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -25,7 +25,10 @@ import yaml
 # project
 from checks import check_status
 from util import LaconicFilter, get_hostname, get_next_id, yLoader
+from utils.platform import Platform
 from utils.profile import pretty_statistics
+if Platform.is_windows():
+    from utils.debug import run_check  # noqa - windows debug purpose
 
 log = logging.getLogger(__name__)
 

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -14,6 +14,7 @@ from pprint import pformat
 from checks import AgentCheck
 from config import get_checksd_path
 from util import get_os, get_hostname
+from utils.debug import get_check  # noqa -  FIXME 5.5.0 AgentCheck tests should not use this
 
 log = logging.getLogger('tests')
 
@@ -84,29 +85,6 @@ def kill_subprocess(process_obj):
             ctypes.windll.kernel32.CloseHandle(handle)
         else:
             os.kill(process_obj.pid, signal.SIGKILL)
-
-
-def get_check(name, config_str):
-    checksd_path = get_checksd_path(get_os())
-    if checksd_path not in sys.path:
-        sys.path.append(checksd_path)
-    check_module = __import__(name)
-    check_class = None
-    classes = inspect.getmembers(check_module, inspect.isclass)
-    for name, clsmember in classes:
-        if AgentCheck in clsmember.__bases__:
-            check_class = clsmember
-            break
-    if check_class is None:
-        raise Exception("Unable to import check %s. Missing a class that inherits AgentCheck" % name)
-
-    agentConfig = {
-        'version': '0.1',
-        'api_key': 'tota'
-    }
-
-    return check_class.from_yaml(yaml_text=config_str, check_name=name,
-                                 agentConfig=agentConfig)
 
 
 class Fixtures(object):

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -1,0 +1,63 @@
+# stdlib
+import inspect
+import os
+from pprint import pprint
+import sys
+
+# datadog
+from config import get_checksd_path, get_confd_path
+from util import get_os
+
+
+def run_check(name, path=None):
+    """
+    Test custom checks on Windows.
+    """
+    # Read the config file
+
+    confd_path = path or os.path.join(get_confd_path(get_os()), '%s.yaml' % name)
+
+    try:
+        f = open(confd_path)
+    except IOError:
+        raise Exception('Unable to open configuration at %s' % confd_path)
+
+    config_str = f.read()
+    f.close()
+
+    # Run the check
+    check, instances = get_check(name, config_str)
+    if not instances:
+        raise Exception('YAML configuration returned no instances.')
+    for instance in instances:
+        check.check(instance)
+        if check.has_events():
+            print "Events:\n"
+            pprint(check.get_events(), indent=4)
+        print "Metrics:\n"
+        pprint(check.get_metrics(), indent=4)
+
+
+def get_check(name, config_str):
+    from checks import AgentCheck
+
+    checksd_path = get_checksd_path(get_os())
+    if checksd_path not in sys.path:
+        sys.path.append(checksd_path)
+    check_module = __import__(name)
+    check_class = None
+    classes = inspect.getmembers(check_module, inspect.isclass)
+    for name, clsmember in classes:
+        if AgentCheck in clsmember.__bases__:
+            check_class = clsmember
+            break
+    if check_class is None:
+        raise Exception("Unable to import check %s. Missing a class that inherits AgentCheck" % name)
+
+    agentConfig = {
+        'version': '0.1',
+        'api_key': 'tota'
+    }
+
+    return check_class.from_yaml(yaml_text=config_str, check_name=name,
+                                 agentConfig=agentConfig)


### PR DESCRIPTION
PR #1571 introduced a bad regression: 'run_check' method was deleted
beside it is still used on Windows to debug.