### PR TITLE
[windows_service] add debug logs

### DIFF
--- a/checks.d/windows_service.py
+++ b/checks.d/windows_service.py
@@ -41,6 +41,7 @@ class WindowsService(AgentCheck):
             raise Exception('No services defined in windows_service.yaml')
 
         for service in services:
+            self.log.debug(u"Looking for service name: %s" % service)
             results = w.Win32_Service(name=service)
             if len(results) == 0:
                 self.warning(u"No services found matching %s" % service)


### PR DESCRIPTION
Windows Service check lacks of logs, thus, it is quite difficult to
troubleshoot.
Adding `debug` level logs to fix that.