### PR TITLE
[logging] Fix logs duplication in jmxfetch.log

### DIFF
--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -1,6 +1,7 @@
 # set up logging before importing any other components
-from config import initialize_logging  # noqa
-initialize_logging('jmxfetch')
+if __name__ == '__main__':
+    from config import initialize_logging  # noqa
+    initialize_logging('jmxfetch')
 
 # std
 import glob


### PR DESCRIPTION
Replaces #1850 , which was very "hacky".

The collector logs were being duplicated to `jmxfetch.log` because `agent.py` imports `jmxfetch.py`, which causes the `initialize_logging` method to be called twice.

This fixes the issue by only initializing logging in `jmxfetch.py` when it's the main module (and not imported from another module).