### PR TITLE
Allow for more complex object hiearchy in debug.get_check

### DIFF
--- a/utils/debug.py
+++ b/utils/debug.py
@@ -47,10 +47,17 @@ def get_check(name, config_str):
     check_module = __import__(name)
     check_class = None
     classes = inspect.getmembers(check_module, inspect.isclass)
+
+    max_hierarchy_len = 0
     for name, clsmember in classes:
         if AgentCheck in clsmember.__bases__:
             check_class = clsmember
             break
+        class_hierarchy = inspect.getmro(clsmember)
+        if AgentCheck in class_hierarchy:
+            if len(class_hier) > max_hierarchy_len:
+               max_hierarchy_len = len(class_hierarchy)
+               check_class = clsmember
     if check_class is None:
         raise Exception("Unable to import check %s. Missing a class that inherits AgentCheck" % name)
 


### PR DESCRIPTION
In the original version of get_check(name,config_str),
if the class specified by name was not a direct
subclass of AgentCheck, the get_check function would return the
direct subclass of AgentCheck. This verison takes into account the object
hierarchy and returns the lowest class on the object hierarchy instead.
Examples for this are HTTPCheck(NetworkCheck(AgentCheck))