### PR TITLE
OpenStack integration

### DIFF
--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -192,7 +192,11 @@ class OpenstackCheck(AgentCheck):
         resp = self._make_request_with_auth_fallback(url, headers)
 
         net_details = resp.json()
-        service_check_tags = ['network:{0}'.format(network_id)]
+        service_check_tags = [
+            'network:{0}'.format(network_id),
+            'network_name:{0}'.format(net_details.get('network', {}).get('name')),
+            'tenant_id:{0}'.format(net_details.get('network', {}).get('tenant_id'))
+        ]
 
         if net_details.get('admin_state_up'):
             self.service_check(self.NETWORK_SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags)

--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -47,6 +47,7 @@ class IncompleteConfig(Exception):
 class OpenstackCheck(AgentCheck):
 
     HYPERVISOR_STATE_UP = 'up'
+    HYPERVISOR_STATE_DOWN = 'down'
     NETWORK_STATE_UP = 'UP'
 
     DEFAULT_KEYSTONE_API_VERSION = 'v3'
@@ -181,8 +182,8 @@ class OpenstackCheck(AgentCheck):
             net_details = resp.json()
             for network in net_details['networks']:
                 network_ids.append(network['id'])
-        except:
-            self.warning('Unable to get the list of all network ids.')
+        except Exception as e:
+            self.warning('Unable to get the list of all network ids: {0}'.format(str(e)))
 
         return network_ids
 
@@ -247,13 +248,13 @@ class OpenstackCheck(AgentCheck):
             stats[hyp] = {}
             try:
                 stats[hyp]['payload'] = self.get_stats_for_single_hypervisor(hyp)
-            except:
-                self.warning('Unable to get stats for hypervisor {0}.'.format(hyp))
+            except Exception as e:
+                self.warning('Unable to get stats for hypervisor {0}: {1}'.format(hyp, str(e)))
 
             try:
                 stats[hyp]['uptime'] = self.get_uptime_for_single_hypervisor(hyp)
-            except:
-                self.warning('Unable to get uptime for hypervisor {0}.'.format(hyp))
+            except Exception as e:
+                self.warning('Unable to get uptime for hypervisor {0}: {1}'.format(hyp, str(e)))
 
         return stats
 
@@ -267,8 +268,8 @@ class OpenstackCheck(AgentCheck):
             hv_list = resp.json()
             for hv in hv_list['hypervisors']:
                 hypervisor_ids.append(hv['id'])
-        except:
-            self.warning('Unable to get the list of all hypervisors.')
+        except Exception as e:
+            self.warning('Unable to get the list of all hypervisors: {0}'.format(str(e)))
 
         return hypervisor_ids
 
@@ -294,7 +295,7 @@ class OpenstackCheck(AgentCheck):
                 if uptime.get('uptime_sec', 0) > 0:
                     hyp_state = self.HYPERVISOR_STATE_UP
                 else:
-                    hyp_state = 'down'
+                    hyp_state = self.HYPERVISOR_STATE_DOWN
             except:
                 # This creates the AgentCheck.UNKNOWN state
                 pass

--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -357,7 +357,7 @@ class OpenstackCheck(AgentCheck):
                     metric_label = "openstack.nova.{0}".format(label)
                     self.gauge(metric_label, val, tags=tags)
 
-            uptime = v['uptime']
+            uptime = v.get('uptime', {})
             load_averages = uptime['loads']
 
             assert len(load_averages) == 3

--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -244,10 +244,16 @@ class OpenstackCheck(AgentCheck):
 
         stats = {}
         for hyp in hypervisors:
-            stats[hyp] = {
-                'payload': self.get_stats_for_single_hypervisor(hyp),
-                'uptime': self.get_uptime_for_single_hypervisor(hyp)
-            }
+            try:
+                stats[hyp]['payload'] = self.get_stats_for_single_hypervisor(hyp)
+            except:
+                self.warning('Unable to get stats for hypervisor {0}.'.format(hyp))
+
+            try:
+                stats[hyp]['uptime'] = self.get_uptime_for_single_hypervisor(hyp)
+            except:
+                self.warning('Unable to get uptime for hypervisor {0}.'.format(hyp))
+
         return stats
 
     def get_all_hypervisor_ids(self):

--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -129,8 +129,9 @@ class OpenstackCheck(AgentCheck):
 
         payload = {"auth": {"scope": auth_scope, "identity": identity}}
         auth_url = "{0}/{1}/auth/tokens".format(keystone_server_url, self.DEFAULT_KEYSTONE_API_VERSION)
+        headers = {'Content-Type': 'application/json'}
 
-        resp = requests.post(auth_url, data=json.dumps(payload))
+        resp = requests.post(auth_url, headers=headers, data=json.dumps(payload))
         resp.raise_for_status()
 
         self._nova_url = self.get_nova_url_from_auth_response(resp.json(),

--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -193,11 +193,15 @@ class OpenstackCheck(AgentCheck):
         resp = self._make_request_with_auth_fallback(url, headers)
 
         net_details = resp.json()
-        service_check_tags = [
-            'network:{0}'.format(network_id),
-            'network_name:{0}'.format(net_details.get('network', {}).get('name')),
-            'tenant_id:{0}'.format(net_details.get('network', {}).get('tenant_id'))
-        ]
+        service_check_tags = ['network:{0}'.format(network_id)]
+
+        network_name = net_details.get('network', {}).get('name')
+        if network_name is not None:
+            service_check_tags.append('network_name:{0}'.format(network_name))
+
+        tenant_id = net_details.get('network', {}).get('tenant_id')
+        if tenant_id is not None:
+            service_check_tags.append('tenant_id:{0}'.format(tenant_id))
 
         if net_details.get('admin_state_up'):
             self.service_check(self.NETWORK_SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags)

--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -148,6 +148,12 @@ class OpenstackCheck(AgentCheck):
 
         for entry in catalog:
             if entry['name'] == match:
+                for ep in entry['endpoints']:
+                    if ep.get('interface', '') == 'public':
+                        url = ep.get('url', None)
+                        if url is not None:
+                            return url
+                # Fall back to the 1st one
                 return entry['endpoints'][0].get('url', '')
         else:
             return None
@@ -194,6 +200,12 @@ class OpenstackCheck(AgentCheck):
         nova_match = 'novav21' if nova_version == 'v2.1' else 'nova'
         for entry in catalog:
             if entry['name'] == nova_match:
+                for ep in entry['endpoints']:
+                    if ep.get('interface', '') == 'public':
+                        url = ep.get('url', None)
+                        if url is not None:
+                            return url
+                # Fall back to the 1st one
                 return entry['endpoints'][0].get('url', '')
         else:
             return None

--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -346,7 +346,11 @@ class OpenstackCheck(AgentCheck):
         for _, v in stats.iteritems():
             payload = v['payload']
 
-            tags = ['hypervisor:{0}'.format(payload['hypervisor_hostname']),'virt_type:{0}'.format(payload['hypervisor_type'])]
+            tags = [
+                'hypervisor:{0}'.format(payload['hypervisor_hostname']),
+                'hypervisor_id:{0}'.format(payload['id']),
+                'virt_type:{0}'.format(payload['hypervisor_type'])
+            ]
 
             for label, val in payload.iteritems():
                 if label in NOVA_HYPERVISOR_METRICS:

--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -358,13 +358,11 @@ class OpenstackCheck(AgentCheck):
                     metric_label = "openstack.nova.{0}".format(label)
                     self.gauge(metric_label, val, tags=tags)
 
-            uptime = v.get('uptime', {})
-            load_averages = uptime['loads']
-
-            assert len(load_averages) == 3
-            for i, avg in enumerate([1, 5, 15]):
-                self.gauge('openstack.nova.hypervisor_load.{0}'.format(avg), load_averages[i], tags=tags)
-
+            load_averages = v.get('uptime', {}).get('loads', None)
+            if load_averages is not None:
+                assert len(load_averages) == 3
+                for i, avg in enumerate([1, 5, 15]):
+                    self.gauge('openstack.nova.hypervisor_load.{0}'.format(avg), load_averages[i], tags=tags)
 
     def check(self, instance):
 

--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -244,6 +244,7 @@ class OpenstackCheck(AgentCheck):
 
         stats = {}
         for hyp in hypervisors:
+            stats[hyp] = {}
             try:
                 stats[hyp]['payload'] = self.get_stats_for_single_hypervisor(hyp)
             except:

--- a/conf.d/openstack.yaml.example
+++ b/conf.d/openstack.yaml.example
@@ -1,10 +1,10 @@
 init_config:
        # Where your identity server lives (please omit the trailing slash). Note the server must support Identity API v3
       keystone_server_url: "https://my-keystone-server.com"
-      
+
       # Nova API version to use - this check supports v2 and v2.1 (default)
-      #nova_api_version: 'v2.1' 
-      
+      #nova_api_version: 'v2.1'
+
       # The authorization scope that will be used to request a token from Identity API v3
       auth_scope:
           project:
@@ -22,8 +22,11 @@ init_config:
       # IDs of Nova Hypervisors to monitor
       hypervisor_ids:
           - 1
-          
-      # IDs of Nova Servers to monitor    
+
+      # Enable this option to list all hypervisors and check each one
+      # check_all_hypervisors: true
+
+      # IDs of Nova Servers to monitor
       server_ids:
           - 68d6a5f3-cc08-4a9f-aafd-150d8ee9e695
           - cfc98054-0b25-4182-a77a-c7f4bf5e574d
@@ -31,6 +34,9 @@ init_config:
       #IDs of Neutron networks to monitor
       network_ids:
           - 2f60042a-0d46-4023-905a-aebf23a350ff
+
+      # Enable this option to list all networks and check each one
+      # check_all_networks: true
 
 # No need to change this. No instance-level config
 instances:


### PR DESCRIPTION
Hi @talwai, I was talking with @2bethere and @irabinovitch about using the OpenStack integration here at Lithium. I needed to make a few changes to your script in order to get it to work. Here's a PR that will merge my changes into your branch. I'm not sure if that's something you want or not so feel free to reject it. I just wanted to share up my changes. This branch is based on PR #1864 

In addition to the policy changes listed https://gist.github.com/talwai/7445f16c2584b8caffe2 I also modified `compute_extension:v3:os-hypervisors`, `compute_extension:v3:os-server-diagnostics`, `compute_extension:availability_zone:detail`, `compute_extension:v3:os-availability-zone:detail`.

Key changes:
- Can, assuming permissions allow, dynamically get the list of hypervisors and networks to monitor
- Better handling of the uptime api calls for when a hypervisor's nova-compute service is offline.
- Nova pre v2.1 does not support the 'state' field in the hypervisor data so I'm falling back to check uptime.
- Some versions of the Keystone api requires the content-type application/json header to be sent.
- In the service catalog, use the 'public' urls instead of just the first one.