### PR TITLE
[core] deprecate 'use_dd' flag

### DIFF
--- a/config.py
+++ b/config.py
@@ -360,12 +360,6 @@ def get_config(parse_args=True, cfg_path=None, options=None):
         #
 
         # FIXME unnecessarily complex
-
-        if config.has_option('Main', 'use_dd'):
-            agentConfig['use_dd'] = config.get('Main', 'use_dd').lower() in ("yes", "true")
-        else:
-            agentConfig['use_dd'] = True
-
         agentConfig['use_forwarder'] = False
         if options is not None and options.use_forwarder:
             listen_port = 17123
@@ -399,10 +393,6 @@ def get_config(parse_args=True, cfg_path=None, options=None):
             agentConfig['use_web_info_page'] = config.get('Main', 'use_web_info_page').lower() in ("yes", "true")
         else:
             agentConfig['use_web_info_page'] = True
-
-        if not agentConfig['use_dd']:
-            sys.stderr.write("Please specify at least one endpoint to send metrics to. This can be done in datadog.conf.")
-            exit(2)
 
         # Which API key to use
         agentConfig['api_key'] = config.get('Main', 'api_key')

--- a/ddagent.py
+++ b/ddagent.py
@@ -163,19 +163,14 @@ class AgentTransaction(Transaction):
 
     @classmethod
     def set_endpoints(cls):
+        """
+        Set Datadog endpoint if an API key exists.
+        """
+        if not cls._application._agentConfig.get('api_key'):
+            log.warning(u"No API key was found. Aborting endpoint setting.")
+            return
 
-        # Only send data to Datadog if an API KEY exists
-        # i.e. user is also Datadog user
-        try:
-            is_dd_user = 'api_key' in cls._application._agentConfig\
-                and 'use_dd' in cls._application._agentConfig\
-                and cls._application._agentConfig['use_dd']\
-                and cls._application._agentConfig.get('api_key')
-            if is_dd_user:
-                log.warn("You are a Datadog user so we will send data to https://app.datadoghq.com")
-                cls._endpoints.append(DD_ENDPOINT)
-        except Exception:
-            log.info("Not a Datadog user")
+        cls._endpoints.append(DD_ENDPOINT)
 
     def __init__(self, data, headers, msg_type=""):
         self._data = data


### PR DESCRIPTION
`use_dd` is deprecated and always set to `True`. Remove it to improve
code readability.

Fix #1856.