### PR TITLE
[deps] bump ntplib version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 ###########################################################
 
 boto==2.36.0
-ntplib==0.3.2
+ntplib==0.3.3
 # the libyaml bindings are optional
 pyyaml==3.11
 # note: requests is also used in many checks


### PR DESCRIPTION
Apparently `0.3.2` has disappeared from PyPi . 

cc @elafarge 