### PR TITLE
Rather than grabbing in_use from df, calculate for precision

### DIFF
--- a/checks.d/disk.py
+++ b/checks.d/disk.py
@@ -176,14 +176,18 @@ class Disk(AgentCheck):
 
     def _collect_metrics_manually(self, device):
         result = {}
+
+        used = float(device[3])
+        free = float(device[4])
+
         # device is
         # ["/dev/sda1", "ext4", 524288,  171642,  352646, "33%", "/"]
         result[self.METRIC_DISK.format('total')] = float(device[2])
-        result[self.METRIC_DISK.format('used')] = float(device[3])
-        result[self.METRIC_DISK.format('free')] = float(device[4])
-        if len(device[5]) > 1 and device[5][-1] == '%':
-            result[self.METRIC_DISK.format('in_use')] = \
-                float(device[5][:-1]) / 100.0
+        result[self.METRIC_DISK.format('used')] = used
+        result[self.METRIC_DISK.format('free')] = free
+
+        # Rather than grabbing in_use, let's calculate it to be more precise
+        result[self.METRIC_DISK.format('in_use')] = used / (used + free)
 
         result.update(self._collect_inodes_metrics(device[-1]))
         return result


### PR DESCRIPTION
Currently, for our manual checks, we are just grabbing the percentage for disk in_use from the output of df. This produces a percentage with no decimal precision. To improve this precision, let's calculate the disk in_use metric ourselves based on the free and used values supplied by df. This calculation is consistent with how df calculates disk usage, but isn't rounded up.

Calculation: <disk_used> / (<disk_used> + <disk_free>)

Further Proof:
We don't calculate in_use as (<disk_used> / <disk_total>), because <disk_total> includes reserved space that is inaccessable by the user. Calculating this way would produce a misleading value that is of a lower percentage than what df shows.