### PR TITLE
Update http_check.py

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -268,7 +268,7 @@ class HTTPCheck(NetworkCheck):
         url = instance.get('url')
 
         o = urlparse(url)
-        host = o.netloc
+        host = o.hostname
 
         port = o.port or 443
 


### PR DESCRIPTION
Fix SSL cert check when specifying a non-default port in the URL.

Currently if you specify something like the following in your http_check.yaml file, then the SSL check will fail as o.netloc will return "localhost:2610" instead of just "localhost".

        url: https://localhost:2610/status