### PR TITLE
[vmware] Adding network.received and network.transmitted to basic_metrics.py

### DIFF
--- a/checks/libs/vmware/basic_metrics.py
+++ b/checks/libs/vmware/basic_metrics.py
@@ -89,4 +89,16 @@ BASIC_METRICS = {
         'rollup'       : 'average',
         'entity'       : ['VirtualMachine', 'HostSystem', 'ResourcePool']
     },
+    'network.received': {
+        's_type'       : 'rate',
+        'unit'         : 'kiloBytesPerSecond',
+        'rollup'       : 'average',
+        'entity'       : ['VirtualMachine', 'HostSystem']
+    },
+    'network.transmitted': {
+        's_type'       : 'rate',
+        'unit'         : 'kiloBytesPerSecond',
+        'rollup'       : 'average',
+        'entity'       : ['VirtualMachine', 'HostSystem']
+    },
 }


### PR DESCRIPTION
The vsphere dashboard is currently attempting to use these two metrics, but they are not included in the basic metrics collected. This should add those metrics, without the need to enable all metrics (read: a TON of metrics).

The vsphere dashboard is also trying to display disk.usage and mem.usage, which are also not basic metrics, but those are not being added at this time, because their compatibility is unknown as shown [here](https://github.com/DataDog/dd-agent/blob/master/checks/libs/vmware/all_metrics.py#L1215) and [here](https://github.com/DataDog/dd-agent/blob/master/checks/libs/vmware/all_metrics.py#L699)