### PR TITLE
Force exclusion of CDROM (iso9660) from disk check

### DIFF
--- a/checks.d/disk.py
+++ b/checks.d/disk.py
@@ -52,6 +52,9 @@ class Disk(AgentCheck):
         self._all_partitions = _is_affirmative(
             instance.get('all_partitions', False))
 
+        # Force exclusion of CDROM (iso9660) from disk check
+        self._excluded_filesystems.append('iso9660')
+
         # FIXME: 6.x, drop use_mount option in datadog.conf
         self._load_legacy_option(instance, 'use_mount', False,
                                  operation=_is_affirmative)

--- a/tests/checks/mock/test_disk.py
+++ b/tests/checks/mock/test_disk.py
@@ -167,7 +167,7 @@ class TestCheckDisk(AgentCheckTest):
         self.check._load_conf({})
 
         self.assertFalse(self.check._use_mount)
-        self.assertEqual(self.check._excluded_filesystems, [])
+        self.assertEqual(self.check._excluded_filesystems, ['iso9660'])
         self.assertEqual(self.check._excluded_disks, [])
         self.assertFalse(self.check._tag_by_filesystem)
         self.assertFalse(self.check._all_partitions)


### PR DESCRIPTION
Currently the agent disk check is including the monitoring of mounted cd-rom images. This isn't good as these are read-only and already have 100% usage. This is a threat for triggers false positives.

Solution is to forcibly exclude CDROM (iso9660) filesystems from the disk check.