### PR TITLE
Collect the number of rabbitmq partitions per node

### DIFF
--- a/checks.d/rabbitmq.py
+++ b/checks.d/rabbitmq.py
@@ -19,43 +19,44 @@ MAX_DETAILED_NODES = 100
 # collect is above 90% of the limit:
 ALERT_THRESHOLD = 0.9
 QUEUE_ATTRIBUTES = [
-    # Path, Name
-    ('active_consumers', 'active_consumers'),
-    ('consumers', 'consumers'),
-    ('consumer_utilisation', 'consumer_utilisation'),
+    # Path, Name, Operation
+    ('active_consumers', 'active_consumers', float),
+    ('consumers', 'consumers', float),
+    ('consumer_utilisation', 'consumer_utilisation', float),
 
-    ('memory', 'memory'),
+    ('memory', 'memory', float),
 
-    ('messages', 'messages'),
-    ('messages_details/rate', 'messages.rate'),
+    ('messages', 'messages', float),
+    ('messages_details/rate', 'messages.rate', float),
 
-    ('messages_ready', 'messages_ready'),
-    ('messages_ready_details/rate', 'messages_ready.rate'),
+    ('messages_ready', 'messages_ready', float),
+    ('messages_ready_details/rate', 'messages_ready.rate', float),
 
-    ('messages_unacknowledged', 'messages_unacknowledged'),
-    ('messages_unacknowledged_details/rate', 'messages_unacknowledged.rate'),
+    ('messages_unacknowledged', 'messages_unacknowledged', float),
+    ('messages_unacknowledged_details/rate', 'messages_unacknowledged.rate', float),
 
-    ('message_stats/ack', 'messages.ack.count'),
-    ('message_stats/ack_details/rate', 'messages.ack.rate'),
+    ('message_stats/ack', 'messages.ack.count', float),
+    ('message_stats/ack_details/rate', 'messages.ack.rate', float),
 
-    ('message_stats/deliver', 'messages.deliver.count'),
-    ('message_stats/deliver_details/rate', 'messages.deliver.rate'),
+    ('message_stats/deliver', 'messages.deliver.count', float),
+    ('message_stats/deliver_details/rate', 'messages.deliver.rate', float),
 
-    ('message_stats/deliver_get', 'messages.deliver_get.count'),
-    ('message_stats/deliver_get_details/rate', 'messages.deliver_get.rate'),
+    ('message_stats/deliver_get', 'messages.deliver_get.count', float),
+    ('message_stats/deliver_get_details/rate', 'messages.deliver_get.rate', float),
 
-    ('message_stats/publish', 'messages.publish.count'),
-    ('message_stats/publish_details/rate', 'messages.publish.rate'),
+    ('message_stats/publish', 'messages.publish.count', float),
+    ('message_stats/publish_details/rate', 'messages.publish.rate', float),
 
-    ('message_stats/redeliver', 'messages.redeliver.count'),
-    ('message_stats/redeliver_details/rate', 'messages.redeliver.rate'),
+    ('message_stats/redeliver', 'messages.redeliver.count', float),
+    ('message_stats/redeliver_details/rate', 'messages.redeliver.rate', float),
 ]
 
 NODE_ATTRIBUTES = [
-    ('fd_used', 'fd_used'),
-    ('mem_used', 'mem_used'),
-    ('run_queue', 'run_queue'),
-    ('sockets_used', 'sockets_used'),
+    ('fd_used', 'fd_used', float),
+    ('mem_used', 'mem_used', float),
+    ('run_queue', 'run_queue', float),
+    ('sockets_used', 'sockets_used', float),
+    ('partitions', 'partitions', len)
 ]
 
 ATTRIBUTES = {
@@ -248,7 +249,7 @@ class RabbitMQ(AgentCheck):
                 # FIXME 6.x: remove this suffix or unify (sc doesn't have it)
                 tags.append('rabbitmq_%s:%s' % (tag_list[t], tag))
 
-        for attribute, metric_name in ATTRIBUTES[object_type]:
+        for attribute, metric_name, operation in ATTRIBUTES[object_type]:
             # Walk down through the data path, e.g. foo/bar => d['foo']['bar']
             root = data
             keys = attribute.split('/')
@@ -259,7 +260,7 @@ class RabbitMQ(AgentCheck):
             if value is not None:
                 try:
                     self.gauge('rabbitmq.%s.%s' % (
-                        METRIC_SUFFIX[object_type], metric_name), float(value), tags=tags)
+                        METRIC_SUFFIX[object_type], metric_name), operation(value), tags=tags)
                 except ValueError:
                     self.log.debug("Caught ValueError for %s %s = %s  with tags: %s" % (
                         METRIC_SUFFIX[object_type], attribute, value, tags))

--- a/tests/checks/integration/test_rabbitmq.py
+++ b/tests/checks/integration/test_rabbitmq.py
@@ -33,6 +33,7 @@ COMMON_METRICS = [
     'rabbitmq.node.mem_used',
     'rabbitmq.node.run_queue',
     'rabbitmq.node.sockets_used',
+    'rabbitmq.node.partitions'
 ]
 
 
@@ -46,6 +47,8 @@ class RabbitMQCheckTest(AgentCheckTest):
         # Node attributes
         for mname in COMMON_METRICS:
             self.assertMetricTagPrefix(mname, 'rabbitmq_node', count=1)
+
+        self.assertMetric('rabbitmq.node.partitions', value=0)
 
         # Queue attributes, should be only one queue fetched
         # TODO: create a 'fake consumer' and get missing metrics
@@ -65,6 +68,8 @@ class RabbitMQCheckTest(AgentCheckTest):
         for mname in Q_METRICS:
             self.assertMetricTag('rabbitmq.queue.%s' %
                                  mname, 'rabbitmq_queue:test1', count=1)
+
+        self.assertMetric('rabbitmq.queue.messages', value=1, count=1)
 
         self.assertServiceCheckOK('rabbitmq.aliveness', tags=['vhost:/'])
 

--- a/tests/checks/integration/test_rabbitmq.py
+++ b/tests/checks/integration/test_rabbitmq.py
@@ -48,7 +48,7 @@ class RabbitMQCheckTest(AgentCheckTest):
         for mname in COMMON_METRICS:
             self.assertMetricTagPrefix(mname, 'rabbitmq_node', count=1)
 
-        self.assertMetric('rabbitmq.node.partitions', value=0)
+        self.assertMetric('rabbitmq.node.partitions', value=0, count=1)
 
         # Queue attributes, should be only one queue fetched
         # TODO: create a 'fake consumer' and get missing metrics
@@ -68,8 +68,6 @@ class RabbitMQCheckTest(AgentCheckTest):
         for mname in Q_METRICS:
             self.assertMetricTag('rabbitmq.queue.%s' %
                                  mname, 'rabbitmq_queue:test1', count=1)
-
-        self.assertMetric('rabbitmq.queue.messages', value=1, count=1)
 
         self.assertServiceCheckOK('rabbitmq.aliveness', tags=['vhost:/'])
 


### PR DESCRIPTION
When running a RabbitMQ cluster, the "partitions" attribute in the response of /api/nodes indicates if the cluster is in a split brain situation:
```
...
"partitions": []
...
```
The length of this array is collected as the metric "rabbitmq.node.partitions"