### PR TITLE
[process] Re-enable check on Windows

### DIFF
--- a/win32/gui.py
+++ b/win32/gui.py
@@ -118,7 +118,6 @@ EXCLUDED_WINDOWS_CHECKS = [
     'mesos',
     'network',
     'postfix',
-    'process',
     'ssh_check',
     'zk',
 ]


### PR DESCRIPTION
The check is working agian since 5.4.0 but it was never re-enabled in
the GUI. Here's the commit that does it :)