### PR TITLE
[snmp] add debug level logs

### DIFF
--- a/checks.d/snmp.py
+++ b/checks.d/snmp.py
@@ -1,5 +1,6 @@
 # std
 from collections import defaultdict
+from functools import wraps
 
 # 3rd party
 from pysnmp.entity.rfc3413.oneliner import cmdgen
@@ -10,6 +11,7 @@ from pysnmp.smi.exval import noSuchInstance, noSuchObject
 # project
 from checks import AgentCheck
 from config import _is_affirmative
+
 
 
 # Additional types that are not part of the SNMP protocol. cf RFC 2856
@@ -56,23 +58,41 @@ class SnmpCheck(AgentCheck):
             mibs_path = init_config.get("mibs_folder")
             ignore_nonincreasing_oid = _is_affirmative(
                 init_config.get("ignore_nonincreasing_oid", False))
-        SnmpCheck.create_command_generator(mibs_path, ignore_nonincreasing_oid)
 
-    @classmethod
-    def create_command_generator(cls, mibs_path, ignore_nonincreasing_oid):
+        # Create SNMP command generator and aliases
+        self.create_command_generator(mibs_path, ignore_nonincreasing_oid)
+
+    def snmp_logger(self, func):
+        """
+        Decorator to log, with DEBUG level, SNMP commands
+        """
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            self.log.debug("Running SNMP command {0} on OIDS {1}"
+                           .format(func.__name__, args[2:]))
+            result = func(*args, **kwargs)
+            self.log.debug("Returned vars: {0}".format(result[-1]))
+            return result
+        return wrapper
+
+    def create_command_generator(self, mibs_path, ignore_nonincreasing_oid):
         '''
         Create a command generator to perform all the snmp query.
         If mibs_path is not None, load the mibs present in the custom mibs
         folder. (Need to be in pysnmp format)
         '''
-        cls.cmd_generator = cmdgen.CommandGenerator()
-        cls.cmd_generator.ignoreNonIncreasingOid = ignore_nonincreasing_oid
+        self.cmd_generator = cmdgen.CommandGenerator()
+        self.cmd_generator.ignoreNonIncreasingOid = ignore_nonincreasing_oid
         if mibs_path is not None:
-            mib_builder = cls.cmd_generator.snmpEngine.msgAndPduDsp.\
+            mib_builder = self.cmd_generator.snmpEngine.msgAndPduDsp.\
                 mibInstrumController.mibBuilder
             mib_sources = mib_builder.getMibSources() + \
                 (builder.DirMibSource(mibs_path), )
             mib_builder.setMibSources(*mib_sources)
+
+        # Set aliases for snmpget and snmpgetnext with logging
+        self.snmpget = self.snmp_logger(self.cmd_generator.getCmd)
+        self.snmpgetnext = self.snmp_logger(self.cmd_generator.nextCmd)
 
     @classmethod
     def get_auth_data(cls, instance):
@@ -161,8 +181,7 @@ class SnmpCheck(AgentCheck):
         while first_oid < len(oids):
 
             # Start with snmpget command
-            snmp_command = self.cmd_generator.getCmd
-            error_indication, error_status, error_index, var_binds = snmp_command(
+            error_indication, error_status, error_index, var_binds = self.snmpget(
                 auth_data,
                 transport_target,
                 *(oids[first_oid:first_oid + OID_BATCH_SIZE]),
@@ -194,8 +213,7 @@ class SnmpCheck(AgentCheck):
 
             if missing_results:
                 # If we didn't catch the metric using snmpget, try snmpnext
-                snmp_command = self.cmd_generator.nextCmd
-                error_indication, error_status, error_index, var_binds_table = snmp_command(
+                error_indication, error_status, error_index, var_binds_table = self.snmpgetnext(
                     auth_data,
                     transport_target,
                     *missing_results,
@@ -226,7 +244,7 @@ class SnmpCheck(AgentCheck):
                 oid = result_oid.asTuple()
                 matching = ".".join([str(i) for i in oid])
                 results[matching] = value
-
+        self.log.debug("Raw results: {0}".format(results))
         return results
 
     def check(self, instance):


### PR DESCRIPTION
SNMP check lacks of logs, thus, it is quite difficult to troubleshoot.
Adding debug level logs to fix that.