### PR TITLE
[flare] Remove proxy credentials from collected datadog.conf

### DIFF
--- a/utils/flare.py
+++ b/utils/flare.py
@@ -1,6 +1,7 @@
 # stdlib
 import atexit
 import cStringIO as StringIO
+from collections import namedtuple
 from functools import partial
 import glob
 try:
@@ -74,11 +75,29 @@ class Flare(object):
     """
 
     DATADOG_SUPPORT_URL = '/support/flare'
-    PASSWORD_REGEX = re.compile('( *(\w|_)*pass(word)?:).+')
-    URI_REGEX = re.compile('(.*\ [A-Za-z0-9]+)\:\/\/([A-Za-z0-9]+)\:(.+)\@')
+
+    CredentialPattern = namedtuple('CredentialPattern', ['pattern', 'replacement', 'label'])
+    CHECK_CREDENTIALS = [
+        CredentialPattern(
+            re.compile('( *(\w|_)*pass(word)?:).+'),
+            r'\1 ********',
+            'password'
+        ),
+        CredentialPattern(
+            re.compile('(.*\ [A-Za-z0-9]+)\:\/\/([A-Za-z0-9]+)\:(.+)\@'),
+            r'\1://\2:********@',
+            'password in a uri'
+        ),
+    ]
+    MAIN_CREDENTIALS = [
+        CredentialPattern(
+            re.compile('^api_key: *\w+(\w{5})$'),
+            r'api_key: *************************\1',
+            'api_key'
+        ),
+    ]
     COMMENT_REGEX = re.compile('^ *#.*')
-    APIKEY_REGEX = re.compile('^api_key: *\w+(\w{5})$')
-    REPLACE_APIKEY = r'api_key: *************************\1'
+
     COMPRESSED_FILE = 'datadog-agent-{0}.tar.bz2'
     # We limit to 10MB arbitrarily
     MAX_UPLOAD_SIZE = 10485000
@@ -230,11 +249,11 @@ class Flare(object):
     # Collect all conf
     def _add_conf_tar(self):
         conf_path = get_config_path()
-        if self._can_read(conf_path):
-            self._add_file_tar(
-                self._strip_comment(conf_path),
-                os.path.join('etc', 'datadog.conf'),
-                original_file_path=conf_path
+        if self._can_read(conf_path, output=False):
+            self._add_clean_conf(
+                conf_path,
+                'etc',
+                self.MAIN_CREDENTIALS
             )
 
         if not Platform.is_windows():
@@ -242,17 +261,20 @@ class Flare(object):
                 os.path.dirname(get_config_path()),
                 'supervisor.conf'
             )
-            if self._can_read(supervisor_path):
-                self._add_file_tar(
-                    self._strip_comment(supervisor_path),
-                    os.path.join('etc', 'supervisor.conf'),
-                    original_file_path=supervisor_path
+            if self._can_read(supervisor_path, output=False):
+                self._add_clean_conf(
+                    supervisor_path,
+                    'etc'
                 )
 
         for file_path in glob.glob(os.path.join(get_confd_path(), '*.yaml')) +\
                 glob.glob(os.path.join(get_confd_path(), '*.yaml.default')):
             if self._can_read(file_path, output=False):
-                self._add_clean_confd(file_path)
+                self._add_clean_conf(
+                    file_path,
+                    os.path.join('etc', 'confd'),
+                    self.CHECK_CREDENTIALS
+                )
 
     # Collect JMXFetch-specific info and save to jmxinfo directory if jmx config
     # files are present and valid
@@ -328,50 +350,56 @@ class Flare(object):
                 log.warn("  * not readable - {0}".format(f))
             return False
 
-    # Return path to a temp file without comment
-    def _strip_comment(self, file_path):
-        fh, temp_path = tempfile.mkstemp(prefix='dd')
-        atexit.register(os.remove, temp_path)
-        with os.fdopen(fh, 'w') as temp_file:
-            with open(file_path, 'r') as orig_file:
-                for line in orig_file.readlines():
-                    if not self.COMMENT_REGEX.match(line):
-                        temp_file.write(re.sub(self.APIKEY_REGEX, self.REPLACE_APIKEY, line))
-
-        return temp_path
-
-    # Remove password before collecting the file
-    def _add_clean_confd(self, file_path):
+    def _add_clean_conf(self, file_path, target_dir, credential_patterns=None):
         basename = os.path.basename(file_path)
 
-        temp_path, password_found = self._strip_password(file_path)
-        log.info("  * {0}{1}".format(file_path, password_found))
+        temp_path, log_message = self._strip_credentials(file_path, credential_patterns)
+        log.info('  * {0}{1}'.format(file_path, log_message))
         self._add_file_tar(
             temp_path,
-            os.path.join('etc', 'conf.d', basename),
+            os.path.join(target_dir, basename),
             original_file_path=file_path
         )
 
-    # Return path to a temp file without password and comment
-    def _strip_password(self, file_path):
+    # Return path to a temp file without comments on which the credential patterns have been applied
+    def _strip_credentials(self, file_path, credential_patterns=None):
+        if not credential_patterns:
+            credential_patterns = []
+        credentials_found = set()
         fh, temp_path = tempfile.mkstemp(prefix='dd')
         atexit.register(os.remove, temp_path)
         with os.fdopen(fh, 'w') as temp_file:
             with open(file_path, 'r') as orig_file:
-                password_found = ''
                 for line in orig_file.readlines():
-                    if self.PASSWORD_REGEX.match(line):
-                        line = re.sub(self.PASSWORD_REGEX, r'\1 ********', line)
-                        password_found = ' - this file contains a password which '\
-                                         'has been removed in the version collected'
-                    if self.URI_REGEX.match(line):
-                        line = re.sub(self.URI_REGEX, r'\1://\2:********@', line)
-                        password_found = ' - this file contains a password in a uri which '\
-                                         'has been removed in the version collected'
                     if not self.COMMENT_REGEX.match(line):
-                        temp_file.write(line)
+                        clean_line, credential_found = self._clean_credentials(line, credential_patterns)
+                        temp_file.write(clean_line)
+                        if credential_found:
+                            credentials_found.add(credential_found)
 
-        return temp_path, password_found
+        credentials_log = ''
+        if len(credentials_found) > 1:
+            credentials_log = ' - this file contains credentials ({0}) which'\
+                              ' have been removed in the collected version'\
+                              .format(', '.join(credentials_found))
+        elif len(credentials_found) == 1:
+            credentials_log = ' - this file contains a credential ({0}) which'\
+                              ' has been removed in the collected version'\
+                              .format(credentials_found.pop())
+
+        return temp_path, credentials_log
+
+    # Remove credentials from a given line
+    def _clean_credentials(self, line, credential_patterns):
+        credential_found = None
+        for credential_pattern in credential_patterns:
+            if credential_pattern.pattern.match(line):
+                line = re.sub(credential_pattern.pattern, credential_pattern.replacement, line)
+                credential_found = credential_pattern.label
+                # only one pattern should match per line
+                break
+
+        return line, credential_found
 
     # Add output of the command to the tarfile
     def _add_command_output_tar(self, name, command, command_desc=None):

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -95,6 +95,11 @@ class Flare(object):
             r'api_key: *************************\1',
             'api_key'
         ),
+        CredentialPattern(
+            re.compile('^(proxy_user|proxy_password): *.+'),
+            r'\1: ********',
+            'proxy credentials'
+        ),
     ]
     COMMENT_REGEX = re.compile('^ *#.*')
 


### PR DESCRIPTION
Also added a message in the output to make credentials removal from `datadog.conf` explicit. The message is similar to what is already displayed for the yaml files in `conf.d`, for instance:

```
2015-09-22 19:05:08,842 | INFO | dd.collector | utils.flare(flare.py:340) |   * /etc/dd-agent/datadog.conf - this file contains credentials which have been removed in the version collected: api_key, proxy credentials
2015-09-22 19:05:08,844 | INFO | dd.collector | utils.flare(flare.py:340) |   * /etc/dd-agent/supervisor.conf
2015-09-22 19:05:08,849 | INFO | dd.collector | utils.flare(flare.py:340) |   * /etc/dd-agent/conf.d/elastic.yaml - this file contains a password which has been removed in the version collected
2015-09-22 19:05:08,851 | INFO | dd.collector | utils.flare(flare.py:340) |   * /etc/dd-agent/conf.d/nginx.yaml
```