### PR TITLE
Add docker_image_tagless tag to docker check

### DIFF
--- a/checks.d/docker.py
+++ b/checks.d/docker.py
@@ -178,6 +178,10 @@ class Docker(AgentCheck):
                 tag = self._make_tag(key, container[key], instance)
                 if tag:
                     container_tags.append(tag)
+                if key == "Image":
+                    itag = self._make_tag('docker_image_tagless', re.sub(':.*', '', container[key]), instance)
+                    if itag:
+                        container_tags.append(itag)
             if container['Id'] in running_containers_ids:
                 self.set("docker.containers.running", container['Id'], tags=container_tags)
             else:


### PR DESCRIPTION
Can be useful if you need to group images with same name but different tags