### PR TITLE
[btrfs] track usage based on used bytes instead of free bytes

### DIFF
--- a/checks.d/btrfs.py
+++ b/checks.d/btrfs.py
@@ -132,7 +132,7 @@ class BTRFS(AgentCheck):
                 ]
 
                 free = total_bytes - used_bytes
-                usage = float(free) / float(total_bytes)
+                usage = float(used_bytes) / float(total_bytes)
 
                 self.gauge('system.disk.btrfs.total', total_bytes, tags=tags, device_name=device)
                 self.gauge('system.disk.btrfs.used', used_bytes, tags=tags, device_name=device)


### PR DESCRIPTION
In other datadog stats (eg. `system.fs.inodes.in_use`, `system.disk.in_use`), 0 means no usage, and 1 means full usage.

This change makes `btrfs.disk.btrfs.usage` report values in the same way: 1 = 100% usage.