### PR TITLE
[logging] Avoid initializing logging multiple times

### DIFF
--- a/config.py
+++ b/config.py
@@ -992,6 +992,11 @@ def get_logging_config(cfg_path=None):
 
 
 def initialize_logging(logger_name):
+    # This function should only be called once per process, return here if it's already been called
+    if hasattr(initialize_logging, "called"):
+        return
+    initialize_logging.called = True
+
     try:
         logging_config = get_logging_config()
 


### PR DESCRIPTION
The initialization of logging is usually done at the beginning of a python module. This can lead the init of logging to happen multiple times when a module that has already initialized it imports another module that also inits it, which causes the logs of the first module to be duplicated in the second module's logs.

For instance `agent.py` imports `jmxfetch.py`, which causes the collector's logs to also end up in `jmxfetch.py`'s logs.

I don't think we ever want the init of logging to happen multiple times per process, hence this commit.

Open for discussion as I'm not sure I'm aware of all the possible consequences of this change.