### PR TITLE
Recalculate disk.in_use to make consistent with df's Use% metric

### DIFF
--- a/checks.d/disk.py
+++ b/checks.d/disk.py
@@ -96,10 +96,21 @@ class Disk(AgentCheck):
             tags = [part.fstype] if self._tag_by_filesystem else []
             device_name = part.mountpoint if self._use_mount else part.device
 
+            # Note: psutil (0.3.0 to at least 3.1.1) calculates in_use as (used / total)
+            #       The problem here is that total includes reserved space the user
+            #       doesn't have access to. This causes psutil to calculate a misleadng
+            #       percentage for in_use; a lower percentage than df shows.
+
+            # Calculate in_use w/o reserved space; consistent w/ df's Use% metric.
+            pmets = self._collect_part_metrics(part, disk_usage)
+            used = 'system.disk.used'
+            free = 'system.disk.free'
+            pmets['system.disk.in_use'] = pmets[used] / (pmets[used] + pmets[free])
+
             # legacy check names c: vs psutil name C:\\
             if Platform.is_win32():
                 device_name = device_name.strip('\\').lower()
-            for metric_name, metric_value in self._collect_part_metrics(part, disk_usage).iteritems():
+            for metric_name, metric_value in pmets.iteritems():
                 self.gauge(metric_name, metric_value,
                            tags=tags, device_name=device_name)
         # And finally, latency metrics, a legacy gift from the old Windows Check


### PR DESCRIPTION
As it turns out psutil is actually UNDER counting disk.in_use because it is INCLUDING reserved space.
The solution, to bring this back to what df shows, is to calculate the disk usage ourselves by doing ( disk.used / (disk.used + disk.free) ), which will completely ignore the root space.

I separated 'system.disk.used' and 'system.disk.free' into different variables for readability.

Further Proof:
The calculation by psutil of disk.total is (disk.free + disk.used + <root_reserved_space>). You can prove that disk.total is including root space by adding disk.free + disk.used. The number you'll come up with is exactly <root_reserved_space> less than disk.total.

The calculation by psutil of disk.in_use is ( disk.used / disk.total ), pushing the percentage down because the disk.total includes the <root_reserved_space>.