### PR TITLE
[packaging][rpm] Check the RPM signature

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -98,7 +98,7 @@ if [ $OS = "RedHat" ]; then
     else
         ARCHI="x86_64"
     fi
-    $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = http://yum.datadoghq.com/rpm/$ARCHI/\nenabled=1\ngpgcheck=0\npriority=1' > /etc/yum.repos.d/datadog.repo"
+    $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/$ARCHI/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public' > /etc/yum.repos.d/datadog.repo"
 
     printf "\033[34m* Installing the Datadog Agent package\n\033[0m\n"
 


### PR DESCRIPTION
This enables GPG signature check when installing RPM packages from our
one line install script. The key is also downloaded (just the first time
therefore it's rather DNS-spoofing proof).
We'll have to switch all these URLs to HTTPS as soon as it's enabled on
the `yum.datadoghq.com` domain.

[skip ci]