### PR TITLE
[packaging] do not fail if non-datadog repos are in a bad state

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -109,7 +109,7 @@ if [ $OS = "RedHat" ]; then
             $sudo_cmd yum -y remove datadog-agent-base
         fi
     fi
-    $sudo_cmd yum -y install datadog-agent
+    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install datadog-agent
 elif [ $OS = "Debian" ]; then
     printf "\033[34m\n* Installing APT package sources for Datadog\n\033[0m\n"
     $sudo_cmd sh -c "echo 'deb http://apt.datadoghq.com/ stable main' > /etc/apt/sources.list.d/datadog.list"

--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -123,7 +123,7 @@ see the logs above to determine the cause.
 If the failing repository is Datadog, please contact Datadog support.
 *****
 "
-    $sudo_cmd apt-get update
+    $sudo_cmd apt-get update -o Dir::Etc::sourcelist="sources.list.d/datadog.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
     ERROR_MESSAGE="ERROR
 Failed to install the Datadog package, sometimes it may be
 due to another APT source failing. See the logs above to


### PR DESCRIPTION
Tested on CentOS 5 and Ubuntu 12 (needs to be run on dd-agent-testing).