### PR TITLE
[checks.d][openstack] add monitoring for Openstack Nova and Neutron

### DIFF
--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -1,7 +1,22 @@
-import json
-import requests
+# stdlib
+from datetime import datetime, timedelta
+from urlparse import urljoin
 
+# project
 from checks import AgentCheck
+from util import get_hostname
+
+# 3p
+import requests
+import simplejson as json
+
+SOURCE_TYPE = 'openstack'
+
+DEFAULT_KEYSTONE_API_VERSION = 'v3'
+DEFAULT_NOVA_API_VERSION = 'v2.1'
+DEFAULT_NEUTRON_API_VERSION = 'v2.0'
+
+DEFAULT_API_REQUEST_TIMEOUT = 5 # seconds
 
 NOVA_HYPERVISOR_METRICS = [
     'current_workload',
@@ -37,122 +52,372 @@ NOVA_SERVER_METRICS = [
 
 NOVA_SERVER_INTERFACE_SEGMENTS = ['_rx', '_tx']
 
+PROJECT_METRICS = dict([
+    ("maxImageMeta", "max_image_meta"),
+    ("maxPersonality", "max_personality"),
+    ("maxPersonalitySize", "max_personality_size"),
+    ("maxSecurityGroupRules", "max_security_group_rules"),
+    ("maxSecurityGroups", "max_security_groups"),
+    ("maxServerMeta", "max_server_meta"),
+    ("maxTotalCores", "max_total_cores"),
+    ("maxTotalFloatingIps", "max_total_floating_ips"),
+    ("maxTotalInstances", "max_total_instances"),
+    ("maxTotalKeypairs", "max_total_keypairs"),
+    ("maxTotalRAMSize", "max_total_ram_size"),
 
-class OpenstackAuthFailure(Exception):
+    ("totalImageMetaUsed", "total_image_meta_used"),
+    ("totalPersonalityUsed", "total_personality_used"),
+    ("totalPersonalitySizeUsed", "total_personality_size_used"),
+    ("totalSecurityGroupRulesUsed", "total_security_group_rules_used"),
+    ("totalSecurityGroupsUsed", "total_security_groups_used"),
+    ("totalServerMetaUsed", "total_server_meta_used"),
+    ("totalCoresUsed", "total_cores_used"),
+    ("totalFloatingIpsUsed", "total_floating_ips_used"),
+    ("totalInstancesUsed", "total_instances_used"),
+    ("totalKeypairsUsed", "total_keypairs_used"),
+    ("totalRAMUsed", "total_ram_used"),
+])
+
+class OpenStackAuthFailure(Exception):
+    pass
+
+class InstancePowerOffFailure(Exception):
     pass
 
 class IncompleteConfig(Exception):
     pass
 
-class OpenstackCheck(AgentCheck):
+class IncompleteAuthScope(IncompleteConfig):
+    pass
+
+class IncompleteIdentity(IncompleteConfig):
+    pass
+
+class MissingEndpoint(Exception):
+    pass
+
+class MissingNovaEndpoint(MissingEndpoint):
+    pass
+
+class MissingNeutronEndpoint(MissingEndpoint):
+    pass
+
+class KeystoneUnreachable(Exception):
+    pass
+
+
+class OpenStackProjectScope(object):
+    """
+    Container class for a single project's authorization scope
+    Embeds the auth token to be included with API requests, and refreshes
+    the token on expiry
+    """
+    def __init__(self, auth_token, auth_scope, service_catalog):
+        self.auth_token = auth_token
+
+        # Store some identifiers for this project
+        self.project_name = auth_scope["project"].get("name")
+        self.domain_id = auth_scope["project"].get("domain", {}).get("id")
+        self.tenant_id = auth_scope["project"].get("id")
+        self.service_catalog = service_catalog
+
+    @classmethod
+    def from_config(cls, init_config, instance_config):
+        keystone_server_url = init_config.get("keystone_server_url")
+        if not keystone_server_url:
+            raise IncompleteConfig()
+
+        ssl_verify = init_config.get("ssl_verify", False)
+        nova_api_version = init_config.get("nova_api_version", DEFAULT_NOVA_API_VERSION)
+
+        auth_scope = cls.get_auth_scope(instance_config)
+        identity = cls.get_user_identity(instance_config)
+
+        try:
+            auth_resp = cls.request_auth_token(auth_scope, identity, keystone_server_url, ssl_verify)
+        except (requests.exceptions.HTTPError, requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
+            raise KeystoneUnreachable()
+
+        auth_token = auth_resp.headers.get('X-Subject-Token')
+
+        service_catalog = KeystoneCatalog.from_auth_response(
+            auth_resp.json(), nova_api_version
+        )
+
+        # (NOTE): aaditya
+        # In some cases, the nova url is returned without the tenant id suffixed
+        # e.g. http://172.0.0.1:8774 rather than http://172.0.0.1:8774/<tenant_id>
+        # It is still unclear when this happens, but for now the user can configure
+        # `append_tenant_id` to manually add this suffix for downstream requests
+        if instance_config.get("append_tenant_id", False):
+            t_id = auth_scope["project"].get("id")
+
+            assert t_id and t_id not in service_catalog.nova_endpoint,\
+                """Incorrect use of append_tenant_id, please inspect the service catalog response of your Identity server.
+                   You may need to disable this flag if your Nova service url contains the tenant_id already"""
+
+            service_catalog.nova_endpoint = urljoin(service_catalog.nova_endpoint, t_id)
+
+        return cls(auth_token, auth_scope, service_catalog)
+
+    @classmethod
+    def get_auth_scope(cls, instance_config):
+        """
+        Parse authorization scope out of init_config
+
+        To guarantee a uniquely identifiable scope, expects either:
+        {'project': {'name': 'my_project', 'domain': {'id': 'my_domain_id'}}}
+        OR
+        {'project': {'id': 'my_project_id'}}
+        """
+        auth_scope = instance_config.get('auth_scope')
+        if not auth_scope or not auth_scope.get('project'):
+            raise IncompleteAuthScope()
+
+        if auth_scope['project'].get('name'):
+            # We need to add a domain scope to avoid name clashes. Search for one. If not raise IncompleteConfig
+            if not auth_scope['project'].get('domain', {}).get('id'):
+                raise IncompleteAuthScope()
+        else:
+            # Assume a unique project id has been given
+            if not auth_scope['project'].get('id'):
+                raise IncompleteAuthScope()
+
+        return auth_scope
+
+    @classmethod
+    def get_user_identity(cls, instance_config):
+        """
+        Parse user identity out of init_config
+
+        To guarantee a uniquely identifiable user, expects
+        {"user": {"name": "my_username", "password": "my_password",
+                  "domain": {"id": "my_domain_id"}
+                  }
+        }
+        """
+        user = instance_config.get('user')
+        if not user\
+                or not user.get('name')\
+                or not user.get('password')\
+                or not user.get("domain")\
+                or not user.get("domain").get("id"):
+
+            raise IncompleteIdentity()
+
+        identity = {
+            "methods": ['password'],
+            "password": {"user": user}
+        }
+        return identity
+
+    @classmethod
+    def request_auth_token(cls, auth_scope, identity, keystone_server_url, ssl_verify):
+        payload = {"auth": {"scope": auth_scope, "identity": identity}}
+        auth_url = urljoin(keystone_server_url, "{0}/auth/tokens".format(DEFAULT_KEYSTONE_API_VERSION))
+        headers = {'Content-Type': 'application/json'}
+
+        resp = requests.post(auth_url, headers=headers, data=json.dumps(payload), verify=ssl_verify, timeout=DEFAULT_API_REQUEST_TIMEOUT)
+        resp.raise_for_status()
+
+        return resp
+
+
+class KeystoneCatalog(object):
+    """
+    A registry of services, scoped to the project, returned by the identity server
+    Contains parsers for retrieving service endpoints from the server auth response
+    """
+    def __init__(self, nova_endpoint, neutron_endpoint):
+        self.nova_endpoint = nova_endpoint
+        self.neutron_endpoint = neutron_endpoint
+
+    @classmethod
+    def from_auth_response(cls, json_response, nova_api_version):
+        return cls(
+            nova_endpoint=cls.get_nova_endpoint(json_response, nova_api_version),
+            neutron_endpoint=cls.get_neutron_endpoint(json_response)
+        )
+
+    @classmethod
+    def get_neutron_endpoint(cls, json_resp):
+        """
+        Parse the service catalog returned by the Identity API for an endpoint matching the Neutron service
+        Sends a CRITICAL service check when none are found registered in the Catalog
+        """
+        catalog = json_resp.get('token', {}).get('catalog', [])
+        match = 'neutron'
+
+        neutron_endpoint = None
+        for entry in catalog:
+            if entry['name'] == match:
+                valid_endpoints = {}
+                for ep in entry['endpoints']:
+                    interface = ep.get('interface','')
+                    if interface in ['public', 'internal']:
+                        valid_endpoints[interface] = ep['url']
+
+                if valid_endpoints:
+                    # Favor public endpoints over internal
+                    neutron_endpoint = valid_endpoints.get("public",
+                                        valid_endpoints.get("internal"))
+                    break
+        else:
+            raise MissingNeutronEndpoint()
+
+        return neutron_endpoint
+
+    @classmethod
+    def get_nova_endpoint(cls, json_resp, nova_api_version=None):
+        """
+        Parse the service catalog returned by the Identity API for an endpoint matching the Nova service with the requested version
+        Sends a CRITICAL service check when no viable candidates are found in the Catalog
+        """
+        nova_version = nova_api_version or DEFAULT_NOVA_API_VERSION
+        catalog = json_resp.get('token', {}).get('catalog', [])
+
+        nova_match = 'novav21' if nova_version == 'v2.1' else 'nova'
+
+        for entry in catalog:
+            if entry['name'] == nova_match:
+                # Collect any endpoints on the public or internal interface
+                valid_endpoints = {}
+                for ep in entry['endpoints']:
+                    interface = ep.get('interface','')
+                    if interface in ['public', 'internal']:
+                        valid_endpoints[interface] = ep['url']
+
+                if valid_endpoints:
+                    # Favor public endpoints over internal
+                    nova_endpoint = valid_endpoints.get("public",
+                                        valid_endpoints.get("internal"))
+                    return nova_endpoint
+        else:
+            raise MissingNovaEndpoint()
+
+
+class OpenStackCheck(AgentCheck):
+    CACHE_TTL = {
+        "aggregates": 300, # seconds
+        "physical_hosts": 300,
+        "hypervisors": 300
+    }
+
+    FETCH_TIME_ACCESSORS = {
+        "aggregates": "_last_aggregate_fetch_time",
+        "physical_hosts": "_last_host_fetch_time",
+        "hypervisors": "_last_hypervisor_fetch_time"
+
+    }
 
     HYPERVISOR_STATE_UP = 'up'
+    HYPERVISOR_STATE_DOWN = 'down'
     NETWORK_STATE_UP = 'UP'
 
-    DEFAULT_KEYSTONE_API_VERSION = 'v3'
-    DEFAULT_NOVA_API_VERSION = 'v2.1'
-    DEFAULT_NEUTRON_API_VERSION = 'v2.0'
+    NETWORK_API_SC = 'openstack.neutron.api.up'
+    COMPUTE_API_SC = 'openstack.nova.api.up'
+    IDENTITY_API_SC = 'openstack.keystone.api.up'
 
-    HYPERVISOR_SERVICE_CHECK_NAME = 'openstack.nova.hypervisor.up'
-    NETWORK_SERVICE_CHECK_NAME = 'openstack.neutron.network.up'
+    # Service checks for individual hypervisors and networks
+    HYPERVISOR_SC = 'openstack.nova.hypervisor.up'
+    NETWORK_SC = 'openstack.neutron.network.up'
+
 
     HYPERVISOR_CACHE_EXPIRY = 120 # seconds
 
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
 
-        # Make sure auth happens at initialization
-        self._auth_required = True
+        self._ssl_verify = init_config.get("ssl_verify", True)
+        self.keystone_server_url = init_config.get("keystone_server_url")
+        if not self.keystone_server_url:
+            raise IncompleteConfig()
 
-        self._auth_token = None
-        self._nova_url = None
-        self._neutron_url = None
+        ### Cache some things between runs for values that change rarely
+        self._aggregate_list = None
 
-    def _make_request_with_auth_fallback(self, url, headers=None):
+        # Mapping of check instances to associated OpenStack project scopes
+        self.instance_map = {}
+
+        # Mapping of Nova-managed servers to tags
+        self.external_host_tags = {}
+
+    def _make_request_with_auth_fallback(self, url, headers=None, verify=True, params=None):
+        """
+        Generic request handler for OpenStack API requests
+        Raises specialized Exceptions for commonly encountered error codes
+        """
         try:
-            resp = requests.get(url, headers=headers)
+            resp = requests.get(url, headers=headers, verify=verify, params=params, timeout=DEFAULT_API_REQUEST_TIMEOUT)
             resp.raise_for_status()
         except requests.exceptions.HTTPError:
             if resp.status_code == 401:
                 self.log.info('Need to reauthenticate before next check')
-                raise OpenstackAuthFailure
+
+                # Delete the scope, we'll populate a new one on the next run for this instance
+                self.delete_current_scope()
+            elif resp.status_code == 409:
+                raise InstancePowerOffFailure()
             else:
                 raise
 
-        return resp
+        return resp.json()
 
-    ### Check config accessors
-    def _get_auth_scope(self):
-        auth_scope = self.init_config.get('auth_scope')
-        if not auth_scope or not auth_scope.get('project') or not auth_scope.get('project').get('name'):
-            self.warning("Please specify the auth scope via the `auth_scope` variable in your init_config.\n" +
-                         "The auth_scope should look like: {'project': {'name': 'my_project'}}")
-            raise IncompleteConfig
+    def _instance_key(self, instance):
+        i_key = instance.get('name')
+        if not i_key:
+            # We need a name to identify this instance
+            raise IncompleteConfig()
+        return i_key
 
-        if not auth_scope['project'].get('domain', {}).get('id'):
-            auth_scope['project']['domain'] = {'id': 'default'}
-        self.log.debug("Auth Scope: %s", auth_scope)
-        return auth_scope
+    def delete_current_scope(self):
+        scope_to_delete = self._current_scope
+        for i_key, scope in self.instance_map.items():
+            if scope is scope_to_delete:
+                self.log.debug("Deleting current scope: %s", i_key)
+                del self.instance_map[i_key]
 
-    def _get_identity_by_method(self):
-        user = self.init_config.get('user')
-        if not user or not user.get('name') or not user.get('password'):
-            self.warning("Please specify the user via the `user` variable in your init_config.\n" +
-                         "This is the user you would use to authenticate with Keystone v3 via password auth.\n" +
-                         "The user should look like: {'password': 'my_password', 'name': 'my_name'}")
-            raise IncompleteConfig
+    def get_scope_for_instance(self, instance):
+        i_key = self._instance_key(instance)
+        self.log.debug("Getting scope for instance %s", i_key)
+        return self.instance_map[i_key]
 
-        if not user.get('domain', {}).get('id'):
-            user['domain'] = {'id': 'default'}
+    def set_scope_for_instance(self, instance, scope):
+        i_key = self._instance_key(instance)
+        self.log.debug("Setting scope for instance %s", i_key)
+        self.instance_map[i_key] = scope
 
-        identity = {
-            "methods": ['password'],
-            "password": {"user": user}
-        }
-        self.log.debug("Identity: %s", identity)
-        return identity
+    def delete_scope_for_instance(self, instance):
+        i_key = self._instance_key(instance)
+        self.log.debug("Deleting scope for instance %s", i_key)
+        del self.instance_map[i_key]
 
-    def _get_keystone_server_url(self):
-        return self.init_config.get('keystone_server_url')
-    ###
+    def get_auth_token(self, instance=None):
+        if not instance:
+            # Assume instance scope is populated on self
+            return self._current_scope.auth_token
 
-    ### Auth
-    def get_auth_token_from_auth_response(self, resp):
-        return resp.headers.get('X-Subject-Token')
-
-    def authenticate(self):
-        keystone_api_version = self.init_config.get('keystone_api_version', self.DEFAULT_KEYSTONE_API_VERSION)
-
-        auth_scope = self._get_auth_scope()
-        identity = self._get_identity_by_method()
-        keystone_server_url = self._get_keystone_server_url()
-
-        payload = {"auth": {"scope": auth_scope, "identity": identity}}
-        auth_url = "{0}/{1}/auth/tokens".format(keystone_server_url, self.DEFAULT_KEYSTONE_API_VERSION)
-
-        resp = requests.post(auth_url, data=json.dumps(payload))
-        resp.raise_for_status()
-
-        self._nova_url = self.get_nova_url_from_auth_response(resp.json(),
-                                                              nova_version=self.init_config.get('nova_api_version'))
-
-        self._neutron_url = self.get_neutron_url_from_auth_response(resp.json())
-        self._auth_token = self.get_auth_token_from_auth_response(resp)
-    ###
+        return self.get_scope_for_instance(instance).auth_token
 
     ### Network
-    def get_neutron_url_from_auth_response(self, json_resp):
-        catalog = json_resp.get('token', {}).get('catalog', [])
-        match = 'neutron'
+    def get_neutron_endpoint(self, instance=None):
+        if not instance:
+            # Assume instance scope is populated on self
+            return self._current_scope.service_catalog.neutron_endpoint
 
-        for entry in catalog:
-            if entry['name'] == match:
-                return entry['endpoints'][0].get('url', '')
-        else:
-            return None
+        return self.get_scope_for_instance(instance).service_catalog.neutron_endpoint
 
     def get_network_stats(self):
-        network_ids = self.init_config.get('network_ids', [])
+        """
+        Collect stats for all reachable networks
+        """
+
+        # FIXME: (aaditya) Check all networks defaults to true until we can reliably assign agents to networks to monitor
+        if self.init_config.get('check_all_networks', True):
+            network_ids = list(set(self.get_all_network_ids()) - set(self.init_config.get('exclude_network_ids', [])))
+        else:
+            network_ids = self.init_config.get('network_ids', [])
+
         if not network_ids:
             self.warning("Your check is not configured to monitor any networks.\n" +
                          "Please list `network_ids` under your init_config")
@@ -160,20 +425,47 @@ class OpenstackCheck(AgentCheck):
         for nid in network_ids:
             self.get_stats_for_single_network(nid)
 
+    def get_all_network_ids(self):
+        url = '{0}/{1}/networks'.format(self.get_neutron_endpoint(), DEFAULT_NEUTRON_API_VERSION)
+        headers = {'X-Auth-Token': self.get_auth_token()}
+
+        network_ids = []
+        try:
+            net_details = self._make_request_with_auth_fallback(url, headers, verify=self._ssl_verify)
+            for network in net_details['networks']:
+                network_ids.append(network['id'])
+        except Exception as e:
+            self.warning('Unable to get the list of all network ids: {0}'.format(str(e)))
+        return network_ids
 
     def get_stats_for_single_network(self, network_id):
-        url = '{0}/{1}/networks/{2}'.format(self._neutron_url, self.DEFAULT_NEUTRON_API_VERSION, network_id)
-        headers = {'X-Auth-Token': self._auth_token}
-        resp = self._make_request_with_auth_fallback(url, headers)
+        url = '{0}/{1}/networks/{2}'.format(self.get_neutron_endpoint(), DEFAULT_NEUTRON_API_VERSION, network_id)
+        headers = {'X-Auth-Token': self.get_auth_token()}
+        net_details = self._make_request_with_auth_fallback(url, headers, verify=self._ssl_verify)
 
-        net_details = resp.json()
         service_check_tags = ['network:{0}'.format(network_id)]
 
+        network_name = net_details.get('network', {}).get('name')
+        if network_name is not None:
+            service_check_tags.append('network_name:{0}'.format(network_name))
+
+        tenant_id = net_details.get('network', {}).get('tenant_id')
+        if tenant_id is not None:
+            service_check_tags.append('tenant_id:{0}'.format(tenant_id))
+
         if net_details.get('admin_state_up'):
-            self.service_check(self.NETWORK_SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags)
+            self.service_check(self.NETWORK_SC, AgentCheck.OK, tags=service_check_tags)
         else:
-            self.service_check(self.NETWORK_SERVICE_CHECK_NAME, AgentCheck.OK, tags=service_check_tags)
+            self.service_check(self.NETWORK_SC, AgentCheck.CRITICAL, tags=service_check_tags)
     ###
+
+    ### Compute
+    def get_nova_endpoint(self, instance=None):
+        if not instance:
+            # Assume instance scope is populated on self
+            return self._current_scope.service_catalog.nova_endpoint
+
+        return self.get_scope_for_instance(instance).service_catalog.nova_endpoint
 
     def _parse_uptime_string(self, uptime):
         """ Parse u' 16:53:48 up 1 day, 21:34,  3 users,  load average: 0.04, 0.14, 0.19\n' """
@@ -186,121 +478,373 @@ class OpenstackCheck(AgentCheck):
             'uptime_sec': uptime_sec
         }
 
-    ### Compute
-    def get_nova_url_from_auth_response(self, json_resp, nova_version=None):
-        nova_version = nova_version or self.DEFAULT_NOVA_API_VERSION
-        catalog = json_resp.get('token', {}).get('catalog', [])
-        nova_match = 'novav21' if nova_version == 'v2.1' else 'nova'
-        for entry in catalog:
-            if entry['name'] == nova_match:
-                return entry['endpoints'][0].get('url', '')
+
+    def get_all_hypervisor_ids(self, filter_by_host=None):
+        nova_version = self.init_config.get("nova_api_version", DEFAULT_NOVA_API_VERSION)
+        if nova_version == "v2.1":
+            url = '{0}/os-hypervisors'.format(self.get_nova_endpoint())
+            headers = {'X-Auth-Token': self.get_auth_token()}
+
+            hypervisor_ids = []
+            try:
+                hv_list = self._make_request_with_auth_fallback(url, headers, verify=self._ssl_verify)
+                for hv in hv_list['hypervisors']:
+                    if filter_by_host and hv['hypervisor_hostname'] == filter_by_host:
+                        # Assume one-one relationship between hypervisor and host, return the 1st found
+                        return [hv['id']]
+
+                    hypervisor_ids.append(hv['id'])
+            except Exception as e:
+                self.warning('Unable to get the list of all hypervisors: {0}'.format(str(e)))
+
+            return hypervisor_ids
         else:
-            return None
+            if not self.init_config.get("hypervisor_ids"):
+                self.warning("Nova API v2 requires admin privileges to index hypervisors. " +
+                             "Please specify the hypervisor you wish to monitor under the `hypervisor_ids` section")
+                return []
+            return self.init_config.get("hypervisor_ids")
 
-    def get_hypervisor_stats(self):
-        hypervisors = self.init_config.get('hypervisor_ids', [])
+    def get_all_aggregate_hypervisors(self):
+        url = '{0}/os-aggregates'.format(self.get_nova_endpoint())
+        headers = {'X-Auth-Token': self.get_auth_token()}
 
-        if not hypervisors:
-            self.warning("Your check is not configured to monitor any hypervisors.\n" +
-                         "Please list `hypervisor_ids` under your init_config")
+        hypervisor_aggregate_map = {}
+        try:
+            aggregate_list = self._make_request_with_auth_fallback(url, headers, verify=self._ssl_verify)
+            for v in aggregate_list['aggregates']:
+                for host in v['hosts']:
+                    hypervisor_aggregate_map[host] = {
+                        'aggregate': v['name'],
+                        'availability_zone': v['availability_zone']
+                    }
 
-        stats = {}
-        for hyp in hypervisors:
-            stats[hyp] = {
-                'payload': self.get_stats_for_single_hypervisor(hyp),
-                'uptime': self.get_uptime_for_single_hypervisor(hyp)
-            }
-        return stats
+        except Exception as e:
+            self.warning('Unable to get the list of aggregates: {0}'.format(str(e)))
+
+        return hypervisor_aggregate_map
 
     def get_uptime_for_single_hypervisor(self, hyp_id):
-        url = '{0}/os-hypervisors/{1}/uptime'.format(self._nova_url, hyp_id)
-        headers = {'X-Auth-Token': self._auth_token}
+        url = '{0}/os-hypervisors/{1}/uptime'.format(self.get_nova_endpoint(), hyp_id)
+        headers = {'X-Auth-Token': self.get_auth_token()}
 
-        resp = self._make_request_with_auth_fallback(url, headers)
-        uptime = resp.json()['hypervisor']['uptime']
+        resp = self._make_request_with_auth_fallback(url, headers, verify=self._ssl_verify)
+        uptime = resp['hypervisor']['uptime']
         return self._parse_uptime_string(uptime)
 
-    def get_stats_for_single_hypervisor(self, hyp_id):
-        url = '{0}/os-hypervisors/{1}'.format(self._nova_url, hyp_id)
-        headers = {'X-Auth-Token': self._auth_token}
-        resp = self._make_request_with_auth_fallback(url, headers)
-        hyp = resp.json()['hypervisor']
-        service_check_tags = ['hypervisor:{0}'.format(hyp['hypervisor_hostname'])]
+    def get_stats_for_single_hypervisor(self, hyp_id, host_tags=None):
+        url = '{0}/os-hypervisors/{1}'.format(self.get_nova_endpoint(), hyp_id)
+        headers = {'X-Auth-Token': self.get_auth_token()}
+        resp = self._make_request_with_auth_fallback(url, headers, verify=self._ssl_verify)
+        hyp = resp['hypervisor']
+        host_tags = host_tags or []
+        tags = [
+            'hypervisor:{0}'.format(hyp['hypervisor_hostname']),
+            'hypervisor_id:{0}'.format(hyp['id']),
+            'virt_type:{0}'.format(hyp['hypervisor_type'])
+        ]
+        tags.extend(host_tags)
 
-        if hyp['state'] != self.HYPERVISOR_STATE_UP:
-            self.service_check(self.HYPERVISOR_SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                               tags=service_check_tags)
+        try:
+            uptime = self.get_uptime_for_single_hypervisor(hyp['id'])
+        except Exception as e:
+            self.warning('Unable to get uptime for hypervisor {0}: {1}'.format(hyp['id'], str(e)))
+            uptime = {}
+
+        hyp_state = hyp.get('state', None)
+        if hyp_state is None:
+            try:
+                # Fall back for pre Nova v2.1 to the uptime response
+                if uptime.get('uptime_sec', 0) > 0:
+                    hyp_state = self.HYPERVISOR_STATE_UP
+                else:
+                    hyp_state = self.HYPERVISOR_STATE_DOWN
+            except:
+                # This creates the AgentCheck.UNKNOWN state
+                pass
+
+        if hyp_state is None:
+            self.service_check(self.HYPERVISOR_SC, AgentCheck.UNKNOWN,
+                               tags=tags)
+        elif hyp_state != self.HYPERVISOR_STATE_UP:
+            self.service_check(self.HYPERVISOR_SC, AgentCheck.CRITICAL,
+                               tags=tags)
         else:
-            self.service_check(self.HYPERVISOR_SERVICE_CHECK_NAME, AgentCheck.OK,
-                               tags=service_check_tags)
+            self.service_check(self.HYPERVISOR_SC, AgentCheck.OK,
+                               tags=tags)
 
-        return hyp
+        for label, val in hyp.iteritems():
+            if label in NOVA_HYPERVISOR_METRICS:
+                metric_label = "openstack.nova.{0}".format(label)
+                self.gauge(metric_label, val, tags=tags)
 
-    def get_server_stats(self):
-        server_ids = self.init_config.get('server_ids', [])
-        if not server_ids:
-            self.warning("Your check is not configured to monitor any servers.\n" +
-                         "Please list `server_ids` under your init_config in openstack.yaml")
-
-        for sid in server_ids:
-            self.get_stats_for_single_server(sid)
-
-    def get_stats_for_single_server(self, server_id):
-        def _is_valid_metric(label):
-            return label in NOVA_SERVER_METRICS or any(seg in label for seg in NOVA_SERVER_INTERFACE_SEGMENTS)
-
-        url = '{0}/servers/{1}/diagnostics'.format(self._nova_url, server_id)
-        headers = {'X-Auth-Token': self._auth_token}
-        resp = self._make_request_with_auth_fallback(url, headers)
-
-        server_stats = resp.json()
-        tags = ['server:{0}'.format(server_id)]
-
-        for st in server_stats:
-            if _is_valid_metric(st):
-                self.gauge("openstack.nova.server.{0}".format(st), server_stats[st], tags=tags)
-
-    ###
-
-    def nova_stats_to_metrics(self, stats):
-        for _, v in stats.iteritems():
-            payload = v['payload']
-
-            tags = ['hypervisor:{0}'.format(payload['hypervisor_hostname']),'virt_type:{0}'.format(payload['hypervisor_type'])]
-
-            for label, val in payload.iteritems():
-                if label in NOVA_HYPERVISOR_METRICS:
-                    metric_label = "openstack.nova.{0}".format(label)
-                    self.gauge(metric_label, val, tags=tags)
-
-            uptime = v['uptime']
-            load_averages = uptime['loads']
-
+        load_averages = uptime.get("loads")
+        if load_averages is not None:
             assert len(load_averages) == 3
             for i, avg in enumerate([1, 5, 15]):
                 self.gauge('openstack.nova.hypervisor_load.{0}'.format(avg), load_averages[i], tags=tags)
 
+    def get_all_server_ids(self, filter_by_host=None):
+        query_params = {}
+        if filter_by_host:
+            query_params["host"] = filter_by_host
+
+        url = '{0}/servers'.format(self.get_nova_endpoint())
+        headers = {'X-Auth-Token': self.get_auth_token()}
+
+        server_ids = []
+        try:
+            resp = self._make_request_with_auth_fallback(url, headers, verify=self._ssl_verify, params=query_params)
+
+            server_ids = [s['id'] for s in resp['servers']]
+        except Exception as e:
+            self.warning('Unable to get the list of all servers: {0}'.format(str(e)))
+
+        return server_ids
+
+    def get_stats_for_single_server(self, server_id, tags=None):
+        def _is_valid_metric(label):
+            return label in NOVA_SERVER_METRICS or any(seg in label for seg in NOVA_SERVER_INTERFACE_SEGMENTS)
+
+        url = '{0}/servers/{1}/diagnostics'.format(self.get_nova_endpoint(), server_id)
+        headers = {'X-Auth-Token': self.get_auth_token()}
+        server_stats = {}
+
+        try:
+            server_stats = self._make_request_with_auth_fallback(url, headers, verify=self._ssl_verify)
+        except InstancePowerOffFailure:
+            self.warning("Server %s is powered off and cannot be monitored" % server_id)
+        except Exception as e:
+            self.warning("Unknown error when monitoring %s : %s" % (server_id, e))
+
+        if server_stats:
+            tags = tags or []
+            for st in server_stats:
+                if _is_valid_metric(st):
+                    self.gauge("openstack.nova.server.{0}".format(st.replace("-", "_")), server_stats[st], tags=tags, hostname=server_id)
+
+
+    def get_stats_for_single_project(self, project):
+        def _is_valid_metric(label):
+            return label in PROJECT_METRICS
+
+        url = '{0}/limits'.format(self.get_nova_endpoint())
+        headers = {'X-Auth-Token': self.get_auth_token()}
+        server_stats = self._make_request_with_auth_fallback(url, headers, params={"tenant_id": project['id']})
+
+        tags = ['tenant_id:{0}'.format(project['id'])]
+        if 'name' in project:
+            tags.append('project_name:{0}'.format(project['name']))
+
+        for st in server_stats['limits']['absolute']:
+            if _is_valid_metric(st):
+                metric_key = PROJECT_METRICS[st]
+                self.gauge("openstack.nova.limits.{0}".format(metric_key), server_stats['limits']['absolute'][st], tags=tags)
+
+    ###
+
+    ### Cache util
+    def _is_expired(self, entry):
+        assert entry in ["aggregates", "physical_hosts", "hypervisors"]
+        ttl = self.CACHE_TTL.get(entry)
+        last_fetch_time = getattr(self, self.FETCH_TIME_ACCESSORS.get(entry))
+        return datetime.now() - last_fetch_time > timedelta(seconds=ttl)
+
+    def _get_and_set_aggregate_list(self):
+        if not self._aggregate_list or self._is_expired("aggregates"):
+            self._aggregate_list = self.get_all_aggregate_hypervisors()
+            self._last_aggregate_fetch_time = datetime.now()
+
+        return self._aggregate_list
+    ###
+
+    def _send_api_service_checks(self, instance_scope):
+        # Nova
+        headers = {"X-Auth-Token": instance_scope.auth_token}
+
+        try:
+            requests.get(instance_scope.service_catalog.nova_endpoint, headers=headers, verify=self._ssl_verify, timeout=DEFAULT_API_REQUEST_TIMEOUT)
+            self.service_check(self.COMPUTE_API_SC, AgentCheck.OK, tags=["keystone_server:%s" % self.init_config.get("keystone_server_url")])
+        except (requests.exceptions.HTTPError, requests.exceptions.Timeout, requests.exceptions.ConnectionError):
+            self.service_check(self.COMPUTE_API_SC, AgentCheck.CRITICAL, tags=["keystone_server:%s" % self.init_config.get("keystone_server_url")])
+
+        # Neutron
+        try:
+            requests.get(instance_scope.service_catalog.neutron_endpoint, headers=headers, verify=self._ssl_verify, timeout=DEFAULT_API_REQUEST_TIMEOUT)
+            self.service_check(self.NETWORK_API_SC, AgentCheck.OK, tags=["keystone_server:%s" % self.init_config.get("keystone_server_url")])
+        except (requests.exceptions.HTTPError, requests.exceptions.Timeout, requests.exceptions.ConnectionError):
+            self.service_check(self.NETWORK_API_SC, AgentCheck.CRITICAL, tags=["keystone_server:%s" % self.init_config.get("keystone_server_url")])
+
+    def ensure_auth_scope(self, instance):
+        """
+        Guarantees a valid auth scope for this instance, and returns it
+
+        Communicates with the identity server and initializes a new scope when one is absent, or has been forcibly removed due to token expiry
+        """
+        try:
+            instance_scope = self.get_scope_for_instance(instance)
+        except KeyError:
+
+            # We're missing a project scope for this instance
+            # Let's populate it now
+            try:
+                instance_scope = OpenStackProjectScope.from_config(self.init_config, instance)
+                self.service_check(self.IDENTITY_API_SC, AgentCheck.OK, tags=["server:%s" % self.init_config.get("keystone_server_url")])
+            except KeystoneUnreachable:
+                self.warning("The agent could not contact the specified identity server at %s . Are you sure it is up at that address?" % self.init_config.get("keystone_server_url"))
+                self.service_check(self.IDENTITY_API_SC, AgentCheck.CRITICAL, tags=["server:%s" % self.init_config.get("keystone_server_url")])
+
+                # If Keystone is down/unreachable, we default the Nova and Neutron APIs to UNKNOWN since we cannot access the service catalog
+                self.service_check(self.NETWORK_API_SC, AgentCheck.UNKNOWN, tags=["keystone_server:%s" % self.init_config.get("keystone_server_url")])
+                self.service_check(self.COMPUTE_API_SC, AgentCheck.UNKNOWN, tags=["keystone_server:%s" % self.init_config.get("keystone_server_url")])
+
+                raise
+
+            except MissingNovaEndpoint:
+                self.warning("The agent could not find a compatible Nova endpoint in your service catalog!")
+                self.service_check(self.COMPUTE_API_SC, AgentCheck.CRITICAL, tags=["keystone_server:%s" % self.init_config.get("keystone_server_url")])
+
+            except MissingNeutronEndpoint:
+                self.warning("The agent could not find a compatible Neutron endpoint in your service catalog!")
+                self.service_check(self.NETWORK_API_SC, AgentCheck.CRITICAL, tags=["keystone_server:%s" % self.init_config.get("keystone_server_url")])
+
+            self.set_scope_for_instance(instance, instance_scope)
+
+        return instance_scope
 
     def check(self, instance):
 
         try:
-            if self._auth_required:
-                self.authenticate()
+            instance_scope = self.ensure_auth_scope(instance)
 
-            self.log.debug("Running check with creds: \n")
-            self.log.debug("Nova Url: %s", self._nova_url)
-            self.log.debug("Neutron Url: %s", self._neutron_url)
-            self.log.debug("Auth Token: %s", self._auth_token)
+            self._send_api_service_checks(instance_scope)
+            # Store the scope on the object so we don't have to keep passing it around
+            self._current_scope = instance_scope
 
-            try:
-                hyp_stats = self.get_hypervisor_stats()
-                self.nova_stats_to_metrics(hyp_stats)
+            self.log.debug("Running check with credentials: \n")
+            self.log.debug("Nova Url: %s", self.get_nova_endpoint())
+            self.log.debug("Neutron Url: %s", self.get_neutron_endpoint())
+            self.log.debug("Auth Token: %s", self.get_auth_token())
 
-                self.get_server_stats()
-                self.get_network_stats()
-            except OpenstackAuthFailure:
-                self._auth_required = True
+            # Restrict monitoring to this (host, hypervisor, project)
+            # and it's guest servers
 
-        except IncompleteConfig:
-            self.warning("Configuration Incomplete! Check your openstack.yaml file")
-            return
+            hyp = self.get_local_hypervisor()
+            project = self.get_scoped_project(instance)
+
+            # Restrict monitoring to non-excluded servers
+            excluded_server_ids = self.init_config.get("exclude_server_ids", [])
+            servers = list(
+                set(self.get_servers_managed_by_hypervisor()) - set(excluded_server_ids)
+            )
+
+            host_tags = self._get_tags_for_host()
+
+            for sid in servers:
+                server_tags = ["nova_managed_server"]
+                self.external_host_tags[sid] = host_tags
+                self.get_stats_for_single_server(sid, tags=server_tags)
+
+            if hyp:
+                self.get_stats_for_single_hypervisor(hyp, host_tags=host_tags)
+            else:
+                self.warning("Couldn't get hypervisor to monitor for host: %s" % self.get_my_hostname())
+
+            if project:
+                self.get_stats_for_single_project(project)
+
+            # For now, monitor all networks
+            self.get_network_stats()
+
+        except IncompleteConfig as e:
+            if isinstance(e, IncompleteAuthScope):
+                self.warning("""Please specify the auth scope via the `auth_scope` variable in your init_config.\n
+                             The auth_scope should look like: \n
+                            {'project': {'name': 'my_project', 'domain': {'id': 'my_domain_id'}}}\n
+                            OR\n
+                            {'project': {'id': 'my_project_id'}}
+                             """)
+            elif isinstance(e, IncompleteIdentity):
+                self.warning("Please specify the user via the `user` variable in your init_config.\n" +
+                             "This is the user you would use to authenticate with Keystone v3 via password auth.\n" +
+                             "The user should look like: {'password': 'my_password', 'name': 'my_name', 'domain': {'id': 'my_domain_id'}}")
+            else:
+                self.warning("Configuration Incomplete! Check your openstack.yaml file")
+
+
+    #### Local Info accessors
+    def get_local_hypervisor(self):
+        """
+        Returns the hypervisor running on this host, and assumes a 1-1 between host and hypervisor
+        """
+        # Look up hypervisors available filtered by my hostname
+        host = self.get_my_hostname()
+        hyp = self.get_all_hypervisor_ids(filter_by_host=host)
+        if hyp:
+            return hyp[0]
+
+    def get_scoped_project(self, instance):
+        """
+        Returns the project that this instance of the check is scoped to
+        """
+        project_auth_scope = self.get_scope_for_instance(instance)
+        if project_auth_scope.tenant_id:
+            return {"id": project_auth_scope.tenant_id}
+
+        filter_params = {
+            "name": project_auth_scope.project_name,
+            "domain_id": project_auth_scope.domain_id
+        }
+
+        url = "{0}/{1}/{2}".format(self.keystone_server_url, DEFAULT_KEYSTONE_API_VERSION, "projects")
+        headers = {'X-Auth-Token': self.get_auth_token(instance)}
+
+        projects = []
+        try:
+            project_details = self._make_request_with_auth_fallback(url, headers, params=filter_params)
+            assert len(project_details["projects"]) == 1, "Non-unique project credentials"
+            return project_details["projects"][0]
+        except Exception as e:
+            self.warning('Unable to get the list of all project ids: {0}'.format(str(e)))
+
+        return None
+
+
+
+    def get_my_hostname(self):
+        """
+        Returns a best guess for the hostname registered with OpenStack for this host
+        """
+        return self.init_config.get("os_host") or get_hostname(self.agentConfig)
+
+    def get_servers_managed_by_hypervisor(self):
+        return self.get_all_server_ids(filter_by_host=self.get_my_hostname())
+
+    def _get_tags_for_host(self):
+        hostname = self.get_my_hostname()
+
+        tags = []
+        if hostname in self._get_and_set_aggregate_list():
+            tags.append('aggregate:{0}'.format(self._aggregate_list[hostname]['aggregate']))
+            # Need to check if there is a value for availability_zone because it is possible to have an aggregate without an AZ
+            if self._aggregate_list[hostname]['availability_zone']:
+                tags.append('availability_zone:{0}'.format(self._aggregate_list[hostname]['availability_zone']))
+        else:
+            self.log.info('Unable to find hostname {0} in aggregate list. Assuming this host is unaggregated'.format(hostname))
+
+        return tags
+
+    ### For attaching tags to hosts that are not the host running the agent
+
+    def get_external_host_tags(self):
+        """ Returns a list of tags for every guest server that is detected by the OpenStack
+        integration.
+        List of pairs (hostname, list_of_tags)
+        """
+        self.log.info("Collecting external_host_tags now")
+        external_host_tags = []
+        for k,v in self.external_host_tags.iteritems():
+            external_host_tags.append((k, {SOURCE_TYPE: v}))
+
+        self.log.debug("Sending external_host_tags: %s", external_host_tags)
+        return external_host_tags

--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -1,0 +1,306 @@
+import json
+import requests
+
+from checks import AgentCheck
+
+NOVA_HYPERVISOR_METRICS = [
+    'current_workload',
+    'disk_available_least',
+    'free_disk_gb',
+    'free_ram_mb',
+    'local_gb',
+    'local_gb_used',
+    'memory_mb',
+    'memory_mb_used',
+    'running_vms',
+    'vcpus',
+    'vcpus_used',
+]
+
+NOVA_SERVER_METRICS = [
+    "hdd_errors",
+    "hdd_read",
+    "hdd_read_req",
+    "hdd_write",
+    "hdd_write_req",
+    "memory",
+    "memory-actual",
+    "memory-rss",
+    "cpu0_time",
+
+    "vda_errors",
+    "vda_read",
+    "vda_read_req",
+    "vda_write",
+    "vda_write_req"
+]
+
+NOVA_SERVER_INTERFACE_SEGMENTS = ['_rx', '_tx']
+
+
+class OpenstackAuthFailure(Exception):
+    pass
+
+class IncompleteConfig(Exception):
+    pass
+
+class OpenstackCheck(AgentCheck):
+
+    HYPERVISOR_STATE_UP = 'up'
+    NETWORK_STATE_UP = 'UP'
+
+    DEFAULT_KEYSTONE_API_VERSION = 'v3'
+    DEFAULT_NOVA_API_VERSION = 'v2.1'
+    DEFAULT_NEUTRON_API_VERSION = 'v2.0'
+
+    HYPERVISOR_SERVICE_CHECK_NAME = 'openstack.nova.hypervisor.up'
+    NETWORK_SERVICE_CHECK_NAME = 'openstack.neutron.network.up'
+
+    HYPERVISOR_CACHE_EXPIRY = 120 # seconds
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+
+        # Make sure auth happens at initialization
+        self._auth_required = True
+
+        self._auth_token = None
+        self._nova_url = None
+        self._neutron_url = None
+
+    def _make_request_with_auth_fallback(self, url, headers=None):
+        try:
+            resp = requests.get(url, headers=headers)
+            resp.raise_for_status()
+        except requests.exceptions.HTTPError:
+            if resp.status_code == 401:
+                self.log.info('Need to reauthenticate before next check')
+                raise OpenstackAuthFailure
+            else:
+                raise
+
+        return resp
+
+    ### Check config accessors
+    def _get_auth_scope(self):
+        auth_scope = self.init_config.get('auth_scope')
+        if not auth_scope or not auth_scope.get('project') or not auth_scope.get('project').get('name'):
+            self.warning("Please specify the auth scope via the `auth_scope` variable in your init_config.\n" +
+                         "The auth_scope should look like: {'project': {'name': 'my_project'}}")
+            raise IncompleteConfig
+
+        if not auth_scope['project'].get('domain', {}).get('id'):
+            auth_scope['project']['domain'] = {'id': 'default'}
+        self.log.debug("Auth Scope: %s", auth_scope)
+        return auth_scope
+
+    def _get_identity_by_method(self):
+        user = self.init_config.get('user')
+        if not user or not user.get('name') or not user.get('password'):
+            self.warning("Please specify the user via the `user` variable in your init_config.\n" +
+                         "This is the user you would use to authenticate with Keystone v3 via password auth.\n" +
+                         "The user should look like: {'password': 'my_password', 'name': 'my_name'}")
+            raise IncompleteConfig
+
+        if not user.get('domain', {}).get('id'):
+            user['domain'] = {'id': 'default'}
+
+        identity = {
+            "methods": ['password'],
+            "password": {"user": user}
+        }
+        self.log.debug("Identity: %s", identity)
+        return identity
+
+    def _get_keystone_server_url(self):
+        return self.init_config.get('keystone_server_url')
+    ###
+
+    ### Auth
+    def get_auth_token_from_auth_response(self, resp):
+        return resp.headers.get('X-Subject-Token')
+
+    def authenticate(self):
+        keystone_api_version = self.init_config.get('keystone_api_version', self.DEFAULT_KEYSTONE_API_VERSION)
+
+        auth_scope = self._get_auth_scope()
+        identity = self._get_identity_by_method()
+        keystone_server_url = self._get_keystone_server_url()
+
+        payload = {"auth": {"scope": auth_scope, "identity": identity}}
+        auth_url = "{0}/{1}/auth/tokens".format(keystone_server_url, self.DEFAULT_KEYSTONE_API_VERSION)
+
+        resp = requests.post(auth_url, data=json.dumps(payload))
+        resp.raise_for_status()
+
+        self._nova_url = self.get_nova_url_from_auth_response(resp.json(),
+                                                              nova_version=self.init_config.get('nova_api_version'))
+
+        self._neutron_url = self.get_neutron_url_from_auth_response(resp.json())
+        self._auth_token = self.get_auth_token_from_auth_response(resp)
+    ###
+
+    ### Network
+    def get_neutron_url_from_auth_response(self, json_resp):
+        catalog = json_resp.get('token', {}).get('catalog', [])
+        match = 'neutron'
+
+        for entry in catalog:
+            if entry['name'] == match:
+                return entry['endpoints'][0].get('url', '')
+        else:
+            return None
+
+    def get_network_stats(self):
+        network_ids = self.init_config.get('network_ids', [])
+        if not network_ids:
+            self.warning("Your check is not configured to monitor any networks.\n" +
+                         "Please list `network_ids` under your init_config")
+
+        for nid in network_ids:
+            self.get_stats_for_single_network(nid)
+
+
+    def get_stats_for_single_network(self, network_id):
+        url = '{0}/{1}/networks/{2}'.format(self._neutron_url, self.DEFAULT_NEUTRON_API_VERSION, network_id)
+        headers = {'X-Auth-Token': self._auth_token}
+        resp = self._make_request_with_auth_fallback(url, headers)
+
+        net_details = resp.json()
+        service_check_tags = ['network:{0}'.format(network_id)]
+
+        if net_details.get('admin_state_up'):
+            self.service_check(self.NETWORK_SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags)
+        else:
+            self.service_check(self.NETWORK_SERVICE_CHECK_NAME, AgentCheck.OK, tags=service_check_tags)
+    ###
+
+    def _parse_uptime_string(self, uptime):
+        """ Parse u' 16:53:48 up 1 day, 21:34,  3 users,  load average: 0.04, 0.14, 0.19\n' """
+        uptime = uptime.strip()
+        load_averages = uptime[uptime.find('load average:'):].split(':')[1].split(',')
+        uptime_sec = uptime.split(',')[0]
+
+        return {
+            'loads': map(float, load_averages),
+            'uptime_sec': uptime_sec
+        }
+
+    ### Compute
+    def get_nova_url_from_auth_response(self, json_resp, nova_version=None):
+        nova_version = nova_version or self.DEFAULT_NOVA_API_VERSION
+        catalog = json_resp.get('token', {}).get('catalog', [])
+        nova_match = 'novav21' if nova_version == 'v2.1' else 'nova'
+        for entry in catalog:
+            if entry['name'] == nova_match:
+                return entry['endpoints'][0].get('url', '')
+        else:
+            return None
+
+    def get_hypervisor_stats(self):
+        hypervisors = self.init_config.get('hypervisor_ids', [])
+
+        if not hypervisors:
+            self.warning("Your check is not configured to monitor any hypervisors.\n" +
+                         "Please list `hypervisor_ids` under your init_config")
+
+        stats = {}
+        for hyp in hypervisors:
+            stats[hyp] = {
+                'payload': self.get_stats_for_single_hypervisor(hyp),
+                'uptime': self.get_uptime_for_single_hypervisor(hyp)
+            }
+        return stats
+
+    def get_uptime_for_single_hypervisor(self, hyp_id):
+        url = '{0}/os-hypervisors/{1}/uptime'.format(self._nova_url, hyp_id)
+        headers = {'X-Auth-Token': self._auth_token}
+
+        resp = self._make_request_with_auth_fallback(url, headers)
+        uptime = resp.json()['hypervisor']['uptime']
+        return self._parse_uptime_string(uptime)
+
+    def get_stats_for_single_hypervisor(self, hyp_id):
+        url = '{0}/os-hypervisors/{1}'.format(self._nova_url, hyp_id)
+        headers = {'X-Auth-Token': self._auth_token}
+        resp = self._make_request_with_auth_fallback(url, headers)
+        hyp = resp.json()['hypervisor']
+        service_check_tags = ['hypervisor:{0}'.format(hyp['hypervisor_hostname'])]
+
+        if hyp['state'] != self.HYPERVISOR_STATE_UP:
+            self.service_check(self.HYPERVISOR_SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
+                               tags=service_check_tags)
+        else:
+            self.service_check(self.HYPERVISOR_SERVICE_CHECK_NAME, AgentCheck.OK,
+                               tags=service_check_tags)
+
+        return hyp
+
+    def get_server_stats(self):
+        server_ids = self.init_config.get('server_ids', [])
+        if not server_ids:
+            self.warning("Your check is not configured to monitor any servers.\n" +
+                         "Please list `server_ids` under your init_config in openstack.yaml")
+
+        for sid in server_ids:
+            self.get_stats_for_single_server(sid)
+
+    def get_stats_for_single_server(self, server_id):
+        def _is_valid_metric(label):
+            return label in NOVA_SERVER_METRICS or any(seg in label for seg in NOVA_SERVER_INTERFACE_SEGMENTS)
+
+        url = '{0}/servers/{1}/diagnostics'.format(self._nova_url, server_id)
+        headers = {'X-Auth-Token': self._auth_token}
+        resp = self._make_request_with_auth_fallback(url, headers)
+
+        server_stats = resp.json()
+        tags = ['server:{0}'.format(server_id)]
+
+        for st in server_stats:
+            if _is_valid_metric(st):
+                self.gauge("openstack.nova.server.{0}".format(st), server_stats[st], tags=tags)
+
+    ###
+
+    def nova_stats_to_metrics(self, stats):
+        for _, v in stats.iteritems():
+            payload = v['payload']
+
+            tags = ['hypervisor:{0}'.format(payload['hypervisor_hostname']),'virt_type:{0}'.format(payload['hypervisor_type'])]
+
+            for label, val in payload.iteritems():
+                if label in NOVA_HYPERVISOR_METRICS:
+                    metric_label = "openstack.nova.{0}".format(label)
+                    self.gauge(metric_label, val, tags=tags)
+
+            uptime = v['uptime']
+            load_averages = uptime['loads']
+
+            assert len(load_averages) == 3
+            for i, avg in enumerate([1, 5, 15]):
+                self.gauge('openstack.nova.hypervisor_load.{0}'.format(avg), load_averages[i], tags=tags)
+
+
+    def check(self, instance):
+
+        try:
+            if self._auth_required:
+                self.authenticate()
+
+            self.log.debug("Running check with creds: \n")
+            self.log.debug("Nova Url: %s", self._nova_url)
+            self.log.debug("Neutron Url: %s", self._neutron_url)
+            self.log.debug("Auth Token: %s", self._auth_token)
+
+            try:
+                hyp_stats = self.get_hypervisor_stats()
+                self.nova_stats_to_metrics(hyp_stats)
+
+                self.get_server_stats()
+                self.get_network_stats()
+            except OpenstackAuthFailure:
+                self._auth_required = True
+
+        except IncompleteConfig:
+            self.warning("Configuration Incomplete! Check your openstack.yaml file")
+            return

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -644,7 +644,10 @@ class AgentCheck(object):
         """ Add a warning message that will be printed in the info page
         :param warning_message: String. Warning message to be displayed
         """
-        self.warnings.append(str(warning_message))
+        warning_message = str(warning_message)
+
+        self.log.warning(warning_message)
+        self.warnings.append(warning_message)
 
     def get_library_info(self):
         if self.library_versions is not None:

--- a/conf.d/openstack.yaml.example
+++ b/conf.d/openstack.yaml.example
@@ -1,37 +1,67 @@
 init_config:
-       # Where your identity server lives (please omit the trailing slash). Note the server must support Identity API v3
-      keystone_server_url: "https://my-keystone-server.com"
-      
+      # All directives prefixed with a '#' sign are optional and will default to sane values when omitted
+
+      # Where your identity server lives (please omit the trailing slash). Note that the server must support Identity API v3
+      keystone_server_url: "https://my-keystone-server.com:<port>"
+
+      # The hostname of this machine registered with Nova. Defaults to socket.gethostname()
+      # os_host: my_hostname
+
       # Nova API version to use - this check supports v2 and v2.1 (default)
-      #nova_api_version: 'v2.1' 
-      
+      # nova_api_version: 'v2.1'
+
+      # IDs of Nova Hypervisors to monitor
+      # This is only required when nova_api_version is set to `v2` since
+      # indexing hypervsiors is restricted to `admin`s in Compute API v2
+      # With v2.1, the check will intelligently discover the locally running
+      # hypervisor, based on the hypervisor_hostname
+
+      # hypervisor_ids:
+      #    - 1
+
+      # IDs of networks to exclude from monitoring (by default the agent will collect metrics from networks returned by the neutron:get_networks operation)
+      # exclude_network_ids:
+      #    - network_1
+
+      # Whether to enable SSL certificate verification for HTTP requests. Defaults to true, you may
+      # need to set to false when using self-signed certs
+      # ssl_verify: true
+
+instances:
+    - name: instance_1 # A required unique identifier for this instance
+
       # The authorization scope that will be used to request a token from Identity API v3
+      # The auth scope must resolve to 1 of the following structures:
+      # {'project': {'name': 'my_project', 'domain': 'my_domain} OR {'project': {'id': 'my_project_id'}}
       auth_scope:
           project:
-              name: my_project_name
-              #domain:
-              #    id: default
+              id: my_project_id
 
+          # Alternately
+
+          # project:
+          #     name: my_project_name
+          #     domain:
+          #         id: default
+
+
+      # User credentials
       # Password is the only auth method supported right now
+      # To guarantee a uniquely identifiable user expects username, password
+      # and user domain id
+      # `user` should resolve to a structure like {'password': 'my_password', 'name': 'my_name', 'domain': {'id': 'my_domain_id'}}
       user:
           password: my_password
           name: datadog
-          #domain:
-          #    id: default
+          domain:
+              id: default
 
-      # IDs of Nova Hypervisors to monitor
-      hypervisor_ids:
-          - 1
-          
-      # IDs of Nova Servers to monitor    
-      server_ids:
-          - 68d6a5f3-cc08-4a9f-aafd-150d8ee9e695
-          - cfc98054-0b25-4182-a77a-c7f4bf5e574d
-      
-      #IDs of Neutron networks to monitor
-      network_ids:
-          - 2f60042a-0d46-4023-905a-aebf23a350ff
+      # In some cases, the nova url is returned without the tenant id suffixed
+      # e.g. http://172.0.0.1:8774 rather than http://172.0.0.1:8774/<tenant_id>
+      # The user can set append_tenant_id` to true manually add this suffix for downstream requests
+      # append_tenant_id: false
 
-# No need to change this. No instance-level config
-instances:
-    [{}]
+      # IDs of servers to exclude from monitoring (by default the agent will collect metrics from all guest servers for this project that are running on the host
+      # exclude_server_ids:
+      #    - server_1
+      #    - server_2

--- a/conf.d/openstack.yaml.example
+++ b/conf.d/openstack.yaml.example
@@ -1,0 +1,37 @@
+init_config:
+       # Where your identity server lives (please omit the trailing slash). Note the server must support Identity API v3
+      keystone_server_url: "https://my-keystone-server.com"
+      
+      # Nova API version to use - this check supports v2 and v2.1 (default)
+      #nova_api_version: 'v2.1' 
+      
+      # The authorization scope that will be used to request a token from Identity API v3
+      auth_scope:
+          project:
+              name: my_project_name
+              #domain:
+              #    id: default
+
+      # Password is the only auth method supported right now
+      user:
+          password: my_password
+          name: datadog
+          #domain:
+          #    id: default
+
+      # IDs of Nova Hypervisors to monitor
+      hypervisor_ids:
+          - 1
+          
+      # IDs of Nova Servers to monitor    
+      server_ids:
+          - 68d6a5f3-cc08-4a9f-aafd-150d8ee9e695
+          - cfc98054-0b25-4182-a77a-c7f4bf5e574d
+      
+      #IDs of Neutron networks to monitor
+      network_ids:
+          - 2f60042a-0d46-4023-905a-aebf23a350ff
+
+# No need to change this. No instance-level config
+instances:
+    [{}]

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -43,9 +43,11 @@ def get_check_class(name):
 
 def load_class(check_name, class_name):
     """
-    Retrieve a class with the given name among the given check module.
+    Retrieve a class with the given name within the given check module.
     """
     checksd_path = get_checksd_path(get_os())
+    if checksd_path not in sys.path:
+        sys.path.append(checksd_path)
     check_module = __import__(check_name)
     classes = inspect.getmembers(check_module, inspect.isclass)
     for name, clsmember in classes:

--- a/tests/checks/mock/test_openstack.py
+++ b/tests/checks/mock/test_openstack.py
@@ -1,0 +1,303 @@
+from time import sleep
+from unittest import TestCase
+from checks import AgentCheck
+from tests.checks.common import AgentCheckTest, load_check, load_class
+from mock import patch
+
+
+OS_CHECK_NAME = 'openstack'
+
+OpenStackProjectScope = load_class(OS_CHECK_NAME, "OpenStackProjectScope")
+KeystoneCatalog = load_class(OS_CHECK_NAME, "KeystoneCatalog")
+IncompleteConfig = load_class(OS_CHECK_NAME, "IncompleteConfig")
+IncompleteAuthScope = load_class(OS_CHECK_NAME, "IncompleteAuthScope")
+IncompleteIdentity = load_class(OS_CHECK_NAME, "IncompleteIdentity")
+
+
+class MockHTTPResponse(object):
+    def __init__(self, response_dict, headers):
+        self.response_dict = response_dict
+        self.headers = headers
+
+    def json(self):
+        return self.response_dict
+
+EXAMPLE_AUTH_RESPONSE = {
+    u'token': {
+        u'methods': [
+            u'password'
+        ],
+        u'roles': [
+            {
+                u'id': u'f20c215f5a4d47b7a6e510bc65485ced',
+                u'name': u'datadog_monitoring'
+            },
+            {
+                u'id': u'9fe2ff9ee4384b1894a90878d3e92bab',
+                u'name': u'_member_'
+            }
+        ],
+        u'expires_at': u'2015-11-02T15: 57: 43.911674Z',
+        u'project': {
+            u'domain': {
+                u'id': u'default',
+                u'name': u'Default'
+            },
+            u'id': u'0850707581fe4d738221a72db0182876',
+            u'name': u'admin'
+        },
+        u'catalog': [
+            {
+                u'endpoints': [
+                    {
+                        u'url': u'http://10.0.2.15:8773/',
+                        u'interface': u'public',
+                        u'region': u'RegionOne',
+                        u'region_id': u'RegionOne',
+                        u'id': u'541baeb9ab7542609d7ae307a7a9d5f0'
+                    },
+                    {
+                        u'url': u'http: //10.0.2.15:8773/',
+                        u'interface': u'admin',
+                        u'region': u'RegionOne',
+                        u'region_id': u'RegionOne',
+                        u'id': u'5c648acaea9941659a5dc04fb3b18e49'
+                    },
+                    {
+                        u'url': u'http: //10.0.2.15:8773/',
+                        u'interface': u'internal',
+                        u'region': u'RegionOne',
+                        u'region_id': u'RegionOne',
+                        u'id': u'cb70e610620542a1804522d365226981'
+                    }
+                ],
+                u'type': u'compute',
+                u'id': u'1398dc02f9b7474eb165106485033b48',
+                u'name': u'nova'
+            },
+            {
+                u'endpoints': [
+                    {
+                        u'url': u'http://10.0.2.15:8774/v2.1/0850707581fe4d738221a72db0182876',
+                        u'interface': u'internal',
+                        u'region': u'RegionOne',
+                        u'region_id': u'RegionOne',
+                        u'id': u'354e35ed19774e398f80dc2a90d07f4b'
+                    },
+                    {
+                        u'url': u'http://10.0.2.15:8774/v2.1/0850707581fe4d738221a72db0182876',
+                        u'interface': u'public',
+                        u'region': u'RegionOne',
+                        u'region_id': u'RegionOne',
+                        u'id': u'36e8e2bf24384105b9d56a65b0900172'
+                    },
+                    {
+                        u'url': u'http://10.0.2.15:8774/v2.1/0850707581fe4d738221a72db0182876',
+                        u'interface': u'admin',
+                        u'region': u'RegionOne',
+                        u'region_id': u'RegionOne',
+                        u'id': u'de93edcbf7f9446286687ec68423c36f'
+                    }
+                ],
+                u'type': u'computev21',
+                u'id': u'2023bd4f451849ba8abeaaf283cdde4f',
+                u'name': u'novav21'
+            },
+            {
+                u'endpoints': [
+                    {
+                        u'url': u'http://10.0.2.15:9292',
+                        u'interface': u'internal',
+                        u'region': u'RegionOne',
+                        u'region_id': u'RegionOne',
+                        u'id': u'7c1e318d8f7f42029fcb591598df2ef5'
+                    },
+                    {
+                        u'url': u'http://10.0.2.15:9292',
+                        u'interface': u'public',
+                        u'region': u'RegionOne',
+                        u'region_id': u'RegionOne',
+                        u'id': u'afcc88b1572f48a38bb393305dc2b584'
+                    },
+                    {
+                        u'url': u'http://10.0.2.15:9292',
+                        u'interface': u'admin',
+                        u'region': u'RegionOne',
+                        u'region_id': u'RegionOne',
+                        u'id': u'd9730dbdc07844d785913219da64a197'
+                    }
+                ],
+                u'type': u'network',
+                u'id': u'21ad241f26194bccb7d2e49ee033d5a2',
+                u'name': u'neutron'
+            },
+
+        ],
+        u'extras': {
+
+        },
+        u'user': {
+            u'domain': {
+                u'id': u'default',
+                u'name': u'Default'
+            },
+            u'id': u'5f10e63fbd6b411186e561dc62a9a675',
+            u'name': u'datadog'
+        },
+        u'audit_ids': [
+            u'OMQQg9g3QmmxRHwKrfWxyQ'
+        ],
+        u'issued_at': u'2015-11-02T14: 57: 43.911697Z'
+    }
+}
+MOCK_HTTP_RESPONSE = MockHTTPResponse(response_dict=EXAMPLE_AUTH_RESPONSE, headers={"X-Subject-Token": "fake_token"})
+
+class OSProjectScopeTest(TestCase):
+    BAD_AUTH_SCOPES = [
+        {"auth_scope": {}},
+        {"auth_scope": {"project": {}}},
+        {"auth_scope": {"project": {"id": ""}}},
+        {"auth_scope": {"project": {"name": "test"}}},
+        {"auth_scope": {"project": {"name": "test", "domain": {}}}},
+        {"auth_scope": {"project": {"name": "test", "domain": {"id": ""}}}},
+    ]
+
+    GOOD_AUTH_SCOPES = [
+        {"auth_scope": {"project": {"id": "test_project_id"}}},
+        {"auth_scope": {"project": {"name": "test", "domain": {"id": "test_id"}}}},
+    ]
+
+    BAD_USERS = [
+        {"user": {}},
+        {"user": {"name": ""}},
+        {"user": {"name": "test_name", "password": ""}},
+        {"user": {"name": "test_name", "password": "test_pass", "domain": {}}},
+        {"user": {"name": "test_name", "password": "test_pass", "domain": {"id": ""}}},
+    ]
+
+    GOOD_USERS = [
+        {"user": {"name": "test_name", "password": "test_pass", "domain": {"id": "test_id"}}},
+    ]
+
+    def _test_bad_auth_scope(self, scope):
+        with self.assertRaises(IncompleteAuthScope):
+            OpenStackProjectScope.get_auth_scope(scope)
+
+    def test_get_auth_scope(self):
+        for scope in self.BAD_AUTH_SCOPES:
+            self._test_bad_auth_scope(scope)
+
+        for scope in self.GOOD_AUTH_SCOPES:
+            auth_scope = OpenStackProjectScope.get_auth_scope(scope)
+
+            # Should pass through unchanged
+            self.assertEqual(auth_scope, scope.get("auth_scope"))
+
+    def _test_bad_user(self, user):
+        with self.assertRaises(IncompleteIdentity):
+            OpenStackProjectScope.get_user_identity(user)
+
+
+    def test_get_user_identity(self):
+        for user in self.BAD_USERS:
+            self._test_bad_user(user)
+
+        for user in self.GOOD_USERS:
+            parsed_user = OpenStackProjectScope.get_user_identity(user)
+            self.assertEqual(parsed_user, {"methods": ["password"], "password": user})
+
+    def test_from_config(self):
+        init_config = {"keystone_server_url": "http://10.0.2.15:5000", "nova_api_version": "v2"}
+        bad_instance_config = {}
+
+        good_instance_config = {"user": self.GOOD_USERS[0]["user"], "auth_scope": self.GOOD_AUTH_SCOPES[0]["auth_scope"]}
+
+        with self.assertRaises(IncompleteConfig):
+            OpenStackProjectScope.from_config(init_config, bad_instance_config)
+
+        with patch("openstack.OpenStackProjectScope.request_auth_token", return_value=MOCK_HTTP_RESPONSE):
+            append_config = good_instance_config.copy()
+            append_config["append_tenant_id"] = True
+            scope = OpenStackProjectScope.from_config(init_config, append_config)
+            self.assertIsInstance(scope, OpenStackProjectScope)
+
+            self.assertEqual(scope.auth_token, "fake_token")
+            self.assertEqual(scope.tenant_id, "test_project_id")
+
+            # Test that append flag worked
+            self.assertEqual(scope.service_catalog.nova_endpoint, "http://10.0.2.15:8773/test_project_id")
+
+
+class KeyStoneCatalogTest(TestCase):
+
+    def test_get_nova_endpoint(self):
+        self.assertEqual(KeystoneCatalog.get_nova_endpoint(EXAMPLE_AUTH_RESPONSE), u"http://10.0.2.15:8774/v2.1/0850707581fe4d738221a72db0182876")
+        self.assertEqual(KeystoneCatalog.get_nova_endpoint(EXAMPLE_AUTH_RESPONSE, nova_api_version="v2"), u"http://10.0.2.15:8773/")
+
+    def test_get_neutron_endpoint(self):
+        self.assertEqual(KeystoneCatalog.get_neutron_endpoint(EXAMPLE_AUTH_RESPONSE), u"http://10.0.2.15:9292")
+
+    def test_from_auth_response(self):
+        catalog = KeystoneCatalog.from_auth_response(EXAMPLE_AUTH_RESPONSE, "v2.1")
+        self.assertIsInstance(catalog, KeystoneCatalog)
+        self.assertEqual(catalog.neutron_endpoint, u"http://10.0.2.15:9292")
+        self.assertEqual(catalog.nova_endpoint, u"http://10.0.2.15:8774/v2.1/0850707581fe4d738221a72db0182876")
+
+class TestCheckOpenStack(AgentCheckTest):
+    CHECK_NAME = OS_CHECK_NAME
+
+    MOCK_CONFIG = {
+        "init_config": {
+            "keystone_server_url": "http://10.0.2.15:5000",
+            "ssl_verify": False,
+        },
+        "instances": [
+            {
+                "name" : "test_name", "user": {"name": "test_name", "password": "test_pass", "domain": {"id": "test_id"}},
+                "auth_scope": {"project": {"id": "test_project_id"}}
+            }
+        ]
+    }
+
+    def setUp(self):
+        self.check = load_check(self.CHECK_NAME, self.MOCK_CONFIG, self.DEFAULT_AGENT_CONFIG)
+
+    def test_ensure_auth_scope(self):
+        instance = self.MOCK_CONFIG["instances"][0]
+
+        with self.assertRaises(KeyError):
+            self.check.get_scope_for_instance(instance)
+
+        with patch("openstack.OpenStackProjectScope.request_auth_token", return_value=MOCK_HTTP_RESPONSE):
+            scope = self.check.ensure_auth_scope(instance)
+
+            self.assertEqual(self.check.get_scope_for_instance(instance), scope)
+            self.check._send_api_service_checks(scope)
+
+            self.service_checks = self.check.get_service_checks()
+
+            # Expect OK, since we've mocked an API response
+            self.assertServiceCheck(self.check.IDENTITY_API_SC, status=AgentCheck.OK, count=1)
+
+            # Expect CRITICAL since URLs are non-existent
+            self.assertServiceCheck(self.check.COMPUTE_API_SC, status=AgentCheck.CRITICAL, count=1)
+            self.assertServiceCheck(self.check.NETWORK_API_SC, status=AgentCheck.CRITICAL, count=1)
+
+            self.check._current_scope = scope
+
+        self.check.delete_current_scope()
+        with self.assertRaises(KeyError):
+            self.check.get_scope_for_instance(instance)
+
+    def test_parse_uptime_string(self):
+        uptime_parsed = self.check._parse_uptime_string(u' 16:53:48 up 1 day, 21:34,  3 users,  load average: 0.04, 0.14, 0.19\n')
+        self.assertEqual(uptime_parsed.get('loads'), [0.04, 0.14, 0.19])
+
+    def test_cache_utils(self):
+        self.check.CACHE_TTL["aggregates"] = 1
+        expected_aggregates = {"hyp_1": ["aggregate:staging", "availability_zone:test"]}
+
+        with patch("openstack.OpenStackCheck.get_all_aggregate_hypervisors", return_value=expected_aggregates):
+            self.assertEqual(self.check._get_and_set_aggregate_list(), expected_aggregates)
+            sleep(1.5)
+            self.assertTrue(self.check._is_expired("aggregates"))


### PR DESCRIPTION
The OpenStack `AgentCheck` is intended to run besides individual hypervisors. It can be scoped to any set of projects living on that host via instance-level config, 

At the hypervisor-level it collects:

- [Hypervisor Uptime and Statistics](http://developer.openstack.org/api-ref-compute-v2.1.html#os-hypervisors-v2.1) 

At the project-level it collects:
- [Diagnostics for guest servers within that project](http://developer.openstack.org/api-ref-compute-v2.1.html#diagnostics-v2.1)
- [Absolute limits for the project](http://developer.openstack.org/api-ref-compute-v2.1.html#limits-v2.1)

Additionally it sends service checks to register the UP/DOWN state of networks discovered by the agent, 
the locally running hypervisor, and the outward-facing (`public || internal`) API services of Nova, Neutron and Keystone

### Authentication
While the check will run without issues as an `admin` user, it is recommended to configure a read-only `datadog` user and configure the check with the corresponding user/password. Instructions on setting up the datadog user + role , as well as the changes required to the `policy.json` file can be found [here](https://gist.github.com/talwai/b8698e061795cec9f263#configure-a-datadog-user)

### A note on compatibility
Authentication is performed via the password method, and requires Identity API v3
Nova API v2 and v2.1 are supported, with minor additional configuration necessary for v2
