### PR TITLE
[http_check] Improve SSL cert configuration & validation

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -167,7 +167,7 @@ class HTTPCheck(NetworkCheck):
                 ))
 
         if ssl_expire and urlparse(addr)[0] == "https":
-            status, msg = self.check_cert_expiration(instance)
+            status, msg = self.check_cert_expiration(instance, timeout)
             service_checks.append((
                 self.SC_SSL_CERT, status, msg
             ))
@@ -273,7 +273,7 @@ class HTTPCheck(NetworkCheck):
                            message=msg
                            )
 
-    def check_cert_expiration(self, instance):
+    def check_cert_expiration(self, instance, timeout):
         warning_days = int(instance.get('days_warning', 14))
         url = instance.get('url')
 
@@ -284,6 +284,7 @@ class HTTPCheck(NetworkCheck):
 
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(float(timeout))
             sock.connect((host, port))
             ssl_sock = ssl.wrap_socket(sock, cert_reqs=ssl.CERT_REQUIRED,
                                        ca_certs=self.ca_certs)

--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -60,14 +60,15 @@ class HTTPCheck(NetworkCheck):
         include_content = _is_affirmative(instance.get('include_content', False))
         ssl = _is_affirmative(instance.get('disable_ssl_validation', True))
         ssl_expire = _is_affirmative(instance.get('check_certificate_expiration', True))
+        instance_ca_certs = instance.get('ca_certs', self.ca_certs)
 
         return url, username, password, http_response_status_code, timeout, include_content,\
-            headers, response_time, content_match, tags, ssl, ssl_expire
+            headers, response_time, content_match, tags, ssl, ssl_expire, instance_ca_certs
 
     def _check(self, instance):
         addr, username, password, http_response_status_code, timeout, include_content, headers,\
             response_time, content_match, tags, disable_ssl_validation,\
-            ssl_expire = self._load_conf(instance)
+            ssl_expire, instance_ca_certs = self._load_conf(instance)
         start = time.time()
 
         service_checks = []
@@ -83,7 +84,7 @@ class HTTPCheck(NetworkCheck):
                 auth = (username, password)
 
             r = requests.get(addr, auth=auth, timeout=timeout, headers=headers,
-                             verify=not disable_ssl_validation)
+                             verify=False if disable_ssl_validation else instance_ca_certs)
 
         except socket.timeout, e:
             length = int((time.time() - start) * 1000)
@@ -167,7 +168,7 @@ class HTTPCheck(NetworkCheck):
                 ))
 
         if ssl_expire and urlparse(addr)[0] == "https":
-            status, msg = self.check_cert_expiration(instance, timeout)
+            status, msg = self.check_cert_expiration(instance, timeout, instance_ca_certs)
             service_checks.append((
                 self.SC_SSL_CERT, status, msg
             ))
@@ -273,7 +274,7 @@ class HTTPCheck(NetworkCheck):
                            message=msg
                            )
 
-    def check_cert_expiration(self, instance, timeout):
+    def check_cert_expiration(self, instance, timeout, instance_ca_certs):
         warning_days = int(instance.get('days_warning', 14))
         url = instance.get('url')
 
@@ -287,7 +288,7 @@ class HTTPCheck(NetworkCheck):
             sock.settimeout(float(timeout))
             sock.connect((host, port))
             ssl_sock = ssl.wrap_socket(sock, cert_reqs=ssl.CERT_REQUIRED,
-                                       ca_certs=self.ca_certs)
+                                       ca_certs=instance_ca_certs)
             cert = ssl_sock.getpeercert()
 
         except Exception as e:

--- a/conf.d/http_check.yaml.example
+++ b/conf.d/http_check.yaml.example
@@ -60,13 +60,22 @@ instances:
     # This is mostly useful when checking SSL connections signed with
     # certificates that are not themselves signed by a public authority.
     # When true, the check logs a warning in collector.log
+    # Defaults to true, set to false if you want SSL certificate validation.
     #
     # disable_ssl_validation: true
+
+    # Path of trusted CA certificates used to validate the SSL certificate
+    # for this url.
+    # Overrides the default path and the one specified in init_config.
+    #
+    # ca_certs: /etc/ssl/certs/ca-certificates.crt
 
     # The (optional) ssl_expire will instruct the check
     # to create a service check that checks the expiration of the
     # ssl certificate. Allow for a warning to occur when x days are
     # left in the certificate.
+    # The SSL certificate will always be validated for this additional
+    # service check regardless of the value of disable_ssl_validation
     #
     # check_certificate_expiration: true
     # days_warning: 14

--- a/tests/checks/integration/test_http_check.py
+++ b/tests/checks/integration/test_http_check.py
@@ -52,7 +52,7 @@ CONFIG_SSL_ONLY = {
         'days_warning': 14
     }, {
         'name': 'cert_exp_soon',
-        'url': 'https://github.com',
+        'url': 'https://google.com',
         'timeout': 1,
         'check_certificate_expiration': True,
         'days_warning': 9999
@@ -135,7 +135,7 @@ class HTTPCheckTest(AgentCheckTest):
         self.assertServiceCheckOK("http.can_connect", tags=tags)
         self.assertServiceCheckOK("http.ssl_cert", tags=tags)
 
-        tags = ['url:https://github.com', 'instance:cert_exp_soon']
+        tags = ['url:https://google.com', 'instance:cert_exp_soon']
         self.assertServiceCheckOK("http.can_connect", tags=tags)
         self.assertServiceCheckWarning("http.ssl_cert", tags=tags)
 

--- a/tests/core/test_service_checks.py
+++ b/tests/core/test_service_checks.py
@@ -35,7 +35,8 @@ class ServiceCheckTestCase(AgentCheckTest):
         self.load_check(config, agentConfig)
         url, username, password, http_response_status_code, timeout,\
             include_content, headers, response_time, content_match,\
-            tags, ssl, ssl_expiration = self.check._load_conf(config['instances'][0])
+            tags, ssl, ssl_expiration,\
+            instance_ca_certs = self.check._load_conf(config['instances'][0])
 
         self.assertEqual(headers["X-Auth-Token"], "SOME-AUTH-TOKEN", headers)
         expected_headers = agent_headers(agentConfig).get('User-Agent')


### PR DESCRIPTION
Improves a few things:

- custom CA certificates are used in the `http.can_connect` check (in addition to the `http.ssl_cert` check)
- instance-level CA certificate files can be defined
- fixes flaky test