### PR TITLE
[osx][install_script] Remove confusing sudo prompt

### DIFF
--- a/packaging/osx/install.sh
+++ b/packaging/osx/install.sh
@@ -45,15 +45,16 @@ if [ ! $apikey ]; then
 fi
 
 # Install the agent
-printf "\033[34m\n* Downloading and installing datadog-agent\n\033[0m"
+printf "\033[34m\n* Downloading datadog-agent\n\033[0m"
 rm -f $dmg_file
 curl $dmg_url > $dmg_file
-if [ "$sudo_cmd" = "sudo" ]; then
-    printf "\033[34m\n  Your password is needed to install and configure the agent \n\033[0m"
-fi
+printf "\033[34m\n* Installing datadog-agent, you might be asked for your sudo password...\n\033[0m"
 $sudo_cmd hdiutil detach "/Volumes/datadog_agent" >/dev/null 2>&1 || true
+printf "\033[34m\n    - Mounting the DMG installer...\n\033[0m"
 $sudo_cmd hdiutil attach "$dmg_file" -mountpoint "/Volumes/datadog_agent" >/dev/null
+printf "\033[34m\n    - Unpacking and copying files (this usually takes about a minute) ...\n\033[0m"
 cd / && $sudo_cmd /usr/sbin/installer -pkg `find "/Volumes/datadog_agent" -name \*.pkg 2>/dev/null` -target / >/dev/null
+printf "\033[34m\n    - Unmounting the DMG installer ...\n\033[0m"
 $sudo_cmd hdiutil detach "/Volumes/datadog_agent" >/dev/null
 
 # Set the configuration


### PR DESCRIPTION
We use to display a prompt when asking for a sudo password which turns
out to be useful if the user's sudo password is cached because recently
used in the same terminal... that's really confusing and in addition, it
leads customers to type their password in clear on a terminal, which
isn't really cool.

This has been removed and we now rely on the system prompt only when the
sudo password is needed :)

We keep on notifying the user he MAY be asked for his sudo password
since OSX just shows `password`, it made sense to precise that it
actually means the SUDO password and not the one on Datadog or whatever.

[skip ci]