### PR TITLE
[process] Improve sampling of cpu.pct

### DIFF
--- a/conf.d/process.yaml.example
+++ b/conf.d/process.yaml.example
@@ -10,7 +10,6 @@ instances:
 #                    return the counter of all the processes that contain the string
 #    exact_match: (optional) Boolean. Default to True, if you want to look for an arbitrary
 #                 string, use exact_match: False
-#    cpu_check_interval: (optional) CPU percent check interval: 0.1 - 1.0 sec.
 #    ignore_denied_access: (optional) Boolean. Default to True, when getting the number of files descriptors, dd-agent user might
 #    get a denied access. Set this to true to not issue a warning if that happens.
 #    thresholds: (optional) Two ranges: critical and warning


### PR DESCRIPTION
See https://github.com/DataDog/dd-agent/issues/1660

Improvements:
- Non-blocking call to `cpu_percent` after the first sample
- After the first sample, retrieves an averaged value since the last call (instead of an averaged value over the fraction of a second defined by `cpu_check_interval`)

The first sample of `cpu.pct` on every process still uses a blocking call so that the check can retrieve a value as soon as it finds new processes. Setting the `cpu_check_interval` to `0` removes that first blocking call.

Also fixed the handling of the cache of AccessDenied PIDs (it was previously refreshed at every run of every instance).