### PR TITLE
[core] log collector runs's exceptions

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -30,6 +30,7 @@ from util import (
     get_uuid,
     Timer,
 )
+from utils.debug import log_exceptions
 from utils.jmx import JMXFiles
 from utils.subprocess_output import subprocess
 
@@ -247,6 +248,7 @@ class Collector(object):
     def _stats_for_display(raw_stats):
         return pprint.pformat(raw_stats, indent=4)
 
+    @log_exceptions(log)
     def run(self, checksd=None, start_event=True):
         """
         Collect data from each check and submit their data.

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -1,12 +1,34 @@
 # stdlib
+from functools import wraps
+from pprint import pprint
 import inspect
 import os
-from pprint import pprint
 import sys
 
 # datadog
 from config import get_checksd_path, get_confd_path
 from util import get_os
+
+
+def log_exceptions(logger):
+    """
+    A decorator that catches any exceptions thrown by the decorated function and
+    logs them along with a traceback.
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                result = func(*args, **kwargs)
+            except Exception:
+                logger.exception(
+                    u"Uncaught exception while running {0}".format(func.__name__)
+                )
+                raise
+            return result
+        return wrapper
+    return decorator
+
 
 
 def run_check(name, path=None):


### PR DESCRIPTION
* Create a decorator that catches any exceptions thrown by the decorated
  function and logs them along with a traceback.
* Use it with `Collector.run` method to help troubleshooting.
* Avoid code duplication between Windows and other environments.