### PR TITLE
[ci] enable coverage tests :tada:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
 env:
   global:
     - CONCURRENCY=2
+    - COVERAGE=true
     - NOSE_FILTER="not windows"
     - INTEGRATIONS_DIR=$HOME/embedded
     - PIP_CACHE=$HOME/.cache/pip

--- a/tests/checks/integration/test_http_check.py
+++ b/tests/checks/integration/test_http_check.py
@@ -5,7 +5,6 @@ import time
 import mock
 
 # project
-from checks import AgentCheck
 from tests.checks.common import AgentCheckTest
 
 RESULTS_TIMEOUT = 5
@@ -107,33 +106,24 @@ class HTTPCheckTest(AgentCheckTest):
         # HTTP connection error
         tags = ['url:https://thereisnosuchlink.com', 'instance:conn_error']
 
-        self.assertServiceCheck("http.can_connect", status=AgentCheck.CRITICAL,
-                                tags=tags
-                                )
+        self.assertServiceCheckCritical("http.can_connect", tags=tags)
 
         # Wrong HTTP response status code
         tags = ['url:http://httpbin.org/404', 'instance:http_error_status_code']
-        self.assertServiceCheck("http.can_connect",
-            status=AgentCheck.CRITICAL,
-            tags=tags)
+        self.assertServiceCheckCritical("http.can_connect", tags=tags)
 
-        self.assertServiceCheck("http.can_connect", status=AgentCheck.OK,
-                                tags=tags, count=0)
+        self.assertServiceCheckOK("http.can_connect", tags=tags, count=0)
 
         # HTTP response status code match
         tags = ['url:http://httpbin.org/404', 'instance:status_code_match', 'foo:bar']
-        self.assertServiceCheck("http.can_connect", status=AgentCheck.OK,
-                                tags=tags)
+        self.assertServiceCheckOK("http.can_connect", tags=tags)
 
         # Content match & mismatching
         tags = ['url:https://github.com', 'instance:cnt_mismatch']
-        self.assertServiceCheck("http.can_connect", status=AgentCheck.CRITICAL,
-                                tags=tags)
-        self.assertServiceCheck("http.can_connect", status=AgentCheck.OK,
-                                tags=tags, count=0)
+        self.assertServiceCheckCritical("http.can_connect", tags=tags)
+        self.assertServiceCheckOK("http.can_connect", tags=tags, count=0)
         tags = ['url:https://github.com', 'instance:cnt_match']
-        self.assertServiceCheck("http.can_connect", status=AgentCheck.OK,
-                                tags=tags)
+        self.assertServiceCheckOK("http.can_connect", tags=tags)
 
         self.coverage_report()
 
@@ -142,16 +132,16 @@ class HTTPCheckTest(AgentCheckTest):
         # Overrides self.service_checks attribute when values are available
         self.service_checks = self.wait_for_async_service_checks(6)
         tags = ['url:https://github.com', 'instance:good_cert']
-        self.assertServiceCheck("http.ssl_cert", status=AgentCheck.OK,
-                                tags=tags)
+        self.assertServiceCheckOK("http.can_connect", tags=tags)
+        self.assertServiceCheckOK("http.ssl_cert", tags=tags)
 
         tags = ['url:https://github.com', 'instance:cert_exp_soon']
-        self.assertServiceCheck("http.ssl_cert", status=AgentCheck.WARNING,
-                                tags=tags)
+        self.assertServiceCheckOK("http.can_connect", tags=tags)
+        self.assertServiceCheckWarning("http.ssl_cert", tags=tags)
 
         tags = ['url:https://thereisnosuchlink.com', 'instance:conn_error']
-        self.assertServiceCheck("http.ssl_cert", status=AgentCheck.CRITICAL,
-                                tags=tags)
+        self.assertServiceCheckCritical("http.can_connect", tags=tags)
+        self.assertServiceCheckCritical("http.ssl_cert", tags=tags)
 
         self.coverage_report()
 
@@ -162,6 +152,6 @@ class HTTPCheckTest(AgentCheckTest):
         # Needed for the HTTP headers
         self.service_checks = self.wait_for_async_service_checks(2)
         tags = ['url:https://github.com', 'instance:expired_cert']
-        self.assertServiceCheck("http.ssl_cert", status=AgentCheck.CRITICAL,
-                                tags=tags)
+        self.assertServiceCheckOK("http.can_connect", tags=tags)
+        self.assertServiceCheckCritical("http.ssl_cert", tags=tags)
         self.coverage_report()

--- a/tests/checks/integration/test_lighttpd.py
+++ b/tests/checks/integration/test_lighttpd.py
@@ -8,11 +8,13 @@ from tests.checks.common import AgentCheckTest
 class TestLighttpd(AgentCheckTest):
     CHECK_NAME = 'lighttpd'
     CHECK_GAUGES = [
-        'lighttpd.performance.busy_servers',
         'lighttpd.net.bytes',
+        'lighttpd.net.bytes_per_s',
         'lighttpd.net.hits',
+        'lighttpd.net.request_per_s',
+        'lighttpd.performance.busy_servers',
         'lighttpd.performance.idle_server',
-        'lighttpd.performance.uptime'
+        'lighttpd.performance.uptime',
     ]
 
     def __init__(self, *args, **kwargs):

--- a/tests/checks/mock/test_disk.py
+++ b/tests/checks/mock/test_disk.py
@@ -131,6 +131,8 @@ class TestCheckDisk(AgentCheckTest):
         for metric, value in self.GAUGES_VALUES.iteritems():
             self.assertMetric(metric, value=value, tags=[],
                               device_name=DEFAULT_DEVICE_NAME)
+            # backward compatibility with the old check
+            self.assertMetric(metric, tags=[], device_name='udev')
 
         self.coverage_report()
 


### PR DESCRIPTION
In order to do this:
- `elastic`: add tests for new metrics from
  https://github.com/DataDog/dd-agent/pull/1507
- `http_check`: add a missing service check test (`http.can_connect` is also
  collected when testing `http.ssl_cert`)
- `disk`: 100% coverage for the 5.4.2 check (full compatibility with old check)
- `lighttpd`: add two missing metrics for 100% coverage

Waiting on https://github.com/DataDog/dd-agent/pull/1730 for the coverage metadata fix.