### PR TITLE
[http_check] Add quote to http copy for clarity

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -149,7 +149,7 @@ class HTTPCheck(NetworkCheck):
                     service_checks.append((
                         self.SC_STATUS,
                         Status.DOWN,
-                        "Content %s not found in response" % content_match
+                        'Content "%s" not found in response' % content_match
                     ))
             else:
                 self.log.debug("%s is UP" % addr)


### PR DESCRIPTION
Per customer request:
> The `content_match` text is not picked out of the body of the email, so it’s not clear.

[Related card](https://trello.com/c/4TXcnGc8/314-copy-update-for-http-tcp-check-message)