### PR TITLE
[disk] disable all_partitions by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@ Changes
 =======
 
 # 5.4.1 / 06-16-2015
+**Linux or Source Install only**
 
 ### Details
 https://github.com/DataDog/dd-agent/compare/5.4.0...5.4.1
 
 ### Changes
-* [BUGFIX] Disk: get metrics only from physical disk by default. See [#1700][]
+* [BUGFIX] Disk: Get metrics only from physical disk by default. See [#1700][]
+* [BUGFIX] Kafka: Fix indentation issue in the configuration YAML example file. See [#1701][]
 
 
 # 5.4.0 / 06-16-2015
@@ -1738,6 +1740,7 @@ If you use ganglia, you want this version.
 [#1666]: https://github.com/DataDog/dd-agent/issues/1666
 [#1679]: https://github.com/DataDog/dd-agent/issues/1679
 [#1700]: https://github.com/DataDog/dd-agent/issues/1700
+[#1701]: https://github.com/DataDog/dd-agent/issues/1701
 [@AirbornePorcine]: https://github.com/AirbornePorcine
 [@CaptTofu]: https://github.com/CaptTofu
 [@Osterjour]: https://github.com/Osterjour

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changes
 =======
 
+# 5.4.1 / 06-16-2015
+
+### Details
+https://github.com/DataDog/dd-agent/compare/5.4.0...5.4.1
+
+### Changes
+* [BUGFIX] Disk: get metrics only from physical disk by default. See [#1700][]
+
+
 # 5.4.0 / 06-16-2015
 ### Details
 https://github.com/DataDog/dd-agent/compare/5.3.2...5.4.0
@@ -1728,6 +1737,7 @@ If you use ganglia, you want this version.
 [#1664]: https://github.com/DataDog/dd-agent/issues/1664
 [#1666]: https://github.com/DataDog/dd-agent/issues/1666
 [#1679]: https://github.com/DataDog/dd-agent/issues/1679
+[#1700]: https://github.com/DataDog/dd-agent/issues/1700
 [@AirbornePorcine]: https://github.com/AirbornePorcine
 [@CaptTofu]: https://github.com/CaptTofu
 [@Osterjour]: https://github.com/Osterjour

--- a/checks.d/disk.py
+++ b/checks.d/disk.py
@@ -49,8 +49,12 @@ class Disk(AgentCheck):
         self._excluded_disks = instance.get('excluded_disks', [])
         self._tag_by_filesystem = _is_affirmative(
             instance.get('tag_by_filesystem', False))
+        # On Windows, we need all_partitions to True by default to collect
+        # metrics about remote disks
+        # On Linux, we need all_partitions to False to avoid collecting metrics
+        # about nodev filesystems
         self._all_partitions = _is_affirmative(
-            instance.get('all_partitions', True))
+            instance.get('all_partitions', Platform.is_win32()))
 
         # FIXME: 6.x, drop use_mount option in datadog.conf
         self._load_legacy_option(instance, 'use_mount', False,

--- a/conf.d/disk.yaml.default
+++ b/conf.d/disk.yaml.default
@@ -24,6 +24,7 @@ instances:
     # tag_by_filesystem: no
     #
     # The (optional) all_partitions parameter will instruct the check to
-    # only get metrics for physical disks if set to no
-    # all_partitions: yes
-
+    # get metrics for all partitions (and not only physical disks)
+    # On Windows, this parameter default is 'yes' in order to get remote disks
+    # metrics; if they are not needed, set it to 'no'
+    # all_partitions: no

--- a/tests/checks/mock/test_disk.py
+++ b/tests/checks/mock/test_disk.py
@@ -172,6 +172,7 @@ class TestCheckDisk(AgentCheckTest):
                         agent_config={'use_mount': 'yes'})
         self.assertFalse(self.check._use_mount)
 
+    # FIXME: test default options on Windows (not the same all_partitions)
     def test_default_options(self):
         self.load_check({'instances': [{}]})
         self.check._load_conf({})
@@ -180,7 +181,7 @@ class TestCheckDisk(AgentCheckTest):
         self.assertEqual(self.check._excluded_filesystems, [])
         self.assertEqual(self.check._excluded_disks, [])
         self.assertFalse(self.check._tag_by_filesystem)
-        self.assertTrue(self.check._all_partitions)
+        self.assertFalse(self.check._all_partitions)
         self.assertEqual(self.check._excluded_disk_re, re.compile('^$'))
 
     def test_ignore_empty_regex(self):


### PR DESCRIPTION
Otherwise a lot of useless/temp partitions appear.
See https://github.com/giampaolo/psutil/blob/58711c2db81d437fdcf5b8aedf68bfd00fc089fd/psutil/_pslinux.py#L651-L653