### PR TITLE
[mongo] report dbtop metrics

### DIFF
--- a/checks.d/go_expvar.py
+++ b/checks.d/go_expvar.py
@@ -16,12 +16,14 @@ TAGS = "tags"
 
 GAUGE = "gauge"
 RATE = "rate"
+COUNTER = "counter"
 DEFAULT_TYPE = GAUGE
 
 
 SUPPORTED_TYPES = {
     GAUGE: AgentCheck.gauge,
     RATE: AgentCheck.rate,
+    COUNTER: AgentCheck.increment,
 }
 
 DEFAULT_METRIC_NAMESPACE = "go_expvar"

--- a/checks.d/gunicorn.py
+++ b/checks.d/gunicorn.py
@@ -68,7 +68,7 @@ class GUnicornCheck(AgentCheck):
         for proc in worker_procs:
             # cpu time is the sum of user + system time.
             try:
-                cpu_time_by_pid[proc.pid] = sum(proc.get_cpu_times())
+                cpu_time_by_pid[proc.pid] = sum(proc.cpu_times())
             except psutil.NoSuchProcess:
                 self.warning('Process %s disappeared while scanning' % proc.name)
                 continue
@@ -83,7 +83,7 @@ class GUnicornCheck(AgentCheck):
                 # The process is not running anymore, we didn't collect initial cpu times
                 continue
             try:
-                cpu_time = sum(proc.get_cpu_times())
+                cpu_time = sum(proc.cpu_times())
             except Exception:
                 # couldn't collect cpu time. assume it's dead.
                 self.log.debug("Couldn't collect cpu time for %s" % proc)

--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -128,6 +128,27 @@ class MongoDb(AgentCheck):
         "tcmalloc.tcmalloc.transfer_cache_free_bytes": GAUGE,
     }
 
+    DBTOP = [
+        "commands.count",
+        "commands.time",
+        "getmore.count",
+        "getmore.time",
+        "insert.count",
+        "insert.time",
+        "queries.count",
+        "queries.time",
+        "readLock.count",
+        "readLock.time",
+        "remove.count",
+        "remove.time",
+        "total.count",
+        "total.time",
+        "update.count",
+        "update.time",
+        "writeLock.count",
+        "writeLock.time",
+    ]
+
     def __init__(self, name, init_config, agentConfig, instances=None):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
         self._last_state_by_server = {}
@@ -448,3 +469,39 @@ class MongoDb(AgentCheck):
                 metric_name = self._normalize(metric_name, submit_method)
                 metrics_tags = tags + ['cluster:db:%s' % st]
                 submit_method(self, metric_name, val, tags=metrics_tags)
+
+        # Report the usage metrics for dbs/collections
+        try:
+            dbtop = db.command('top')
+            for ns, ns_metrics in dbtop['totals'].iteritems():
+                if "." not in ns:
+                    continue
+
+                # configure tags for db name and collection name
+                dbname, collname = ns.split(".", 1)
+                ns_tags = tags + ["db:%s" % dbname, "collection:%s" % collname]
+
+                # iterate over DBTOP metrics
+                for m in self.DBTOP:
+                    # each metric is of the form: x.y.z with z optional
+                    # and can be found at ns_metrics[x][y][z]
+                    value = ns_metrics
+                    try:
+                        for c in m.split("."):
+                            value = value[c]
+                    except Exception:
+                        continue
+
+                    # value is now status[x][y][z]
+                    if not isinstance(val, (int, long, float)):
+                        raise TypeError(
+                            u"{0} value is a {1}, it should be an int, a float or a long instead."
+                            .format(metric_name, type(val))
+                        )
+
+                    # prepend these metrics to namespace them
+                    m = "usage." + m
+                    m = self.normalize(m.lower(), 'mongodb')
+                    self.gauge(m, value, tags=ns_tags)
+        except Exception, e:
+            self.log.warning('Failed to record `top` metrics %s' % str(e))

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -33,7 +33,7 @@ if Platform.is_windows():
 log = logging.getLogger(__name__)
 
 # Default methods run when collecting info about the agent in developer mode
-DEFAULT_PSUTIL_METHODS = ['get_memory_info', 'get_io_counters']
+DEFAULT_PSUTIL_METHODS = ['memory_info', 'io_counters']
 
 AGENT_METRICS_CHECK_NAME = 'agent_metrics'
 

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -21,6 +21,7 @@ from config import get_system_stats, get_version
 from resources.processes import Processes as ResProcesses
 import checks.system.unix as u
 import checks.system.win32 as w32
+import checks.system.common as common
 import modules
 from util import (
     EC2,
@@ -188,7 +189,7 @@ class Collector(object):
             'memory': u.Memory(log),
             'processes': u.Processes(log),
             'cpu': u.Cpu(log),
-            'system': u.System(log)
+            'system': common.System(log)
         }
 
         # Win32 System `Checks
@@ -197,7 +198,8 @@ class Collector(object):
             'proc': w32.Processes(log),
             'memory': w32.Memory(log),
             'network': w32.Network(log),
-            'cpu': w32.Cpu(log)
+            'cpu': w32.Cpu(log),
+            'system': common.System(log)
         }
 
         # Old-style metric checks

--- a/checks/system/common.py
+++ b/checks/system/common.py
@@ -1,0 +1,8 @@
+from checks import Check
+
+# 3rd party
+import uptime
+
+class System(Check):
+    def check(self, agentConfig):
+        return {"system.uptime": uptime.uptime()}

--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -215,15 +215,6 @@ class IO(Check):
             return False
 
 
-class System(Check):
-    def check(self, agentConfig):
-        if Platform.is_linux():
-            with open("/proc/uptime", "r") as f:
-                uptime_seconds = float(f.readline().split()[0])
-            return {"system.uptime": uptime_seconds}
-        return {}
-
-
 class Load(Check):
 
     def check(self, agentConfig):

--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -187,9 +187,9 @@ class Cpu(Check):
 
         cpu_percent = psutil.cpu_times()
 
-        self.save_sample('system.cpu.user', 100 * cpu_percent.user / psutil.NUM_CPUS)
-        self.save_sample('system.cpu.idle', 100 * cpu_percent.idle / psutil.NUM_CPUS)
-        self.save_sample('system.cpu.system', 100 * cpu_percent.system / psutil.NUM_CPUS)
+        self.save_sample('system.cpu.user', 100 * cpu_percent.user / psutil.cpu_count())
+        self.save_sample('system.cpu.idle', 100 * cpu_percent.idle / psutil.cpu_count())
+        self.save_sample('system.cpu.system', 100 * cpu_percent.system / psutil.cpu_count())
 
         return self.get_metrics()
 

--- a/ci/zookeeper.rb
+++ b/ci/zookeeper.rb
@@ -1,7 +1,7 @@
 require './ci/common'
 
 def zk_version
-  ENV['FLAVOR_VERSION'] || '3.4.6'
+  ENV['FLAVOR_VERSION'] || '3.4.7'
 end
 
 def zk_rootdir
@@ -16,7 +16,7 @@ namespace :ci do
       unless Dir.exist? File.expand_path(zk_rootdir)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/zookeeper-#{zk_version}.tar.gz\
-             http://mirror.cogentco.com/pub/apache/zookeeper/zookeeper-#{zk_version}/zookeeper-#{zk_version}.tar.gz)
+            http://archive.apache.org/dist/zookeeper/zookeeper-#{zk_version}/zookeeper-#{zk_version}.tar.gz)
         sh %(mkdir -p #{zk_rootdir})
         sh %(tar zxf $VOLATILE_DIR/zookeeper-#{zk_version}.tar.gz\
              -C #{zk_rootdir} --strip-components=1)

--- a/conf.d/agent_metrics.yaml.default
+++ b/conf.d/agent_metrics.yaml.default
@@ -1,15 +1,15 @@
 init_config:
     process_metrics:
-        - name: get_memory_info
+        - name: memory_info
           type: gauge
           active: yes
-        - name: get_io_counters
+        - name: io_counters
           type: rate
           active: yes
-        - name: get_num_threads
+        - name: num_threads
           type: gauge
           active: yes
-        - name: get_connections
+        - name: connections
           type: gauge
           active: no
 

--- a/conf.d/go_expvar.yaml.example
+++ b/conf.d/go_expvar.yaml.example
@@ -3,6 +3,10 @@ init_config:
 instances:
   # Most memstats metrics are exported by default
   # See http://godoc.org/runtime#MemStats for their explanation
+  # Note that you can specify a `type` for the metrics. One of:
+  #  * counter
+  #  * gauge (the default)
+  #  * rate (note that this will show up as a gauge in Datadog that is meant to be seen as a "per second rate")
 
   - expvar_url: http://localhost:8080/debug/vars
     # namespace: examplenamespace         # The default metric namespace is 'go_expvar', define your own
@@ -20,9 +24,9 @@ instances:
     #       - "metric_tag2:tag_value2"
     #   - path: memstats/Alloc            # metric will be reported as a gauge by default
     #   - path: memstats/Lookups
-    #     type: rate
+    #     type: rate                      # metric should be reported as a rate instead of the default gauge
     #   - path: memstats/Mallocs          # with no name specified, the metric name will default to a path based name
-    #     type: rate
+    #     type: counter                   # report as a counter instead of the default gauge
     #   - path: memstats/Frees
     #     type: rate
     #   - path: memstats/BySize/1/Mallocs # You can get nested values by separating them with "/"

--- a/conf.d/tomcat.yaml.example
+++ b/conf.d/tomcat.yaml.example
@@ -66,17 +66,19 @@ init_config:
             metric_type: counter
     - include:
         type: Cache
-        accessCount:
-          alias: tomcat.cache.access_count
-          metric_type: counter
-        hitsCounts:
-          alias: tomcat.cache.hits_count
-          metric_type: counter
+        attribute:
+          accessCount:
+            alias: tomcat.cache.access_count
+            metric_type: counter
+          hitsCounts:
+            alias: tomcat.cache.hits_count
+            metric_type: counter
     - include:
         type: JspMonitor
-        jspCount:
-          alias: tomcat.jsp.count
-          metric_type: counter
-        jspReloadCount:
-          alias: tomcat.jsp.reload_count
-          metric_type: counter
+        attribute:
+          jspCount:
+            alias: tomcat.jsp.count
+            metric_type: counter
+          jspReloadCount:
+            alias: tomcat.jsp.reload_count
+            metric_type: counter

--- a/packaging/datadog-agent/source/agent
+++ b/packaging/datadog-agent/source/agent
@@ -3,7 +3,6 @@ BASEDIR=$(dirname $0)
 cd "$BASEDIR/.."
 
 PATH=$BASEDIR/../venv/bin:$PATH
-EMBEDDED_BIN_PATH="/opt/datadog-agent/embedded/bin"
 
 SUPERVISOR_NOT_RUNNING="Supervisor is not running"
 SUPERVISOR_CONF_FILE='supervisord/supervisord.conf'
@@ -109,7 +108,7 @@ case $action in
         ;;
 
     reload)
-        $EMBEDDED_BIN_PATH/kill -HUP `cat $COLLECTOR_PIDFILE`
+        kill -HUP `cat $COLLECTOR_PIDFILE`
         exit $?
         ;;
 

--- a/packaging/osx/datadog-agent
+++ b/packaging/osx/datadog-agent
@@ -4,7 +4,6 @@ DESC="Datadog Agent"
 AGENTPATH="/opt/datadog-agent/agent/agent.py"
 FORWARDERPATH="/opt/datadog-agent/agent/ddagent.py"
 DOGSTATSDPATH="/opt/datadog-agent/agent/dogstatsd.py"
-KILL_PATH="/opt/datadog-agent/embedded/bin/kill"
 AGENTCONF="/opt/datadog-agent/etc/datadog.conf"
 SUPERVISOR_PIDFILE="/opt/datadog-agent/run/datadog-supervisord.pid"
 SUPERVISOR_CONF_FILE="/opt/datadog-agent/etc/supervisor.conf"
@@ -98,7 +97,7 @@ case $1 in
         ;;
 
     reload)
-        $KILL_PATH -HUP `cat $COLLECTOR_PIDFILE`
+        kill -HUP `cat $COLLECTOR_PIDFILE`
         exit $?
         ;;
 

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -9,7 +9,7 @@ pycurl==7.19.5.1
 # checks.d/gunicorn.py
 # checks.d/btrfs.py
 # checks.d/system_core.py
-psutil==2.1.1
+psutil==3.3.0
 
 # checks.d/snmp.py
 # Require a compiler because pycrypto is a dep

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ requests==2.6.0
 simplejson==3.6.5
 supervisor==3.1.3
 tornado==3.2.2
+uptime==3.0.1
 
 ###########################################################
 # These modules are for checks. But they are

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ if sys.platform == 'win32':
         'pysnmp.entity.rfc3413.oneliner.*',
         'pyVim.*',
         'pyVmomi.*',
+        'uptime',
 
         # agent
         'checks.network_checks',

--- a/tests/checks/mock/test_agent_metrics.py
+++ b/tests/checks/mock/test_agent_metrics.py
@@ -9,12 +9,12 @@ MOCK_CONFIG = {
     'instances': [
         {'process_metrics': [
             {
-                'name': 'get_memory_info',
+                'name': 'memory_info',
                 'type': 'gauge',
                 'active': 'yes'
             },
             {
-                'name': 'get_cpu_times',
+                'name': 'cpu_times',
                 'type': 'rate',
                 'active': 'yes'
             },
@@ -26,7 +26,7 @@ MOCK_CONFIG_2 = {
     'instances': [
         {'process_metrics': [
             {
-                'name': 'get_memory_info',
+                'name': 'memory_info',
                 'type': 'gauge',
                 'active': 'yes'
             },

--- a/tests/checks/mock/test_sysstat.py
+++ b/tests/checks/mock/test_sysstat.py
@@ -8,8 +8,8 @@ from checks.system.unix import (
     IO,
     Load,
     Memory,
-    System,
 )
+from checks.system.common import System
 from config import get_system_stats
 from tests.checks.common import get_check
 from utils.platform import Platform

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -89,6 +89,7 @@ def find_cgroup_filename_pattern(mountpoints, container_id):
         stat_file_path_coreos = os.path.join(mountpoint, "system.slice")
         stat_file_path_kubernetes = os.path.join(mountpoint, container_id)
         stat_file_path_kubernetes_docker = os.path.join(mountpoint, "system", "docker", container_id)
+        stat_file_path_docker_daemon = os.path.join(mountpoint, "docker-daemon", "docker", container_id)
 
         if os.path.exists(stat_file_path_lxc):
             return os.path.join('%(mountpoint)s/lxc/%(id)s/%(file)s')
@@ -100,6 +101,9 @@ def find_cgroup_filename_pattern(mountpoints, container_id):
             return os.path.join('%(mountpoint)s/%(id)s/%(file)s')
         elif os.path.exists(stat_file_path_kubernetes_docker):
             return os.path.join('%(mountpoint)s/system/docker/%(id)s/%(file)s')
+        elif os.path.exists(stat_file_path_docker_daemon):
+            return os.path.join('%(mountpoint)s/docker-daemon/docker/%(id)s/%(file)s')
+
 
     raise MountException("Cannot find Docker cgroup directory. Be sure your system is supported.")
 


### PR DESCRIPTION
The output of dbtop from the mongo server web interface is very useful for debugging performance issues. It is available as the `top` admin command and combined with tags makes for a great experience with datadog.

I'm using it here:
![mongodb datadog 2015-09-11 09-49-30](https://cloud.githubusercontent.com/assets/293802/9820704/6fef8378-586a-11e5-9683-74b029074d13.jpg)

