### PR TITLE
Have the mongo check be configurable for dbStats only

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -172,6 +172,8 @@ class MongoDb(AgentCheck):
             'ssl_ca_certs': instance.get('ssl_ca_certs', None)
         }
 
+        db_stats_only = instance.get('db_stats_only', False)
+
         for key, param in ssl_params.items():
             if param is None:
                 del ssl_params[key]
@@ -227,9 +229,12 @@ class MongoDb(AgentCheck):
 
         self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=service_check_tags)
 
-        status = db["$cmd"].find_one({"serverStatus": 1})
-        if status['ok'] == 0:
-            raise Exception(status['errmsg'].__str__())
+        if not db_stats_only:
+            status = db["$cmd"].find_one({"serverStatus": 1})
+            if status['ok'] == 0:
+                raise Exception(status['errmsg'].__str__())
+        else:
+            status = {}
 
         status['stats'] = db.command('dbstats')
 

--- a/conf.d/mongo.yaml.example
+++ b/conf.d/mongo.yaml.example
@@ -15,3 +15,7 @@ instances:
     # ssl_certfile: # Path to the certificate file used to identify the local connection against mongod.
     # ssl_cert_reqs: # Specifies whether a certificate is required from the other side of the connection, and whether it will be validated if provided.
     # ssl_ca_certs: #  Path to the ca_certs file
+
+    # Optional parameter that will not call 'serverStatus' on this database. 'serverStatus' should only be called once per server, not database.
+    # If you are monitoring multiple databases, you will want to set this to true for each database that is not the admin database.
+    # db_stats_only: False # (default to False)


### PR DESCRIPTION
This fixes the issue of having multiple databases will get the serverStatus data and report the values multiple times to Datadog. Also if the server has auth enabled, serverStatus will fail on non admin databases that are added to the check, when using the recommended 'clusterMonitor' role