### PR TITLE
[snmp] do not infinite loop on `error_status`

### DIFF
--- a/checks.d/snmp.py
+++ b/checks.d/snmp.py
@@ -193,14 +193,6 @@ class SnmpCheck(AgentCheck):
             # Raise on error_indication
             self.raise_on_error_indication(error_indication, instance)
 
-            # Continue on error_status
-            if error_status:
-                message = "{0} for instance {1}".format(error_status.prettyPrint(),
-                                                        instance["ip_address"])
-                instance["service_check_error"] = message
-                self.log.warning(message)
-                continue
-
             missing_results = []
             complete_results = []
 
@@ -225,13 +217,12 @@ class SnmpCheck(AgentCheck):
                 # Raise on error_indication
                 self.raise_on_error_indication(error_indication, instance)
 
-                # Continue on error_status
                 if error_status:
                     message = "{0} for instance {1}".format(error_status.prettyPrint(),
                                                             instance["ip_address"])
                     instance["service_check_error"] = message
                     self.log.warning(message)
-                    continue
+
                 for table_row in var_binds_table:
                     complete_results.extend(table_row)
 

--- a/checks.d/snmp.py
+++ b/checks.d/snmp.py
@@ -188,6 +188,8 @@ class SnmpCheck(AgentCheck):
                 lookupValues=lookup_names,
                 lookupNames=lookup_names)
 
+            first_oid = first_oid + OID_BATCH_SIZE
+
             # Raise on error_indication
             self.raise_on_error_indication(error_indication, instance)
 
@@ -234,7 +236,6 @@ class SnmpCheck(AgentCheck):
                     complete_results.extend(table_row)
 
             all_binds.extend(complete_results)
-            first_oid = first_oid + OID_BATCH_SIZE
 
         for result_oid, value in all_binds:
             if lookup_names:


### PR DESCRIPTION
Fix SNMP check infinite loop when SNMP command returns an
`error_status`. Update `first_oid` reference before `continue`
statements are called.