### PR TITLE
[couchdb] Improve error handling and add Blacklist support.

### DIFF
--- a/checks.d/couch.py
+++ b/checks.d/couch.py
@@ -19,6 +19,10 @@ class CouchDb(AgentCheck):
     SOURCE_TYPE_NAME = 'couchdb'
     TIMEOUT = 5
 
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+        self.db_blacklist = {}
+
     def _create_metric(self, data, tags=None):
         overall_stats = data.get('stats', {})
         for key, stats in overall_stats.items():
@@ -42,8 +46,10 @@ class CouchDb(AgentCheck):
         auth = None
         if 'user' in instance and 'password' in instance:
             auth = (instance['user'], instance['password'])
-
-        r = requests.get(url, auth=auth, headers=headers(self.agentConfig),
+        # Override Accept request header so that failures are not redirected to the Futon web-ui
+        request_headers = headers(self.agentConfig)
+        request_headers['Accept'] = 'text/json'
+        r = requests.get(url, auth=auth, headers=request_headers,
                          timeout=int(instance.get('timeout', self.TIMEOUT)))
         r.raise_for_status()
         return r.json()
@@ -98,8 +104,10 @@ class CouchDb(AgentCheck):
 
         # Get the list of whitelisted databases.
         db_whitelist = instance.get('db_whitelist')
+        self.db_blacklist.setdefault(server,[])
+        self.db_blacklist[server].extend(instance.get('db_blacklist',[]))
         whitelist = set(db_whitelist) if db_whitelist else None
-        databases = set(self._get_stats(url, instance))
+        databases = set(self._get_stats(url, instance)) - set(self.db_blacklist[server])
         databases = databases.intersection(whitelist) if whitelist else databases
 
         if len(databases) > self.MAX_DB:
@@ -108,9 +116,15 @@ class CouchDb(AgentCheck):
 
         for dbName in databases:
             url = urljoin(server, dbName)
-
-            db_stats = self._get_stats(url, instance)
+            try:
+                db_stats = self._get_stats(url, instance)
+            except requests.exceptions.HTTPError as e:
+                couchdb['databases'][dbName] = None
+                if (e.response.status_code == 403) or (e.response.status_code == 401):
+                    self.db_blacklist[server].append(dbName)
+                    self.warning('Database %s is not readable by the configured user. It will be added to the blacklist. Please restart the agent to clear.' % dbName)
+                    del couchdb['databases'][dbName]
+                    continue
             if db_stats is not None:
                 couchdb['databases'][dbName] = db_stats
-
         return couchdb

--- a/ci/couchdb.rb
+++ b/ci/couchdb.rb
@@ -75,6 +75,16 @@ namespace :ci do
       sh %(#{couchdb_rootdir}/bin/couchdb -b)
       # Couch takes some time to start
       Wait.for 5984
+
+      # Create a test database
+      sh %(curl -X PUT http://localhost:5984/kennel)
+
+      # Create a user
+      sh %(curl -X PUT http://localhost:5984/_config/admins/dduser -d '"pawprint"')
+
+      # Restrict test databse to authenticated user
+      sh %(curl -X PUT http://dduser:pawprint@127.0.0.1:5984/kennel/_security \
+           -d '{"admins":{"names":[],"roles":[]},"members":{"names":["dduser"],"roles":[]}}')
     end
 
     task script: ['ci:common:script'] do

--- a/conf.d/couch.yaml.example
+++ b/conf.d/couch.yaml.example
@@ -4,6 +4,10 @@ instances:
   # The `db_whitelist` should contain the names of the databases meant to be checked.
   # If no whitelist is specified, all databases will be checked.
   #
+  # The `db_blacklist` should contain the names of any databases meant to be excluded
+  # from being checked. If a database is listed in both the blacklist and whitelist,
+  # the blacklist will take precedence.
+  #
   # You should also notice that no more than 50 databases will be checked, if you have
   # whitelisted more than 50 or if you have more than 50 databases and no whitelist,
   # only the first 50 databases will be checked.
@@ -13,6 +17,10 @@ instances:
     # password: password            # optional
     # timeout: 5                    # in seconds
     # db_whitelist:
+    #  - db1
+    #  - db2
+    #  - db3
+    # db_blacklist:
     #  - db1
     #  - db2
     #  - db3

--- a/tests/checks/integration/test_couch.py
+++ b/tests/checks/integration/test_couch.py
@@ -1,8 +1,7 @@
-# 3p
+from checks import AgentCheck
+
 from nose.plugins.attrib import attr
 
-# project
-from checks import AgentCheck
 from tests.checks.common import AgentCheckTest
 
 
@@ -10,7 +9,29 @@ from tests.checks.common import AgentCheckTest
 class CouchTestCase(AgentCheckTest):
 
     CHECK_NAME = 'couch'
+
+    # Publicly readable databases
     DB_NAMES = ['_users', '_replicator']
+
+    # Databases required a logged in user
+    RESTRICTED_DB_NAMES = ['kennel']
+
+    GLOBAL_GAUGES = [
+        'couchdb.couchdb.auth_cache_hits',
+        'couchdb.couchdb.auth_cache_misses',
+        'couchdb.httpd.requests',
+        'couchdb.httpd_request_methods.GET',
+        'couchdb.httpd_request_methods.PUT',
+        'couchdb.couchdb.request_time',
+        'couchdb.couchdb.open_os_files',
+        'couchdb.couchdb.open_databases',
+        'couchdb.httpd_status_codes.200',
+        'couchdb.httpd_status_codes.201',
+        'couchdb.httpd_status_codes.400',
+        'couchdb.httpd_status_codes.401',
+        'couchdb.httpd_status_codes.404',
+    ]
+
     CHECK_GAUGES = [
         'couchdb.by_db.disk_size',
         'couchdb.by_db.doc_count',
@@ -22,10 +43,24 @@ class CouchTestCase(AgentCheckTest):
 
     def test_couch(self):
         self.run_check(self.config)
+
+        # Metrics should have been emitted for any publicly readable databases.
         for db_name in self.DB_NAMES:
             tags = ['instance:http://localhost:5984', 'db:{0}'.format(db_name)]
             for gauge in self.CHECK_GAUGES:
                 self.assertMetric(gauge, tags=tags, count=1)
+
+        # No metrics should be available for any restricted databases as
+        # we are querying anonymously
+        for db_name in self.RESTRICTED_DB_NAMES:
+            tags = ['instance:http://localhost:5984', 'db:{0}'.format(db_name)]
+            for gauge in self.CHECK_GAUGES:
+                self.assertMetric(gauge, tags=tags, count=0)
+
+        # Check global metrics
+        for gauge in self.GLOBAL_GAUGES:
+            tags = ['instance:http://localhost:5984']
+            self.assertMetric(gauge, tags=tags, at_least=0)
 
         self.assertServiceCheck(self.check.SERVICE_CHECK_NAME,
                                 status=AgentCheck.OK,
@@ -33,6 +68,17 @@ class CouchTestCase(AgentCheckTest):
                                 count=1)
 
         self.coverage_report()
+
+    def test_couch_authorized_user(self):
+        self.config['instances'][0]['user'] = 'dduser'
+        self.config['instances'][0]['password'] = 'pawprint'
+        self.run_check(self.config)
+
+        # As an authorized user we should be able to read restricted databases
+        for db_name in self.RESTRICTED_DB_NAMES:
+            tags = ['instance:http://localhost:5984', 'db:{0}'.format(db_name)]
+            for gauge in self.CHECK_GAUGES:
+                self.assertMetric(gauge, tags=tags, count=1)
 
     def test_bad_config(self):
         self.assertRaises(
@@ -44,3 +90,27 @@ class CouchTestCase(AgentCheckTest):
                                 status=AgentCheck.CRITICAL,
                                 tags=['instance:http://localhost:5985'],
                                 count=1)
+
+    def test_couch_whitelist(self):
+        DB_WHITELIST = ["_users"]
+        self.config['instances'][0]['db_whitelist'] = DB_WHITELIST
+        self.run_check(self.config)
+        for db_name in self.DB_NAMES:
+            tags = ['instance:http://localhost:5984', 'db:{0}'.format(db_name)]
+            for gauge in self.CHECK_GAUGES:
+                if db_name in DB_WHITELIST:
+                    self.assertMetric(gauge, tags=tags, count=1)
+                else:
+                    self.assertMetric(gauge, tags=tags, count=0)
+
+    def test_couch_blacklist(self):
+        DB_BLACKLIST = ["_replicator"]
+        self.config['instances'][0]['db_blacklist'] = DB_BLACKLIST
+        self.run_check(self.config)
+        for db_name in self.DB_NAMES:
+            tags = ['instance:http://localhost:5984', 'db:{0}'.format(db_name)]
+            for gauge in self.CHECK_GAUGES:
+                if db_name in DB_BLACKLIST:
+                    self.assertMetric(gauge, tags=tags, count=0)
+                else:
+                    self.assertMetric(gauge, tags=tags, count=1)


### PR DESCRIPTION
- fail gracefully when one or more individual dbs are not readable by the configured user.
- allow blacklisting of specific databases via db_blacklist in couch.yaml
- append to blacklist at run time if unable to query a given db's stats