### PR TITLE
[jmxfetch][windows] wait JMXFetch exit to exit

### DIFF
--- a/win32/agent.py
+++ b/win32/agent.py
@@ -306,6 +306,7 @@ class JMXFetchProcess(multiprocessing.Process):
         Override `terminate` method to properly exit JMXFetch.
         """
         JMXFetch.write_exit_file()
+        self.join()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
JMXFetch can take up to 15seconds to stop. If we don't wait JMXFetch to
stop and restart the agent, the 'exit_file' might be deleted before
JMXFetch has time to catch it.
This might also fix 'restart' warnings at installation upgrades.