### PR TITLE
[flare] Add JMXFetch-specific info

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -27,7 +27,6 @@ os.umask(022)
 from checks.check_status import CollectorStatus
 from checks.collector import Collector
 from config import (
-    get_confd_path,
     get_config,
     get_parsed_args,
     get_system_stats,
@@ -35,14 +34,13 @@ from config import (
 )
 from daemon import AgentSupervisor, Daemon
 from emitter import http_emitter
-from jmxfetch import JMX_LIST_COMMANDS, JMXFetch
 from util import (
     EC2,
     get_hostname,
-    get_os,
     Watchdog,
 )
 from utils.flare import configcheck, Flare
+from utils.jmx import jmx_command
 from utils.pidfile import PidFile
 from utils.profile import AgentProfiler
 
@@ -329,33 +327,7 @@ def main():
         configcheck()
 
     elif 'jmx' == command:
-        if len(args) < 2 or args[1] not in JMX_LIST_COMMANDS.keys():
-            print "#" * 80
-            print "JMX tool to be used to help configuring your JMX checks."
-            print "See http://docs.datadoghq.com/integrations/java/ for more information"
-            print "#" * 80
-            print "\n"
-            print "You have to specify one of the following commands:"
-            for command, desc in JMX_LIST_COMMANDS.iteritems():
-                print "      - %s [OPTIONAL: LIST OF CHECKS]: %s" % (command, desc)
-            print "Example: sudo /etc/init.d/datadog-agent jmx list_matching_attributes tomcat jmx solr"
-            print "\n"
-
-        else:
-            jmx_command = args[1]
-            checks_list = args[2:]
-            confd_directory = get_confd_path(get_os())
-
-            jmx_process = JMXFetch(confd_directory, agentConfig)
-            jmx_process.configure()
-            should_run = jmx_process.should_run()
-
-            if should_run:
-                jmx_process.run(jmx_command, checks_list, reporter="console")
-            else:
-                print "Couldn't find any valid JMX configuration in your conf.d directory: %s" % confd_directory
-                print "Have you enabled any JMX check ?"
-                print "If you think it's not normal please get in touch with Datadog Support"
+        jmx_command(args[1:], agentConfig)
 
     elif 'flare' == command:
         Flare.check_user_rights()

--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -21,7 +21,7 @@ import yaml
 import config
 from config import _is_affirmative, _windows_commondata_path, get_config
 from util import plural
-from utils.jmxfiles import JMXFiles
+from utils.jmx import JMXFiles
 from utils.ntp import get_ntp_args
 from utils.pidfile import PidFile
 from utils.platform import Platform

--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -88,7 +88,10 @@ def logger_info():
     if len(root_logger.handlers) > 0:
         for handler in root_logger.handlers:
             if isinstance(handler, logging.StreamHandler):
-                loggers.append(handler.stream.name)
+                try:
+                    loggers.append(handler.stream.name)
+                except AttributeError:
+                    loggers.append("unnamed stream")
             if isinstance(handler, logging.handlers.SysLogHandler):
                 if isinstance(handler.address, basestring):
                     loggers.append('syslog:%s' % handler.address)

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -30,7 +30,7 @@ from util import (
     get_uuid,
     Timer,
 )
-from utils.jmxfiles import JMXFiles
+from utils.jmx import JMXFiles
 from utils.subprocess_output import subprocess
 
 log = logging.getLogger(__name__)

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -18,7 +18,7 @@ from config import (
     PathNotFound,
 )
 from util import get_os, yLoader
-from utils.jmxfiles import JMXFiles
+from utils.jmx import JMXFiles
 from utils.platform import Platform
 from utils.subprocess_output import subprocess
 
@@ -113,7 +113,15 @@ class JMXFetch(object):
         """
         return self.jmx_checks is not None and self.jmx_checks != []
 
-    def run(self, command=None, check_list=None, reporter=None):
+    def run(self, command=None, check_list=None, reporter=None, redirect_std_streams=False):
+        """
+        Run JMXFetch
+
+        redirect_std_streams: if left to False, the stdout and stderr of JMXFetch are streamed
+        directly to the environment's stdout and stderr and cannot be retrieved via python's
+        sys.stdout and sys.stderr. Set to True to redirect these streams to python's sys.stdout
+        and sys.stderr.
+        """
 
         if check_list or self.jmx_checks is None:
             # (Re)set/(re)configure JMXFetch parameters when `check_list` is specified or
@@ -131,7 +139,7 @@ class JMXFetch(object):
 
             if len(self.jmx_checks) > 0:
                 return self._start(self.java_bin_path, self.java_options, self.jmx_checks,
-                                   command, reporter, self.tools_jar_path)
+                                   command, reporter, self.tools_jar_path, redirect_std_streams)
             else:
                 # We're exiting purposefully, so exit with zero (supervisor's expected
                 # code). HACK: Sleep a little bit so supervisor thinks we've started cleanly
@@ -207,7 +215,7 @@ class JMXFetch(object):
 
         return (jmx_checks, invalid_checks, java_bin_path, java_options, tools_jar_path)
 
-    def _start(self, path_to_java, java_run_opts, jmx_checks, command, reporter, tools_jar_path):
+    def _start(self, path_to_java, java_run_opts, jmx_checks, command, reporter, tools_jar_path, redirect_std_streams):
         statsd_port = self.agentConfig.get('dogstatsd_port', "8125")
         if reporter is None:
             reporter = "statsd:%s" % str(statsd_port)
@@ -260,14 +268,27 @@ class JMXFetch(object):
                 subprocess_args.insert(1, opt)
 
             log.info("Running %s" % " ".join(subprocess_args))
-            jmx_process = subprocess.Popen(subprocess_args, close_fds=True)
+
+            # Launch JMXfetch subprocess
+            jmx_process = subprocess.Popen(
+                subprocess_args,
+                close_fds=not redirect_std_streams,  # set to True instead of False when the streams are redirected for WIN compatibility
+                stdout=subprocess.PIPE if redirect_std_streams else None,
+                stderr=subprocess.PIPE if redirect_std_streams else None
+            )
             self.jmx_process = jmx_process
 
             # Register SIGINT and SIGTERM signal handlers
             self.register_signal_handlers()
 
-            # Wait for JMXFetch to return
-            jmx_process.wait()
+            if redirect_std_streams:
+                # Wait for JMXFetch to return, and write out the stdout and stderr of JMXFetch to sys.stdout and sys.stderr
+                out, err = jmx_process.communicate()
+                sys.stdout.write(out)
+                sys.stderr.write(err)
+            else:
+                # Wait for JMXFetch to return
+                jmx_process.wait()
 
             return jmx_process.returncode
 

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -98,11 +98,12 @@ class JMXFetch(object):
         except ValueError:
             log.exception("Unable to register signal handlers.")
 
-    def configure(self, checks_list=None):
+    def configure(self, checks_list=None, clean_status_file=True):
         """
         Instantiate JMXFetch parameters, clean potential previous run leftovers.
         """
-        JMXFiles.clean_status_file()
+        if clean_status_file:
+            JMXFiles.clean_status_file()
 
         self.jmx_checks, self.invalid_checks, self.java_bin_path, self.java_options, self.tools_jar_path = \
             self.get_configuration(self.confd_path, checks_list=checks_list)

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -17,7 +17,7 @@ from config import (
     get_logging_config,
     PathNotFound,
 )
-from util import get_os, yLoader
+from util import yLoader
 from utils.jmx import JMXFiles
 from utils.platform import Platform
 from utils.subprocess_output import subprocess
@@ -416,9 +416,8 @@ class JMXFetch(object):
 
 def init(config_path=None):
     agentConfig = get_config(parse_args=False, cfg_path=config_path)
-    osname = get_os()
     try:
-        confd_path = get_confd_path(osname)
+        confd_path = get_confd_path()
     except PathNotFound, e:
         log.error("No conf.d folder found at '%s' or in the directory where"
                   "the Agent is currently deployed.\n" % e.args[0])

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -228,8 +228,7 @@ class Flare(object):
             log.info("  * datadog-agent jmx {0} output".format(command))
             self._add_command_output_tar(
                 os.path.join('jmxinfo', '{0}.log'.format(command)),
-                partial(self._jmx_command_call, command),
-                'jmxfetch'
+                partial(self._jmx_command_call, command)
             )
 
         # java version
@@ -238,8 +237,7 @@ class Flare(object):
             os.path.join('jmxinfo', 'java_version.log'),
             # We use lambda so that JMXFetch.get_configuration is evaluated in _add_command_output_tar,
             # which captures the logging output from JMXFetch
-            lambda: self._java_version(JMXFetch.get_configuration(get_confd_path())[2]),
-            'jmxfetch'
+            lambda: self._java_version(JMXFetch.get_configuration(get_confd_path())[2])
         )
 
     # Check if the file is readable (and log it)
@@ -295,23 +293,14 @@ class Flare(object):
         return temp_path, password_found
 
     # Add output of the command to the tarfile
-    def _add_command_output_tar(self, name, command, logger_name=None):
+    def _add_command_output_tar(self, name, command):
         backup_out, backup_err = sys.stdout, sys.stderr
-        backup_handlers = logging.root.handlers[:]
         out, err = StringIO.StringIO(), StringIO.StringIO()
-        if logger_name:
-            # If specified, redirect logger output to `out`
-            logger = logging.getLogger(logger_name)
-            backup_logger_handlers = logger.handlers[:]
-            logger.handlers = [logging.StreamHandler(out)]
-            backup_logger_propagate = logger.propagate
-            logger.propagate = False
+        backup_handlers = logging.root.handlers[:]
+        logging.root.handlers = [logging.StreamHandler(out)]
         sys.stdout, sys.stderr = out, err
         command()
         sys.stdout, sys.stderr = backup_out, backup_err
-        if logger_name:
-            logger.handlers = backup_logger_handlers
-            logger.propagate = backup_logger_propagate
         logging.root.handlers = backup_handlers
         _, temp_path = tempfile.mkstemp(prefix='dd')
         with open(temp_path, 'w') as temp_file:

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -25,6 +25,7 @@ from config import (
     get_logging_config,
     get_url_endpoint,
 )
+from jmxfetch import JMXFetch
 from util import get_hostname
 from utils.jmx import jmx_command, JMXFiles
 from utils.platform import Platform
@@ -231,6 +232,16 @@ class Flare(object):
                 'jmxfetch'
             )
 
+        # java version
+        log.info("  * java -version output")
+        self._add_command_output_tar(
+            os.path.join('jmxinfo', 'java_version.log'),
+            # We use lambda so that JMXFetch.get_configuration is evaluated in _add_command_output_tar,
+            # which captures the logging output from JMXFetch
+            lambda: self._java_version(JMXFetch.get_configuration(get_confd_path())[2]),
+            'jmxfetch'
+        )
+
     # Check if the file is readable (and log it)
     @classmethod
     def _can_read(cls, f, output=True, warn=True):
@@ -378,6 +389,14 @@ class Flare(object):
             jmx_command([command], self._config, redirect_std_streams=True)
         except Exception, e:
             print "Unable to call jmx command {0}: {1}".format(command, e)
+
+    # Print java version
+    def _java_version(self, java_bin_path):
+        java_bin_path = java_bin_path or 'java'
+        try:
+            self._print_output_command([java_bin_path, '-version'])
+        except OSError:
+            print 'Unable to execute java bin with command: {0}'.format(java_bin_path)
 
     # Run a pip freeze
     def _pip_freeze(self):

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -393,7 +393,7 @@ class Flare(object):
         try:
             status = subprocess.check_output(command, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError, e:
-            status = 'Not able to get ouput, exit number {0}, exit ouput:\n'\
+            status = 'Not able to get output, exit number {0}, exit output:\n'\
                      '{1}'.format(str(e.returncode), e.output)
         print status
 

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -259,9 +259,6 @@ class Flare(object):
 
     # Add output of the command to the tarfile
     def _add_command_output_tar(self, name, command):
-        temp_path = os.path.join(tempfile.gettempdir(), name)
-        if os.path.exists(temp_path):
-            os.remove(temp_path)
         backup_out, backup_err = sys.stdout, sys.stderr
         backup_handlers = logging.root.handlers[:]
         out, err = StringIO.StringIO(), StringIO.StringIO()
@@ -269,6 +266,7 @@ class Flare(object):
         command()
         sys.stdout, sys.stderr = backup_out, backup_err
         logging.root.handlers = backup_handlers
+        _, temp_path = tempfile.mkstemp(prefix='dd')
         with open(temp_path, 'w') as temp_file:
             temp_file.write(">>>> STDOUT <<<<\n")
             temp_file.write(out.getvalue())

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -258,13 +258,23 @@ class Flare(object):
         return temp_path, password_found
 
     # Add output of the command to the tarfile
-    def _add_command_output_tar(self, name, command):
+    def _add_command_output_tar(self, name, command, logger_name=None):
         backup_out, backup_err = sys.stdout, sys.stderr
         backup_handlers = logging.root.handlers[:]
         out, err = StringIO.StringIO(), StringIO.StringIO()
+        if logger_name:
+            # If specified, redirect logger output to `out`
+            logger = logging.getLogger(logger_name)
+            backup_logger_handlers = logger.handlers[:]
+            logger.handlers = [logging.StreamHandler(out)]
+            backup_logger_propagate = logger.propagate
+            logger.propagate = False
         sys.stdout, sys.stderr = out, err
         command()
         sys.stdout, sys.stderr = backup_out, backup_err
+        if logger_name:
+            logger.handlers = backup_logger_handlers
+            logger.propagate = backup_logger_propagate
         logging.root.handlers = backup_handlers
         _, temp_path = tempfile.mkstemp(prefix='dd')
         with open(temp_path, 'w') as temp_file:

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -1,6 +1,7 @@
 # stdlib
 import atexit
 import cStringIO as StringIO
+from functools import partial
 import glob
 import logging
 import os.path
@@ -25,6 +26,7 @@ from config import (
     get_url_endpoint,
 )
 from util import get_hostname
+from utils.jmx import jmx_command, JMXFiles
 from utils.platform import Platform
 
 # Globals
@@ -73,13 +75,13 @@ class Flare(object):
         self._cmdline = cmdline
         self._init_tarfile()
         self._save_logs_path()
-        config = get_config()
-        self._api_key = config.get('api_key')
+        self._config = get_config()
+        self._api_key = self._config.get('api_key')
         self._url = "{0}{1}".format(
-            get_url_endpoint(config.get('dd_url'), endpoint_type='flare'),
+            get_url_endpoint(self._config.get('dd_url'), endpoint_type='flare'),
             self.DATADOG_SUPPORT_URL
         )
-        self._hostname = get_hostname(config)
+        self._hostname = get_hostname(self._config)
         self._prefix = "datadog-{0}".format(self._hostname)
 
     # On Unix system, check that the user is root (to call supervisorctl & status)
@@ -110,6 +112,7 @@ class Flare(object):
         self._add_command_output_tar('status.log', self._supervisor_status)
         log.info("  * datadog-agent info output")
         self._add_command_output_tar('info.log', self._info_all)
+        self._add_jmxinfo_tar()
         log.info("  * pip freeze")
         self._add_command_output_tar('freeze.log', self._pip_freeze)
 
@@ -206,15 +209,38 @@ class Flare(object):
             if self._can_read(file_path, output=False):
                 self._add_clean_confd(file_path)
 
+    # Collect JMXFetch-specific info and save to jmxinfo directory
+    def _add_jmxinfo_tar(self):
+        # status files (before listing beans because executing jmxfetch overwrites status files)
+        for file_name, file_path in [
+            (JMXFiles._STATUS_FILE, JMXFiles.get_status_file_path()),
+            (JMXFiles._PYTHON_STATUS_FILE, JMXFiles.get_python_status_file_path())
+        ]:
+            if self._can_read(file_path, warn=False):
+                self._tar.add(
+                    file_path,
+                    os.path.join(self._prefix, 'jmxinfo', file_name)
+                )
+
+        # beans lists
+        for command in ['list_matching_attributes', 'list_everything']:
+            log.info("  * datadog-agent jmx {0} output".format(command))
+            self._add_command_output_tar(
+                os.path.join('jmxinfo', '{0}.log'.format(command)),
+                partial(self._jmx_command_call, command),
+                'jmxfetch'
+            )
+
     # Check if the file is readable (and log it)
     @classmethod
-    def _can_read(cls, f, output=True):
+    def _can_read(cls, f, output=True, warn=True):
         if os.access(f, os.R_OK):
             if output:
                 log.info("  * {0}".format(f))
             return True
         else:
-            log.warn("  * not readable - {0}".format(f))
+            if warn:
+                log.warn("  * not readable - {0}".format(f))
             return False
 
     # Return path to a temp file without comment
@@ -345,6 +371,13 @@ class Flare(object):
         CollectorStatus.print_latest_status(verbose=True)
         DogstatsdStatus.print_latest_status(verbose=True)
         ForwarderStatus.print_latest_status(verbose=True)
+
+    # Call jmx_command with std streams redirection
+    def _jmx_command_call(self, command):
+        try:
+            jmx_command([command], self._config, redirect_std_streams=True)
+        except Exception, e:
+            print "Unable to call jmx command {0}: {1}".format(command, e)
 
     # Run a pip freeze
     def _pip_freeze(self):

--- a/utils/jmx.py
+++ b/utils/jmx.py
@@ -9,7 +9,7 @@ import yaml
 
 # datadog
 from config import _windows_commondata_path, get_confd_path
-from util import get_os, yDumper
+from util import yDumper
 from utils.pidfile import PidFile
 from utils.platform import Platform
 
@@ -36,7 +36,7 @@ def jmx_command(args, agent_config, redirect_std_streams=False):
     else:
         jmx_command = args[0]
         checks_list = args[1:]
-        confd_directory = get_confd_path(get_os())
+        confd_directory = get_confd_path()
 
         jmx_process = JMXFetch(confd_directory, agent_config)
         jmx_process.configure()

--- a/utils/jmx.py
+++ b/utils/jmx.py
@@ -8,13 +8,46 @@ import time
 import yaml
 
 # datadog
-from config import _windows_commondata_path
-from util import yDumper
+from config import _windows_commondata_path, get_confd_path
+from util import get_os, yDumper
 from utils.pidfile import PidFile
 from utils.platform import Platform
 
-
 log = logging.getLogger(__name__)
+
+
+def jmx_command(args, agent_config, redirect_std_streams=False):
+    """
+    Run JMXFetch with the given command if it is valid (and print user-friendly info if it's not)
+    """
+    from jmxfetch import JMX_LIST_COMMANDS, JMXFetch
+    if len(args) < 1 or args[0] not in JMX_LIST_COMMANDS.keys():
+        print "#" * 80
+        print "JMX tool to be used to help configuring your JMX checks."
+        print "See http://docs.datadoghq.com/integrations/java/ for more information"
+        print "#" * 80
+        print "\n"
+        print "You have to specify one of the following commands:"
+        for command, desc in JMX_LIST_COMMANDS.iteritems():
+            print "      - %s [OPTIONAL: LIST OF CHECKS]: %s" % (command, desc)
+        print "Example: sudo /etc/init.d/datadog-agent jmx list_matching_attributes tomcat jmx solr"
+        print "\n"
+
+    else:
+        jmx_command = args[0]
+        checks_list = args[1:]
+        confd_directory = get_confd_path(get_os())
+
+        jmx_process = JMXFetch(confd_directory, agent_config)
+        jmx_process.configure()
+        should_run = jmx_process.should_run()
+
+        if should_run:
+            jmx_process.run(jmx_command, checks_list, reporter="console", redirect_std_streams=redirect_std_streams)
+        else:
+            print "Couldn't find any valid JMX configuration in your conf.d directory: %s" % confd_directory
+            print "Have you enabled any JMX check ?"
+            print "If you think it's not normal please get in touch with Datadog Support"
 
 
 class JMXFiles(object):

--- a/win32/agent.py
+++ b/win32/agent.py
@@ -28,7 +28,7 @@ import dogstatsd
 from emitter import http_emitter
 from jmxfetch import JMXFetch
 import modules
-from util import get_hostname, get_os
+from util import get_hostname
 from utils.jmx import JMXFiles
 from utils.profile import AgentProfiler
 
@@ -320,8 +320,7 @@ class JMXFetchProcess(multiprocessing.Process):
         self.hostname = hostname
 
         try:
-            osname = get_os()
-            confd_path = get_confd_path(osname)
+            confd_path = get_confd_path()
             self.jmx_daemon = JMXFetch(confd_path, agentConfig)
             self.jmx_daemon.configure()
             self.is_enabled = self.jmx_daemon.should_run()

--- a/win32/agent.py
+++ b/win32/agent.py
@@ -29,7 +29,7 @@ from emitter import http_emitter
 from jmxfetch import JMXFetch
 import modules
 from util import get_hostname, get_os
-from utils.jmxfiles import JMXFiles
+from utils.jmx import JMXFiles
 from utils.profile import AgentProfiler
 
 log = logging.getLogger(__name__)

--- a/win32/gui.py
+++ b/win32/gui.py
@@ -45,7 +45,7 @@ from config import (
     get_config_path,
     get_version,
 )
-from util import get_os, yLoader
+from util import yLoader
 
 log = logging.getLogger(__name__)
 
@@ -102,7 +102,7 @@ SYSTEM_TRAY_MENU = [
 
 def get_checks():
     checks = {}
-    conf_d_directory = get_confd_path(get_os())
+    conf_d_directory = get_confd_path()
 
     for filename in sorted(os.listdir(conf_d_directory)):
         module_name, ext = osp.splitext(filename)


### PR DESCRIPTION
Adds in a `jmxinfo` directory:

- 2 JMXFetch status files: `jmx_status.yaml` and `jmx_status_python.yaml`
- JMXfetch commands output: `list_matching_attributes` and `list_everything`
- `java -version` output (using the configured java path) in a `java_version.log` file

@remh One thing that may not work properly in flare is the change I've made here https://github.com/DataDog/dd-agent/compare/olivielpeau/jmx-flare?expand=1#diff-64a477c26f008c29252aad6c1499c099R271 , which basically leaves file descriptors open (`close_fds=False`) when the JMXFetch subprocess is launched from the flare command. Do you know what issues can happen when the main process leaves the file descriptors open ?

cc @degemer @yannmh 