### PR TITLE
[elastic] Added common JVM metrics

### DIFF
--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -163,6 +163,8 @@ class ESCheck(AgentCheck):
         "elasticsearch.http.total_opened": ("gauge", "http.total_opened"),
         "jvm.mem.heap_committed": ("gauge", "jvm.mem.heap_committed_in_bytes"),
         "jvm.mem.heap_used": ("gauge", "jvm.mem.heap_used_in_bytes"),
+        "jvm.mem.heap_in_use": ("gauge", "jvm.mem.heap_used_percent"),
+        "jvm.mem.heap_max": ("gauge", "jvm.mem.heap_max_in_bytes"),
         "jvm.mem.non_heap_committed": ("gauge", "jvm.mem.non_heap_committed_in_bytes"),
         "jvm.mem.non_heap_used": ("gauge", "jvm.mem.non_heap_used_in_bytes"),
         "jvm.threads.count": ("gauge", "jvm.threads.count"),

--- a/tests/checks/integration/test_elastic.py
+++ b/tests/checks/integration/test_elastic.py
@@ -135,6 +135,8 @@ STATS_METRICS = {  # Metrics that are common to all Elasticsearch versions
     "elasticsearch.http.total_opened": ("gauge", "http.total_opened"),
     "jvm.mem.heap_committed": ("gauge", "jvm.mem.heap_committed_in_bytes"),
     "jvm.mem.heap_used": ("gauge", "jvm.mem.heap_used_in_bytes"),
+    "jvm.mem.heap_in_use": ("gauge", "jvm.mem.heap_used_percent"),
+    "jvm.mem.heap_max": ("gauge", "jvm.mem.heap_max_in_bytes"),
     "jvm.mem.non_heap_committed": ("gauge", "jvm.mem.non_heap_committed_in_bytes"),
     "jvm.mem.non_heap_used": ("gauge", "jvm.mem.non_heap_used_in_bytes"),
     "jvm.threads.count": ("gauge", "jvm.threads.count"),


### PR DESCRIPTION
The metrics `heap_used_percent` and `heap_max_in_bytes` have been added
to the elasticsearch integration following up a customer request.