### PR TITLE
[supervisord] selct processes by regexp name match

### DIFF
--- a/ci/resources/supervisord/supervisord.yaml
+++ b/ci/resources/supervisord/supervisord.yaml
@@ -1,6 +1,0 @@
-init_config:
-
-instances:
-   - name: travis
-     socket: unix://VOLATILE_DIR//supervisor.sock
-     host: http://127.0.0.1

--- a/ci/supervisord.rb
+++ b/ci/supervisord.rb
@@ -21,12 +21,10 @@ namespace :ci do
 
     task before_script: ['ci:common:before_script'] do
       sh %(mkdir -p $VOLATILE_DIR/supervisor)
-      %w(supervisord.conf supervisord.yaml).each do |conf|
-        sh %(cp $TRAVIS_BUILD_DIR/ci/resources/supervisord/#{conf}\
-             $VOLATILE_DIR/supervisor/)
-        sh %(sed -i -- 's/VOLATILE_DIR/#{ENV['VOLATILE_DIR'].gsub '/', '\/'}/g'\
-           $VOLATILE_DIR/supervisor/#{conf})
-      end
+      sh %(cp $TRAVIS_BUILD_DIR/ci/resources/supervisord/supervisord.conf\
+           $VOLATILE_DIR/supervisor/)
+      sh %(sed -i -- 's/VOLATILE_DIR/#{ENV['VOLATILE_DIR'].gsub '/', '\/'}/g'\
+         $VOLATILE_DIR/supervisor/supervisord.conf)
 
       3.times do |i|
         sh %(cp $TRAVIS_BUILD_DIR/ci/resources/supervisord/program_#{i}.sh\

--- a/conf.d/supervisord.yaml.example
+++ b/conf.d/supervisord.yaml.example
@@ -36,6 +36,8 @@ instances:
 #     port: 9001       # Optional. Defaults to 9001. The port number.
 #     user: user       # Optional. Required only if a username is configured.
 #     pass: pass       # Optional. Required only if a password is configured.
+#     proc_regex:      # Optional. Regex pattern[s] matching the names of processes to monitor
+#      - 'myprocess-\d\d$'
 #     proc_names:      # Optional. The process to monitor within this supervisord instance.
 #      - apache2       #           If not specified, the check will monitor all processes.
 #      - webapp

--- a/tests/checks/integration/test_supervisord.py
+++ b/tests/checks/integration/test_supervisord.py
@@ -1,48 +1,89 @@
 # stdlib
 import os
 from time import sleep
-import unittest
 
 # 3p
 from nose.plugins.attrib import attr
 
 # project
-from tests.checks.common import get_check
+from checks import AgentCheck
+from tests.checks.common import AgentCheckTest
+
+PROCESSES = ["program_0", "program_1", "program_2"]
+STATUSES = ["down", "up", "unknown"]
 
 
 @attr(requires='supervisord')
-class TestSupervisordCheck(unittest.TestCase):
+class TestSupervisordCheck(AgentCheckTest):
+    CHECK_NAME = 'supervisord'
 
-    def test_travis_supervisord(self):
-        """Integration test for supervisord check. Using a supervisord on Travis."""
+    SUPERVISORD_CONFIG = [{
+        'name': "travis",
+        'socket': "unix://{0}//supervisor.sock".format(os.environ['VOLATILE_DIR']),
+    }]
 
-        # Load yaml config
-        config_str = open(os.environ['VOLATILE_DIR'] + '/supervisor/supervisord.yaml', 'r').read()
-        self.assertTrue(config_str is not None and len(config_str) > 0, msg=config_str)
+    BAD_SUPERVISORD_CONFIG = [{
+        'name': "travis",
+        'socket': "unix:///wrong/path/supervisor.sock",
+        'host': "http://127.0.0.1",
+    }]
 
-        # init the check and get the instances
-        check, instances = get_check('supervisord', config_str)
-        self.assertTrue(check is not None, msg=check)
-        self.assertEquals(len(instances), 1)
+    # Supervisord should run 3 programs for 10, 20 and 30 seconds
+    # respectively.
+    # The following dictionnary shows the processes by state for each iteration.
+    PROCESSES_BY_STATE_BY_ITERATION = map(
+        lambda x: dict(up=PROCESSES[x:], down=PROCESSES[:x], unknown=[]),
+        range(4)
+    )
 
-        # Supervisord should run 3 programs for 30, 60 and 90 seconds
-        # respectively. The tests below will ensure that the process count
-        # metric is reported correctly after (roughly) 10, 40, 70 and 100 seconds
+    def test_check(self):
+        """
+        Run Supervisord check and assess coverage
+        """
+        config = {'instances': self.SUPERVISORD_CONFIG}
+        instance_tags = ["supervisord_server:travis"]
+
         for i in range(4):
-            try:
-                # Run the check
-                check.check(instances[0])
-            except Exception, e:
-                # Make sure that it ran successfully
-                self.assertTrue(False, msg=str(e))
-            else:
-                up, down = 0, 0
-                for name, timestamp, value, meta in check.get_metrics():
-                    if name == 'supervisord.process.count':
-                        if 'status:up' in meta['tags']:
-                            up = value
-                        elif 'status:down' in meta['tags']:
-                            down = value
-                self.assertEquals(up, 3 - i)
-                self.assertEquals(down, i)
-                sleep(10)
+            # Run the check
+            self.run_check(config)
+
+            # Check metrics and service checks scoped by process
+            for proc in PROCESSES:
+                process_tags = instance_tags + ["supervisord_process:{0}".format(proc)]
+                process_status = AgentCheck.OK if proc in \
+                    self.PROCESSES_BY_STATE_BY_ITERATION[i]['up'] else AgentCheck.CRITICAL
+
+                self.assertMetric("supervisord.process.uptime", tags=process_tags, count=1)
+                self.assertServiceCheck("supervisord.process.status", status=process_status,
+                                        tags=process_tags, count=1)
+            # Check instance metrics
+            for status in STATUSES:
+                status_tags = instance_tags + ["status:{0}".format(status)]
+                count_processes = len(self.PROCESSES_BY_STATE_BY_ITERATION[i][status])
+                self.assertMetric("supervisord.process.count", value=count_processes,
+                                  tags=status_tags, count=1)
+
+            # Check service checks
+            self.assertServiceCheck("supervisord.can_connect", status=AgentCheck.OK,
+                                    tags=instance_tags, count=1)
+
+            # Raises when COVERAGE=true and coverage < 100%
+            self.coverage_report()
+
+            # Sleep 10s to give enough time to processes to terminate
+            sleep(10)
+
+    def test_connection_falure(self):
+        """
+        Service check reports connection failure
+        """
+        config = {'instances': self.BAD_SUPERVISORD_CONFIG}
+        instance_tags = ["supervisord_server:travis"]
+
+        self.assertRaises(
+            Exception,
+            lambda: self.run_check(config)
+        )
+        self.assertServiceCheck("supervisord.can_connect", status=AgentCheck.CRITICAL,
+                                tags=instance_tags, count=1)
+        self.coverage_report()

--- a/tests/checks/mock/test_supervisord.py
+++ b/tests/checks/mock/test_supervisord.py
@@ -132,7 +132,7 @@ instances:
             'host': 'invalid_host',
             'port': 9009
         }],
-        'error_message': """Cannot connect to http://invalid_host:9009. Make sure that supervisor is running and XML-RPC inet interface is enabled."""
+        'error_message': """Cannot connect to http://invalid_host:9009. Make sure supervisor is running and XML-RPC inet interface is enabled."""
     }, {
         'yaml': """
 init_config:
@@ -174,6 +174,47 @@ instances:
                 ('supervisord.process.count', 0, {'type': 'gauge', 'tags': ['supervisord_server:server0', 'status:down']}),
                 ('supervisord.process.count', 0, {'type': 'gauge', 'tags': ['supervisord_server:server0', 'status:unknown']}),
                 ('supervisord.process.uptime', 125, {'type': 'gauge', 'tags': ['supervisord_server:server0', 'supervisord_process:mysql']})
+            ]
+        },
+        'expected_service_checks': {
+            'server0': [{
+                'status': AgentCheck.OK,
+                'tags': ['supervisord_server:server0'],
+                'check': 'supervisord.can_connect',
+            }, {
+                'status': AgentCheck.OK,
+                'tags': ['supervisord_server:server0', 'supervisord_process:mysql'],
+                'check': 'supervisord.process.status'
+            }]
+        }
+    }, {
+        'yaml': """
+init_config:
+
+instances:
+  - name: server0
+    host: localhost
+    port: 9001
+    proc_regex:
+      - '^mysq.$'
+      - invalid_process""",
+        'expected_instances': [{
+                               'name': 'server0',
+                               'host': 'localhost',
+                               'port': 9001,
+                               'proc_regex': ['^mysq.$', 'invalid_process']
+                               }],
+        'expected_metrics': {
+            'server0': [
+                ('supervisord.process.count', 1,
+                 {'type': 'gauge', 'tags': ['supervisord_server:server0', 'status:up']}),
+                ('supervisord.process.count', 0,
+                 {'type': 'gauge', 'tags': ['supervisord_server:server0', 'status:down']}),
+                ('supervisord.process.count', 0,
+                 {'type': 'gauge', 'tags': ['supervisord_server:server0', 'status:unknown']}),
+                ('supervisord.process.uptime', 125, {'type': 'gauge',
+                                                     'tags': ['supervisord_server:server0',
+                                                              'supervisord_process:mysql']})
             ]
         },
         'expected_service_checks': {


### PR DESCRIPTION
From @ckrough:
Adds the ability to select processes to monitor by regex name match.

- Check will monitor processes whose names match the list of regex patterns provided in 'proc_regex'
- Check will monitor processes whose names exactly match the strings provided in 'proc_names'
- All processes matching proc_names OR proc_regex filters are monitored.
- All processes are monitored when no proc_names or proc_regex filters are defined.
- Sample configuration provides proc_regex examples

My two cents:
- Rebased on dd-agent 5.4 to solve conflicts. 
- Upgrade integration tests to use AgentCheckTest. Assess full coverage.

Original PR #1375. Thanks a lot @ckrough !