### PR TITLE
[mesos_master] Fix error on non leader nodes

### DIFF
--- a/checks.d/mesos_master.py
+++ b/checks.d/mesos_master.py
@@ -170,13 +170,13 @@ class MesosMaster(AgentCheck):
 
     def _check_leadership(self, url, timeout):
         state_metrics = self._get_master_state(url, timeout)
+        self.leader = False
 
         if state_metrics is not None:
             self.version = map(int, state_metrics['version'].split('.'))
             if state_metrics['leader'] == state_metrics['pid']:
                 self.leader = True
-        else:
-            self.leader = False
+
         return state_metrics
 
     def check(self, instance):


### PR DESCRIPTION
On a non leader node, this is the error one of our customer got:
instance #0 [ERROR]: "'MesosMaster' object has no attribute 'leader'"

This commit should fix this issue.