### PR TITLE
[system] Filter SunOS memory_cap kstats by module

### DIFF
--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -504,7 +504,7 @@ class Memory(Check):
         elif sys.platform == 'sunos5':
             try:
                 memData = {}
-                kmem = sp.Popen(["kstat", "-c", "zone_memory_cap", "-p"],
+                kmem = sp.Popen(["kstat", "-m", "memory_cap", "-c", "zone_memory_cap", "-p"],
                                 stdout=sp.PIPE,
                                 close_fds=True).communicate()[0]
 


### PR DESCRIPTION
On large SunOS systems, the kstat population is often quite large.  Using `kstat -c <class>` requires a full scan of the metric list and can be slow/expensive.  Filtering by `module` allows kstat consumers to use the kstat index (which includes `module`, `name` and `instance`, but not `class`). Using this filter strategy for the `zone_memory_cap` check results in a speedup of 1-2 orders of magnitude.