### PR TITLE
[RabbitMQ] Fix variable for absolute queue name situations

### DIFF
--- a/checks.d/rabbitmq.py
+++ b/checks.d/rabbitmq.py
@@ -212,7 +212,7 @@ class RabbitMQ(AgentCheck):
                 absolute_name = '%s/%s' % (data_line.get("vhost"), name)
                 if absolute_name in explicit_filters:
                     matching_lines.append(data_line)
-                    explicit_filters.remove(name)
+                    explicit_filters.remove(absolute_name)
                     continue
 
                 for p in regex_filters:


### PR DESCRIPTION
Fixing issue #1819
where exception `ValueError: list.remove(x): x not in list` is raised
any time there is a queue with an absolute name (format `vhost/queue_name`)
in the rabbitmq.yaml