### PR TITLE
Checking that attribute retreived by wmi_property is not None

### DIFF
--- a/checks.d/wmi_check.py
+++ b/checks.d/wmi_check.py
@@ -109,8 +109,12 @@ class WMICheck(AgentCheck):
                     # Special-case metric will just submit 1 for every value
                     # returned in the result.
                     val = 1
-                else:
+                elif getattr(res, wmi_property):
                     val = float(getattr(res, wmi_property))
+                else:
+                    self.log.warning("When extracting metrics with wmi, found a null value for property '{0}'. "
+                                     "Metric type of property is {1}."
+                                     .format(wmi_property, mtype))
 
                 try:
                     func = getattr(self, mtype)


### PR DESCRIPTION
Discovered that when wmi_check.py is run, that depending upon the yaml configuration, it can end up pulling attributes that have a value of None, which will throw a TypeError complaining that float() cannot coerce something that is not a string nor an integer. Specifically, this issue came to light with a config that setup grabbing metrics for the `FreeSpace` and `Size` properties from the `Win32_LogicalDisk` class. This runs for all disks, including CD-ROMs, which will report nothing for either property.

The fix is to check tht the attribute retrieved by wmi_property is not None before attempting to coerce to a float.

I'll not for the record as well, in regard to the specific situation that this turned up in, that we are already collecting disk usage statistics in `checks.d/disk.py`, and specifically `FreeSpace` would probably correspond to `system.disk.free` and `Size` to `system.disk.total`, for each disk.