### PR TITLE
Remove psutil dependency in the agent core

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -19,8 +19,8 @@ import signal
 import sys
 import time
 
-# 3p
-from psutil import pid_exists
+# project
+from utils.process import pid_exists
 
 log = logging.getLogger(__name__)
 

--- a/tests/test_utils_process.py
+++ b/tests/test_utils_process.py
@@ -1,0 +1,19 @@
+# stdlib
+import os
+import unittest
+
+# project
+from utils.process import pid_exists
+
+
+class UtilsProcessTest(unittest.TestCase):
+    def test_my_own_pid(self):
+        my_pid = os.getpid()
+        self.assertTrue(pid_exists(my_pid))
+
+    def test_inexistant_pid(self):
+        # There will be one point where we finally find a free PID
+        for pid in xrange(30000):
+            if not pid_exists(pid):
+                return
+        raise Exception("Probably a bug in pid_exists or more than 30000 procs!!")

--- a/utils/process.py
+++ b/utils/process.py
@@ -1,0 +1,52 @@
+# stdlib
+import errno
+import os
+
+# 3p
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
+# project
+from util import Platform
+
+
+def pid_exists(pid):
+    """
+    Check if a pid exists.
+    Lighter than psutil.pid_exists
+    """
+    if psutil:
+        return psutil.pid_exists(pid)
+
+    # We don't support windows for now
+    if Platform.is_windows():
+        raise NotImplementedError("pid_exists is not implemented for Windows")
+
+    # Code from psutil._psposix.pid_exists
+    # See https://github.com/giampaolo/psutil/blob/master/psutil/_psposix.py
+    if pid == 0:
+        # According to "man 2 kill" PID 0 has a special meaning:
+        # it refers to <<every process in the process group of the
+        # calling process>> so we don't want to go any further.
+        # If we get here it means this UNIX platform *does* have
+        # a process with id 0.
+        return True
+    try:
+        os.kill(pid, 0)
+    except OSError as err:
+        if err.errno == errno.ESRCH:
+            # ESRCH == No such process
+            return False
+        elif err.errno == errno.EPERM:
+            # EPERM clearly means there's a process to deny access to
+            return True
+        else:
+            # According to "man 2 kill" possible error values are
+            # (EINVAL, EPERM, ESRCH) therefore we should never get
+            # here. If we do let's be explicit in considering this
+            # an error.
+            raise err
+    else:
+        return True

--- a/utils/process.py
+++ b/utils/process.py
@@ -20,9 +20,17 @@ def pid_exists(pid):
     if psutil:
         return psutil.pid_exists(pid)
 
-    # We don't support windows for now
     if Platform.is_windows():
-        raise NotImplementedError("pid_exists is not implemented for Windows")
+        import ctypes  # Available from python2.5
+        kernel32 = ctypes.windll.kernel32
+        synchronize = 0x100000
+
+        process = kernel32.OpenProcess(synchronize, 0, pid)
+        if process != 0:
+            kernel32.CloseHandle(process)
+            return True
+        else:
+            return False
 
     # Code from psutil._psposix.pid_exists
     # See https://github.com/giampaolo/psutil/blob/master/psutil/_psposix.py


### PR DESCRIPTION
The `Daemon` class got an additional dependency with `psutil` with this commit 21ba11a, which broke the source install.
The problem is that the core of the agent now depends on psutil, which is not installed in the install from source (because psutil needs a lot of stuff to be built). This fixes the issue by removing this hard dependency.

Cherry-picked 2 commits from https://github.com/DataDog/dd-agent/pull/1504 so that the source install can be fixed for the 5.5 release.