### PR TITLE
Add Nagios Plugin Runner… Plugin

### DIFF
--- a/checks.d/nagios_runner.py
+++ b/checks.d/nagios_runner.py
@@ -1,0 +1,53 @@
+import subprocess
+
+from checks import AgentCheck
+
+# Runs arbitrary commands, but expects the exit code of the executed command
+# to adhere to the Nagios Plugin API:
+# https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/pluginapi.html
+# Config file looks like:
+#
+# init_config:
+# # Not required for this check
+#
+# instances:
+#     - name: "some.check.name1"
+#       command: "/path/to/command with args"
+#     - name: "some.check.name2"
+#       command: "/path/to/command with args2"
+class NagiosRunner(AgentCheck):
+    def __init__(self, name, init_config, agentConfig):
+        AgentCheck.__init__(self, name, init_config, agentConfig)
+        self.last_ts = {}
+
+    def check(self, instance):
+
+        cmd = instance.get('command')
+        name = instance.get('name')
+
+        status = AgentCheck.UNKNOWN
+        try:
+            output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
+            status = AgentCheck.OK
+            # If we get here it's because the exit code was 0
+            self.log.debug("Got OK {0}".format(name))
+        except subprocess.CalledProcessError as e:
+            # This is thrown if return code is != 0
+            ret = e.returncode
+            self.log.debug("Got NOK {0}: {1}".format(name, ret))
+            if ret == 1:
+                status = AgentCheck.WARNING
+                output = e.output
+            elif ret == 2:
+                status = AgentCheck.CRITICAL
+                output = e.output
+            else:
+                status = AgentCheck.UNKNOWN
+                output = e.output
+
+        self.service_check(
+            name,
+            status,
+            message = output,
+            tags = []
+        )

--- a/conf.d/nagios_runner.yaml.example
+++ b/conf.d/nagios_runner.yaml.example
@@ -1,0 +1,7 @@
+init_config:
+
+instances:
+  # - name: i.am.a.service.check.name
+  #   command: /usr/bin/foobar -A baz -C gorch
+  # - name: nagios.check.swap
+  #   command: /usr/lib/nagios/plugins/check_swap -w 524288000 -c 104857600 


### PR DESCRIPTION
# What's this PR do?

Adds a `nagios_runner` plugin which allows you to execute Nagios plugins — or any command that follows [Nagios' Plugin API](https://assets.nagios.com/downloads/nagioscore/docs/nagioscore/3/en/pluginapi.html) and output Service Checks

# Motivation

Stripe has a significant number of in-house Nagios plugins that test non-trivial system things. There are also capabilities of Nagios plugins that do not exist in the Datadog agent. Rather than invest the time to port all of these plugins to Datadog and have to maintain both for a time, it's much easier to reuse them with the Datadog agent as Service Checks!

# Notes

* This does **not** convert Nagios plugin output in to metrics. I saw the very outdated *bernard* branch tried to do that. It's not necessary in my world to do that, as we use the plugins in a Service Check way.
* This might not be useful for everyone, but it definitely is for us. I'm also happy to make it a separate repo that people can grab and install themselves.
* I am not tied to naming of the plugin or it's configuration. Happy to change these.
* Service checks don't seem to be documented anywhere plainly. There are mentioned all over and clearly a first-class thing, but I can't find a good page for them and how to use them semantically. An area for improvement?