### PR TITLE
[util] Incorporating security-groups into tags collected from ec2

### DIFF
--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -33,6 +33,9 @@ api_key:
 # Collect AWS EC2 custom tags as agent tags
 # collect_ec2_tags: no
 
+# Incorporate security-groups into tags collected from AWS EC2
+# collect_security_groups: no
+
 # Enable Agent Developer Mode
 # Agent Developer Mode collects and sends more fine-grained metrics about agent and check performance
 # developer_mode: no

--- a/util.py
+++ b/util.py
@@ -356,6 +356,8 @@ class EC2(object):
             tag_object = connection.get_all_tags({'resource-id': EC2.metadata['instance-id']})
 
             EC2_tags = [u"%s:%s" % (tag.name, tag.value) for tag in tag_object]
+            if agentConfig.get('collect_security_groups') and EC2.metadata.get('security-groups'):
+                EC2_tags.append(u"security-group-name:{0}".format(EC2.metadata.get('security-groups')))
 
         except Exception:
             log.exception("Problem retrieving custom EC2 tags")


### PR DESCRIPTION
Looks like the agent pulls AWS host tags, but doesn't pull `security-groups`. Additionally, it doesn't look like there is a good way to grab security group ids from EC2, however we do have access to the security group names. The fix to apply here is simply to make sure we add that to the tags collected as `security-group-name:<name>`.