### PR TITLE
[checks] Handle requests raised timeouts in http_check

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -85,27 +85,7 @@ class HTTPCheck(NetworkCheck):
             r = requests.get(addr, auth=auth, timeout=timeout, headers=headers,
                              verify=not disable_ssl_validation)
 
-        except socket.timeout, e:
-            length = int((time.time() - start) * 1000)
-            self.log.info("%s is DOWN, error: %s. Connection failed after %s ms"
-                          % (addr, str(e), length))
-            service_checks.append((
-                self.SC_STATUS,
-                Status.DOWN,
-                "%s. Connection failed after %s ms" % (str(e), length)
-            ))
-
-        except requests.exceptions.ConnectionError, e:
-            length = int((time.time() - start) * 1000)
-            self.log.info("%s is DOWN, error: %s. Connection failed after %s ms"
-                          % (addr, str(e), length))
-            service_checks.append((
-                self.SC_STATUS,
-                Status.DOWN,
-                "%s. Connection failed after %s ms" % (str(e), length)
-            ))
-
-        except requests.exceptions.Timeout, e:
+        except (socket.timeout, requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
             length = int((time.time() - start) * 1000)
             self.log.info("%s is DOWN, error: %s. Connection failed after %s ms"
                           % (addr, str(e), length))

--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -105,6 +105,16 @@ class HTTPCheck(NetworkCheck):
                 "%s. Connection failed after %s ms" % (str(e), length)
             ))
 
+        except requests.exceptions.Timeout, e:
+            length = int((time.time() - start) * 1000)
+            self.log.info("%s is DOWN, error: %s. Connection failed after %s ms"
+                          % (addr, str(e), length))
+            service_checks.append((
+                self.SC_STATUS,
+                Status.DOWN,
+                "%s. Connection failed after %s ms" % (str(e), length)
+            ))
+
         except socket.error, e:
             length = int((time.time() - start) * 1000)
             self.log.info("%s is DOWN, error: %s. Connection failed after %s ms"


### PR DESCRIPTION
This fixes a bug reported by a customer where the service check wasn't set to DOWN since the exception was caught by the last, general except.