### PR TITLE
[packaging] Tighten permissions on datadog.conf

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -147,6 +147,8 @@ if [ -e /etc/dd-agent/datadog.conf ]; then
 else
     printf "\033[34m\n* Adding your API key to the Agent configuration: /etc/dd-agent/datadog.conf\n\033[0m\n"
     $sudo_cmd sh -c "sed 's/api_key:.*/api_key: $apikey/' /etc/dd-agent/datadog.conf.example > /etc/dd-agent/datadog.conf"
+    $sudo_cmd chown dd-agent:root /etc/dd-agent/datadog.conf
+    $sudo_cmd chmod 640 /etc/dd-agent/datadog.conf
 fi
 
 restart_cmd="$sudo_cmd /etc/init.d/datadog-agent restart"

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -260,6 +260,7 @@ print_done
 printf "Configuring datadog.conf file......" | tee -a $logfile
 if [ $apikey ]; then
     sed "s/api_key:.*/api_key: $apikey/" $dd_base/agent/datadog.conf.example > $dd_base/agent/datadog.conf 2>> $logfile
+    chmod 640 $dd_base/agent/datadog.conf
 else
   printf "No api key set. Assuming there is already a configuration file present." | tee -a $logfile
 fi

--- a/packaging/osx/install.sh
+++ b/packaging/osx/install.sh
@@ -61,6 +61,7 @@ if egrep 'api_key:( APIKEY)?$' "/opt/datadog-agent/etc/datadog.conf" > /dev/null
     printf "\033[34m\n* Adding your API key to the Agent configuration: datadog.conf\n\033[0m\n"
     $sudo_cmd sh -c "sed -i '' 's/api_key:.*/api_key: $apikey/' \"/opt/datadog-agent/etc/datadog.conf\""
     $sudo_cmd chown $real_user:admin "/opt/datadog-agent/etc/datadog.conf"
+    $sudo_cmd chmod 640 /opt/datadog-agent/etc/datadog.conf
     printf "\033[34m* Restarting the Agent...\n\033[0m\n"
     $cmd_real_user "/opt/datadog-agent/bin/datadog-agent" restart >/dev/null
 else


### PR DESCRIPTION
Unix install scripts now set mode `640` and owner `dd-agent:root` (when applicable) to datadog.conf, as it can contain sensitive data (the api key in particular).

The permissions are set only when the file is not already there.