### PR TITLE
[network] Use `ss` instead of `netstat` on linux

### DIFF
--- a/checks.d/network.py
+++ b/checks.d/network.py
@@ -8,6 +8,7 @@ import subprocess
 # project
 from checks import AgentCheck
 from utils.platform import Platform
+from utils.subprocess_output import get_subprocess_output
 
 BSD_TCP_METRICS = [
     (re.compile("^\s*(\d+) data packets \(\d+ bytes\) retransmitted\s*$"), 'system.net.tcp.retrans_packs'),
@@ -143,9 +144,7 @@ class Network(AgentCheck):
                 for ip_version in ['4', '6']:
                     # Call `ss` for each IP version because there's no built-in way of distinguishing
                     # between the IP versions in the output
-                    ss = subprocess.Popen(["ss", "-n", "-u", "-t", "-a", "-{0}".format(ip_version)],
-                                          stdout=subprocess.PIPE,
-                                          close_fds=True).communicate()[0]
+                    ss = get_subprocess_output(["ss", "-n", "-u", "-t", "-a", "-{0}".format(ip_version)], self.log)
                     # Netid  State      Recv-Q Send-Q     Local Address:Port       Peer Address:Port
                     # udp    UNCONN     0      0              127.0.0.1:8125                  *:*
                     # udp    ESTAB      0      0              127.0.0.1:37036         127.0.0.1:8125
@@ -164,9 +163,7 @@ class Network(AgentCheck):
 
             except OSError:
                 self.log.info("`ss` not found: using `netstat` as a fallback")
-                netstat = subprocess.Popen(["netstat", "-n", "-u", "-t", "-a"],
-                                           stdout=subprocess.PIPE,
-                                           close_fds=True).communicate()[0]
+                netstat = get_subprocess_output(["netstat", "-n", "-u", "-t", "-a"], self.log)
                 # Active Internet connections (w/o servers)
                 # Proto Recv-Q Send-Q Local Address           Foreign Address         State
                 # tcp        0      0 46.105.75.4:80          79.220.227.193:2032     SYN_RECV

--- a/tests/checks/fixtures/network/netstat
+++ b/tests/checks/fixtures/network/netstat
@@ -1,0 +1,16 @@
+Active Internet connections (servers and established)
+Proto Recv-Q Send-Q Local Address           Foreign Address         State
+tcp        0    128 0.0.0.0:6379            0.0.0.0:*               LISTEN
+tcp        0    128 0.0.0.0:6380            0.0.0.0:*               LISTEN
+tcp        0      0 127.0.0.1:80            127.0.0.1:51650         TIME_WAIT
+tcp        0      0 127.0.0.1:58414         127.0.0.1:9200          TIME_WAIT
+tcp        0      0 10.0.2.15:45637         10.0.2.15:9300          ESTABLISHED
+tcp6       0    128 :::6380                 :::*                    LISTEN
+tcp6       0      0 127.0.0.1:58488         127.0.0.1:7199          TIME_WAIT
+tcp6       0      0 127.0.0.1:42395         127.0.0.1:2181          ESTABLISHED
+tcp6       0      0 127.0.0.1:58439         127.0.0.1:7199          CLOSING
+udp        0      0 127.0.0.1:48135         127.0.0.1:8125          ESTABLISHED
+udp        0      0 127.0.0.1:8125          0.0.0.0:*
+udp6       0      0 fe80::a00:27ff:fee9:123 :::*                    ESTABLISHED
+udp6       0      0 fe80::a00:27ff:fe1c:123 :::*
+udp6       0      0 :::111                  :::*

--- a/tests/checks/fixtures/network/ss_ipv4
+++ b/tests/checks/fixtures/network/ss_ipv4
@@ -1,0 +1,8 @@
+Netid  State      Recv-Q Send-Q     Local Address:Port       Peer Address:Port
+udp    ESTAB      0      0              127.0.0.1:48135         127.0.0.1:8125
+udp    UNCONN     0      0              127.0.0.1:8125                  *:*
+tcp    LISTEN     0      128                    *:6379                  *:*
+tcp    LISTEN     0      128                    *:6380                  *:*
+tcp    TIME-WAIT  0      0              127.0.0.1:80            127.0.0.1:51650
+tcp    TIME-WAIT  0      0              127.0.0.1:58414         127.0.0.1:9200
+tcp    ESTAB      0      0              10.0.2.15:45637         10.0.2.15:9300

--- a/tests/checks/fixtures/network/ss_ipv6
+++ b/tests/checks/fixtures/network/ss_ipv6
@@ -1,0 +1,8 @@
+Netid  State      Recv-Q Send-Q     Local Address:Port       Peer Address:Port
+udp    UNCONN     0      0                     :::111                  :::*
+udp    UNCONN     0      0        fe80::a00:27ff:fe1c:3c4:123                  :::*
+udp    ESTAB      0      0       fe80::a00:27ff:fee9:10ee:123                  :::*
+tcp    LISTEN     0      128                   :::6380                 :::*
+tcp    TIME-WAIT  0      0       ::ffff:127.0.0.1:58488  ::ffff:127.0.0.1:7199
+tcp    ESTAB      0      0       ::ffff:127.0.0.1:42395  ::ffff:127.0.0.1:2181
+tcp    CLOSING    0      0       ::ffff:127.0.0.1:58439  ::ffff:127.0.0.1:7199

--- a/tests/checks/mock/test_network.py
+++ b/tests/checks/mock/test_network.py
@@ -1,0 +1,71 @@
+# 3p
+import mock
+
+# project
+from tests.checks.common import AgentCheckTest, Fixtures
+
+
+def ss_popen_mock(*args, **kwargs):
+    popen_mock = mock.Mock()
+    if args[0][-1] == '-4':
+        popen_mock.communicate.return_value = (Fixtures.read_file('ss_ipv4'), None)
+    elif args[0][-1] == '-6':
+        popen_mock.communicate.return_value = (Fixtures.read_file('ss_ipv6'), None)
+
+    return popen_mock
+
+
+def netstat_popen_mock(*args, **kwargs):
+    if args[0][0] == 'ss':
+        raise OSError
+    elif args[0][0] == 'netstat':
+        popen_mock = mock.Mock()
+        popen_mock.communicate.return_value = (Fixtures.read_file('netstat'), None)
+        return popen_mock
+
+
+class TestCheckNetwork(AgentCheckTest):
+    CHECK_NAME = 'network'
+
+    def setUp(self):
+        self.config = {
+            "instances": [
+                {
+                    "collect_connection_state": True
+                }
+            ]
+        }
+        self.load_check(self.config)
+
+    CX_STATE_GAUGES_VALUES = {
+        'system.net.udp4.connections': 2,
+        'system.net.udp6.connections': 3,
+        'system.net.tcp4.established': 1,
+        'system.net.tcp4.opening': 0,
+        'system.net.tcp4.closing': 0,
+        'system.net.tcp4.listening': 2,
+        'system.net.tcp4.time_wait': 2,
+        'system.net.tcp6.established': 1,
+        'system.net.tcp6.opening': 0,
+        'system.net.tcp6.closing': 1,
+        'system.net.tcp6.listening': 1,
+        'system.net.tcp6.time_wait': 1,
+    }
+
+    @mock.patch('subprocess.Popen', side_effect=ss_popen_mock)
+    @mock.patch('network.Platform.is_linux', return_value=True)
+    def test_cx_state_linux_ss(self, mock_popen, mock_platform):
+        self.run_check({})
+
+        # Assert metrics
+        for metric, value in self.CX_STATE_GAUGES_VALUES.iteritems():
+            self.assertMetric(metric, value=value)
+
+    @mock.patch('subprocess.Popen', side_effect=netstat_popen_mock)
+    @mock.patch('network.Platform.is_linux', return_value=True)
+    def test_cx_state_linux_netstat(self, mock_popen, mock_platform):
+        self.run_check({})
+
+        # Assert metrics
+        for metric, value in self.CX_STATE_GAUGES_VALUES.iteritems():
+            self.assertMetric(metric, value=value)


### PR DESCRIPTION
`netstat` is deprecated on many distributions, `ss` is its replacement and is present by default in the `PATH` on most of the distributions that I've tested (CentOS >= 6, Ubuntu >= 12.04, but not on CentOS 5).

We still fallback to `netstat` if `ss` is not installed.

Addresses https://github.com/DataDog/dd-agent/issues/1156

I've also checked that `subprocess.Popen` doesn't hang with `stdout=PIPE`: as long as we use it with `communicate()` (which we do here) we should be fine.