### PR TITLE
[docker] strip newlines from API responses

### DIFF
--- a/checks.d/docker.py
+++ b/checks.d/docker.py
@@ -383,6 +383,8 @@ class Docker(AgentCheck):
             raise
 
         response = request.read()
+        response = response.replace('\n','') # Some Docker API versions occassionally send newlines in responses
+
         if multi and "}{" in response: # docker api sometimes returns juxtaposed json dictionaries
             response = "[{0}]".format(response.replace("}{", "},{"))
 


### PR DESCRIPTION
Some versions of the Docker `/events` API have juxtaposed JSON dictionaries in the response. We had some logic to handle the basic case, but we did not have any to account for newlines between juxtaposed dictionaries. The latter causes our parsing to break. This accounts for that by getting rid off any newlines in the response.
