### PR TITLE
[tests] add mocked tests for internal /run folder

### DIFF
--- a/tests/core/test_run_files.py
+++ b/tests/core/test_run_files.py
@@ -5,15 +5,7 @@ import unittest
 # 3p
 import mock
 
-# Mock gettempdir for testing
-import tempfile
-tempfile.gettempdir = mock.Mock(return_value='/a/test/tmp/dir')
-
 # project
-# Mock _windows_commondata_path for testing
-import config
-config._windows_commondata_path = mock.Mock(return_value="C:\Windows\App Data")
-
 from checks.check_status import AgentStatus
 
 class TestRunFiles(unittest.TestCase):
@@ -24,6 +16,7 @@ class TestRunFiles(unittest.TestCase):
     _mac_run_dir = '/'.join(_my_dir.split('/')[:-4])
     _linux_run_dir = '/opt/datadog-agent/run'
 
+    @mock.patch('checks.check_status._windows_commondata_path', return_value="C:\Windows\App Data")
     @mock.patch('utils.platform.Platform.is_win32', return_value=True)
     def test_agent_status_pickle_file_win32(self, *mocks):
         ''' Test pickle file location on win32 '''
@@ -39,6 +32,7 @@ class TestRunFiles(unittest.TestCase):
         expected_path = os.path.join(self._mac_run_dir, 'AgentStatus.pickle')
         self.assertEqual(AgentStatus._get_pickle_path(), expected_path)
 
+    @mock.patch('utils.pidfile.tempfile.gettempdir', return_value='/a/test/tmp/dir')
     @mock.patch('utils.platform.Platform.is_win32', return_value=False)
     @mock.patch('utils.platform.Platform.is_mac', return_value=True)
     def test_agent_status_pickle_file_mac_source(self, *mocks):

--- a/tests/core/test_run_files.py
+++ b/tests/core/test_run_files.py
@@ -14,7 +14,7 @@ tempfile.gettempdir = mock.Mock(return_value='/a/test/tmp/dir')
 # project
 # Mock _windows_commondata_path for testing
 import config
-config._windows_commondata_path = mock.Mock(return_value='./windows_commondata')
+config._windows_commondata_path = mock.Mock(return_value="C:\Windows\App Data")
 
 from checks.check_status import AgentStatus
 
@@ -28,7 +28,7 @@ class TestRunFiles(unittest.TestCase):
     @mock.patch('utils.platform.Platform.is_win32', return_value=True)
     def test_agent_status_pickle_file_win32(self, *mocks):
         ''' Test pickle file location on win32 '''
-        expected_path = os.path.join('.', 'windows_commondata', 'Datadog', 'AgentStatus.pickle')
+        expected_path = os.path.join('C:\Windows\App Data', 'Datadog', 'AgentStatus.pickle')
         # check AgentStatus pickle created
         self.assertEqual(AgentStatus._get_pickle_path(), expected_path)
 

--- a/tests/core/test_run_files.py
+++ b/tests/core/test_run_files.py
@@ -1,24 +1,21 @@
 # stdlib
 import os
 import shlex
-import signal
 import subprocess
-import time
 import unittest
 
 # 3p
 import mock
-from nose.plugins.attrib import attr
 
 # Mock gettempdir for testing
-import tempfile; tempfile.gettempdir = mock.Mock(return_value='/a/test/tmp/dir')
+import tempfile
+tempfile.gettempdir = mock.Mock(return_value='/a/test/tmp/dir')
 
 # project
 # Mock _windows_commondata_path for testing
-import config; config._windows_commondata_path = mock.Mock(return_value='./windows_commondata')
+import config
+config._windows_commondata_path = mock.Mock(return_value='./windows_commondata')
 
-
-from utils.pidfile import PidFile
 from checks.check_status import AgentStatus
 
 class TestRunFiles(unittest.TestCase):
@@ -27,14 +24,6 @@ class TestRunFiles(unittest.TestCase):
     # Mac run directory expected location
     _my_dir = os.path.dirname(os.path.abspath(__file__))
     _mac_run_dir = '/'.join(_my_dir.split('/')[:-4])
-
-    def setUp(self):
-        self.agent_daemon = None
-
-    def tearDown(self):
-        if self.agent_daemon:
-            args = shlex.split('python agent.py stop')
-            subprocess.Popen(args).communicate()
 
     @mock.patch('utils.platform.Platform.is_win32', return_value=True)
     def test_agent_status_pickle_file_win32(self, *mocks):

--- a/tests/core/test_run_files.py
+++ b/tests/core/test_run_files.py
@@ -1,7 +1,5 @@
 # stdlib
 import os
-import shlex
-import subprocess
 import unittest
 
 # 3p
@@ -24,6 +22,7 @@ class TestRunFiles(unittest.TestCase):
     # Mac run directory expected location
     _my_dir = os.path.dirname(os.path.abspath(__file__))
     _mac_run_dir = '/'.join(_my_dir.split('/')[:-4])
+    _linux_run_dir = '/opt/datadog-agent/run'
 
     @mock.patch('utils.platform.Platform.is_win32', return_value=True)
     def test_agent_status_pickle_file_win32(self, *mocks):
@@ -45,4 +44,13 @@ class TestRunFiles(unittest.TestCase):
     def test_agent_status_pickle_file_mac_source(self, *mocks):
         ''' Test pickle file location when running a Mac source install '''
         expected_path = os.path.join('/a/test/tmp/dir', 'AgentStatus.pickle')
+        self.assertEqual(AgentStatus._get_pickle_path(), expected_path)
+
+    @mock.patch('os.path.isdir', return_value=True)
+    @mock.patch('utils.pidfile.PidFile.get_dir', return_value=_linux_run_dir)
+    @mock.patch('utils.platform.Platform.is_win32', return_value=False)
+    @mock.patch('utils.platform.Platform.is_mac', return_value=False)
+    def test_agent_status_pickle_file_linux(self, *mocks):
+        ''' Test pickle file location when running on Linux '''
+        expected_path = os.path.join('/opt/datadog-agent/run', 'AgentStatus.pickle')
         self.assertEqual(AgentStatus._get_pickle_path(), expected_path)

--- a/tests/core/test_run_files.py
+++ b/tests/core/test_run_files.py
@@ -1,0 +1,59 @@
+# stdlib
+import os
+import shlex
+import signal
+import subprocess
+import time
+import unittest
+
+# 3p
+import mock
+from nose.plugins.attrib import attr
+
+# Mock gettempdir for testing
+import tempfile; tempfile.gettempdir = mock.Mock(return_value='/a/test/tmp/dir')
+
+# project
+# Mock _windows_commondata_path for testing
+import config; config._windows_commondata_path = mock.Mock(return_value='./windows_commondata')
+
+
+from utils.pidfile import PidFile
+from checks.check_status import AgentStatus
+
+class TestRunFiles(unittest.TestCase):
+    """ Tests that runfiles (.pid, .sock, .pickle etc.) are written to internal agent folders"""
+
+    # Mac run directory expected location
+    _my_dir = os.path.dirname(os.path.abspath(__file__))
+    _mac_run_dir = '/'.join(_my_dir.split('/')[:-4])
+
+    def setUp(self):
+        self.agent_daemon = None
+
+    def tearDown(self):
+        if self.agent_daemon:
+            args = shlex.split('python agent.py stop')
+            subprocess.Popen(args).communicate()
+
+    @mock.patch('utils.platform.Platform.is_win32', return_value=True)
+    def test_agent_status_pickle_file_win32(self, *mocks):
+        ''' Test pickle file location on win32 '''
+        expected_path = os.path.join('.', 'windows_commondata', 'Datadog', 'AgentStatus.pickle')
+        # check AgentStatus pickle created
+        self.assertEqual(AgentStatus._get_pickle_path(), expected_path)
+
+    @mock.patch('utils.pidfile.PidFile.get_dir', return_value=_mac_run_dir)
+    @mock.patch('utils.platform.Platform.is_win32', return_value=False)
+    @mock.patch('utils.platform.Platform.is_mac', return_value=True)
+    def test_agent_status_pickle_file_mac_dmg(self, *mocks):
+        ''' Test pickle file location when running a Mac DMG install '''
+        expected_path = os.path.join(self._mac_run_dir, 'AgentStatus.pickle')
+        self.assertEqual(AgentStatus._get_pickle_path(), expected_path)
+
+    @mock.patch('utils.platform.Platform.is_win32', return_value=False)
+    @mock.patch('utils.platform.Platform.is_mac', return_value=True)
+    def test_agent_status_pickle_file_mac_source(self, *mocks):
+        ''' Test pickle file location when running a Mac source install '''
+        expected_path = os.path.join('/a/test/tmp/dir', 'AgentStatus.pickle')
+        self.assertEqual(AgentStatus._get_pickle_path(), expected_path)


### PR DESCRIPTION
Add a test that checks the logic of `AgentStatus._get_pickle_path` to ensure that the `.pickle` file gets written to an internal folder