### PR TITLE
[consul] Send more than the last service check

### DIFF
--- a/checks.d/consul.py
+++ b/checks.d/consul.py
@@ -188,7 +188,7 @@ class ConsulCheck(AgentCheck):
                 if check["ServiceID"]:
                     tags.append("service-id:{0}".format(check["ServiceID"]))
 
-            self.service_check(self.HEALTH_CHECK, status, tags=tags)
+                self.service_check(self.HEALTH_CHECK, status, tags=tags)
 
         except Exception as e:
             self.service_check(self.CONSUL_CHECK, AgentCheck.CRITICAL,


### PR DESCRIPTION
At the moment, the consul check will only send the status of the last
service check in `/api/health/state/any`.

This pull request will send the status of all the service checks it can
find.