### PR TITLE
[mesos] Support Mesos version 0.23.0

### DIFF
--- a/checks.d/mesos.py
+++ b/checks.d/mesos.py
@@ -22,6 +22,8 @@ class Mesos(AgentCheck):
         default_timeout = self.init_config.get('default_timeout', 5)
         timeout = float(instance.get('timeout', default_timeout))
 
+        self.version = self.get_version(url, timeout)
+
         response = self.get_master_roles(url, timeout)
         if response is not None:
             for role in response['roles']:
@@ -42,8 +44,9 @@ class Mesos(AgentCheck):
         response = self.get_master_state(url, timeout)
         if response is not None:
             tags = instance_tags
-            for attr in ['deactivated_slaves','failed_tasks','finished_tasks','killed_tasks','lost_tasks','staged_tasks','started_tasks']:
-                self.gauge('mesos.state.' + attr, response[attr], tags=tags)
+            if self.version <= [0, 22, 0]:
+                for attr in ['deactivated_slaves','failed_tasks','finished_tasks','killed_tasks','lost_tasks','staged_tasks','started_tasks']:
+                    self.gauge('mesos.state.' + attr, response[attr], tags=tags)
 
             for framework in response['frameworks']:
                 tags = ['framework:' + framework['id']] + instance_tags
@@ -63,10 +66,19 @@ class Mesos(AgentCheck):
         return self.get_json(url + "/master/roles.json", timeout)
 
     def get_master_stats(self, url, timeout):
-        return self.get_json(url + "/master/stats.json", timeout)
+        if self.version >= [0, 23, 0]:
+            endpoint = '/metrics/snapshot'
+        else:
+            endpoint = '/stats.json'
+        return self.get_json(url + endpoint, timeout)
 
     def get_master_state(self, url, timeout):
         return self.get_json(url + "/master/state.json", timeout)
+
+    def get_version(self, url, timeout):
+        data = self.get_json(url + "/master/state.json", timeout)
+        version = map(int, data['version'].split('.'))
+        return version
 
     def get_json(self, url, timeout):
         # Use a hash of the URL as an aggregation key


### PR DESCRIPTION
### Problem

datadog-agent 5.4.3 is not compatible with mesos version 0.23.0.
I got the error below...
```
Datadog's mesos integration is reporting:
Instance #0[ERROR]:"'failed_tasks'"
```

### Pull Request

/master/stats.json has been migrated to /metrics /snapshot from mesos 0.23.0,
and the following state attr keys has obsolete from mesos 0.23.0.
```
deactivated_slaves
failed_tasks
finished_tasks
killed_tasks
lost_tasks
staged_tasks
started_tasks
```