### PR TITLE
[jmxfetch] move status & exit files to '/run'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ See [#1621][]
 
 * [IMPROVEMENT] Limit process restart attempts on Windows on a specific time frame. See [#1664][]
 * [IMPROVEMENT] Only start the Collector and Dogstatsd when needed. See [#1569][]
-* [IMPROVEMENT] Use internal `/run` for temporary pid and pickle files. See [#1569][]
+* [IMPROVEMENT] Use internal `/run` for temporary pid, pickle and JMXFetch files. See [#1569][], [#1679][]
 * [IMPROVEMENT] Disk: New check based on `psutil` replaces the old system check. See [#1596][]
 * [IMPROVEMENT] JMXFetch: Run JMXFetch as `dd-agent` user. See [#1619][]
 * [IMPROVEMENT] NTP: Use Datadog NTP pool. See [#1618][]
@@ -1727,6 +1727,7 @@ If you use ganglia, you want this version.
 [#1657]: https://github.com/DataDog/dd-agent/issues/1657
 [#1664]: https://github.com/DataDog/dd-agent/issues/1664
 [#1666]: https://github.com/DataDog/dd-agent/issues/1666
+[#1679]: https://github.com/DataDog/dd-agent/issues/1679
 [@AirbornePorcine]: https://github.com/AirbornePorcine
 [@CaptTofu]: https://github.com/CaptTofu
 [@Osterjour]: https://github.com/Osterjour

--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -19,8 +19,9 @@ import yaml
 
 # project
 import config
-from config import get_config, get_jmx_status_path, _is_affirmative, _windows_commondata_path
+from config import get_config, _is_affirmative, _windows_commondata_path
 from util import plural
+from utils.jmxfiles import JMXFiles
 from utils.ntp import get_ntp_args
 from utils.pidfile import PidFile
 from utils.platform import Platform
@@ -849,8 +850,8 @@ def get_jmx_status():
         ###
     """
     check_statuses = []
-    java_status_path = os.path.join(get_jmx_status_path(), "jmx_status.yaml")
-    python_status_path = os.path.join(get_jmx_status_path(), "jmx_status_python.yaml")
+    java_status_path = JMXFiles.get_status_file_path()
+    python_status_path = JMXFiles.get_python_status_file_path()
     if not os.path.exists(java_status_path) and not os.path.exists(python_status_path):
         log.debug("There is no jmx_status file at: %s or at: %s" % (java_status_path, python_status_path))
         return []

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -20,7 +20,6 @@ from checks.ganglia import Ganglia
 import checks.system.unix as u
 import checks.system.win32 as w32
 from config import get_system_stats, get_version
-import jmxfetch
 import modules
 from resources.processes import Processes as ResProcesses
 from util import (
@@ -31,6 +30,7 @@ from util import (
     get_uuid,
     Timer,
 )
+from utils.jmxfiles import JMXFiles
 from utils.subprocess_output import subprocess
 
 log = logging.getLogger(__name__)
@@ -730,7 +730,8 @@ class Collector(object):
         if self.agentConfig['create_dd_check_tags'] and \
                 self._should_send_additional_data('dd_check_tags'):
             app_tags_list = [DD_CHECK_TAG.format(c.name) for c in self.initialized_checks_d]
-            app_tags_list.extend([DD_CHECK_TAG.format(cname) for cname in jmxfetch._get_jmx_appnames()])
+            app_tags_list.extend([DD_CHECK_TAG.format(cname) for cname
+                                  in JMXFiles.get_jmx_appnames()])
 
             if 'system' not in payload['host-tags']:
                 payload['host-tags']['system'] = []

--- a/config.py
+++ b/config.py
@@ -9,7 +9,6 @@ import string
 import sys
 import glob
 import inspect
-import tempfile
 import traceback
 import re
 import imp
@@ -889,14 +888,6 @@ def get_log_format(logger_name):
 
 def get_syslog_format(logger_name):
     return 'dd.%s[%%(process)d]: %%(levelname)s (%%(filename)s:%%(lineno)s): %%(message)s' % logger_name
-
-
-def get_jmx_status_path():
-    if Platform.is_win32():
-        path = os.path.join(_windows_commondata_path(), 'Datadog')
-    else:
-        path = tempfile.gettempdir()
-    return path
 
 
 def get_logging_config(cfg_path=None):

--- a/utils/jmxfiles.py
+++ b/utils/jmxfiles.py
@@ -1,0 +1,109 @@
+# std
+import logging
+import os
+import tempfile
+import time
+
+# 3rd party
+import yaml
+
+# datadog
+from config import _windows_commondata_path
+from util import yDumper
+from utils.pidfile import PidFile
+from utils.platform import Platform
+
+
+log = logging.getLogger(__name__)
+
+
+class JMXFiles(object):
+    """
+    A small helper class for JMXFetch status & exit files.
+    """
+    _STATUS_FILE = 'jmx_status.yaml'
+    _PYTHON_STATUS_FILE = 'jmx_status_python.yaml'
+    _JMX_EXIT_FILE = 'jmxfetch_exit'
+
+    @classmethod
+    def _get_dir(cls):
+        if Platform.is_win32():
+            path = os.path.join(_windows_commondata_path(), 'Datadog')
+        elif os.path.isdir(PidFile.get_dir()):
+            path = PidFile.get_dir()
+        else:
+            path = tempfile.gettempdir()
+        return path
+
+    @classmethod
+    def _get_file_path(cls, file):
+        return os.path.join(cls._get_dir(), file)
+
+    @classmethod
+    def get_status_file_path(cls):
+        return cls._get_file_path(cls._STATUS_FILE)
+
+    @classmethod
+    def get_python_status_file_path(cls):
+        return cls._get_file_path(cls._PYTHON_STATUS_FILE)
+
+    @classmethod
+    def get_python_exit_file_path(cls):
+        return cls._get_file_path(cls._JMX_EXIT_FILE)
+
+    @classmethod
+    def write_status_file(cls, invalid_checks):
+        data = {
+            'timestamp': time.time(),
+            'invalid_checks': invalid_checks
+        }
+        stream = file(os.path.join(cls._get_dir(), cls._PYTHON_STATUS_FILE), 'w')
+        yaml.dump(data, stream, Dumper=yDumper)
+        stream.close()
+
+    @classmethod
+    def write_exit_file(cls):
+        """
+        Create a 'special' file, which acts as a trigger to exit JMXFetch.
+        Note: Windows only
+        """
+        open(os.path.join(cls._get_dir(), cls._JMX_EXIT_FILE), 'a').close()
+
+    @classmethod
+    def clean_status_file(cls):
+        """
+        Removes JMX status files
+        """
+        try:
+            os.remove(os.path.join(cls._get_dir(), cls._STATUS_FILE))
+        except OSError:
+            pass
+        try:
+            os.remove(os.path.join(cls._get_dir(), cls._PYTHON_STATUS_FILE))
+        except OSError:
+            pass
+
+    @classmethod
+    def clean_exit_file(cls):
+        """
+        Remove exit file trigger -may not exist-.
+        Note: Windows only
+        """
+        try:
+            os.remove(os.path.join(cls._get_dir(), cls._JMX_EXIT_FILE))
+        except OSError:
+            pass
+
+    @classmethod
+    def get_jmx_appnames(cls):
+        """
+        Retrieves the running JMX checks based on the {tmp}/jmx_status.yaml file
+        updated by JMXFetch (and the only communication channel between JMXFetch
+        and the collector since JMXFetch).
+        """
+        check_names = []
+        jmx_status_path = os.path.join(cls._get_dir(), cls._STATUS_FILE)
+        if os.path.exists(jmx_status_path):
+            jmx_checks = yaml.load(file(jmx_status_path)).get('checks', {})
+            check_names = [name for name in jmx_checks.get('initialized_checks', {}).iterkeys()]
+        return check_names

--- a/win32/agent.py
+++ b/win32/agent.py
@@ -22,11 +22,12 @@ from config import (
     set_win32_cert_path,
     PathNotFound,
 )
-import dogstatsd
 from ddagent import Application
+import dogstatsd
 from emitter import http_emitter
 from jmxfetch import JMXFetch
 from util import get_hostname, get_os
+from utils.jmxfiles import JMXFiles
 
 log = logging.getLogger(__name__)
 
@@ -298,14 +299,14 @@ class JMXFetchProcess(multiprocessing.Process):
 
     def run(self):
         if self.is_enabled:
-            JMXFetch.clean_exit_file()
+            JMXFiles.clean_exit_file()
             self.jmx_daemon.run()
 
     def terminate(self):
         """
         Override `terminate` method to properly exit JMXFetch.
         """
-        JMXFetch.write_exit_file()
+        JMXFiles.write_exit_file()
         self.join()
 
 


### PR DESCRIPTION
Use '/run' for JMXFetch status & exit files instead of '/tmp/'. Move more functions to '/utils'.