### PR TITLE
[mysql] rename max connections for clarity

### DIFF
--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -17,7 +17,7 @@ RATE = "rate"
 
 STATUS_VARS = {
     'Connections': ('mysql.net.connections', RATE),
-    'Max_used_connections': ('mysql.net.max_connections', GAUGE),
+    'Max_used_connections': ('mysql.net.max_used_connections', GAUGE),
     'Open_files': ('mysql.performance.open_files', GAUGE),
     'Table_locks_waited': ('mysql.performance.table_locks_waited', GAUGE),
     'Threads_connected': ('mysql.performance.threads_connected', GAUGE),


### PR DESCRIPTION
calling Max_used_connections just max_connections leads to confusion as it sounds like it would be the my.cnf max_connections variable (IMO)
