### PR TITLE
Add support for MemAvailable for newer Linux kernels.

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -307,6 +307,8 @@ class Collector(object):
                     'memPhysUsed': memory.get('physUsed'),
                     'memPhysPctUsable': memory.get('physPctUsable'),
                     'memPhysFree': memory.get('physFree'),
+                    'memPhysAvailable':memory.get('physAvailable'),
+                    'memPhysPctAvailable':memory.get('physPctAvailable'),
                     'memPhysTotal': memory.get('physTotal'),
                     'memPhysUsable': memory.get('physUsable'),
                     'memSwapUsed': memory.get('swapUsed'),

--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -303,6 +303,7 @@ class Memory(Check):
             # $ cat /proc/meminfo
             # MemTotal:        7995360 kB
             # MemFree:         1045120 kB
+            # MemAvailable:    1253920 kB
             # Buffers:          226284 kB
             # Cached:           775516 kB
             # SwapCached:       248868 kB
@@ -361,6 +362,7 @@ class Memory(Check):
             try:
                 memData['physTotal'] = int(meminfo.get('MemTotal', 0)) / 1024
                 memData['physFree'] = int(meminfo.get('MemFree', 0)) / 1024
+                memData['physAvailable'] = int(meminfo.get('MemAvailable', 0)) / 1024
                 memData['physBuffers'] = int(meminfo.get('Buffers', 0)) / 1024
                 memData['physCached'] = int(meminfo.get('Cached', 0)) / 1024
                 memData['physShared'] = int(meminfo.get('Shmem', 0)) / 1024
@@ -371,6 +373,7 @@ class Memory(Check):
 
                 if memData['physTotal'] > 0:
                     memData['physPctUsable'] = float(memData['physUsable']) / float(memData['physTotal'])
+                    memData['physPctAvailable'] = float(memData['physAvailable']) / float(memData['physTotal'])
             except Exception:
                 self.logger.exception('Cannot compute stats from /proc/meminfo')
 


### PR DESCRIPTION
See discussion at https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773 - MemAvailable is preferable to manually calculating using MemFree, Buffers, Cached, Shared, etc.