### PR TITLE
[wmi] new AgentCheck for WMI metrics

### DIFF
--- a/checks.d/wmi_alternative_check.py
+++ b/checks.d/wmi_alternative_check.py
@@ -1,0 +1,222 @@
+# stdlib
+from collections import namedtuple
+
+# 3rd
+import pywintypes
+from win32com.client import Dispatch
+
+# project
+from checks import AgentCheck
+
+
+WMIMetric = namedtuple('WMIMetric', ['name', 'value', 'tags'])
+
+
+class InvalidWMIQuery(Exception):
+    """
+    Invalid WMI Query.
+    """
+    pass
+
+
+class MissingTagBy(Exception):
+    """
+    WMI query returned multiple rows but no `tag_by` value was given.
+    """
+    pass
+
+
+class WMIAlternativeCheck(AgentCheck):
+    """
+    An alternative to Datadog agent WMI check.
+
+    Windows only.
+    """
+    def __init__(self, name, init_config, agentConfig, instances):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+        self.wmi_conns = {}
+        self.wmi_props = {}
+
+    def check(self, instance):
+        """
+        Fetch WMI metrics.
+        """
+        # Connection information
+        host = instance.get('host', "localhost")
+        namespace = instance.get('namespace', "root\\cimv2")
+        username = instance.get('username', "")
+        password = instance.get('password', "")
+
+        # WMI instance
+        wmi_class = instance.get('class')
+        metrics = instance.get('metrics')
+        filters = instance.get('filters')
+        tag_by = instance.get('tag_by')
+
+        # Get connection, (metric name, metric type) by WMI property map and the property list
+        w = self._get_wmi_conn(host, namespace, username, password)
+        metric_name_and_type_by_property, properties = self._get_wmi_properties(host, namespace,
+                                                                                wmi_class, metrics)
+
+        results = self._query_wmi(w, wmi_class, properties, filters, tag_by)
+        metrics = self._extract_metrics(results, tag_by)
+        self._submit_metrics(metrics, metric_name_and_type_by_property)
+
+    def _get_wmi_conn(self, host, namespace, username, password):
+        """
+        Create and cache WMI connections.
+        """
+        key = "{host}:{namespace}:{username}:{password}".format(
+            host=host, namespace=namespace,
+            username=username, password=password
+        )
+        if key not in self.wmi_conns:
+            server = Dispatch("WbemScripting.SWbemLocator")
+            self.log.debug(u"Connection to {host} with namespace {namespace}".format(
+                host=host,
+                namespace=namespace
+            )
+            )
+            self.wmi_conns[key] = server.ConnectServer(host, namespace, username, password)
+        return self.wmi_conns[key]
+
+    def _get_wmi_properties(self, host, namespace, wmi_class, metrics):
+        """
+        Create and cache a (metric name, metric type) by WMI property map and a property list.
+        """
+        key = "{host}:{namespace}:{wmi_class}".format(
+            host=host,
+            namespace=namespace,
+            wmi_class=wmi_class
+        )
+
+        if key not in self.wmi_props:
+            metric_name_by_property = {
+                wmi_property.lower(): (metric_name, metric_type)
+                for wmi_property, metric_name, metric_type in metrics
+            }
+            properties = map(lambda x: x[0], metrics)
+            self.wmi_props[key] = (metric_name_by_property, properties)
+
+        return self.wmi_props[key]
+
+    @staticmethod
+    def _format_filter(filters):
+        """
+        Transform filters to a comprehensive WQL `WHERE` clause.
+        """
+        def build_where_clause(fltr):
+            """
+            Recursively build `WHERE` clause.
+            """
+            f = fltr.pop()
+            prop, value = f.popitem()
+
+            if len(fltr) == 0:
+                return "{property} = '{constant}'".format(
+                    property=prop,
+                    constant=value
+                )
+            return "{property} = '{constant}' AND {more}".format(
+                property=prop,
+                constant=value,
+                more=build_where_clause(fltr)
+            )
+
+        if not filters:
+            return ""
+
+        return " WHERE {clause}".format(clause=build_where_clause(filters))
+
+    def _query_wmi(self, w, wmi_class, wmi_properties, filters, tag_by):
+        """
+        Query WMI using WMI Query Language (WQL).
+
+        Returns: List of unknown COMObject.
+        """
+        formated_wmi_properties = ",".join(wmi_properties)
+        wql = "Select {properties} from {wmi_class}{filters}".format(
+            properties=formated_wmi_properties,
+            wmi_class=wmi_class,
+            filters=self._format_filter(filters)
+        )
+        self.log.debug(u"Querying WMI: {0}".format(wql))
+
+        results = w.ExecQuery(wql)
+
+        try:
+            self._raise_for_invalid(results, tag_by)
+        except InvalidWMIQuery:
+            self.log.warning(u"Invalid WMI query: {0}".format(wql))
+            results = []
+        except MissingTagBy:
+            raise Exception(u"WMI query returned multiple rows but no `tag_by` value was given. "
+                            "class={wmi_class} - properties={wmi_properties}".format(
+                                wmi_class=wmi_class,
+                                wmi_properties=wmi_properties
+                            )
+                            )
+
+        return results
+
+    def _extract_metrics(self, results, tag_by):
+        """
+        Extract, parse and tag metrics from WMI query results.
+
+        Returns: List of WMIMetric
+        ```
+        [
+            WMIMetric("FreeMegabytes", 19742, ["name:_total"]),
+            WMIMetric("AvgDiskBytesPerWrite", 1536, ["name:c:"]),
+        ]
+        ```
+        """
+        metrics = []
+        for res in results:
+            tags = []
+            for wmi_property in res.Properties_:
+                if wmi_property.Name == tag_by:
+                    tags.append(
+                        "{name}:{value}".format(
+                            name=tag_by.lower(),
+                            value=str(wmi_property.Value).lower()
+                        )
+                    )
+                    continue
+                try:
+                    metrics.append(WMIMetric(wmi_property.Name, float(wmi_property.Value), tags))
+                except ValueError:
+                    self.log.warning(u"When extracting metrics with WMI, found a non digit value"
+                                     " for property '{0}'.".format(wmi_property.Name))
+                    continue
+        return metrics
+
+    def _submit_metrics(self, metrics, metric_name_and_type_by_property):
+        """
+        Submit metrics to Datadog with the right name and type.
+        """
+        for metric in metrics:
+
+            metric_key = (metric.name).lower()
+            metric_name, metric_type = metric_name_and_type_by_property[metric_key]
+
+            try:
+                func = getattr(self, metric_type)
+            except AttributeError:
+                raise Exception(u"Invalid metric type: {0}".format(metric_type))
+
+            func(metric_name, metric.value, metric.tags)
+
+    @staticmethod
+    def _raise_for_invalid(result, tag_by):
+        """
+        Raise:
+        * `InvalidWMIQuery`: when the result returned by the WMI query is invalid
+        * `MissingTagBy`: when the result returned by tge WMI query contains multiple rows
+            but no `tag_by` value was given
+        """
+        try:
+            if len(result) > 1 and not tag_by:
+                raise MissingTagBy
+        except (pywintypes.com_error):
+            raise InvalidWMIQuery

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -41,6 +41,20 @@ def get_check_class(name):
     return check_class
 
 
+def load_class(check_name, class_name):
+    """
+    Retrieve a class with the given name among the given check module.
+    """
+    checksd_path = get_checksd_path(get_os())
+    check_module = __import__(check_name)
+    classes = inspect.getmembers(check_module, inspect.isclass)
+    for name, clsmember in classes:
+        if name == class_name:
+            return clsmember
+
+    raise Exception(u"Unable to import class {0} from the check module.".format(class_name))
+
+
 def load_check(name, config, agentConfig):
     checksd_path = get_checksd_path(get_os())
     if checksd_path not in sys.path:
@@ -134,6 +148,12 @@ class AgentCheckTest(unittest.TestCase):
     def load_check(self, config, agent_config=None):
         agent_config = agent_config or self.DEFAULT_AGENT_CONFIG
         self.check = load_check(self.CHECK_NAME, config, agent_config)
+
+    def load_class(self, name):
+        """
+        Retrieve a class with the given name among the check module.
+        """
+        return load_class(self.CHECK_NAME, name)
 
     # Helper function when testing rates
     def run_check_twice(self, config, agent_config=None, mocks=None,

--- a/tests/checks/fixtures/wmi_alternative/win32_perfformatteddata_perfdisk_logicaldisk
+++ b/tests/checks/fixtures/wmi_alternative/win32_perfformatteddata_perfdisk_logicaldisk
@@ -1,0 +1,2 @@
+AvgDiskBytesPerWrite 1536
+FreeMegabytes 19742

--- a/tests/checks/mock/test_wmi_alternative.py
+++ b/tests/checks/mock/test_wmi_alternative.py
@@ -1,0 +1,233 @@
+# 3rd
+from mock import Mock
+
+# project
+from tests.checks.common import AgentCheckTest, Fixtures
+
+
+def load_fixture(f, args):
+    """
+    Build a WMI query result from a file and given parameters.
+    """
+    properties = []
+
+    # Build from file
+    data = Fixtures.read_file(f)
+    for l in data.splitlines():
+        property_name, property_value = l.split(" ")
+        properties.append(Mock(Name=property_name, Value=property_value))
+
+    # Append extra information
+    property_name, property_value = args
+    properties.append(Mock(Name=property_name, Value=property_value))
+
+    return [Mock(Properties_=properties)]
+
+
+class MockWMIConnection(object):
+    """
+    Mocked WMI connection.
+    Save connection parameters so it can be tested.
+    """
+    def __init__(self, wmi_conn_args):
+        super(MockWMIConnection, self).__init__()
+        self._wmi_conn_args = wmi_conn_args
+
+    def get_conn_args(self):
+        """
+        Return parameters used to set up the WMI connection.
+        """
+        return self._wmi_conn_args
+
+    def ExecQuery(self, wql):
+        if wql == "Select AvgDiskBytesPerWrite,FreeMegabytes "\
+                  "from Win32_PerfFormattedData_PerfDisk_LogicalDisk":
+            results = load_fixture("win32_perfformatteddata_perfdisk_logicaldisk", ("Name", "C:"))
+            results += load_fixture("win32_perfformatteddata_perfdisk_logicaldisk", ("Name", "D:"))
+            return results
+
+        return []
+
+
+class MockDispatch(object):
+    """
+    Mock for win32com.client Dispatch class.
+    """
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def ConnectServer(self, *args, **kwargs):
+        """
+        Return a MockWMIConnection
+        """
+        wmi_conn_args = (args, kwargs)
+        return MockWMIConnection(wmi_conn_args)
+
+
+class WMITestCase(AgentCheckTest):
+    CHECK_NAME = 'wmi_alternative_check'
+
+    WMI_CONNECTION_CONFIG = {
+        'host': "myhost",
+        'namespace': "some/namespace",
+        'username': "datadog",
+        'password': "datadog",
+        'class': "Win32_OperatingSystem",
+        'metrics': [["NumberOfProcesses", "system.proc.count", "gauge"],
+                    ["NumberOfUsers", "system.users.count", "gauge"]]
+    }
+
+    WMI_CONFIG = {
+        'class': "Win32_PerfFormattedData_PerfDisk_LogicalDisk",
+        'metrics': [["AvgDiskBytesPerWrite", "winsys.disk.avgdiskbytesperwrite", "gauge"],
+                    ["FreeMegabytes", "winsys.disk.freemegabytes", "gauge"]],
+        'tag_by': "Name"
+    }
+
+    WMI_CONFIG_NO_TAG_BY = {
+        'class': "Win32_PerfFormattedData_PerfDisk_LogicalDisk",
+        'metrics': [["AvgDiskBytesPerWrite", "winsys.disk.avgdiskbytesperwrite", "gauge"],
+                    ["FreeMegabytes", "winsys.disk.freemegabytes", "gauge"]],
+    }
+
+    WMI_CONFIG_FILTER = {
+        'class': "Win32_PerfFormattedData_PerfDisk_LogicalDisk",
+        'metrics': [["AvgDiskBytesPerWrite", "winsys.disk.avgdiskbytesperwrite", "gauge"],
+                    ["FreeMegabytes", "winsys.disk.freemegabytes", "gauge"]],
+        'filters': [{'Name': "C:"}]
+    }
+
+    def setUp(self):
+        """
+        Mock WMI related Python packages, so it can be tested on any environment.
+        """
+        import sys
+        sys.modules['pywintypes'] = Mock()
+        sys.modules['win32com'] = Mock()
+        sys.modules['win32com.client'] = Mock(Dispatch=MockDispatch)
+
+    def assertWMIConnWith(self, wmi_instance, param):
+        """
+        Helper, assert that the WMI connection was established with the right parameter and value.
+        """
+        wmi_conn_args, wmi_conn_kwargs = wmi_instance.get_conn_args()
+        if isinstance(param, tuple):
+            key, value = param
+            self.assertIn(key, wmi_conn_kwargs)
+            self.assertEquals(wmi_conn_kwargs[key], value)
+        else:
+            self.assertIn(param, wmi_conn_args)
+
+    def test_wmi_connection(self):
+        """
+        Establish a WMI connection to the specified host/namespace, with the right credentials.
+        """
+        # Run check
+        config = {
+            'instances': [self.WMI_CONNECTION_CONFIG]
+        }
+        self.run_check(config)
+
+        # WMI connection is cached
+        self.assertIn('myhost:some/namespace:datadog:datadog', self.check.wmi_conns)
+        wmi_conn = self.check.wmi_conns['myhost:some/namespace:datadog:datadog']
+
+        # Connection was established with the right parameters
+        self.assertWMIConnWith(wmi_conn, "myhost")
+        self.assertWMIConnWith(wmi_conn, "some/namespace")
+
+    def test_wmi_properties(self):
+        """
+        Compute a (metric name, metric type) by WMI property map and a property list.
+        """
+        # Set up the check
+        config = {
+            'instances': [self.WMI_CONNECTION_CONFIG]
+        }
+        self.run_check(config)
+
+        # WMI props are cached
+        self.assertIn('myhost:some/namespace:Win32_OperatingSystem', self.check.wmi_props)
+        metric_name_and_type_by_property, properties = \
+            self.check.wmi_props['myhost:some/namespace:Win32_OperatingSystem']
+
+        # Assess
+        self.assertEquals(
+            metric_name_and_type_by_property,
+            {
+                'numberofprocesses': ("system.proc.count", "gauge"),
+                'numberofusers': ("system.users.count", "gauge")
+            }
+        )
+        self.assertEquals(properties, ["NumberOfProcesses", "NumberOfUsers"])
+
+    def test_metric_extraction(self):
+        """
+        Extract metrics from WMI query results.
+        """
+        # Set up the check
+        config = {
+            'instances': [self.WMI_CONNECTION_CONFIG]
+        }
+        self.run_check(config)
+
+        WMIMetric = self.load_class("WMIMetric")
+
+        # Populate results and extract metrics
+        results = load_fixture("win32_perfformatteddata_perfdisk_logicaldisk", ("Name", "_Total"))
+        results += load_fixture("win32_perfformatteddata_perfdisk_logicaldisk", ("Name", "C:"))
+        metrics = self.check._extract_metrics(results, "Name")
+
+        # Assess
+        expected_metrics = [
+            WMIMetric("AvgDiskBytesPerWrite", 1536, ["name:_total"]),
+            WMIMetric("FreeMegabytes", 19742, ["name:_total"]),
+            WMIMetric("AvgDiskBytesPerWrite", 1536, ["name:c:"]),
+            WMIMetric("FreeMegabytes", 19742, ["name:c:"]),
+        ]
+
+        self.assertEquals(metrics, expected_metrics)
+
+    def test_mandatory_tag_by(self):
+        """
+        Exception is raised when the result returned by tge WMI query contains multiple rows
+        but no `tag_by` value was given.
+        """
+        config = {
+            'instances': [self.WMI_CONFIG_NO_TAG_BY]
+        }
+        with self.assertRaises(Exception):
+            self.run_check(config)
+
+    def test_filters(self):
+        """
+        Test the logic behind `_format_filter`
+        """
+        # Set up the check
+        config = {
+            'instances': [self.WMI_CONFIG_FILTER]
+        }
+        self.run_check(config)
+
+        # Test `_format_filter` method
+        no_filters = []
+        filters = [{'Name': "SomeName"}, {'Id': "SomeId"}]
+
+        self.assertEquals("", self.check._format_filter(no_filters))
+        self.assertEquals(" WHERE Id = 'SomeId' AND Name = 'SomeName'",
+                          self.check._format_filter(filters))
+
+    def test_check(self):
+        """
+        Assess check coverage.
+        """
+        # Run the check
+        config = {
+            'instances': [self.WMI_CONFIG]
+        }
+        self.run_check(config)
+
+        for _, mname, _ in self.WMI_CONFIG['metrics']:
+            self.assertMetric(mname, count=2)
+
+        self.coverage_report()


### PR DESCRIPTION
Introducing a new AgentCheck for WMI metrics:
`wmi_alternative_check.py`.

Contrary to the previous `wmi_check.py` AgentCheck, it does not use
`wmi` Python package but directly relies on `win32com.client`: as a
result, queries are about 10 times faster !

It uses the same YAML configuration template file as the previous check,
but does not support the following options yet:
* `constant_tags`
* `tag_queries`