### PR TITLE
[zk] new `zookeeper.bytes_received/sent*` rates 

### DIFF
--- a/checks.d/zk.py
+++ b/checks.d/zk.py
@@ -24,7 +24,6 @@ Tested with Zookeeper versions 3.0.0 to 3.4.5
 
 '''
 # stdlib
-from collections import namedtuple
 from StringIO import StringIO
 import re
 import socket
@@ -39,13 +38,13 @@ class ZKConnectionFailure(Exception):
     pass
 
 
-class ZKMetric(namedtuple('ZKMetric', ['name', 'value', 'm_type'])):
+class ZKMetric(tuple):
     """
     A Zookeeper metric.
-    Named tuple with an optional metric type (default is 'gauge').
+    Tuple with an optional metric type (default is 'gauge').
     """
     def __new__(cls, name, value, m_type="gauge"):
-        return super(ZKMetric, cls).__new__(cls, name, value, m_type)
+        return super(ZKMetric, cls).__new__(cls, [name, value, m_type])
 
 
 class ZookeeperCheck(AgentCheck):
@@ -177,10 +176,12 @@ class ZookeeperCheck(AgentCheck):
         # Received: 101032173
         _, value = buf.readline().split(':')
         metrics.append(ZKMetric('zookeeper.bytes_received', long(value.strip())))
+        metrics.append(ZKMetric('zookeeper.bytes_received_per_second', long(value.strip()), "rate"))
 
         # Sent: 1324
         _, value = buf.readline().split(':')
         metrics.append(ZKMetric('zookeeper.bytes_sent', long(value.strip())))
+        metrics.append(ZKMetric('zookeeper.bytes_sent_per_second', long(value.strip()), "rate"))
 
         if has_connections_val:
             # Connections: 1

--- a/tests/checks/integration/test_zk.py
+++ b/tests/checks/integration/test_zk.py
@@ -37,6 +37,8 @@ class ZooKeeperTestCase(AgentCheckTest):
         'zookeeper.latency.max',
         'zookeeper.bytes_received',
         'zookeeper.bytes_sent',
+        'zookeeper.bytes_received_per_second',
+        'zookeeper.bytes_sent_per_second',
         'zookeeper.connections',
         'zookeeper.connections',
         'zookeeper.bytes_outstanding',
@@ -53,7 +55,7 @@ class ZooKeeperTestCase(AgentCheckTest):
         config = {
             'instances': [self.CONFIG]
         }
-        self.run_check(config)
+        self.run_check_twice(config)
 
         # Test metrics
         for mname in self.METRICS:
@@ -67,7 +69,7 @@ class ZooKeeperTestCase(AgentCheckTest):
 
     def test_wrong_expected_mode(self):
         """
-        Raise a 'critical' service check when ZooKeeper is not in the expected mode
+        Raise a 'critical' service check when ZooKeeper is not in the expected mode.
         """
         config = {
             'instances': [self.WRONG_EXPECTED_MODE]
@@ -79,7 +81,7 @@ class ZooKeeperTestCase(AgentCheckTest):
 
     def test_error_state(self):
         """
-        Raise a 'critical' service check when ZooKeeper is in an error state
+        Raise a 'critical' service check when ZooKeeper is in an error state.
         """
         config = {
             'instances': [self.CONNECTION_FAILURE_CONFIG]


### PR DESCRIPTION
Switch `zookeeper.bytes_received`, `zookeeper.bytes_sent` from `gauge` to `count` type. 
**WARNING**: potential backward incompatibility issues.
Fix #1729.

@remh can you take a pass on it ? I am also wondering if we should use `rate` instead of a `count`, as both are valid.
