### PR TITLE
[directory] Clarify doc on `pattern` config parameter

### DIFF
--- a/conf.d/directory.yaml.example
+++ b/conf.d/directory.yaml.example
@@ -17,7 +17,7 @@ instances:
   # "dirtagname" - string, the name of the tag used for the directory. defaults to "name"
   # "filetagname" - string, the name of the tag used for each file. defaults to "filename"
   # "filegauges" - boolean, when true stats will be an individual gauge per file (max. 20 files!) and not a histogram of the whole directory. default False
-  # "pattern" - string, the `fnmatch` pattern to use when reading the "directory"'s files. default "*"
+  # "pattern" - string, the `fnmatch` pattern to use when reading the "directory"'s files. The pattern will be matched against the files' absolute paths. default "*"
   # "recursive" - boolean, when true the stats will recurse into directories. default False
 
   - directory: "/path/to/directory"


### PR DESCRIPTION
The pattern is matched against the files' absolute paths, which was not clearly stated in the docs.