### PR TITLE
[mongo] make timeout configurable and increase the default

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -9,7 +9,7 @@ import pymongo
 from checks import AgentCheck
 from util import get_hostname
 
-DEFAULT_TIMEOUT = 10
+DEFAULT_TIMEOUT = 30
 
 
 class MongoDb(AgentCheck):
@@ -211,8 +211,9 @@ class MongoDb(AgentCheck):
             self.log.debug("Mongo: cannot extract username and password from config %s" % server)
             do_auth = False
 
+        timeout = float(instance.get('timeout', DEFAULT_TIMEOUT))
         try:
-            conn = pymongo.Connection(server, network_timeout=DEFAULT_TIMEOUT,
+            conn = pymongo.Connection(server, network_timeout=timeout,
                 **ssl_params)
             db = conn[db_name]
         except Exception:

--- a/conf.d/mongo.yaml.example
+++ b/conf.d/mongo.yaml.example
@@ -3,6 +3,9 @@ init_config:
 instances:
   # Specify the MongoDB URI, with database to use for reporting (defaults to "admin")
   - server: mongodb://localhost:27017/admin
+    # Time to wait on creating a MongoDB connection
+    # timeout: 30
+
     # tags:
     #   - optional_tag1
     #   - optional_tag2


### PR DESCRIPTION
We have one MongoDB instance that's misbehaving. It's a bit slow to connect to it because of the problems it's having and so it's difficult to tell what's wrong because we're not getting any metrics from it. 