### PR TITLE
[core] Replace subprocess.Popen with safer get_subprocess_output

### DIFF
--- a/checks.d/disk.py
+++ b/checks.d/disk.py
@@ -12,7 +12,7 @@ except ImportError:
 from checks import AgentCheck
 from config import _is_affirmative
 from util import Platform
-import utils.subprocess_output
+from utils.subprocess_output import get_subprocess_output
 
 
 class Disk(AgentCheck):
@@ -176,9 +176,7 @@ class Disk(AgentCheck):
 
     # no psutil, let's use df
     def collect_metrics_manually(self):
-        df_out = utils.subprocess_output.get_subprocess_output(
-            self.DF_COMMAND + ['-k'], self.log
-        )
+        df_out, _, _ = get_subprocess_output(self.DF_COMMAND + ['-k'], self.log)
         self.log.debug(df_out)
         for device in self._list_devices(df_out):
             self.log.debug("Passed: {0}".format(device))

--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -1,16 +1,16 @@
 # stdlib
-import subprocess
 import os
 import sys
 import re
 import traceback
 
+# 3p
+import pymysql
+
 # project
 from checks import AgentCheck
 from utils.platform import Platform
-
-# 3rd party
-import pymysql
+from utils.subprocess_output import get_subprocess_output
 
 GAUGE = "gauge"
 RATE = "rate"
@@ -385,11 +385,10 @@ class MySql(AgentCheck):
         if pid is None:
             try:
                 if sys.platform.startswith("linux"):
-                    ps = subprocess.Popen(['ps', '-C', 'mysqld', '-o', 'pid'],
-                                          stdout=subprocess.PIPE, close_fds=True).communicate()[0]
-                    pslines = ps.strip().split('\n')
+                    ps, _, _ = get_subprocess_output(['ps', '-C', 'mysqld', '-o', 'pid'], self.log)
+                    pslines = ps.strip().splitlines()
                     # First line is header, second line is mysql pid
-                    if len(pslines) == 2 and pslines[1] != '':
+                    if len(pslines) == 2:
                         pid = int(pslines[1])
             except Exception:
                 self.log.exception("Error while fetching mysql pid from ps")

--- a/checks.d/postfix.py
+++ b/checks.d/postfix.py
@@ -3,6 +3,7 @@ import os
 
 # project
 from checks import AgentCheck
+from utils.subprocess_output import get_subprocess_output
 
 class PostfixCheck(AgentCheck):
     """This check provides metrics on the number of messages in a given postfix queue
@@ -55,8 +56,8 @@ class PostfixCheck(AgentCheck):
                 # can dd-agent user run sudo?
                 test_sudo = os.system('setsid sudo -l < /dev/null')
                 if test_sudo == 0:
-                    count = os.popen('sudo find %s -type f | wc -l' % queue_path)
-                    count = count.readlines()[0].strip()
+                    output, _, _ = get_subprocess_output(['sudo', 'find', queue_path, '-type', 'f'], self.log)
+                    count = len(output.splitlines())
                 else:
                     raise Exception('The dd-agent user does not have sudo access')
 

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -32,7 +32,7 @@ from util import (
 from utils.debug import log_exceptions
 from utils.jmx import JMXFiles
 from utils.platform import Platform
-from utils.subprocess_output import subprocess
+from utils.subprocess_output import get_subprocess_output
 
 log = logging.getLogger(__name__)
 
@@ -635,12 +635,10 @@ class Collector(object):
                     command = "gohai"
                 else:
                     command = "gohai\gohai.exe"
-                gohai_metadata, gohai_log = subprocess.Popen(
-                    [command], stdout=subprocess.PIPE, stderr=subprocess.PIPE
-                ).communicate()
+                gohai_metadata, gohai_err, _ = get_subprocess_output([command], log)
                 payload['gohai'] = gohai_metadata
-                if gohai_log:
-                    log.warning("GOHAI LOG | {0}".format(gohai_log))
+                if gohai_err:
+                    log.warning("GOHAI LOG | {0}".format(gohai_err))
             except OSError as e:
                 if e.errno == 2:  # file not found, expected when install from source
                     log.info("gohai file not found")

--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -12,7 +12,7 @@ import time
 from checks import Check
 from util import get_hostname
 from utils.platform import Platform
-from utils.subprocess_output import subprocess as sp
+from utils.subprocess_output import get_subprocess_output
 
 # locale-resilient float converter
 to_float = lambda s: float(s.replace(",", "."))
@@ -107,9 +107,7 @@ class IO(Check):
         io = {}
         try:
             if Platform.is_linux():
-                stdout = sp.Popen(['iostat', '-d', '1', '2', '-x', '-k'],
-                                  stdout=sp.PIPE,
-                                  close_fds=True).communicate()[0]
+                stdout, _, _ = get_subprocess_output(['iostat', '-d', '1', '2', '-x', '-k'], self.logger)
 
                 #                 Linux 2.6.32-343-ec2 (ip-10-35-95-10)   12/11/2012      _x86_64_        (2 CPU)
                 #
@@ -129,9 +127,8 @@ class IO(Check):
                 io.update(self._parse_linux2(stdout))
 
             elif sys.platform == "sunos5":
-                iostat = sp.Popen(["iostat", "-x", "-d", "1", "2"],
-                                  stdout=sp.PIPE,
-                                  close_fds=True).communicate()[0]
+                output, _, _ = get_subprocess_output(["iostat", "-x", "-d", "1", "2"], self.logger)
+                iostat = output.splitlines()
 
                 #                   extended device statistics <-- since boot
                 # device      r/s    w/s   kr/s   kw/s wait actv  svc_t  %w  %b
@@ -145,7 +142,7 @@ class IO(Check):
                 # sd1         0.0  139.0    0.0 1850.6  0.0  0.0    0.1   0   1
 
                 # discard the first half of the display (stats since boot)
-                lines = [l for l in iostat.split("\n") if len(l) > 0]
+                lines = [l for l in iostat if len(l) > 0]
                 lines = lines[len(lines)/2:]
 
                 assert "extended device statistics" in lines[0]
@@ -160,9 +157,8 @@ class IO(Check):
                         io[cols[0]][self.xlate(headers[i], "sunos")] = cols[i]
 
             elif sys.platform.startswith("freebsd"):
-                iostat = sp.Popen(["iostat", "-x", "-d", "1", "2"],
-                                  stdout=sp.PIPE,
-                                  close_fds=True).communicate()[0]
+                output, _, _ = get_subprocess_output(["iostat", "-x", "-d", "1", "2"], self.logger)
+                iostat = output.splitlines()
 
                 # Be careful!
                 # It looks like SunOS, but some columms (wait, svc_t) have different meaning
@@ -174,7 +170,7 @@ class IO(Check):
                 # ad0        0.0   2.0     0.0    31.8    0   0.2   0
 
                 # discard the first half of the display (stats since boot)
-                lines = [l for l in iostat.split("\n") if len(l) > 0]
+                lines = [l for l in iostat if len(l) > 0]
                 lines = lines[len(lines)/2:]
 
                 assert "extended device statistics" in lines[0]
@@ -188,9 +184,7 @@ class IO(Check):
                     for i in range(1, len(cols)):
                         io[cols[0]][self.xlate(headers[i], "freebsd")] = cols[i]
             elif sys.platform == 'darwin':
-                iostat = sp.Popen(['iostat', '-d', '-c', '2', '-w', '1'],
-                                  stdout=sp.PIPE,
-                                  close_fds=True).communicate()[0]
+                iostat, _, _ = get_subprocess_output(['iostat', '-d', '-c', '2', '-w', '1'], self.logger)
                 #          disk0           disk1          <-- number of disks
                 #    KB/t tps  MB/s     KB/t tps  MB/s
                 #   21.11  23  0.47    20.01   0  0.00
@@ -238,9 +232,7 @@ class Load(Check):
         elif sys.platform in ('darwin', 'sunos5') or sys.platform.startswith("freebsd"):
             # Get output from uptime
             try:
-                uptime = sp.Popen(['uptime'],
-                                  stdout=sp.PIPE,
-                                  close_fds=True).communicate()[0]
+                uptime, _, _ = get_subprocess_output(['uptime'], self.logger)
             except Exception:
                 self.logger.exception('Cannot extract load')
                 return False
@@ -283,9 +275,7 @@ class Memory(Check):
         self.pagesize = 0
         if sys.platform == 'sunos5':
             try:
-                pgsz = sp.Popen(['pagesize'],
-                                stdout=sp.PIPE,
-                                close_fds=True).communicate()[0]
+                pgsz, _, _ = get_subprocess_output(['pagesize'], self.logger)
                 self.pagesize = int(pgsz.strip())
             except Exception:
                 # No page size available
@@ -401,15 +391,15 @@ class Memory(Check):
             macV_minor_version = int(re.match(r'10\.(\d+)\.?.*', macV[0]).group(1))
 
             try:
-                top = sp.Popen(['top', '-l 1'], stdout=sp.PIPE, close_fds=True).communicate()[0]
-                sysctl = sp.Popen(['sysctl', 'vm.swapusage'], stdout=sp.PIPE, close_fds=True).communicate()[0]
+                output, _, _ = get_subprocess_output(['top', '-l 1'], self.logger)
+                top = output.splitlines()
+                sysctl, _, _ = get_subprocess_output(['sysctl', 'vm.swapusage'], self.logger)
             except StandardError:
                 self.logger.exception('getMemoryUsage')
                 return False
 
             # Deal with top
-            lines = top.split('\n')
-            physParts = re.findall(r'([0-9]\d+)', lines[self.topIndex])
+            physParts = re.findall(r'([0-9]\d+)', top[self.topIndex])
 
             # Deal with sysctl
             swapParts = re.findall(r'([0-9]+\.\d+)', sysctl)
@@ -421,16 +411,18 @@ class Memory(Check):
                 physUsedPartIndex = 0
                 physFreePartIndex = 2
 
-            return {'physUsed': physParts[physUsedPartIndex], 'physFree': physParts[physFreePartIndex], 'swapUsed': swapParts[1], 'swapFree': swapParts[2]}
+            return {'physUsed': physParts[physUsedPartIndex],
+                    'physFree': physParts[physFreePartIndex],
+                    'swapUsed': swapParts[1],
+                    'swapFree': swapParts[2]}
 
         elif sys.platform.startswith("freebsd"):
             try:
-                sysctl = sp.Popen(['sysctl', 'vm.stats.vm'], stdout=sp.PIPE, close_fds=True).communicate()[0]
+                output, _, _ = get_subprocess_output(['sysctl', 'vm.stats.vm'], self.logger)
+                sysctl = output.splitlines()
             except Exception:
                 self.logger.exception('getMemoryUsage')
                 return False
-
-            lines = sysctl.split('\n')
 
             # ...
             # vm.stats.vm.v_page_size: 4096
@@ -446,7 +438,7 @@ class Memory(Check):
             regexp = re.compile(r'^vm\.stats\.vm\.(\w+):\s+([0-9]+)')
             meminfo = {}
 
-            for line in lines:
+            for line in sysctl:
                 try:
                     match = re.search(regexp, line)
                     if match is not None:
@@ -481,29 +473,29 @@ class Memory(Check):
 
             # Swap
             try:
-                sysctl = sp.Popen(['swapinfo', '-m'], stdout=sp.PIPE, close_fds=True).communicate()[0]
+                output, _, _ = get_subprocess_output(['swapinfo', '-m'], self.logger)
+                sysctl = output.splitlines()
             except Exception:
                 self.logger.exception('getMemoryUsage')
                 return False
-
-            lines = sysctl.split('\n')
 
             # ...
             # Device          1M-blocks     Used    Avail Capacity
             # /dev/ad0s1b           570        0      570     0%
             # ...
 
-            assert "Device" in lines[0]
+            assert "Device" in sysctl[0]
 
             try:
                 memData['swapTotal'] = 0
                 memData['swapFree'] = 0
                 memData['swapUsed'] = 0
-                for line in lines[1:-1]:
-                    line = line.split()
-                    memData['swapTotal'] += int(line[1])
-                    memData['swapFree'] += int(line[3])
-                    memData['swapUsed'] += int(line[2])
+                for line in sysctl[1:]:
+                    if len(line) > 0:
+                        line = line.split()
+                        memData['swapTotal'] += int(line[1])
+                        memData['swapFree'] += int(line[3])
+                        memData['swapUsed'] += int(line[2])
             except Exception:
                 self.logger.exception('Cannot compute stats from swapinfo')
 
@@ -511,9 +503,9 @@ class Memory(Check):
         elif sys.platform == 'sunos5':
             try:
                 memData = {}
-                kmem = sp.Popen(["kstat", "-m", "memory_cap", "-c", "zone_memory_cap", "-p"],
-                                stdout=sp.PIPE,
-                                close_fds=True).communicate()[0]
+                cmd = ["kstat", "-m", "memory_cap", "-c", "zone_memory_cap", "-p"]
+                output, _, _ = get_subprocess_output(cmd, self.logger)
+                kmem = output.splitlines()
 
                 # memory_cap:360:53aa9b7e-48ba-4152-a52b-a6368c:anon_alloc_fail   0
                 # memory_cap:360:53aa9b7e-48ba-4152-a52b-a6368c:anonpgin  0
@@ -535,7 +527,7 @@ class Memory(Check):
 
                 # turn memory_cap:360:zone_name:key value
                 # into { "key": value, ...}
-                kv = [l.strip().split() for l in kmem.split("\n") if len(l) > 0]
+                kv = [l.strip().split() for l in kmem if len(l) > 0]
                 entries = dict([(k.split(":")[-1], v) for (k, v) in kv])
                 # extract rss, physcap, swap, swapcap, turn into MB
                 convert = lambda v: int(long(v))/2**20
@@ -566,16 +558,13 @@ class Processes(Check):
             ps_arg = 'auxww'
         # Get output from ps
         try:
-            ps = sp.Popen(['ps', ps_arg], stdout=sp.PIPE, close_fds=True).communicate()[0]
+            output, _, _ = get_subprocess_output(['ps', ps_arg], self.logger)
+            processLines = output.splitlines()  # Also removes a trailing empty line
         except StandardError:
             self.logger.exception('getProcesses')
             return False
 
-        # Split out each process
-        processLines = ps.split('\n')
-
         del processLines[0]  # Removes the headers
-        processLines.pop()  # Removes a trailing empty line
 
         processes = []
 
@@ -613,7 +602,8 @@ class Cpu(Check):
                 return 0.0
         try:
             if Platform.is_linux():
-                mpstat = sp.Popen(['mpstat', '1', '3'], stdout=sp.PIPE, close_fds=True).communicate()[0]
+                output, _, _ = get_subprocess_output(['mpstat', '1', '3'], self.logger)
+                mpstat = output.splitlines()
                 # topdog@ip:~$ mpstat 1 3
                 # Linux 2.6.32-341-ec2 (ip)   01/19/2012  _x86_64_  (2 CPU)
                 #
@@ -632,9 +622,8 @@ class Cpu(Check):
                 # 05:27:03 PM  CPU    %user   %nice   %sys %iowait    %irq   %soft  %steal  %idle   intr/s
                 # 05:27:03 PM  all    3.59    0.00    0.68    0.69    0.00   0.00    0.01   95.03    43.65
                 #
-                lines = mpstat.split("\n")
-                legend = [l for l in lines if "%usr" in l or "%user" in l]
-                avg = [l for l in lines if "Average" in l]
+                legend = [l for l in mpstat if "%usr" in l or "%user" in l]
+                avg = [l for l in mpstat if "Average" in l]
                 if len(legend) == 1 and len(avg) == 1:
                     headers = [h for h in legend[0].split() if h not in ("AM", "PM")]
                     data = avg[0].split()
@@ -674,8 +663,8 @@ class Cpu(Check):
             elif sys.platform == 'darwin':
                 # generate 3 seconds of data
                 # ['          disk0           disk1       cpu     load average', '    KB/t tps  MB/s     KB/t tps  MB/s  us sy id   1m   5m   15m', '   21.23  13  0.27    17.85   7  0.13  14  7 79  1.04 1.27 1.31', '    4.00   3  0.01     5.00   8  0.04  12 10 78  1.04 1.27 1.31', '']
-                iostats = sp.Popen(['iostat', '-C', '-w', '3', '-c', '2'], stdout=sp.PIPE, close_fds=True).communicate()[0]
-                lines = [l for l in iostats.split("\n") if len(l) > 0]
+                iostats, _, _ = get_subprocess_output(['iostat', '-C', '-w', '3', '-c', '2'], self.logger)
+                lines = [l for l in iostats.splitlines() if len(l) > 0]
                 legend = [l for l in lines if "us" in l]
                 if len(legend) == 1:
                     headers = legend[0].split()
@@ -696,8 +685,8 @@ class Cpu(Check):
                 # tin  tout  KB/t tps  MB/s   KB/t tps  MB/s   KB/t tps  MB/s  us ni sy in id
                 # 0    69 26.71   0  0.01   0.00   0  0.00   0.00   0  0.00   2  0  0  1 97
                 # 0    78  0.00   0  0.00   0.00   0  0.00   0.00   0  0.00   0  0  0  0 100
-                iostats = sp.Popen(['iostat', '-w', '3', '-c', '2'], stdout=sp.PIPE, close_fds=True).communicate()[0]
-                lines = [l for l in iostats.split("\n") if len(l) > 0]
+                iostats, _, _ = get_subprocess_output(['iostat', '-w', '3', '-c', '2'], self.logger)
+                lines = [l for l in iostats.splitlines() if len(l) > 0]
                 legend = [l for l in lines if "us" in l]
                 if len(legend) == 1:
                     headers = legend[0].split()
@@ -726,8 +715,9 @@ class Cpu(Check):
                 # http://docs.oracle.com/cd/E23824_01/html/821-1462/mpstat-1m.html
                 #
                 # Will aggregate over all processor sets
-                    mpstat = sp.Popen(['mpstat', '-aq', '1', '2'], stdout=sp.PIPE, close_fds=True).communicate()[0]
-                    lines = [l for l in mpstat.split("\n") if len(l) > 0]
+                    output, _, _ = get_subprocess_output(['mpstat', '-aq', '1', '2'], self.logger)
+                    mpstat = output.splitlines()
+                    lines = [l for l in mpstat if len(l) > 0]
                     # discard the first len(lines)/2 lines
                     lines = lines[len(lines)/2:]
                     legend = [l for l in lines if "SET" in l]

--- a/config.py
+++ b/config.py
@@ -1,3 +1,4 @@
+# stdlib
 import ConfigParser
 from cStringIO import StringIO
 import glob
@@ -17,14 +18,14 @@ import sys
 import traceback
 from urlparse import urlparse
 
-# 3rd party
+# 3p
 import yaml
 
 # project
 from util import get_os, yLoader
 from utils.platform import Platform
 from utils.proxy import get_proxy
-from utils.subprocess_output import subprocess
+from utils.subprocess_output import get_subprocess_output
 
 # CONSTANTS
 AGENT_VERSION = "5.6.0"
@@ -571,15 +572,16 @@ def get_system_stats():
     platf = sys.platform
 
     if Platform.is_linux(platf):
-        grep = subprocess.Popen(['grep', 'model name', '/proc/cpuinfo'], stdout=subprocess.PIPE, close_fds=True)
-        wc = subprocess.Popen(['wc', '-l'], stdin=grep.stdout, stdout=subprocess.PIPE, close_fds=True)
-        systemStats['cpuCores'] = int(wc.communicate()[0])
+        output, _, _ = get_subprocess_output(['grep', 'model name', '/proc/cpuinfo'], log)
+        systemStats['cpuCores'] = len(output.splitlines())
 
     if Platform.is_darwin(platf):
-        systemStats['cpuCores'] = int(subprocess.Popen(['sysctl', 'hw.ncpu'], stdout=subprocess.PIPE, close_fds=True).communicate()[0].split(': ')[1])
+        output, _, _ = get_subprocess_output(['sysctl', 'hw.ncpu'], log)
+        systemStats['cpuCores'] = int(output.split(': ')[1])
 
     if Platform.is_freebsd(platf):
-        systemStats['cpuCores'] = int(subprocess.Popen(['sysctl', 'hw.ncpu'], stdout=subprocess.PIPE, close_fds=True).communicate()[0].split(': ')[1])
+        output, _, _ = get_subprocess_output(['sysctl', 'hw.ncpu'], log)
+        systemStats['cpuCores'] = int(output.split(': ')[1])
 
     if Platform.is_linux(platf):
         systemStats['nixV'] = platform.dist()

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -3,18 +3,20 @@ if __name__ == '__main__':
     from config import initialize_logging  # noqa
     initialize_logging('jmxfetch')
 
-# std
+# stdlib
+from contextlib import nested
 import glob
 import logging
 import os
 import signal
 import sys
+import tempfile
 import time
 
-# 3rd party
+# 3p
 import yaml
 
-# datadog
+# project
 from config import (
     DEFAULT_CHECK_FREQUENCY,
     get_confd_path,
@@ -274,26 +276,27 @@ class JMXFetch(object):
 
             log.info("Running %s" % " ".join(subprocess_args))
 
-            # Launch JMXfetch subprocess
-            jmx_process = subprocess.Popen(
-                subprocess_args,
-                close_fds=not redirect_std_streams,  # set to True instead of False when the streams are redirected for WIN compatibility
-                stdout=subprocess.PIPE if redirect_std_streams else None,
-                stderr=subprocess.PIPE if redirect_std_streams else None
-            )
-            self.jmx_process = jmx_process
+            # Launch JMXfetch subprocess manually, w/o get_subprocess_output(), since it's a special case
+            with nested(tempfile.TemporaryFile('rw'), tempfile.TemporaryFile('rw')) as (stdout_f, stderr_f):
+                jmx_process = subprocess.Popen(
+                    subprocess_args,
+                    close_fds=not redirect_std_streams,  # only set to True when the streams are not redirected, for WIN compatibility
+                    stdout=stdout_f if redirect_std_streams else None,
+                    stderr=stderr_f if redirect_std_streams else None
+                )
+                self.jmx_process = jmx_process
 
-            # Register SIGINT and SIGTERM signal handlers
-            self.register_signal_handlers()
+                # Register SIGINT and SIGTERM signal handlers
+                self.register_signal_handlers()
 
-            if redirect_std_streams:
-                # Wait for JMXFetch to return, and write out the stdout and stderr of JMXFetch to sys.stdout and sys.stderr
-                out, err = jmx_process.communicate()
-                sys.stdout.write(out)
-                sys.stderr.write(err)
-            else:
-                # Wait for JMXFetch to return
-                jmx_process.wait()
+                if redirect_std_streams:
+                    # Wait for JMXFetch to return, and write out the stdout and stderr of JMXFetch to sys.stdout and sys.stderr
+                    out, err = jmx_process.communicate()
+                    sys.stdout.write(out)
+                    sys.stderr.write(err)
+                else:
+                    # Wait for JMXFetch to return
+                    jmx_process.wait()
 
             return jmx_process.returncode
 

--- a/resources/processes.py
+++ b/resources/processes.py
@@ -1,6 +1,5 @@
 # stdlib
 from collections import namedtuple
-import subprocess
 
 # project
 from resources import (
@@ -9,6 +8,7 @@ from resources import (
     SnapshotDescriptor,
     SnapshotField,
 )
+from utils.subprocess_output import get_subprocess_output
 
 
 class Processes(ResourcePlugin):
@@ -36,16 +36,13 @@ class Processes(ResourcePlugin):
                 ps_arg = 'aux'
             else:
                 ps_arg = 'auxww'
-            ps = subprocess.Popen(['ps', ps_arg], stdout=subprocess.PIPE, close_fds=True).communicate()[0]
+            output, _, _ = get_subprocess_output(['ps', ps_arg], self.log)
+            processLines = output.splitlines()  # Also removes a trailing empty line
         except Exception, e:
             self.log.exception('Cannot get process list')
             return False
 
-        # Split out each process
-        processLines = ps.split('\n')
-
         del processLines[0]  # Removes the headers
-        processLines.pop()  # Removes a trailing empty line
 
         processes = []
 

--- a/tests/checks/mock/test_disk.py
+++ b/tests/checks/mock/test_disk.py
@@ -120,8 +120,8 @@ class TestCheckDisk(AgentCheckTest):
 
         self.coverage_report()
 
-    @mock.patch('utils.subprocess_output.get_subprocess_output',
-                return_value=Fixtures.read_file('debian-df-Tk'))
+    @mock.patch('disk.get_subprocess_output',
+                return_value=(Fixtures.read_file('debian-df-Tk'), "", 0))
     @mock.patch('os.statvfs', return_value=MockInodesMetrics())
     def test_no_psutil_debian(self, mock_df_output, mock_statvfs):
         self.run_check({'instances': [{'use_mount': 'no',
@@ -136,8 +136,8 @@ class TestCheckDisk(AgentCheckTest):
 
         self.coverage_report()
 
-    @mock.patch('utils.subprocess_output.get_subprocess_output',
-                return_value=Fixtures.read_file('freebsd-df-Tk'))
+    @mock.patch('disk.get_subprocess_output',
+                return_value=(Fixtures.read_file('freebsd-df-Tk'), "", 0))
     @mock.patch('os.statvfs', return_value=MockInodesMetrics())
     def test_no_psutil_freebsd(self, mock_df_output, mock_statvfs):
         self.run_check({'instances': [{'use_mount': 'no',

--- a/tests/checks/mock/test_network.py
+++ b/tests/checks/mock/test_network.py
@@ -7,16 +7,16 @@ from tests.checks.common import AgentCheckTest, Fixtures
 
 def ss_subprocess_mock(*args, **kwargs):
     if args[0][-1] == '-4':
-        return Fixtures.read_file('ss_ipv4')
+        return (Fixtures.read_file('ss_ipv4'), "", 0)
     elif args[0][-1] == '-6':
-        return Fixtures.read_file('ss_ipv6')
+        return (Fixtures.read_file('ss_ipv6'), "", 0)
 
 
 def netstat_subprocess_mock(*args, **kwargs):
     if args[0][0] == 'ss':
         raise OSError
     elif args[0][0] == 'netstat':
-        return Fixtures.read_file('netstat')
+        return (Fixtures.read_file('netstat'), "", 0)
 
 
 class TestCheckNetwork(AgentCheckTest):

--- a/util.py
+++ b/util.py
@@ -25,13 +25,14 @@ except ImportError:
     from yaml import Loader as yLoader  # noqa, imported from here elsewhere
     from yaml import Dumper as yDumper  # noqa, imported from here elsewhere
 
+# project
 # These classes are now in utils/, they are just here for compatibility reasons,
 # if a user actually uses them in a custom check
 # If you're this user, please use utils.pidfile or utils.platform instead
 # FIXME: remove them at a point (6.x)
 from utils.pidfile import PidFile  # noqa, see ^^^
 from utils.platform import Platform
-from utils.subprocess_output import subprocess
+from utils.subprocess_output import get_subprocess_output
 
 
 VALID_HOSTNAME_RFC_1123_PATTERN = re.compile(r"^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$")
@@ -194,9 +195,8 @@ def get_hostname(config=None):
         def _get_hostname_unix():
             try:
                 # try fqdn
-                p = subprocess.Popen(['/bin/hostname', '-f'], stdout=subprocess.PIPE)
-                out, err = p.communicate()
-                if p.returncode == 0:
+                out, _, rtcode = get_subprocess_output(['/bin/hostname', '-f'], log)
+                if rtcode == 0:
                     return out.strip()
             except Exception:
                 return None

--- a/utils/subprocess_output.py
+++ b/utils/subprocess_output.py
@@ -1,4 +1,5 @@
 # stdlib
+from contextlib import nested
 from functools import wraps
 import logging
 import subprocess
@@ -8,23 +9,29 @@ log = logging.getLogger(__name__)
 
 
 # FIXME: python 2.7 has a far better way to do this
-def get_subprocess_output(command, log):
+def get_subprocess_output(command, log, shell=False, stdin=None):
     """
     Run the given subprocess command and return it's output. Raise an Exception
     if an error occurs.
     """
-    with tempfile.TemporaryFile('rw') as stdout_f:
-        proc = subprocess.Popen(command, close_fds=True,
-                                stdout=stdout_f, stderr=subprocess.PIPE)
+
+    # Use tempfile, allowing a larger amount of memory. The subprocess.Popen
+    # docs warn that the data read is buffered in memory. They suggest not to
+    # use subprocess.PIPE if the data size is large or unlimited.
+    with nested(tempfile.TemporaryFile('rw'), tempfile.TemporaryFile('rw')) as (stdout_f, stderr_f):
+        proc = subprocess.Popen(command, close_fds=True, shell=shell,
+                                stdin=stdin, stdout=stdout_f,
+                                stderr=stderr_f)
         proc.wait()
-        err = proc.stderr.read()
+        stderr_f.seek(0)
+        err = stderr_f.read()
         if err:
             log.debug("Error while running {0} : {1}".format(" ".join(command),
                                                              err))
 
         stdout_f.seek(0)
         output = stdout_f.read()
-    return output
+    return (output, err, proc.returncode)
 
 
 def log_subprocess(func):


### PR DESCRIPTION
Issue came up when investigating hostdown issues.
https://datadog.zendesk.com/agent/tickets/30510

It seems as though, periodically, a subprocess call hangs and ultimately causes the watchdog to reset the agent. During this period of time, there is then a host down event, followed by a host recovered event posted to the customers events page. We noticed that it seems as though the hanging happens in various checks (not the same for every host down event). Offending checks have included the customers own custom `iostat` check, as well as our own `postfix` check, and even `resources/processes.py`.

The theory is that this is caused by a hanging call to `subprocess.Popen`. There is a known issue where the use of a `subprocess.PIPE` for stdout (or even stderr) could cause the process to hang once the `subprocess.PIPE` fills up. The solution to this is to use `get_subprocess_output()` in our own `utils/subprocess_output.py`, which uses a file for stdout and stderr, removing such a low memory capacity issue.

To avoid further chasing this problem around the agent, this PR attempts to replace the use of `subprocess.Popen` anywhere it shows up in the agent with `get_subprocess_output()`. There are a few instances where further work will be needed to refactor the code in a clean way, and for those instances, I have added a `FIXME` note.