### PR TITLE
[elasticsearch] Add PShard statistic to ES check

### DIFF
--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -18,6 +18,7 @@ class NodeNotFound(Exception):
 
 ESInstanceConfig = namedtuple(
     'ESInstanceConfig', [
+        'pshard_stats',
         'cluster_stats',
         'password',
         'service_check_tags',
@@ -33,6 +34,43 @@ class ESCheck(AgentCheck):
     SERVICE_CHECK_CLUSTER_STATUS = 'elasticsearch.cluster_health'
 
     DEFAULT_TIMEOUT = 5
+
+    # Clusterwise metrics, pre aggregated on ES, compatible with all ES versions
+    PRIMARY_SHARD_METRICS = {
+        "elasticsearch.primaries.docs.count": ("gauge", "_all.primaries.docs.count"),
+        "elasticsearch.primaries.docs.deleted": ("gauge", "_all.primaries.docs.deleted"),
+        "elasticsearch.primaries.store.size": ("gauge", "_all.primaries.store.size_in_bytes"),
+        "elasticsearch.primaries.indexing.index.total": ("gauge", "_all.primaries.indexing.index_total"),
+        "elasticsearch.primaries.indexing.index.time": ("gauge", "_all.primaries.indexing.index_time_in_millis", lambda v: float(v)/1000),
+        "elasticsearch.primaries.indexing.index.current": ("gauge", "_all.primaries.indexing.index_current"),
+        "elasticsearch.primaries.indexing.delete.total": ("gauge", "_all.primaries.indexing.delete_total"),
+        "elasticsearch.primaries.indexing.delete.time": ("gauge", "_all.primaries.indexing.delete_time_in_millis", lambda v: float(v)/1000),
+        "elasticsearch.primaries.indexing.delete.current": ("gauge", "_all.primaries.indexing.delete_current"),
+        "elasticsearch.primaries.get.total": ("gauge", "_all.primaries.get.total"),
+        "elasticsearch.primaries.get.time": ("gauge", "_all.primaries.get.time_in_millis", lambda v: float(v)/1000),
+        "elasticsearch.primaries.get.current": ("gauge", "_all.primaries.get.current"),
+        "elasticsearch.primaries.get.exists.total": ("gauge", "_all.primaries.get.exists_total"),
+        "elasticsearch.primaries.get.exists.time": ("gauge", "_all.primaries.get.exists_time_in_millis", lambda v: float(v)/1000),
+        "elasticsearch.primaries.get.missing.total": ("gauge", "_all.primaries.get.missing_total"),
+        "elasticsearch.primaries.get.missing.time": ("gauge", "_all.primaries.get.missing_time_in_millis", lambda v: float(v)/1000),
+        "elasticsearch.primaries.search.query.total": ("gauge", "_all.primaries.search.query_total"),
+        "elasticsearch.primaries.search.query.time": ("gauge", "_all.primaries.search.query_time_in_millis", lambda v: float(v)/1000),
+        "elasticsearch.primaries.search.query.current": ("gauge", "_all.primaries.search.query_current"),
+        "elasticsearch.primaries.search.fetch.total": ("gauge", "_all.primaries.search.fetch_total"),
+        "elasticsearch.primaries.search.fetch.time": ("gauge", "_all.primaries.search.fetch_time_in_millis", lambda v: float(v)/1000),
+        "elasticsearch.primaries.search.fetch.current": ("gauge", "_all.primaries.search.fetch_current"),
+        "elasticsearch.primaries.merges.current": ("gauge", "_all.primaries.merges.current"),
+        "elasticsearch.primaries.merges.current.docs": ("gauge", "_all.primaries.merges.current_docs"),
+        "elasticsearch.primaries.merges.current.size": ("gauge", "_all.primaries.merges.current_size_in_bytes"),
+        "elasticsearch.primaries.merges.total": ("gauge", "_all.primaries.merges.total"),
+        "elasticsearch.primaries.merges.total.time": ("gauge", "_all.primaries.merges.total_time_in_millis", lambda v: float(v)/1000),
+        "elasticsearch.primaries.merges.total.docs": ("gauge", "_all.primaries.merges.total_docs"),
+        "elasticsearch.primaries.merges.total.size": ("gauge", "_all.primaries.merges.total_size_in_bytes"),
+        "elasticsearch.primaries.refresh.total": ("gauge", "_all.primaries.refresh.total"),
+        "elasticsearch.primaries.refresh.total.time": ("gauge", "_all.primaries.refresh.total_time_in_millis", lambda v: float(v)/1000),
+        "elasticsearch.primaries.flush.total": ("gauge", "_all.primaries.flush.total"),
+        "elasticsearch.primaries.flush.total.time": ("gauge", "_all.primaries.flush.total_time_in_millis", lambda v: float(v)/1000)
+    }
 
     STATS_METRICS = {  # Metrics that are common to all Elasticsearch versions
         "elasticsearch.docs.count": ("gauge", "indices.docs.count"),
@@ -180,6 +218,8 @@ class ESCheck(AgentCheck):
         if url is None:
             raise Exception("An url must be specified in the instance")
 
+        pshard_stats = _is_affirmative(instance.get('pshard_stats', False))
+
         cluster_stats = _is_affirmative(instance.get('cluster_stats', False))
         if 'is_external' in instance:
             cluster_stats = _is_affirmative(instance.get('is_external', False))
@@ -204,6 +244,7 @@ class ESCheck(AgentCheck):
         timeout = instance.get('timeout') or self.DEFAULT_TIMEOUT
 
         config = ESInstanceConfig(
+            pshard_stats=pshard_stats,
             cluster_stats=cluster_stats,
             password=instance.get('password'),
             service_check_tags=service_check_tags,
@@ -221,8 +262,14 @@ class ESCheck(AgentCheck):
         # (URLs and metrics) accordingly
         version = self._get_es_version(config)
 
-        health_url, nodes_url, stats_url, pending_tasks_url, stats_metrics\
+        health_url, nodes_url, stats_url, pshard_stats_url, pending_tasks_url, stats_metrics\
             = self._define_params(version, config.cluster_stats)
+
+        # Load clusterwise data
+        if config.pshard_stats:
+            pshard_stats_url = urlparse.urljoin(config.url, pshard_stats_url)
+            pshard_stats_data = self._get_data(pshard_stats_url, config)
+            self._process_pshard_stats_data(pshard_stats_data, config)
 
         # Load stats data.
         stats_url = urlparse.urljoin(config.url, stats_url)
@@ -295,6 +342,8 @@ class ESCheck(AgentCheck):
         stats_metrics = dict(self.STATS_METRICS)
         stats_metrics.update(additional_metrics)
 
+        pshard_stats_url = "/_stats"
+
         if version >= [0, 90, 5]:
             # ES versions 0.90.5 and above
             additional_metrics = self.ADDITIONAL_METRICS_POST_0_90_5
@@ -304,7 +353,7 @@ class ESCheck(AgentCheck):
 
         stats_metrics.update(additional_metrics)
 
-        return health_url, nodes_url, stats_url, pending_tasks_url, stats_metrics
+        return health_url, nodes_url, stats_url, pshard_stats_url, pending_tasks_url, stats_metrics
 
     def _get_data(self, url, config, send_sc=True):
         """ Hit a given URL and return the parsed json
@@ -367,6 +416,10 @@ class ESCheck(AgentCheck):
                 self._process_metric(
                     node_data, metric, *desc, tags=config.tags,
                     hostname=metric_hostname)
+
+    def _process_pshard_stats_data(self, data, config):
+        for metric, desc in self.PRIMARY_SHARD_METRICS.iteritems():
+            self._process_metric(data, metric, *desc, tags=config.tags)
 
     def _process_metric(self, data, metric, xtype, path, xform=None,
                         tags=None, hostname=None):

--- a/conf.d/elastic.yaml.example
+++ b/conf.d/elastic.yaml.example
@@ -15,10 +15,19 @@ instances:
   # This parameter was also called `is_external` and you can still use it but it
   # will be removed in version 6.
   #
+  # If you enable the "pshard_stats" flag, statistics over primary shards
+  # will be collected by the check and sent to the backend with the
+  # 'elasticsearch.primary' prefix. It is particularly useful if you want to
+  # get certain metrics without taking replicas into account. For instance,
+  # 'elasticsearch.primaries.docs.count` will give you the total number of
+  # documents in your indexes WITHOUT counting duplicates due to the existence
+  # of replica shards in your ES cluster
+  #
   - url: http://localhost:9200
     # username: username
     # password: password
-    # is_external: false
+    # cluster_stats: false
+    # pshard_stats: false
     # tags:
     #   - 'tag1:key1'
     #   - 'tag2:key2'


### PR DESCRIPTION
Added statistics over primary shards only to our check. They're
basically retrieved under the `_stats` endpoint and are aggregated
metrics on the primary shards. It means that they don't take into
account metrics from replica shards. So for instance
`primaries.docs.count` will contain the total number of documents in the
cluster without replicas. Including replicas would be as simple as
summing the "standiard" document count metric over all nodes in the
cluster.