### PR TITLE
[flake8] enforce sane defaults for import order

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -10,7 +10,7 @@
     (C) Datadog, Inc. 2010-2014 all rights reserved
 '''
 # set up logging before importing any other components
-from config import get_version, initialize_logging
+from config import get_version, initialize_logging # noqa
 initialize_logging('collector')
 
 # stdlib
@@ -35,7 +35,7 @@ from config import (
 )
 from daemon import AgentSupervisor, Daemon
 from emitter import http_emitter
-from jmxfetch import JMXFetch, JMX_LIST_COMMANDS
+from jmxfetch import JMX_LIST_COMMANDS, JMXFetch
 from util import (
     EC2,
     get_hostname,

--- a/checks.d/apache.py
+++ b/checks.d/apache.py
@@ -1,12 +1,12 @@
 # stdlib
 import urlparse
 
-# project
-from util import headers
-from checks import AgentCheck
-
 # 3rd party
 import requests
+
+# project
+from checks import AgentCheck
+from util import headers
 
 
 class Apache(AgentCheck):

--- a/checks.d/btrfs.py
+++ b/checks.d/btrfs.py
@@ -1,16 +1,16 @@
 # stdlib
+import array
+from collections import defaultdict
+import fcntl
+import itertools
 import os
 import struct
-import array
-import itertools
-import fcntl
-from collections import defaultdict
-
-# project
-from checks import AgentCheck
 
 # 3rd party
 import psutil
+
+# project
+from checks import AgentCheck
 
 MIXED = "mixed"
 DATA = "data"

--- a/checks.d/cacti.py
+++ b/checks.d/cacti.py
@@ -1,11 +1,8 @@
 # stdlib
+from collections import namedtuple
 from fnmatch import fnmatch
 import os
 import time
-from collections import namedtuple
-
-# project
-from checks import AgentCheck
 
 # 3rd party
 try:
@@ -13,6 +10,9 @@ try:
 except ImportError:
     rrdtool = None
 import pymysql
+
+# project
+from checks import AgentCheck
 
 CFUNC_TO_AGGR = {
     'AVERAGE': 'avg',

--- a/checks.d/couchbase.py
+++ b/checks.d/couchbase.py
@@ -1,12 +1,12 @@
 # stdlib
 import re
 
-# project
-from util import headers
-from checks import AgentCheck
-
 # 3rd party
 import requests
+
+# project
+from checks import AgentCheck
+from util import headers
 
 # Constants
 COUCHBASE_STATS_PATH = '/pools/default'

--- a/checks.d/docker.py
+++ b/checks.d/docker.py
@@ -1,18 +1,18 @@
 # stdlib
-import urllib2
-import urllib
+from collections import defaultdict
 import httplib
-import socket
 import os
 import re
+import socket
 import time
+import urllib
+import urllib2
 from urlparse import urlsplit
-from util import json
-from collections import defaultdict
 
 # project
 from checks import AgentCheck
 from config import _is_affirmative
+from util import json
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'docker'
 

--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -1,5 +1,5 @@
 # stdlib
-from collections import namedtuple, defaultdict
+from collections import defaultdict, namedtuple
 import time
 import urlparse
 

--- a/checks.d/etcd.py
+++ b/checks.d/etcd.py
@@ -1,9 +1,9 @@
+# 3rd party
+import requests
+
 # project
 from checks import AgentCheck
 from util import headers
-
-# 3rd party
-import requests
 
 
 class Etcd(AgentCheck):

--- a/checks.d/fluentd.py
+++ b/checks.d/fluentd.py
@@ -5,9 +5,8 @@ import urlparse
 import requests
 
 # project
-from util import headers
 from checks import AgentCheck
-
+from util import headers
 
 
 class Fluentd(AgentCheck):

--- a/checks.d/gearmand.py
+++ b/checks.d/gearmand.py
@@ -1,8 +1,8 @@
-# project
-from checks import AgentCheck
-
 # 3rd party
 import gearman
+
+# project
+from checks import AgentCheck
 
 class Gearman(AgentCheck):
     SERVICE_CHECK_NAME = 'gearman.can_connect'

--- a/checks.d/go_expvar.py
+++ b/checks.d/go_expvar.py
@@ -1,12 +1,12 @@
 # stdlib
-import re
 from collections import defaultdict
-
-# project
-from checks import AgentCheck
+import re
 
 # 3rd party
 import requests
+
+# project
+from checks import AgentCheck
 
 DEFAULT_MAX_METRICS = 350
 PATH = "path"

--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -3,13 +3,13 @@ from collections import defaultdict
 import re
 import time
 
+# 3rd party
+import requests
+
 # project
 from checks import AgentCheck
 from config import _is_affirmative
 from util import headers
-
-# 3rd party
-import requests
 
 STATS_URL = "/;csv;norefresh"
 EVENT_TYPE = SOURCE_TYPE_NAME = 'haproxy'

--- a/checks.d/hdfs.py
+++ b/checks.d/hdfs.py
@@ -1,9 +1,9 @@
-# project
-from checks import AgentCheck
-
 # 3rd party
 import snakebite.client
 import snakebite.version
+
+# project
+from checks import AgentCheck
 
 # This is only available on snakebite >= 2.2.0
 # but snakebite 2.x is only compatible with hadoop >= 2.2.0

--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -1,18 +1,18 @@
 # stdlib
 from datetime import datetime
 import os.path
+import re
 import socket
 import ssl
 import time
-import re
 from urlparse import urlparse
 
 # 3rd party
-import tornado
 import requests
+import tornado
 
 # project
-from checks.network_checks import NetworkCheck, Status, EventType
+from checks.network_checks import EventType, NetworkCheck, Status
 from config import _is_affirmative
 from util import headers as agent_headers
 

--- a/checks.d/iis.py
+++ b/checks.d/iis.py
@@ -1,11 +1,11 @@
 '''
 Check the performance counters from IIS
 '''
-# project
-from checks import AgentCheck
-
 # 3rd party
 import wmi
+
+# project
+from checks import AgentCheck
 
 
 class IIS(AgentCheck):

--- a/checks.d/kyototycoon.py
+++ b/checks.d/kyototycoon.py
@@ -1,15 +1,16 @@
 # stdlib
-import re
 from collections import defaultdict
-
-# project
-from checks import AgentCheck
+import re
 
 # 3rd party
 import requests
 
+# project
+from checks import AgentCheck
+
 db_stats = re.compile(r'^db_(\d)+$')
 whitespace = re.compile(r'\s')
+
 
 class KyotoTycoonCheck(AgentCheck):
     """Report statistics about the Kyoto Tycoon DBM-style

--- a/checks.d/lighttpd.py
+++ b/checks.d/lighttpd.py
@@ -1,13 +1,13 @@
 # stdlib
-import urlparse
 import re
-
-# project
-from util import headers
-from checks import AgentCheck
+import urlparse
 
 # 3rd party
 import requests
+
+# project
+from checks import AgentCheck
+from util import headers
 
 VERSION_REGEX = re.compile(r".*/(\d)")
 

--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -1,11 +1,12 @@
 # stdlib
 from urlparse import urljoin
 
+# 3rd party
+import requests
+
 # project
 from checks import AgentCheck
 
-# 3rd party
-import requests
 
 class Marathon(AgentCheck):
 

--- a/checks.d/mcache.py
+++ b/checks.d/mcache.py
@@ -1,8 +1,8 @@
-# project
-from checks import AgentCheck
-
 # 3rd party
 import memcache
+
+# project
+from checks import AgentCheck
 
 # Ref: http://code.sixapart.com/svn/memcached/trunk/server/doc/protocol.txt
 # Name              Type     Meaning

--- a/checks.d/mesos.py
+++ b/checks.d/mesos.py
@@ -2,11 +2,11 @@
 from hashlib import md5
 import time
 
-# project
-from checks import AgentCheck
-
 # 3rd party
 import requests
+
+# project
+from checks import AgentCheck
 
 
 class Mesos(AgentCheck):

--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -1,16 +1,16 @@
 # stdlib
-import subprocess
 import os
-import sys
 import re
+import subprocess
+import sys
 import traceback
+
+# 3rd party
+import pymysql
 
 # project
 from checks import AgentCheck
 from utils.platform import Platform
-
-# 3rd party
-import pymysql
 
 GAUGE = "gauge"
 RATE = "rate"

--- a/checks.d/nagios.py
+++ b/checks.d/nagios.py
@@ -1,10 +1,10 @@
 # stdlib
-import re
 from collections import namedtuple
+import re
 
 # project
-from utils.tailfile import TailFile
 from checks import AgentCheck
+from utils.tailfile import TailFile
 
 # fields order for each event type, as named tuples
 EVENT_FIELDS = {

--- a/checks.d/nginx.py
+++ b/checks.d/nginx.py
@@ -1,14 +1,15 @@
 # stdlib
 import re
-import requests
 import urlparse
 
-# project
-from util import headers
-from checks import AgentCheck
-
 # 3rd party
+import requests
 import simplejson as json
+
+# project
+from checks import AgentCheck
+from util import headers
+
 
 class Nginx(AgentCheck):
     """Tracks basic nginx metrics via the status module

--- a/checks.d/pgbouncer.py
+++ b/checks.d/pgbouncer.py
@@ -2,9 +2,11 @@
 
 Collects metrics from the pgbouncer database.
 """
-from checks import AgentCheck, CheckException
-
+# 3p
 import psycopg2 as pg
+
+# project
+from checks import AgentCheck, CheckException
 
 
 class ShouldRestartException(Exception):

--- a/checks.d/postgres.py
+++ b/checks.d/postgres.py
@@ -2,13 +2,15 @@
 
 Collects database-wide metrics and optionally per-relation metrics, custom metrics.
 """
-# project
-from checks import AgentCheck, CheckException
+# stdlib
+import socket
 
 # 3rd party
 import pg8000 as pg
 from pg8000 import InterfaceError, ProgrammingError
-import socket
+
+# project
+from checks import AgentCheck, CheckException
 
 
 MAX_CUSTOM_RESULTS = 100

--- a/checks.d/rabbitmq.py
+++ b/checks.d/rabbitmq.py
@@ -1,8 +1,8 @@
 # stdlib
-import urlparse
-import time
 import re
+import time
 import urllib
+import urlparse
 
 # 3p
 import requests

--- a/checks.d/redisdb.py
+++ b/checks.d/redisdb.py
@@ -2,15 +2,15 @@
 Redis checks
 '''
 # stdlib
+from collections import defaultdict
 import re
 import time
-from collections import defaultdict
-
-# project
-from checks import AgentCheck
 
 # 3rd party
 import redis
+
+# project
+from checks import AgentCheck
 
 DEFAULT_MAX_SLOW_ENTRIES = 128
 MAX_SLOW_ENTRIES_KEY = "slowlog-max-len"

--- a/checks.d/riak.py
+++ b/checks.d/riak.py
@@ -1,12 +1,12 @@
 # stdlib
 import socket
 
+# 3rd party
+from httplib2 import Http, HttpLib2Error
+import simplejson as json
+
 # project
 from checks import AgentCheck
-
-# 3rd party
-import simplejson as json
-from httplib2 import Http, HttpLib2Error
 
 
 class Riak(AgentCheck):

--- a/checks.d/riakcs.py
+++ b/checks.d/riakcs.py
@@ -1,13 +1,13 @@
 # stdlib
 from collections import defaultdict
 
+# 3rd party
+from boto.s3.connection import S3Connection
+import simplejson as json
+
 # project
 from checks import AgentCheck
 from config import _is_affirmative
-
-# 3rd party
-import simplejson as json
-from boto.s3.connection import S3Connection
 
 
 def multidict(ordered_pairs):

--- a/checks.d/snmp.py
+++ b/checks.d/snmp.py
@@ -1,15 +1,16 @@
 # std
 from collections import defaultdict
 
+# 3rd party
+from pysnmp.entity.rfc3413.oneliner import cmdgen
+import pysnmp.proto.rfc1902 as snmp_type
+from pysnmp.smi import builder
+from pysnmp.smi.exval import noSuchInstance, noSuchObject
+
 # project
 from checks import AgentCheck
 from config import _is_affirmative
 
-# 3rd party
-from pysnmp.entity.rfc3413.oneliner import cmdgen
-from pysnmp.smi.exval import noSuchInstance, noSuchObject
-from pysnmp.smi import builder
-import pysnmp.proto.rfc1902 as snmp_type
 
 # Additional types that are not part of the SNMP protocol. cf RFC 2856
 (CounterBasedGauge64, ZeroBasedCounter64) = builder.MibBuilder().importSymbols(

--- a/checks.d/sqlserver.py
+++ b/checks.d/sqlserver.py
@@ -7,11 +7,11 @@ for information on how to report the metrics available in the sys.dm_os_performa
 # stdlib
 import traceback
 
-# project
-from checks import AgentCheck
-
 # 3rd party
 import adodbapi
+
+# project
+from checks import AgentCheck
 
 ALL_INSTANCES = 'ALL'
 VALID_METRIC_TYPES = ('gauge', 'rate', 'histogram')

--- a/checks.d/system_core.py
+++ b/checks.d/system_core.py
@@ -1,4 +1,7 @@
+# 3p
 import psutil
+
+# project
 from checks import AgentCheck
 
 

--- a/checks.d/system_swap.py
+++ b/checks.d/system_swap.py
@@ -1,5 +1,9 @@
-from checks import AgentCheck
+# 3p
 import psutil
+
+# project
+from checks import AgentCheck
+
 
 class SystemSwap(AgentCheck):
 

--- a/checks.d/tcp_check.py
+++ b/checks.d/tcp_check.py
@@ -3,7 +3,7 @@ import socket
 import time
 
 # project
-from checks.network_checks import NetworkCheck, Status, EventType
+from checks.network_checks import EventType, NetworkCheck, Status
 
 
 class BadConfException(Exception):

--- a/checks.d/teamcity.py
+++ b/checks.d/teamcity.py
@@ -1,6 +1,8 @@
 # stdlib
-import requests
 import time
+
+# 3p
+import requests
 
 # project
 from checks import AgentCheck

--- a/checks.d/tokumx.py
+++ b/checks.d/tokumx.py
@@ -2,10 +2,6 @@
 import time
 import types
 
-# project
-from checks import AgentCheck
-from util import get_hostname
-
 # 3p
 from pymongo import (
     MongoClient,
@@ -13,6 +9,10 @@ from pymongo import (
     uri_parser,
     version as py_version,
 )
+
+# project
+from checks import AgentCheck
+from util import get_hostname
 
 DEFAULT_TIMEOUT = 10
 

--- a/checks.d/vsphere.py
+++ b/checks.d/vsphere.py
@@ -2,7 +2,7 @@
 from copy import deepcopy
 from datetime import datetime, timedelta
 from hashlib import md5
-from Queue import Queue, Empty
+from Queue import Empty, Queue
 import re
 import time
 import traceback

--- a/checks.d/win32_event_log.py
+++ b/checks.d/win32_event_log.py
@@ -2,17 +2,18 @@
 Monitor the Windows Event Log
 '''
 # stdlib
-from datetime import datetime, timedelta
 import calendar
-
-# project
-from checks import AgentCheck
+from datetime import datetime, timedelta
 
 # 3rd party
 import wmi
 
+# project
+from checks import AgentCheck
+
 SOURCE_TYPE_NAME = 'event viewer'
 EVENT_TYPE = 'win32_log_event'
+
 
 class Win32EventLog(AgentCheck):
     def __init__(self, name, init_config, agentConfig):

--- a/checks.d/windows_service.py
+++ b/checks.d/windows_service.py
@@ -1,10 +1,10 @@
 """ Collect status information for Windows services
 """
-# project
-from checks import AgentCheck
-
 # 3rd party
 import wmi
+
+# project
+from checks import AgentCheck
 
 
 class WindowsService(AgentCheck):

--- a/checks.d/wmi_check.py
+++ b/checks.d/wmi_check.py
@@ -5,11 +5,11 @@ Generic WMI check. This check allows you to specify particular metrics that you
 want from WMI in your configuration. Check wmi_check.yaml.example in your conf.d
 directory for more details on configuration.
 '''
-# project
-from checks import AgentCheck
-
 # 3rd party
 import wmi
+
+# project
+from checks import AgentCheck
 
 UP_METRIC = 'Up'
 SEARCH_WILDCARD = '*'

--- a/checks.d/zk.py
+++ b/checks.d/zk.py
@@ -26,8 +26,8 @@ Tested with Zookeeper versions 3.0.0 to 3.4.5
 # stdlib
 import re
 import socket
-import struct
 from StringIO import StringIO
+import struct
 
 # project
 from checks import AgentCheck

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -24,7 +24,7 @@ import yaml
 
 # project
 from checks import check_status
-from util import LaconicFilter, get_hostname, get_next_id, yLoader
+from util import get_hostname, get_next_id, LaconicFilter, yLoader
 from utils.platform import Platform
 from utils.profile import pretty_statistics
 if Platform.is_windows():

--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -19,7 +19,7 @@ import yaml
 
 # project
 import config
-from config import get_config, _is_affirmative, _windows_commondata_path
+from config import _is_affirmative, _windows_commondata_path, get_config
 from util import plural
 from utils.jmxfiles import JMXFiles
 from utils.ntp import get_ntp_args

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -7,15 +7,15 @@ import sys
 import time
 
 # project
-from checks import AgentCheck, AGENT_METRICS_CHECK_NAME, create_service_check
+from checks import AGENT_METRICS_CHECK_NAME, AgentCheck, create_service_check
 from checks.check_status import (
     CheckStatus,
     CollectorStatus,
     EmitterStatus,
-    STATUS_OK,
     STATUS_ERROR,
+    STATUS_OK,
 )
-from checks.datadog import Dogstreams, DdForwarder
+from checks.datadog import DdForwarder, Dogstreams
 from checks.ganglia import Ganglia
 import checks.system.unix as u
 import checks.system.win32 as w32

--- a/checks/datadog.py
+++ b/checks/datadog.py
@@ -1,18 +1,18 @@
 # stdlib
-import glob
-import os
-import sys
-import traceback
-import re
-import time
 from datetime import datetime
-from itertools import groupby  # >= python 2.4
+import glob
+from itertools import groupby
+import os
+import re
+import sys
+import time
+import traceback
 
 # project
-import modules
 from checks import LaconicFilter
-from utils.tailfile import TailFile
+import modules
 from util import windows_friendly_colon_split
+from utils.tailfile import TailFile
 
 if hasattr('some string', 'partition'):
     def partition(s, sep):

--- a/checks/ganglia.py
+++ b/checks/ganglia.py
@@ -1,6 +1,10 @@
-from checks import Check
-import socket
+# stdlib
 from cStringIO import StringIO
+import socket
+
+# project
+from checks import Check
+
 
 class Ganglia(Check):
     BUFFER = 4096

--- a/checks/libs/thread_pool.py
+++ b/checks/libs/thread_pool.py
@@ -19,10 +19,10 @@
 #
 # The methods of a Pool object use all these concepts and expose
 # them to their caller in a very simple way.
-
+# stdlib
+import Queue
 import sys
 import threading
-import Queue
 import traceback
 
 

--- a/checks/network_checks.py
+++ b/checks/network_checks.py
@@ -1,25 +1,25 @@
 # stdlib
 from collections import defaultdict
+from Queue import Empty, Queue
 import threading
 import time
-from Queue import Queue, Empty
 
 # project
-from config import _is_affirmative
 from checks import AgentCheck
-
-# 3rd party
 from checks.libs.thread_pool import Pool
+from config import _is_affirmative
 
 TIMEOUT = 180
 DEFAULT_SIZE_POOL = 6
 MAX_LOOP_ITERATIONS = 1000
 FAILURE = "FAILURE"
 
+
 class Status:
     DOWN = "DOWN"
     WARNING = "WARNING"
     UP = "UP"
+
 
 class EventType:
     DOWN = "servicecheck.state_change.down"

--- a/config.py
+++ b/config.py
@@ -1,31 +1,30 @@
 import ConfigParser
-import os
+from cStringIO import StringIO
+import glob
+import imp
+import inspect
 import itertools
 import logging
 import logging.config
 import logging.handlers
+from optparse import OptionParser, Values
+import os
 import platform
+import re
+from socket import gaierror, gethostbyname
 import string
 import sys
-import glob
-import inspect
 import traceback
-import re
-import imp
-import socket
-from socket import gaierror
-from optparse import OptionParser, Values
-from cStringIO import StringIO
 from urlparse import urlparse
+
+# 3rd party
+import yaml
 
 # project
 from util import get_os, yLoader
 from utils.platform import Platform
 from utils.proxy import get_proxy
 from utils.subprocess_output import subprocess
-
-# 3rd party
-import yaml
 
 # CONSTANTS
 AGENT_VERSION = "5.5.0"
@@ -238,7 +237,7 @@ def get_config_path(cfg_path=None, os_name=None):
 
 def get_default_bind_host():
     try:
-        socket.gethostbyname('localhost')
+        gethostbyname('localhost')
     except gaierror:
         log.warning("localhost seems undefined in your hosts file, using 127.0.0.1 instead")
         return '127.0.0.1'

--- a/daemon.py
+++ b/daemon.py
@@ -12,12 +12,12 @@
 
 # Core modules
 import atexit
+import errno
+import logging
 import os
+import signal
 import sys
 import time
-import logging
-import errno
-import signal
 
 # 3p
 from psutil import pid_exists

--- a/ddagent.py
+++ b/ddagent.py
@@ -10,7 +10,7 @@
     (C) Datadog, Inc. 2010-2013 all rights reserved
 '''
 # set up logging before importing any other components
-from config import initialize_logging
+from config import initialize_logging  # noqa
 initialize_logging('forwarder')
 
 # stdlib
@@ -18,7 +18,7 @@ from datetime import timedelta
 import logging
 import os
 from Queue import Full, Queue
-from socket import gaierror, error as socket_error
+from socket import error as socket_error, gaierror
 import sys
 import threading
 import zlib
@@ -36,7 +36,7 @@ from tornado.escape import json_decode
 import tornado.httpclient
 import tornado.httpserver
 import tornado.ioloop
-from tornado.options import define, parse_command_line, options
+from tornado.options import define, options, parse_command_line
 import tornado.web
 
 # project
@@ -48,14 +48,14 @@ from config import (
     get_version
 )
 import modules
+from transaction import Transaction, TransactionManager
 from util import (
-    get_uuid,
     get_hostname,
     get_tornado_ioloop,
+    get_uuid,
     json,
     Watchdog,
 )
-from transaction import Transaction, TransactionManager
 
 log = logging.getLogger('forwarder')
 log.setLevel(get_logging_config()['log_level'] or logging.INFO)

--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -4,38 +4,40 @@ A Python Statsd implementation with some datadog special sauce.
 """
 
 # set up logging before importing any other components
-from config import initialize_logging
+from config import initialize_logging  # noqa
 initialize_logging('dogstatsd')
 
-import os
-os.umask(022)
 
-from utils.proxy import set_no_proxy_settings
+from utils.proxy import set_no_proxy_settings  # noqa
 set_no_proxy_settings()
 
 # stdlib
 import logging
 import optparse
+import os
 import select
 import signal
 import socket
 import sys
-import zlib
-from time import time, sleep
 import threading
+from time import sleep, time
 from urllib import urlencode
+import zlib
 
-# project
-from aggregator import MetricsBucketAggregator, get_formatter
-from checks.check_status import DogstatsdStatus
-from config import get_config, get_version
-from daemon import Daemon, AgentSupervisor
-from util import get_hostname, plural, get_uuid, chunks
-from utils.pidfile import PidFile
+# For pickle & PID files, see issue 293
+os.umask(022)
 
 # 3rd party
 import requests
 import simplejson as json
+
+# project
+from aggregator import get_formatter, MetricsBucketAggregator
+from checks.check_status import DogstatsdStatus
+from config import get_config, get_version
+from daemon import AgentSupervisor, Daemon
+from util import chunks, get_hostname, get_uuid, plural
+from utils.pidfile import PidFile
 
 # urllib3 logs a bunch of stuff at the info level
 requests_log = logging.getLogger("requests.packages.urllib3")

--- a/dogstream/supervisord_log.py
+++ b/dogstream/supervisord_log.py
@@ -6,9 +6,10 @@ Add to datadog.conf as follows:
 dogstreams: [path_to_supervisord.log]:datadog.streams.supervisord:parse_supervisord
 
 """
+# stdlib
 from datetime import datetime
-import time
 import re
+import time
 
 EVENT_TYPE = "supervisor"
 

--- a/graphite.py
+++ b/graphite.py
@@ -1,11 +1,13 @@
-import struct
-import logging
+# stdlib
 import cPickle as pickle
+import logging
+import struct
+
+# 3p
 from tornado.ioloop import IOLoop
 from tornado.tcpserver import TCPServer
 
 log = logging.getLogger(__name__)
-
 
 
 class GraphiteServer(TCPServer):

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -2,16 +2,21 @@
 import glob
 import logging
 import os
-import sys
 import signal
+import sys
 import time
 
 # 3rd party
 import yaml
 
 # datadog
-from config import get_config, get_confd_path, get_logging_config, \
-    PathNotFound, DEFAULT_CHECK_FREQUENCY
+from config import (
+    DEFAULT_CHECK_FREQUENCY,
+    get_confd_path,
+    get_config,
+    get_logging_config,
+    PathNotFound,
+)
 from util import get_os, yLoader
 from utils.jmxfiles import JMXFiles
 from utils.platform import Platform

--- a/modules.py
+++ b/modules.py
@@ -2,8 +2,8 @@
 """
 
 # stdlib
-import os
 import imp
+import os
 import re
 import sys
 

--- a/packaging/centos/setup-supervisor.py
+++ b/packaging/centos/setup-supervisor.py
@@ -1,7 +1,7 @@
 #! /usr/bin/python
-
-import sys
 import ConfigParser
+import sys
+
 
 def main():
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 nose==1.3.4
 flake8==2.4.0
+flake8-import-order==0.6.1
 mock==1.0.1

--- a/resources/__init__.py
+++ b/resources/__init__.py
@@ -1,9 +1,9 @@
-
+# stdlib
+from collections import namedtuple
 from datetime import datetime, timedelta
 import time
 from types import DictType, ListType, StringTypes
 
-from collections import namedtuple
 
 
 class agg(object):

--- a/resources/processes.py
+++ b/resources/processes.py
@@ -1,8 +1,8 @@
 # stdlib
+from collections import namedtuple
 import subprocess
 
 # project
-from collections import namedtuple
 from resources import (
     agg,
     ResourcePlugin,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 # stdlib
-from setuptools import setup, find_packages
 import sys
+
+# 3p
+from setuptools import find_packages, setup
 
 # project
 from config import get_version

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -3,17 +3,17 @@ import copy
 import inspect
 import logging
 import os
+from pprint import pformat
 import signal
 import sys
 import time
 import traceback
 import unittest
-from pprint import pformat
 
 # project
 from checks import AgentCheck
 from config import get_checksd_path
-from util import get_os, get_hostname
+from util import get_hostname, get_os
 from utils.debug import get_check  # noqa -  FIXME 5.5.0 AgentCheck tests should not use this
 
 log = logging.getLogger('tests')

--- a/tests/checks/integration/test_couch.py
+++ b/tests/checks/integration/test_couch.py
@@ -1,6 +1,9 @@
-from tests.checks.common import AgentCheckTest
+# 3p
 from nose.plugins.attrib import attr
+
+# project
 from checks import AgentCheck
+from tests.checks.common import AgentCheckTest
 
 
 @attr(requires='couchdb')

--- a/tests/checks/integration/test_elastic.py
+++ b/tests/checks/integration/test_elastic.py
@@ -1,14 +1,14 @@
 # stdlib
-import socket
 import os
+import socket
 
 # 3p
-import requests
 from nose.plugins.attrib import attr
+import requests
 
 # project
-from tests.checks.common import AgentCheckTest, load_check
 from config import get_version
+from tests.checks.common import AgentCheckTest, load_check
 
 STATS_METRICS = {  # Metrics that are common to all Elasticsearch versions
     "elasticsearch.docs.count": ("gauge", "indices.docs.count"),

--- a/tests/checks/integration/test_gearmand.py
+++ b/tests/checks/integration/test_gearmand.py
@@ -1,9 +1,9 @@
+# 3rd party
+from nose.plugins.attrib import attr
+
 # Agent
 from checks import AgentCheck
 from tests.checks.common import AgentCheckTest
-
-# 3rd party
-from nose.plugins.attrib import attr
 
 
 @attr(requires='gearman')

--- a/tests/checks/integration/test_go_expvar.py
+++ b/tests/checks/integration/test_go_expvar.py
@@ -1,7 +1,11 @@
+# stdlib
 from collections import defaultdict
-from nose.plugins.attrib import attr
 import time
 
+# 3p
+from nose.plugins.attrib import attr
+
+# project
 from tests.checks.common import AgentCheckTest
 
 

--- a/tests/checks/integration/test_haproxy.py
+++ b/tests/checks/integration/test_haproxy.py
@@ -1,7 +1,11 @@
+# stdlib
 import os
 
-from checks import AgentCheck
+# 3p
 from nose.plugins.attrib import attr
+
+# project
+from checks import AgentCheck
 from tests.checks.common import AgentCheckTest
 from util import get_hostname
 

--- a/tests/checks/integration/test_http_check.py
+++ b/tests/checks/integration/test_http_check.py
@@ -1,6 +1,10 @@
+# stdlibb
 import time
+
+# 3p
 import mock
 
+# project
 from checks import AgentCheck
 from tests.checks.common import AgentCheckTest
 

--- a/tests/checks/integration/test_mcache.py
+++ b/tests/checks/integration/test_mcache.py
@@ -1,7 +1,7 @@
 # stdlib
 import os
+from subprocess import PIPE, Popen
 import time
-from subprocess import Popen, PIPE
 
 # 3p
 import memcache

--- a/tests/checks/integration/test_nginx.py
+++ b/tests/checks/integration/test_nginx.py
@@ -1,7 +1,11 @@
+# stdlib
 import unittest
+
+# 3p
 from nose.plugins.attrib import attr
 
-from tests.checks.common import load_check, Fixtures
+# project
+from tests.checks.common import Fixtures, load_check
 
 
 @attr(requires='nginx')

--- a/tests/checks/integration/test_redisdb.py
+++ b/tests/checks/integration/test_redisdb.py
@@ -10,7 +10,7 @@ import redis
 
 # project
 from checks import AgentCheck
-from tests.checks.common import load_check, AgentCheckTest
+from tests.checks.common import AgentCheckTest, load_check
 
 logger = logging.getLogger()
 

--- a/tests/checks/integration/test_riak.py
+++ b/tests/checks/integration/test_riak.py
@@ -1,5 +1,10 @@
-from nose.plugins.attrib import attr
+# stdlib
 import socket
+
+# 3p
+from nose.plugins.attrib import attr
+
+# project
 from tests.checks.common import AgentCheckTest
 
 

--- a/tests/checks/integration/test_ssh_check.py
+++ b/tests/checks/integration/test_ssh_check.py
@@ -1,7 +1,13 @@
+# stdlib
 import unittest
+
+# 3p
 from nose.plugins.attrib import attr
-from tests.checks.common import load_check
+
+# project
 from checks import AgentCheck
+from tests.checks.common import load_check
+
 
 @attr(requires='ssh')
 class SshTestCase(unittest.TestCase):

--- a/tests/checks/integration/test_supervisord.py
+++ b/tests/checks/integration/test_supervisord.py
@@ -1,9 +1,12 @@
+# stdlib
 import os
 from time import sleep
-
-from nose.plugins.attrib import attr
 import unittest
 
+# 3p
+from nose.plugins.attrib import attr
+
+# project
 from tests.checks.common import get_check
 
 

--- a/tests/checks/integration/test_sysstat.py
+++ b/tests/checks/integration/test_sysstat.py
@@ -1,7 +1,10 @@
-import unittest
-from nose.plugins.attrib import attr
+# stdlib
 import logging
 import os
+import unittest
+
+# 3p
+from nose.plugins.attrib import attr
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__file__)

--- a/tests/checks/mock/test_agent_metrics.py
+++ b/tests/checks/mock/test_agent_metrics.py
@@ -1,6 +1,9 @@
+# 3p
 import mock
-from tests.checks.common import AgentCheckTest, load_check
+
+# project
 from checks import AGENT_METRICS_CHECK_NAME
+from tests.checks.common import AgentCheckTest, load_check
 
 MOCK_CONFIG = {
     'instances': [

--- a/tests/checks/mock/test_cacti.py
+++ b/tests/checks/mock/test_cacti.py
@@ -5,7 +5,7 @@ import shutil
 import unittest
 
 # project
-from tests.checks.common import get_check, Fixtures
+from tests.checks.common import Fixtures, get_check
 
 log = logging.getLogger()
 

--- a/tests/checks/mock/test_directory.py
+++ b/tests/checks/mock/test_directory.py
@@ -1,9 +1,10 @@
+# stdlib
 from itertools import product
 import os
-import tempfile
 import shutil
+import tempfile
 
-
+# project
 from tests.checks.common import AgentCheckTest
 
 

--- a/tests/checks/mock/test_disk.py
+++ b/tests/checks/mock/test_disk.py
@@ -1,6 +1,8 @@
 # stdlib
-import mock
 import re
+
+# 3p
+import mock
 
 # project
 from tests.checks.common import AgentCheckTest, Fixtures

--- a/tests/checks/mock/test_go_expvar.py
+++ b/tests/checks/mock/test_go_expvar.py
@@ -1,8 +1,12 @@
+# stdlib
 from collections import defaultdict
 import copy
-import simplejson as json
 import time
 
+# 3p
+import simplejson as json
+
+# project
 from tests.checks.common import AgentCheckTest, Fixtures
 
 

--- a/tests/checks/mock/test_mesos_master.py
+++ b/tests/checks/mock/test_mesos_master.py
@@ -1,19 +1,28 @@
-from tests.checks.common import AgentCheckTest, get_check_class, Fixtures
-
-from nose.plugins.attrib import attr
-from mock import patch
+# stdlib
 import json
+
+# 3p
+from mock import patch
+from nose.plugins.attrib import attr
+
+# project
+from tests.checks.common import AgentCheckTest, Fixtures, get_check_class
 
 
 def _mocked_get_master_state(*args, **kwargs):
     state = json.loads(Fixtures.read_file('state.json'))
     return state
+
+
 def _mocked_get_master_stats(*args, **kwargs):
     stats = json.loads(Fixtures.read_file('stats.json'))
     return stats
+
+
 def _mocked_get_master_roles(*args, **kwargs):
     roles = json.loads(Fixtures.read_file('roles.json'))
     return roles
+
 
 @attr(requires='mesos_master')
 class TestMesosMaster(AgentCheckTest):

--- a/tests/checks/mock/test_mesos_slave.py
+++ b/tests/checks/mock/test_mesos_slave.py
@@ -1,9 +1,13 @@
-from tests.checks.common import AgentCheckTest, get_check_class, Fixtures
-
-from nose.plugins.attrib import attr
-from mock import patch
-from checks import AgentCheck
+# stdlib
 import json
+
+# 3p
+from mock import patch
+from nose.plugins.attrib import attr
+
+# project
+from checks import AgentCheck
+from tests.checks.common import AgentCheckTest, Fixtures, get_check_class
 
 
 def _mocked_get_state(*args, **kwargs):

--- a/tests/checks/mock/test_postfix.py
+++ b/tests/checks/mock/test_postfix.py
@@ -2,7 +2,7 @@
 import binascii
 import logging
 import os
-from random import shuffle, sample
+from random import sample, shuffle
 import re
 import shutil
 import unittest

--- a/tests/checks/mock/test_riakcs.py
+++ b/tests/checks/mock/test_riakcs.py
@@ -1,8 +1,13 @@
-import unittest
-from tests.checks.common import load_check, Fixtures, AgentCheckTest
-from mock import Mock
+# stdlib
 from socket import error
+import unittest
+
+# 3p
+from mock import Mock
+
+# project
 from checks import AgentCheck
+from tests.checks.common import AgentCheckTest, Fixtures, load_check
 
 
 class RiakCSTest(AgentCheckTest):

--- a/tests/checks/mock/test_supervisord.py
+++ b/tests/checks/mock/test_supervisord.py
@@ -1,9 +1,12 @@
+# stdlib
 from socket import socket
-
-from mock import patch
 import unittest
 import xmlrpclib
 
+# 3p
+from mock import patch
+
+# project
 from checks import AgentCheck
 from tests.checks.common import get_check
 

--- a/tests/core/test_check_status.py
+++ b/tests/core/test_check_status.py
@@ -1,7 +1,15 @@
-
-from checks import AgentCheck
-from checks.check_status import STATUS_OK, STATUS_ERROR, InstanceStatus, CheckStatus, CollectorStatus
+# stdlib
 import nose.tools as nt
+
+# project
+from checks import AgentCheck
+from checks.check_status import (
+    CheckStatus,
+    CollectorStatus,
+    InstanceStatus,
+    STATUS_ERROR,
+    STATUS_OK,
+)
 
 
 class DummyAgentCheck(AgentCheck):
@@ -13,9 +21,9 @@ class DummyAgentCheck(AgentCheck):
 
 def test_check_status_fail():
     instances = [
-        {'pass':True},
-        {'pass':False},
-        {'pass':True}
+        {'pass': True},
+        {'pass': False},
+        {'pass': True}
     ]
 
     check = DummyAgentCheck('dummy_agent_check', {}, {}, instances)
@@ -28,8 +36,8 @@ def test_check_status_fail():
 
 def test_check_status_pass():
     instances = [
-        {'pass':True},
-        {'pass':True},
+        {'pass': True},
+        {'pass': True},
     ]
 
     check = DummyAgentCheck('dummy_agent_check', {}, {}, instances)

--- a/tests/core/test_datadog.py
+++ b/tests/core/test_datadog.py
@@ -1,8 +1,11 @@
 # stdlib
+import calendar
+from datetime import datetime
 import logging
 import os
 import re
 from tempfile import gettempdir, NamedTemporaryFile
+import time
 import unittest
 
 # project
@@ -47,13 +50,10 @@ class ParseClassPlugin(object):
         res[3] = {'metric_type': 'counter'}
         return tuple(res)
 
-import time
-from datetime import datetime
-import calendar
 
 log_event_pattern = re.compile("".join([
-    r"(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) ", # iso timestamp
-    r"\[(?P<alert_type>(ERROR)|(RECOVERY))\] - ", # alert type
+    r"(?P<timestamp>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) ",  # iso timestamp
+    r"\[(?P<alert_type>(ERROR)|(RECOVERY))\] - ",  # alert type
     r"(?P<msg_title>(?P<host>[^ ]*).*)"
 ]))
 alert_types = {

--- a/tests/core/test_dogstatsd.py
+++ b/tests/core/test_dogstatsd.py
@@ -9,7 +9,7 @@ from nose.plugins.attrib import attr
 import nose.tools as nt
 
 # project
-from aggregator import MetricsAggregator, get_formatter, DEFAULT_HISTOGRAM_AGGREGATES
+from aggregator import DEFAULT_HISTOGRAM_AGGREGATES, get_formatter, MetricsAggregator
 
 
 class TestUnitDogStatsd(unittest.TestCase):

--- a/tests/core/test_ec2.py
+++ b/tests/core/test_ec2.py
@@ -1,7 +1,9 @@
 # stdlib
-import unittest
-import types
 import time
+import types
+
+# 3p
+import unittest
 
 # project
 from util import EC2

--- a/tests/core/test_emitter.py
+++ b/tests/core/test_emitter.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
+# 3p
 import unittest
+
+# project
 from emitter import remove_control_chars
+
 
 class TestEmitter(unittest.TestCase):
 

--- a/tests/core/test_flare.py
+++ b/tests/core/test_flare.py
@@ -1,9 +1,9 @@
 # stdlib
-import mock
 import os.path
 import unittest
 
 # 3p
+import mock
 from nose.plugins.attrib import attr
 
 # project

--- a/tests/core/test_histogram.py
+++ b/tests/core/test_histogram.py
@@ -1,6 +1,8 @@
+# stdlib
 import unittest
 
-from aggregator import MetricsAggregator, Histogram
+# project
+from aggregator import Histogram, MetricsAggregator
 from config import get_histogram_aggregates, get_histogram_percentiles
 
 class TestHistogram(unittest.TestCase):

--- a/tests/core/test_payload.py
+++ b/tests/core/test_payload.py
@@ -1,10 +1,11 @@
+# stdlib
 import unittest
+
+#  3p
+from mock import Mock
 
 # project
 from checks.collector import AgentPayload
-
-# 3p
-from mock import Mock
 
 
 class TestAgentPayload(unittest.TestCase):

--- a/tests/core/test_transaction.py
+++ b/tests/core/test_transaction.py
@@ -1,18 +1,21 @@
 # stdlib
+from datetime import datetime, timedelta
 import unittest
-from datetime import timedelta, datetime
 
 # 3rd party
 from nose.plugins.attrib import attr
-from tornado.web import Application
 import requests
 import simplejson as json
+from tornado.web import Application
 
 # project
 from config import get_version
 from ddagent import (
-    MAX_QUEUE_SIZE, THROTTLING_DELAY,
-    APIMetricTransaction, APIServiceCheckTransaction, MetricTransaction
+    APIMetricTransaction,
+    APIServiceCheckTransaction,
+    MAX_QUEUE_SIZE,
+    MetricTransaction,
+    THROTTLING_DELAY,
 )
 from transaction import Transaction, TransactionManager
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,3 +2,5 @@
 exclude = venv/*,embedded/*,.git/*
 max-line-length = 700
 ignore = E128,E203,E226,E231,E241,E251,E261,E265,E302,E303,F841
+application-import-names = agent,aggregator,checks,config,daemon,ddagent,dogstatsd,emitter,graphite,jmxfetch,modules,resources,tests,transaction,util,utils
+import-order-style = google

--- a/transaction.py
+++ b/transaction.py
@@ -1,9 +1,9 @@
 # stdlib
-import sys
-import time
 from datetime import datetime, timedelta
 import logging
 from operator import attrgetter
+import sys
+import time
 
 # project
 from checks.check_status import ForwarderStatus

--- a/util.py
+++ b/util.py
@@ -1,5 +1,4 @@
 # stdlib
-
 from hashlib import md5
 import logging
 import math
@@ -7,7 +6,6 @@ import os
 import platform
 import re
 import signal
-import simplejson as json
 import socket
 import sys
 import time
@@ -16,6 +14,7 @@ import urllib2
 import uuid
 
 # 3p
+import simplejson as json
 import yaml  # noqa, let's guess, probably imported somewhere
 from tornado import ioloop
 try:

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -1,3 +1,4 @@
+# stdlib
 import atexit
 import cStringIO as StringIO
 import glob
@@ -9,6 +10,9 @@ import sys
 import tarfile
 import tempfile
 from time import strftime
+
+# 3p
+import requests
 
 # DD imports
 from checks.check_status import CollectorStatus, DogstatsdStatus, ForwarderStatus
@@ -22,9 +26,6 @@ from config import (
 )
 from util import get_hostname
 from utils.platform import Platform
-
-# 3p
-import requests
 
 # Globals
 log = logging.getLogger(__name__)

--- a/utils/profile.py
+++ b/utils/profile.py
@@ -1,8 +1,8 @@
 # stdlib
-import cProfile
+import cProfile  # noqa, it seems that import-names thinks it's not stdlib
 from cStringIO import StringIO
 import logging
-import pstats
+import pstats  # noqa, same here
 
 log = logging.getLogger('collector')
 

--- a/win32/agent.py
+++ b/win32/agent.py
@@ -1,12 +1,13 @@
 # stdlib
 from collections import deque
 import logging
-import modules
 import multiprocessing
 from optparse import Values
-import servicemanager
 import sys
 import time
+
+# 3p
+import servicemanager
 from win32.common import handle_exe_click
 import win32event
 import win32service
@@ -15,17 +16,18 @@ import win32serviceutil
 # project
 from checks.collector import Collector
 from config import (
-    get_config,
     get_confd_path,
+    get_config,
     get_system_stats,
     load_check_directory,
-    set_win32_cert_path,
     PathNotFound,
+    set_win32_cert_path,
 )
 from ddagent import Application
 import dogstatsd
 from emitter import http_emitter
 from jmxfetch import JMXFetch
+import modules
 from util import get_hostname, get_os
 from utils.jmxfiles import JMXFiles
 

--- a/win32/gui.py
+++ b/win32/gui.py
@@ -5,42 +5,47 @@
 # Licensed under the terms of the CECILL License
 # Modified for Datadog
 
-import sys
+# stdlib
+import logging
 import os
 import os.path as osp
-import thread  # To manage the windows process asynchronously
-import logging
 import platform
-import win32serviceutil
-import win32service
+import sys
+import thread  # To manage the windows process asynchronously
 
+# 3p
 # GUI Imports
-from guidata.qt.QtGui import (QWidget, QVBoxLayout, QSplitter, QFont,
-                              QListWidget, QPushButton, QLabel, QGroupBox,
-                              QHBoxLayout, QMessageBox, QInputDialog,
-                              QSystemTrayIcon, QMenu, QTextEdit)
-from guidata.qt.QtCore import SIGNAL, Qt, QSize, QPoint, QTimer
-
-from guidata.configtools import get_icon, get_family, MONOSPACE
+from guidata.configtools import get_family, get_icon, MONOSPACE
+from guidata.qt.QtCore import QPoint, QSize, Qt, QTimer, SIGNAL
+from guidata.qt.QtGui import (QFont, QGroupBox, QHBoxLayout, QInputDialog,
+                              QLabel, QListWidget, QMenu, QMessageBox,
+                              QPushButton, QSplitter, QSystemTrayIcon,
+                              QTextEdit, QVBoxLayout, QWidget)
 from guidata.qthelpers import get_std_icon
-from spyderlib.widgets.sourcecode.codeeditor import CodeEditor
 
 # small hack to avoid having to patch the spyderlib library
 # Needed because of py2exe bundling not being able to access
 # the spyderlib image sources
 import spyderlib.baseconfig
 spyderlib.baseconfig.IMG_PATH = [""]
+from spyderlib.widgets.sourcecode.codeeditor import CodeEditor
+
+# Windows management & others
+import tornado.template as template
+import win32service
+import win32serviceutil
+import yaml
 
 # Datadog
+from checks.check_status import CollectorStatus, DogstatsdStatus, ForwarderStatus, logger_info
+from config import (
+    _windows_commondata_path,
+    get_confd_path,
+    get_config,
+    get_config_path,
+    get_version,
+)
 from util import get_os, yLoader
-from config import (get_confd_path, get_config_path, get_config,
-    _windows_commondata_path, get_version)
-from checks.check_status import DogstatsdStatus, ForwarderStatus, CollectorStatus, logger_info
-
-# 3rd Party
-import yaml
-import tornado.template as template
-
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
1 - stdlib
2 - 3p
3 - dd-agent
With alphabetical sort inside each category, and also for functions/classes
imported.