### PR TITLE
Fixing indentation issue on alias kafka.net.bytes_out

### DIFF
--- a/conf.d/kafka.yaml.example
+++ b/conf.d/kafka.yaml.example
@@ -35,7 +35,7 @@ init_config:
         attribute:
           MeanRate:
             metric_type: gauge
-          alias: kafka.net.bytes_out
+            alias: kafka.net.bytes_out
     - include:
         domain: 'kafka.server'
         bean: 'kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec'


### PR DESCRIPTION
Fixing indentation issue in the kafka.yaml.example file regarding kafka.net.bytes.