### PR TITLE
[wmi] report zeroes :bug:

### DIFF
--- a/checks.d/wmi_check.py
+++ b/checks.d/wmi_check.py
@@ -109,13 +109,17 @@ class WMICheck(AgentCheck):
                     # Special-case metric will just submit 1 for every value
                     # returned in the result.
                     val = 1
-                elif getattr(res, wmi_property):
-                    val = float(getattr(res, wmi_property))
                 else:
-                    self.log.warning("When extracting metrics with wmi, found a null value"
-                                     " for property '{0}'. Metric type of property is {1}."
-                                     .format(wmi_property, mtype))
-                    continue
+                    try:
+                        val = float(getattr(res, wmi_property))
+                    except ValueError:
+                        self.log.warning("When extracting metrics with WMI, found a non digit value"
+                                         " for property '{0}'.".format(wmi_property))
+                        continue
+                    except AttributeError:
+                        self.log.warning("'{0}' WMI class has no property '{1}'."
+                                         .format(res.__class__.__name__, wmi_property))
+                        continue
 
                 # Submit the metric to Datadog
                 try:


### PR DESCRIPTION
Fix regression with #1800, as 0s were not reported anymore.
Log a warning when the specified WMI property does not exist among the
class, or when the value extracted is not a digit.
Keep the crawler running.