### PR TITLE
Add warning to 'status' and failover to 'info'

### DIFF
--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -167,13 +167,17 @@ case "$1" in
         restart
         ;;
     status)
+        # Note: sh does not support arrays
         # Check for kernel version 3.18+ - overlayfs has known bug affecting unix domain sockets
-        IFS='.' read -ra VERS <<< "$( uname -r )"
+        major=$(echo "$( uname -r )" | cut -d"." -f1)
+        minor=$(echo "$( uname -r )" | cut -d"." -f2)
         # If major version 3, and minor version 18+, OR major version 4+
-        if [[ ( $(( ${VERS[0]} )) -eq 3 && $(( ${VERS[1]} )) -ge 18 ) || ( $(( ${VERS[0]} )) -gt 3 ) ]]; then
-            echo "Warning: Known bug in Linux Kernel 3.18+ causes 'status' to fail."
+        if ( [ $major -eq 3 ] && [ $minor -ge 18 ] ) || [ $major -gt 3 ]; then
+            RED='\033[0;31m' # Red Text
+            NC='\033[0m' # No Color
+            echo "${RED}Warning: Known bug in Linux Kernel 3.18+ causes 'status' to fail.${NC}"
             echo "Calling 'info', instead..."
-            info
+            service datadog-agent info
         else
             check_status
         fi

--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -167,7 +167,16 @@ case "$1" in
         restart
         ;;
     status)
-        check_status
+        # Check for kernel version 3.18+ - overlayfs has known bug affecting unix domain sockets
+        IFS='.' read -ra VERS <<< "$( uname -r )"
+        # If major version 3, and minor version 18+, OR major version 4+
+        if [[ ( $(( ${VERS[0]} )) -eq 3 && $(( ${VERS[1]} )) -ge 18 ) || ( $(( ${VERS[0]} )) -gt 3 ) ]]; then
+            echo "Warning: Known bug in Linux Kernel 3.18+ causes 'status' to fail."
+            echo "Calling 'info', instead..."
+            info
+        else
+            check_status
+        fi
         ;;
     info)
         info "$@"

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -134,7 +134,16 @@ case "$1" in
         ;;
 
     status)
-        check_status
+        # Check for kernel version 3.18+ - overlayfs has known bug affecting unix domain sockets
+        IFS='.' read -ra VERS <<< "$( uname -r )"
+        # If major version 3, and minor version 18+, OR major version 4+
+        if [[ ( $(( ${VERS[0]} )) -eq 3 && $(( ${VERS[1]} )) -ge 18 ) || ( $(( ${VERS[0]} )) -gt 3 ) ]]; then
+            echo "Warning: Known bug in Linux Kernel 3.18+ causes 'status' to fail."
+            echo "Calling 'info', instead..."
+            info
+        else
+            check_status
+        fi
         ;;
 
     restart|force-reload)

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -134,16 +134,21 @@ case "$1" in
         ;;
 
     status)
+        # Note: sh does not support arrays
         # Check for kernel version 3.18+ - overlayfs has known bug affecting unix domain sockets
-        IFS='.' read -ra VERS <<< "$( uname -r )"
+        major=$(echo "$( uname -r )" | cut -d"." -f1)
+        minor=$(echo "$( uname -r )" | cut -d"." -f2)
         # If major version 3, and minor version 18+, OR major version 4+
-        if [[ ( $(( ${VERS[0]} )) -eq 3 && $(( ${VERS[1]} )) -ge 18 ) || ( $(( ${VERS[0]} )) -gt 3 ) ]]; then
-            echo "Warning: Known bug in Linux Kernel 3.18+ causes 'status' to fail."
+        if ( [ $major -eq 3 ] && [ $minor -ge 18 ] ) || [ $major -gt 3 ]; then
+            RED='\033[0;31m' # Red Text
+            NC='\033[0m' # No Color
+            echo "${RED}Warning: Known bug in Linux Kernel 3.18+ causes 'status' to fail.${NC}"
             echo "Calling 'info', instead..."
-            info
+            service datadog-agent info
         else
             check_status
         fi
+        exit $?
         ;;
 
     restart|force-reload)


### PR DESCRIPTION
On a fresh CoreOS install using the dockerized agent (https://registry.hub.docker.com/u/datadog/docker-dd-agent/) running service datadog-agent status in the container will return a misleading error message of "refused connection" followed by "Datadog Agent (supervisor) is NOT running all child processes".

The connection refusal is a known bug in the Linux kernel, introduced in 3.18 with the addition of overlayfs. This bug will show up in any system using kernel 3.18, which hardlinks unix domain sockets on overlayfs. The result is that calling supervisorctl will cause it to refuse the connection. For the record, tcp sockets are unaffected.

This patch adds a warning to the call to 'status' by first checking if the Linux kernel is version 3.18 or higher. If it is, a warning is presented, and we automatically call 'info' instead. If the version is less than 3.18, then functionality continues as normal.