### PR TITLE
[docker] `docker.containers.count` metric

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -101,7 +101,7 @@ class DockerDaemon(AgentCheck):
         if _is_affirmative(instance.get('collect_container_size', True)):
             self._report_container_size(instance, containers_by_id)
 
-        # TODO: bring events back
+        # TODO: bring events back --> OK - need to test
         # Send events from Docker API
         if _is_affirmative(instance.get('collect_events', True)):
             self._process_events(instance, containers_by_id)
@@ -490,7 +490,6 @@ class DockerDaemon(AgentCheck):
         return metrics
 
     # proc files
-    # TODO: return something, yo!
     def _crawl_container_pids(self, container_dict):
         """Crawl `/proc` to find container PIDs and add them to `containers_by_id`."""
         for folder in os.listdir('/proc'):

--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -1,0 +1,457 @@
+# stdlib
+import os
+import re
+# import time
+# from collections import defaultdict
+
+# project
+from checks import AgentCheck
+from config import _is_affirmative
+
+# 3rd party
+from docker import Client
+
+EVENT_TYPE = 'docker'
+
+CGROUP_METRICS = [
+    {
+        "cgroup": "memory",
+        "file": "memory.stat",
+        "metrics": {
+            "cache": ("docker.mem.cache", "gauge"),
+            "rss": ("docker.mem.rss", "gauge"),
+            "swap": ("docker.mem.swap", "gauge"),
+        }
+    },
+    {
+        "cgroup": "cpuacct",
+        "file": "cpuacct.stat",
+        "metrics": {
+            "user": ("docker.cpu.user", "rate"),
+            "system": ("docker.cpu.system", "rate"),
+        },
+    },
+]
+
+TAG_EXTRACTORS = {
+    "docker_image": lambda c: c["Image"],
+    "image_name": lambda c: c["Image"].split(':', 1)[0],
+    "image_tag": lambda c: c["Image"].split(':', 1)[1],
+    "container_command": lambda c: c["Command"],
+    "container_name": lambda c: c['Names'][0].lstrip("/") if c["Names"] else c['Id'][:11],
+}
+
+
+"""WIP for a new docker check
+
+TODO:
+ - All the "TODO" in the code
+ - Support a global "extra_tags" configuration, adding tags to all the metrics/events
+ - Figure out the need to have "per-container" custom tags (often requested)
+ - Figure out what to do with extra cgroups/proc available metrics
+ - Support alternative root / - /rootfs to make it work with docker-dd-agent
+ - Write tests
+ - Test on all the platforms
+"""
+
+
+class DockerDaemon(AgentCheck):
+    """Collect metrics and events from Docker API and cgroups"""
+
+    DEFAULT_SOCKET_TIMEOUT = 5
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+        self._cgroup_filename_pattern = None
+        self._mountpoints = {}
+
+    def check(self, instance):
+        """Run the Docker check for one instance."""
+
+        # Connect to the Docker daemon
+        self._connect_api(instance)
+
+        # Report image metrics
+        if _is_affirmative(instance.get('collect_images_stats', True)):
+            self._count_images(instance)
+
+        # Get the list of containers and the index of their names
+        containers_by_id = self._get_and_count_containers(instance)
+
+        # Report performance container metrics (cpu, mem, net, io)
+        self._report_performance_metrics(instance, containers_by_id)
+
+        # TODO: report container sizes (and image sizes?)
+
+        # TODO: bring events back
+        # Send events from Docker API
+        # if _is_affirmative(instance.get('collect_events', True)):
+        #     self._process_events(instance, containers_by_id)
+
+    def _connect_api(self, instance):
+        base_url = instance.get('url')
+        if not base_url:
+            raise Exception('Invalid configuration, missing "url" parameter')
+        tls = _is_affirmative(instance.get('tls', False))
+        # TODO: figure out an API version to stick to
+        # TODO: configurable timeout
+        self.client = Client(base_url=base_url, tls=tls, timeout=self.DEFAULT_SOCKET_TIMEOUT)
+
+    # Containers
+
+    def _count_images(self, instance):
+        try:
+            active_images = len(self.client.images(quiet=True, all=False))
+            all_images = len(self.client.images(quiet=True, all=True))
+
+            self.gauge("docker.images.available", active_images)
+            self.gauge("docker.images.intermediate", (all_images - active_images))
+        except Exception, e:
+            self.warning("Failed to count Docker images. Exception: {0}".format(e))
+
+    def _get_and_count_containers(self, instance):
+        """List all the containers from the API, filter and count them"""
+
+        service_check_name = 'docker.service_up'
+        try:
+            containers = self.client.containers(all=True)
+        except Exception, e:
+            self.service_check(service_check_name, AgentCheck.CRITICAL,
+                               message="Unable to list Docker containers: {0}".format(e))
+            raise Exception("Failed to collect the list of containers. Exception: {0}".format(e))
+        else:
+            self.service_check(service_check_name, AgentCheck.OK)
+
+        # Filter containers according to the exclude/include rules
+        self._filter_containers(instance, containers)
+
+        containers_by_id = {}
+        for container in containers:
+            tag_names = instance.get("container_tags", ["image_name"])
+            container_tags = self._get_tags(container, tag_names)
+
+            # Check if the container is included/excluded via its tags
+            if self._is_container_excluded(container):
+                continue
+
+            if self._is_container_running(container):
+                self.set("docker.containers.running", container['Id'], tags=container_tags)
+            else:
+                self.set("docker.containers.stopped", container['Id'], tags=container_tags)
+
+            containers_by_id[container['Id']] = container
+
+        return containers_by_id
+
+    def _is_container_running(self, container):
+        """Tells if a container is running, according to its status
+
+        There is no "nice" API field to figure it out. We just look at the "Status" field, knowing how it is generated.
+        See: https://github.com/docker/docker/blob/v1.6.2/daemon/state.go#L35
+        """
+        return container["Status"].startswith("Up") or container["Status"].startswith("Restarting")
+
+    def _get_tags(self, entity, tag_names):
+        """Generate the tags for a given entity (container or image) according to a list of tag names"""
+        tags = []
+        for tag_name in tag_names:
+            tags.append('%s:%s' % (tag_name, self._extract_tag_value(entity, tag_name)))
+
+        return tags
+
+    def _extract_tag_value(self, entity, tag_name):
+        """Extra tag information from the API result (containers or images).
+
+        Cache extracted tags inside the entity object.
+        """
+        if tag_name not in TAG_EXTRACTORS:
+            self.warning("{0} isn't a supported tag".format(tag_name))
+            return
+        # Check for already extracted tags
+        if "_tag_values" not in entity:
+            entity["_tag_values"] = {}
+        if tag_name not in entity["_tag_values"]:
+            entity["_tag_values"][tag_name] = TAG_EXTRACTORS[tag_name](entity).strip()
+
+        return entity["_tag_values"][tag_name]
+
+    def _filter_containers(self, instance, containers):
+        # The reasoning is to check exclude first, so we can skip if there is no exclude
+        if not instance.get("exclude"):
+            instance["filtering_enabled"] = False
+            return
+
+        filtered_tag_names = set()
+        instance["exclude_patterns"] = []
+        instance["include_patterns"] = []
+        # Compile regex
+        for rule in instance.get("exclude", []):
+            instance["exclude_patterns"].append(re.compile(rule))
+            filtered_tag_names.append(rule.split(':')[0])
+        for rule in instance.get("include", []):
+            instance["include_patterns"].append(re.compile(rule))
+            filtered_tag_names.append(rule.split(':')[0])
+
+        for container in containers:
+            container['_is_filtered'] = self._are_tags_filtered(self._get_tags(container, filtered_tag_names))
+            # Log.debug it
+
+    def _are_tags_filtered(self, instance, tags):
+        if self._tags_match_patterns(tags, instance.get("exclude_patterns")):
+            if self._tags_match_patterns(tags, instance.get("include_patterns")):
+                return False
+            return True
+        return False
+
+    def _tags_match_patterns(self, tags, filters):
+        for rule in filters:
+            for tag in tags:
+                if re.match(rule, tag):
+                    return True
+        return False
+
+    def _is_container_excluded(self, container):
+        """Check if a container is excluded according to the filter rules.
+
+        Requires _filter_containers to run first.
+        """
+        return container.get('_is_filtered', False)
+
+    # Performance metrics
+
+    def _report_performance_metrics(self, instance, containers_by_id):
+
+        for container in containers_by_id.itervalues():
+            if self._is_container_excluded(container) or not self._is_container_running(container):
+                continue
+
+            tag_names = instance.get("performance_tags", ["image_name", "container_name"])
+            container_tags = self._get_tags(container, tag_names)
+
+            self._report_cgroup_metrics(container, container_tags)
+            self._report_io_metrics(container, container_tags)
+            self._report_net_metrics(container, container_tags)
+
+    def _report_cgroup_metrics(self, container, tags):
+        for cgroup in CGROUP_METRICS:
+            stat_file = self._get_cgroup_file(cgroup["cgroup"], container['Id'], cgroup['file'])
+            stats = self._parse_cgroup_file(stat_file)
+            if stats:
+                for key, (dd_key, metric_type) in cgroup['metrics'].iteritems():
+                    if key in stats:
+                        getattr(self, metric_type)(dd_key, int(stats[key]), tags=tags)
+
+    def _report_io_metrics(self, container, tags):
+        """Find container IO metrics by looking at /proc/$PID/io - TODO: require root! find another way..."""
+        proc_root = self._get_proc_root(container)
+        proc_io_file = os.path.join(proc_root, 'io')
+
+        fp = None
+        try:
+            fp = open(proc_io_file)
+            values = dict(map(lambda x: x.split(': '), fp.read().splitlines()))
+            self.rate("docker.io.read_bytes", int(values.get("read_bytes")), tags)
+            self.rate("docker.io.write_bytes", int(values.get("write_bytes")), tags)
+        except Exception, e:
+            # It is possible that the container got stopped between the API call and now
+            self.warning("Failed to report IO metrics from file {0}. Exception: {1}".format(proc_io_file, e))
+        finally:
+            if fp is not None:
+                fp.close()
+
+    def _report_net_metrics(self, container, tags):
+        """Find container network metrics by looking at /proc/$PID/net/dev of the container process"""
+        proc_root = self._get_proc_root(container)
+        proc_net_file = os.path.join(proc_root, 'net/dev')
+
+        fp = None
+        try:
+            fp = open(proc_net_file)
+            lines = fp.read().splitlines()
+
+            for l in lines[2:]:
+                cols = l.split(':', 1)
+                interface_name = cols[0].strip()
+                if interface_name == 'eth0':
+                    x = cols[1].split()
+                    self.rate("docker.net.bytes_rcvd", long(x[0]), tags)
+                    self.rate("docker.net.bytes_sent", long(x[8]), tags)
+                    break
+        except Exception, e:
+            # It is possible that the container got stopped between the API call and now
+            self.warning("Failed to report IO metrics from file {0}. Exception: {1}".format(proc_net_file, e))
+        finally:
+            if fp is not None:
+                fp.close()
+
+    # Events
+
+    # def _process_events(self, instance, ids_to_names, skipped_container_ids):
+    #     try:
+    #         api_events = self._get_events(instance)
+    #         aggregated_events = self._pre_aggregate_events(api_events, skipped_container_ids)
+    #         events = self._format_events(aggregated_events, ids_to_names)
+    #         self._report_events(events)
+    #     except (socket.timeout, urllib2.URLError):
+    #         self.warning('Timeout during socket connection. Events will be missing.')
+
+    # def _pre_aggregate_events(self, api_events, skipped_container_ids):
+    #     # Aggregate events, one per image. Put newer events first.
+    #     events = defaultdict(list)
+    #     for event in api_events:
+    #         # Skip events related to filtered containers
+    #         if event['id'] in skipped_container_ids:
+    #             self.log.debug("Excluded event: container {0} status changed to {1}".format(
+    #                 event['id'], event['status']))
+    #             continue
+    #         # Known bug: from may be missing
+    #         if 'from' in event:
+    #             events[event['from']].insert(0, event)
+
+    #     return events
+
+    # def _format_events(self, aggregated_events, ids_to_names):
+    #     events = []
+    #     for image_name, event_group in aggregated_events.iteritems():
+    #         max_timestamp = 0
+    #         status = defaultdict(int)
+    #         status_change = []
+    #         for event in event_group:
+    #             max_timestamp = max(max_timestamp, int(event['time']))
+    #             status[event['status']] += 1
+    #             container_name = event['id'][:12]
+    #             if event['id'] in ids_to_names:
+    #                 container_name = "%s %s" % (container_name, ids_to_names[event['id']])
+    #             status_change.append([container_name, event['status']])
+
+    #         status_text = ", ".join(["%d %s" % (count, st) for st, count in status.iteritems()])
+    #         msg_title = "%s %s on %s" % (image_name, status_text, self.hostname)
+    #         msg_body = (
+    #             "%%%\n"
+    #             "{image_name} {status} on {hostname}\n"
+    #             "```\n{status_changes}\n```\n"
+    #             "%%%"
+    #         ).format(
+    #             image_name=image_name,
+    #             status=status_text,
+    #             hostname=self.hostname,
+    #             status_changes="\n".join(
+    #                 ["%s \t%s" % (change[1].upper(), change[0]) for change in status_change])
+    #         )
+    #         events.append({
+    #             'timestamp': max_timestamp,
+    #             'host': self.hostname,
+    #             'event_type': EVENT_TYPE,
+    #             'msg_title': msg_title,
+    #             'msg_text': msg_body,
+    #             'source_type_name': EVENT_TYPE,
+    #             'event_object': 'docker:%s' % image_name,
+    #         })
+
+    #     return events
+
+    # def _report_events(self, events):
+    #     for ev in events:
+    #         self.log.debug("Creating event: %s" % ev['msg_title'])
+    #         self.event(ev)
+
+    # def _get_events(self, instance):
+    #     """Get the list of events """
+    #     now = int(time.time())
+    #     result = self._get_json(
+    #         "%s/events" % instance["url"],
+    #         params={
+    #             "until": now,
+    #             "since": self._last_event_collection_ts[instance["url"]] or now - 60,
+    #         }, multi=True)
+    #     self._last_event_collection_ts[instance["url"]] = now
+    #     if type(result) == dict:
+    #         result = [result]
+    #     return result
+
+    # Cgroups
+
+    def _get_cgroup_file(self, cgroup, container_id, filename):
+        """Find a specific cgroup file, containing metrics to extract"""
+        if not self._cgroup_filename_pattern:
+            self._cgroup_filename_pattern = self._find_cgroup_filename_pattern()
+
+        return self._cgroup_filename_pattern % (dict(
+            mountpoint=self._mountpoints[cgroup],
+            id=container_id,
+            file=filename,
+        ))
+
+    def _find_cgroup_filename_pattern(self):
+        if not self._mountpoints:
+            docker_root = '/'
+            for metric in CGROUP_METRICS:
+                self._mountpoints[metric["cgroup"]] = self._find_cgroup(metric["cgroup"], docker_root)
+        if self._mountpoints:
+            # We try with different cgroups so that it works even if only one is properly working
+            for mountpoint in self._mountpoints.values():
+                stat_file_path_lxc = os.path.join(mountpoint, "lxc")
+                stat_file_path_docker = os.path.join(mountpoint, "docker")
+                stat_file_path_coreos = os.path.join(mountpoint, "system.slice")
+
+                if os.path.exists(stat_file_path_lxc):
+                    return os.path.join('%(mountpoint)s/lxc/%(id)s/%(file)s')
+                elif os.path.exists(stat_file_path_docker):
+                    return os.path.join('%(mountpoint)s/docker/%(id)s/%(file)s')
+                elif os.path.exists(stat_file_path_coreos):
+                    return os.path.join('%(mountpoint)s/system.slice/docker-%(id)s.scope/%(file)s')
+
+        raise Exception("Cannot find Docker cgroup directory. Be sure your system is supported.")
+
+    def _find_cgroup(self, hierarchy, docker_root):
+        """Finds the mount point for a specified cgroup hierarchy. Works with
+        old style and new style mounts."""
+        fp = None
+        try:
+            fp = open(os.path.join(docker_root, "/proc/mounts"))
+            mounts = map(lambda x: x.split(), fp.read().splitlines())
+        finally:
+            if fp is not None:
+                fp.close()
+        cgroup_mounts = filter(lambda x: x[2] == "cgroup", mounts)
+        if len(cgroup_mounts) == 0:
+            raise Exception(
+                "Can't find mounted cgroups. If you run the Agent inside a container,"
+                " please refer to the documentation.")
+        # Old cgroup style
+        if len(cgroup_mounts) == 1:
+            return os.path.join(docker_root, cgroup_mounts[0][1])
+        for _, mountpoint, _, opts, _, _ in cgroup_mounts:
+            if hierarchy in opts:
+                return os.path.join(docker_root, mountpoint)
+
+    def _parse_cgroup_file(self, stat_file):
+        """Parses a cgroup pseudo file for key/values."""
+        fp = None
+        self.log.debug("Opening cgroup file: %s" % stat_file)
+        try:
+            fp = open(stat_file)
+            return dict(map(lambda x: x.split(), fp.read().splitlines()))
+        except IOError:
+            # It is possible that the container got stopped between the API call and now
+            self.log.info("Can't open %s. Metrics for this container are skipped." % stat_file)
+        finally:
+            if fp is not None:
+                fp.close()
+
+    # proc files
+
+    def _get_proc_root(self, container):
+        """Find PID then proc directory of a container
+
+        Does it with docker inspect. That's for the POC, should use something smarter (such as walking /proc and
+        looking at /proc/$PID/cgroup to make it matches to a container.
+        """
+        if not container.get('_pid'):
+            inspection = self.client.inspect_container(container["Id"])
+            pid = inspection.get("State", {}).get("Pid")
+            # TODO: catch exceptions
+            container["_pid"] = pid
+
+        return '/proc/%s/' % container["_pid"]

--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -168,10 +168,13 @@ class DockerDaemon(AgentCheck):
                 custom_tags = custom_container_tags[container_name]
                 container['_custom_tags'] = custom_tags
             tag_names = instance.get("container_tags", ["image_name"])
-            container_tags = self._get_tags(container, tag_names) + instance.get('tags', []) + custom_tags
+            container_tags = self._get_tags(
+                container, tag_names) + instance.get('tags', []) + custom_tags
             # Check if the container is included/excluded via its tags
             if self._is_container_excluded(container):
                 continue
+
+            self.increment("docker.containers.count", tags=container_tags)
 
             if self._is_container_running(container):
                 self.set("docker.containers.running", container['Id'], tags=container_tags)

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -91,6 +91,12 @@ instances:
     #
     # tags: []
 
+    # If the agent is running in an Amazon ECS task, you can set this flag to true.
+    # It will tag container metrics with the name of the ECS task.
+    # Default: false
+    #
+    # ecs_tag: true
+
     # Custom metrics tagging
     # Define which Docker tags to apply on metrics.
     # Since it impacts the aggregation, modify it carefully (only if you really need it).

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -42,6 +42,7 @@ instances:
 
     # Collect images stats
     # Number of available active images and intermediate images as gauges.
+    # Defaults to true.
     #
     # collect_images_stats: false
 

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -1,4 +1,8 @@
 init_config:
+  # Change the root directory to look at to get cgroup statistics. Useful when running inside a
+  # container with host directories mounted on a different folder. Default: /.
+  # Example for the docker-dd-agent container:
+  # docker_root: /host
 
 instances:
   - ## Daemon and system configuration

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -4,6 +4,11 @@ init_config:
   # Example for the docker-dd-agent container:
   # docker_root: /host
 
+  # Timeout in seconds for the connection to the docker daemon
+  # Default: 5 seconds
+  #
+  # timeout: 10
+
 instances:
   - ## Daemon and system configuration
     ##
@@ -38,11 +43,17 @@ instances:
     #
     # collect_events: true
 
-    # Collect disk usage per container with docker.disk.size metric.
+    # Collect disk usage per container with docker.container.size_rw and
+    # docker.container.size_rootfs metrics.
     # Warning: This might take time for Docker daemon to generate,
     # ensure that `docker ps -a -q` run fast before enabling it.
     #
     # collect_container_size: false
+
+    # Collect disk usage per image with docker.image.size and docker.image.virtual_size metrics.
+    # The check gets this size with the `docker images` command.
+    #
+    # collect_image_size: true
 
     # Collect images stats
     # Number of available active images and intermediate images as gauges.

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -91,11 +91,10 @@ instances:
     #
     # tags: []
 
-    # If the agent is running in an Amazon ECS task, you can set this flag to true.
-    # It will tag container metrics with the name of the ECS task.
-    # Default: false
+    # If the agent is running in an Amazon ECS task, tags container metrics with the ECS task name and version.
+    # Default: true
     #
-    # ecs_tag: true
+    # ecs_tags: false
 
     # Custom metrics tagging
     # Define which Docker tags to apply on metrics.

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -1,0 +1,93 @@
+init_config:
+
+instances:
+  - ## Daemon and system configuration
+    ##
+
+    # URL of the Docker daemon socket to reach the Docker API. HTTP/HTTPS also works.
+    # Warning: if that's a non-local daemon, we won't be able to collect performance metrics.
+    #
+    url: "unix://var/run/docker.sock"
+
+    # Use TLS encryption while communicating with the Docker API
+    #
+    # tls: false
+
+    # Cgroup root (HIDDEN OPTION?)
+    # Directory where cgroup files are located, used to generate performance metrics.
+    # Default: None (auto-detected)
+    #
+    # cgroup_path:
+
+    # Cgroup layout (HIDDEN OPTION?)
+    # How cgroup files are organized inside the cgroup root.
+    # Default: None (auto-detected)
+    # Example: "/%(cgroup_root)s/docker/%(container_id)s/%(file)s"
+    #
+    # cgroup_layout: None
+
+
+    ## Data collection
+    ##
+
+    # Create events whenever a container status change.
+    #
+    # collect_events: true
+
+    # Collect disk usage per container with docker.disk.size metric.
+    # Warning: This might take time for Docker daemon to generate,
+    # ensure that `docker ps -a -q` run fast before enabling it.
+    #
+    # collect_container_size: false
+
+    # Collect images stats
+    # Number of available active images and intermediate images as gauges.
+    #
+    # collect_images_stats: false
+
+    # Exclude containers based on their tags
+    # An excluded container will be completely ignored. The rule is a regex on the tags.
+    #
+    # How it works: exclude first.
+    # If a tag matches an exclude rule, it won't be included unless it also matches an include rule.
+    # Examples:
+    # exclude all, except ubuntu and debian.
+    # exclude: [".*"]
+    # include: ["docker_image:ubuntu", "docker_image:debian"]
+    #
+    # include all, except ubuntu and debian.
+    # exclude: ["docker_image:ubuntu", "docker_image:debian"]
+    # include: []
+    #
+    # Default: include all
+    # exclude: []
+    # include: []
+
+
+    ## Tagging
+    ##
+
+    # You can add extra tags to your Docker metrics with the tags list option.
+    # Example: ["extra_tag", "env:testing"]
+    #
+    # tags: []
+
+    # Custom metrics tagging
+    # Define which Docker tags to apply on metrics.
+    # Since it impacts the aggregation, modify it carefully (only if you really need it).
+    #
+    # Tags for performance metrics.
+    # Available:
+    #   - image_name: Name of the image (example: "nginx")
+    #   - image_tag: Tag of the image (example: "latest")
+    #   - docker_image: LEGACY. The full image name:tag string (example: "nginx:latest")
+    #   - container_id: Short id of the container (example: "ae3bc9c8ae5e")
+    #   - container_name: Name of the container (example: "boring_euclid")
+    #   - container_command: Command ran by the container (example: "echo 1")
+    #
+    # performance_tags: ["image_name", "container_name"]
+
+    # Tags for containers count metrics.
+    # Available: ["image_name", "image_tag", "docker_image", "container_command"]
+    #
+    # container_tags: ["image_name"]

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -112,7 +112,7 @@ instances:
     # container_tags: ["image_name"]
 
     # Tags per container
-    # Define the name of your containers and a list of their tags
+    # Add the name of your containers and a list of the tags you want to assign them
     # tags_per_container_name:
-    #   container0: ["tag0:foo", "tag1:bar"]
+    #   container0: ["tag0:foo", "tag1"]
     #   container1: ["tag2:baz"]

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -40,18 +40,21 @@ instances:
     ##
 
     # Create events whenever a container status change.
+    # Defaults to true.
     #
-    # collect_events: true
+    # collect_events: false
 
     # Collect disk usage per container with docker.container.size_rw and
     # docker.container.size_rootfs metrics.
     # Warning: This might take time for Docker daemon to generate,
     # ensure that `docker ps -a -q` run fast before enabling it.
+    # Defaults to true.
     #
     # collect_container_size: false
 
     # Collect disk usage per image with docker.image.size and docker.image.virtual_size metrics.
     # The check gets this size with the `docker images` command.
+    # Defaults to true.
     #
     # collect_image_size: false
 

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -107,3 +107,9 @@ instances:
     # Available: ["image_name", "image_tag", "docker_image", "container_command"]
     #
     # container_tags: ["image_name"]
+
+    # Tags per container
+    # Define the name of your containers and a list of their tags
+    # tags_per_container_name:
+    #   container0: ["tag0:foo", "tag1:bar"]
+    #   container1: ["tag2:baz"]

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -53,7 +53,7 @@ instances:
     # Collect disk usage per image with docker.image.size and docker.image.virtual_size metrics.
     # The check gets this size with the `docker images` command.
     #
-    # collect_image_size: true
+    # collect_image_size: false
 
     # Collect images stats
     # Number of available active images and intermediate images as gauges.

--- a/tests/checks/mock/test_docker_daemon.py
+++ b/tests/checks/mock/test_docker_daemon.py
@@ -1,0 +1,69 @@
+import docker
+
+from tests.checks.common import AgentCheckTest
+
+
+class TestDockerDaemon(AgentCheckTest):
+    CHECK_NAME = 'docker_daemon'
+
+    CONTAINER_METRICS = [
+        'docker.mem.cache',
+        'docker.mem.cache',
+        'docker.containers.running',
+        'docker.containers.running',
+        'docker.mem.rss',
+        'docker.mem.rss',
+    ]
+
+    IMAGE_METRICS = [
+        'docker.image.virtual_size',
+        'docker.image.virtual_size',
+        'docker.image.size',
+        'docker.image.size',
+        'docker.images.available',
+        'docker.images.intermediate',
+    ]
+
+    def __init__(self, *args, **kwargs):
+        AgentCheckTest.__init__(self, *args, **kwargs)
+        self.metrics_config = {
+            'collect_container_size': True,
+            'collect_events': True,
+            'collect_image_size': True,
+            'url': 'unix://var/run/docker.sock'
+        }
+        self.events_config = {
+            'collect_events': True,
+            'url': 'unix://var/run/docker.sock'
+        }
+        self.tag_config = {
+            'collect_container_size': True,
+            'collect_events': True,
+            'collect_image_size': True,
+            'container_tags': ['image_name'],
+            'performance_tags': ['image_name', 'container_name'],
+            'tags': ['test_tags'],
+            'url': 'unix://var/run/docker.sock'
+        }
+        self.bad_configs = {'url': 'http://10.0.0.1'}
+
+    def test_metric_collection(self):
+        """Test the presence of all the metrics (container & image)."""
+        self.coverage_report()
+
+    def test_events(self):
+        """Test the retrieval of events."""
+        self.coverage_report()
+
+    def test_tagging_system(self):
+        """Test the available tagging features."""
+        # TODO: create named containers to use the tagging per container
+        self.coverage_report()
+
+    def test_container_exclusion_logic(self):
+        """Test the exclusion and inclusion logic for containers."""
+        self.coverage_report()
+
+    def test_bad_config(self):
+        """Assert the failure of a bad config."""
+        self.coverage_report()


### PR DESCRIPTION
Built on top of #1807.
Add a `docker.containers.count` metric to count the number of docker containers.

Fix #1648 as we can now monitor `docker.containers.count - docker.containers.running`. 

Assigning you @remh for the review :mag: 