### PR TITLE
Fix issue requesting current EC2 role

### DIFF
--- a/util.py
+++ b/util.py
@@ -333,7 +333,7 @@ class EC2(object):
             pass
 
         try:
-            iam_role = urllib2.urlopen(EC2.METADATA_URL_BASE + "/iam/security-credentials").read().strip()
+            iam_role = urllib2.urlopen(EC2.METADATA_URL_BASE + "/iam/security-credentials/").read().strip()
             iam_params = json.loads(urllib2.urlopen(EC2.METADATA_URL_BASE + "/iam/security-credentials" + "/" + unicode(iam_role)).read().strip())
             instance_identity = json.loads(urllib2.urlopen(EC2.INSTANCE_IDENTITY_URL).read().strip())
             region = instance_identity['region']


### PR DESCRIPTION
EC2 appears to have changed how you access the collection members of instance metadata--you now need a `/` after each collection to list them:
```
curl http://169.254.169.254/latest/meta-data/iam/security-credentials # nothing
curl http://169.254.169.254/latest/meta-data/iam/security-credentials/
ec2-staging-es
```