### PR TITLE
[docker] Add hierarchical_memory_limit and hierarchical_memsw_limit cgroup metrics to be collected (as optional) from Docker

### DIFF
--- a/checks.d/docker.py
+++ b/checks.d/docker.py
@@ -36,6 +36,8 @@ CGROUP_METRICS = [
             "pgpgin": ("docker.mem.pgpgin", "rate", False),
             "pgpgout": ("docker.mem.pgpgout", "rate", False),
             "unevictable": ("docker.mem.unevictable", "gauge", False),
+            "hierarchical_memory_limit": ("docker.mem.hierarchical_memory_limit", "gauge", False),
+            "hierarchical_memsw_limit": ("docker.mem.hierarchical_memsw_limit", "gauge", False),
         }
     },
     {


### PR DESCRIPTION
Related to https://github.com/DataDog/dd-agent/issues/1739