### PR TITLE
[haproxy] sc send proper hostname

### DIFF
--- a/tests/checks/fixtures/haproxy/haproxy_status
+++ b/tests/checks/fixtures/haproxy/haproxy_status
@@ -1,0 +1,8 @@
+# pxname,svname,qcur,qmax,scur,smax,slim,stot,bin,bout,dreq,dresp,ereq,econ,eresp,wretr,wredis,status,weight,act,bck,chkfail,chkdown,lastchg,downtime,qlimit,pid,iid,sid,throttle,lbtot,tracked,type,rate,rate_lim,rate_max,check_status,check_code,check_duration,hrsp_1xx,hrsp_2xx,hrsp_3xx,hrsp_4xx,hrsp_5xx,hrsp_other,hanafail,req_rate,req_rate_max,req_tot,cli_abrt,srv_abrt,
+a,FRONTEND,,,1,2,12,1,11,11,0,0,0,,,,,OPEN,,,,,,,,,1,1,0,,,,0,1,0,2,,,,0,1,0,0,0,0,,1,1,1,,,
+a,BACKEND,0,0,0,0,12,0,11,11,0,0,,0,0,0,0,UP,0,0,0,,0,1221810,0,,1,1,0,,0,,1,0,,0,,,,0,0,0,0,0,0,,,,,0,0,
+b,FRONTEND,,,1,2,12,11,11,0,0,0,0,,,,,OPEN,,,,,,,,,1,2,0,,,,0,0,0,1,,,,,,,,,,,0,0,0,,,
+b,i-1,0,0,0,1,,1,1,0,,0,,0,0,0,0,UP,1,1,0,0,1,1,30,,1,3,1,,70,,2,0,,1,1,,0,,,,,,,0,,,,0,0,
+b,i-2,0,0,1,1,,1,1,0,,0,,0,0,0,0,UP,1,1,0,0,0,1,0,,1,3,2,,71,,2,0,,1,1,,0,,,,,,,0,,,,0,0,
+b,i-3,0,0,0,1,,1,1,0,,0,,0,0,0,0,UP,1,1,0,0,0,1,0,,1,3,3,,70,,2,0,,1,1,,0,,,,,,,0,,,,0,0,
+b,BACKEND,0,0,1,2,0,421,1,0,0,0,,0,0,0,0,UP,6,6,0,,0,1,0,,1,3,0,,421,,1,0,,1,,,,,,,,,,,,,,0,0,

--- a/tests/checks/integration/test_haproxy.py
+++ b/tests/checks/integration/test_haproxy.py
@@ -1,7 +1,10 @@
+# stdlib
 import os
 
-from checks import AgentCheck
+# 3p
 from nose.plugins.attrib import attr
+
+# project
 from tests.checks.common import AgentCheckTest
 from util import get_hostname
 
@@ -137,15 +140,13 @@ class HaproxyTest(AgentCheckTest):
         for service in services:
             for backend in self.BACKEND_LIST:
                 tags = ['service:' + service, 'backend:' + backend]
-                self.assertServiceCheck(self.check.SERVICE_CHECK_NAME,
-                                        status=AgentCheck.UNKNOWN,
-                                        count=1,
-                                        tags=tags)
+                self.assertServiceCheckUnknown(self.check.SERVICE_CHECK_NAME,
+                                               count=1,
+                                               tags=tags)
             tags = ['service:' + service, 'backend:BACKEND']
-            self.assertServiceCheck(self.check.SERVICE_CHECK_NAME,
-                                    status=AgentCheck.OK,
-                                    count=1,
-                                    tags=tags)
+            self.assertServiceCheckOK(self.check.SERVICE_CHECK_NAME,
+                                      count=1,
+                                      tags=tags)
 
     def test_check(self):
         self.run_check_twice(self.config)
@@ -201,49 +202,3 @@ class HaproxyTest(AgentCheckTest):
         self.assertEquals(self.service_checks[0]['host_name'], '')
 
         self.coverage_report()
-
-    # Keeping a mocked test since it tests the internal
-    # process of service checks
-    def test_count_per_statuses(self):
-        from collections import defaultdict
-        self.run_check(self.config)
-
-        data = """# pxname,svname,qcur,qmax,scur,smax,slim,stot,bin,bout,dreq,dresp,ereq,econ,eresp,wretr,wredis,status,weight,act,bck,chkfail,chkdown,lastchg,downtime,qlimit,pid,iid,sid,throttle,lbtot,tracked,type,rate,rate_lim,rate_max,check_status,check_code,check_duration,hrsp_1xx,hrsp_2xx,hrsp_3xx,hrsp_4xx,hrsp_5xx,hrsp_other,hanafail,req_rate,req_rate_max,req_tot,cli_abrt,srv_abrt,
-a,FRONTEND,,,1,2,12,1,11,11,0,0,0,,,,,OPEN,,,,,,,,,1,1,0,,,,0,1,0,2,,,,0,1,0,0,0,0,,1,1,1,,,
-a,BACKEND,0,0,0,0,12,0,11,11,0,0,,0,0,0,0,UP,0,0,0,,0,1221810,0,,1,1,0,,0,,1,0,,0,,,,0,0,0,0,0,0,,,,,0,0,
-b,FRONTEND,,,1,2,12,11,11,0,0,0,0,,,,,OPEN,,,,,,,,,1,2,0,,,,0,0,0,1,,,,,,,,,,,0,0,0,,,
-b,i-1,0,0,0,1,,1,1,0,,0,,0,0,0,0,UP,1,1,0,0,1,1,30,,1,3,1,,70,,2,0,,1,1,,0,,,,,,,0,,,,0,0,
-b,i-2,0,0,1,1,,1,1,0,,0,,0,0,0,0,UP,1,1,0,0,0,1,0,,1,3,2,,71,,2,0,,1,1,,0,,,,,,,0,,,,0,0,
-b,i-3,0,0,0,1,,1,1,0,,0,,0,0,0,0,UP,1,1,0,0,0,1,0,,1,3,3,,70,,2,0,,1,1,,0,,,,,,,0,,,,0,0,
-b,BACKEND,0,0,1,2,0,421,1,0,0,0,,0,0,0,0,UP,6,6,0,,0,1,0,,1,3,0,,421,,1,0,,1,,,,,,,,,,,,,,0,0,
-""".split('\n')
-
-        # per service
-        self.check._process_data(data, True, False, collect_status_metrics=True,
-                                 collect_status_metrics_by_host=False)
-
-        expected_hosts_statuses = defaultdict(int)
-        expected_hosts_statuses[('b', 'OPEN')] = 1
-        expected_hosts_statuses[('b', 'UP')] = 3
-        expected_hosts_statuses[('a', 'OPEN')] = 1
-        self.assertEquals(self.check.hosts_statuses, expected_hosts_statuses)
-
-        # with collect_aggregates_only set to True
-        self.check._process_data(data, True, True, collect_status_metrics=True,
-                                 collect_status_metrics_by_host=False)
-        self.assertEquals(self.check.hosts_statuses, expected_hosts_statuses)
-
-        # per host
-        self.check._process_data(data, True, False, collect_status_metrics=True,
-                                 collect_status_metrics_by_host=True)
-        expected_hosts_statuses = defaultdict(int)
-        expected_hosts_statuses[('b', 'FRONTEND', 'OPEN')] = 1
-        expected_hosts_statuses[('a', 'FRONTEND', 'OPEN')] = 1
-        expected_hosts_statuses[('b', 'i-1', 'UP')] = 1
-        expected_hosts_statuses[('b', 'i-2', 'UP')] = 1
-        expected_hosts_statuses[('b', 'i-3', 'UP')] = 1
-        self.assertEquals(self.check.hosts_statuses, expected_hosts_statuses)
-
-        self.check._process_data(data, True, True, collect_status_metrics=True,
-                                 collect_status_metrics_by_host=True)
-        self.assertEquals(self.check.hosts_statuses, expected_hosts_statuses)

--- a/tests/checks/mock/test_haproxy.py
+++ b/tests/checks/mock/test_haproxy.py
@@ -1,0 +1,47 @@
+# stdlib
+from collections import defaultdict
+
+# 3p
+from nose.plugins.attrib import attr
+
+# project
+from tests.checks.common import AgentCheckTest, Fixtures
+
+
+@attr(requires='haproxy')
+class HaproxyTest(AgentCheckTest):
+
+    CHECK_NAME = 'haproxy'
+
+    def test_count_per_statuses(self):
+        data = Fixtures.read_file('haproxy_status').splitlines()
+
+        # per service
+        self.check._process_data(data, True, False, collect_status_metrics=True,
+                                 collect_status_metrics_by_host=False)
+
+        expected_hosts_statuses = defaultdict(int)
+        expected_hosts_statuses[('b', 'OPEN')] = 1
+        expected_hosts_statuses[('b', 'UP')] = 3
+        expected_hosts_statuses[('a', 'OPEN')] = 1
+        self.assertEquals(self.check.hosts_statuses, expected_hosts_statuses)
+
+        # with collect_aggregates_only set to True
+        self.check._process_data(data, True, True, collect_status_metrics=True,
+                                 collect_status_metrics_by_host=False)
+        self.assertEquals(self.check.hosts_statuses, expected_hosts_statuses)
+
+        # per host
+        self.check._process_data(data, True, False, collect_status_metrics=True,
+                                 collect_status_metrics_by_host=True)
+        expected_hosts_statuses = defaultdict(int)
+        expected_hosts_statuses[('b', 'FRONTEND', 'OPEN')] = 1
+        expected_hosts_statuses[('a', 'FRONTEND', 'OPEN')] = 1
+        expected_hosts_statuses[('b', 'i-1', 'UP')] = 1
+        expected_hosts_statuses[('b', 'i-2', 'UP')] = 1
+        expected_hosts_statuses[('b', 'i-3', 'UP')] = 1
+        self.assertEquals(self.check.hosts_statuses, expected_hosts_statuses)
+
+        self.check._process_data(data, True, True, collect_status_metrics=True,
+                                 collect_status_metrics_by_host=True)
+        self.assertEquals(self.check.hosts_statuses, expected_hosts_statuses)


### PR DESCRIPTION
* Previously, the var `back_or_front` was not reset, so each loop could use the
  previous `back_or_front`.
* This `back_or_front` var is used to somehow determine the hostname for the
  service_check.
This problem is fixed.

Also:
* split mock and integration tests

Tests might fail.