### PR TITLE
[checks.d][openstack] Get the limits (quotas) for each project (tenant)

### DIFF
--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -37,6 +37,31 @@ NOVA_SERVER_METRICS = [
 
 NOVA_SERVER_INTERFACE_SEGMENTS = ['_rx', '_tx']
 
+PROJECT_METRICS = [
+    "maxImageMeta",
+    "maxPersonality",
+    "maxPersonalitySize",
+    "maxSecurityGroupRules",
+    "maxSecurityGroups",
+    "maxServerMeta",
+    "maxTotalCores",
+    "maxTotalFloatingIps",
+    "maxTotalInstances",
+    "maxTotalKeypairs",
+    "maxTotalRAMSize",
+
+    "totalImageMetaUsed",
+    "totalPersonalityUsed",
+    "totalPersonalitySizeUsed",
+    "totalSecurityGroupRulesUsed",
+    "totalSecurityGroupsUsed",
+    "totalServerMetaUsed",
+    "totalCoresUsed",
+    "totalFloatingIpsUsed",
+    "totalInstancesUsed",
+    "totalKeypairsUsed",
+    "totalRAMUsed"
+]
 
 class OpenstackAuthFailure(Exception):
     pass
@@ -373,6 +398,59 @@ class OpenstackCheck(AgentCheck):
             if _is_valid_metric(st):
                 self.gauge("openstack.nova.server.{0}".format(st), server_stats[st], tags=tags)
 
+    def get_project_stats(self):
+        if self.init_config.get('check_all_projects', False):
+            projects = self.get_all_projects()
+        else:
+            projects = []
+            for project_id in self.init_config.get('project_ids', []):
+                # Make the format of the data match the results from get_all_projects()
+                projects.append({'id': project_id})
+
+        if not projects:
+            self.warning("Your check is not configured to monitor any Projects.\n" +
+                         "Please list `project_ids` under your init_config")
+
+        for project in projects:
+            try:
+                self.get_stats_for_single_project(project)
+            except Exception as e:
+                self.warning('Unable to get stats for Project {0}: {1}'.format(project['id'], str(e)))
+
+    def get_all_projects(self):
+        keystone_api_version = self.init_config.get('keystone_api_version', self.DEFAULT_KEYSTONE_API_VERSION)
+        endpoint_name = 'tenants' if keystone_api_version == 'v2.0' else 'projects'
+        url = "{0}/{1}/{2}".format(self._get_keystone_server_url(), keystone_api_version, endpoint_name)
+        headers = {'X-Auth-Token': self._auth_token}
+
+        projects = []
+        try:
+            resp = self._make_request_with_auth_fallback(url, headers)
+            project_details = resp.json()
+            for project in project_details[endpoint_name]:
+                projects.append(project)
+        except Exception as e:
+            self.warning('Unable to get the list of all project ids: {0}'.format(str(e)))
+
+        return projects
+
+    def get_stats_for_single_project(self, project):
+        def _is_valid_metric(label):
+            return label in PROJECT_METRICS
+
+        url = '{0}/limits?tenant_id={1}'.format(self._nova_url, project['id'])
+        headers = {'X-Auth-Token': self._auth_token}
+        resp = self._make_request_with_auth_fallback(url, headers)
+
+        server_stats = resp.json()
+        tags = ['project_id:{0}'.format(project['id'])]
+        if 'name' in project:
+            tags.append('project_name:{0}'.format(project['name']))
+
+        for st in server_stats['limits']['absolute']:
+            if _is_valid_metric(st):
+                self.gauge("openstack.nova.limits.{0}".format(st), server_stats['limits']['absolute'][st], tags=tags)
+
     ###
 
     def nova_stats_to_metrics(self, stats):
@@ -412,7 +490,10 @@ class OpenstackCheck(AgentCheck):
                 self.nova_stats_to_metrics(hyp_stats)
 
                 self.get_server_stats()
+
                 self.get_network_stats()
+
+                self.get_project_stats()
             except OpenstackAuthFailure:
                 self._auth_required = True
 

--- a/conf.d/openstack.yaml.example
+++ b/conf.d/openstack.yaml.example
@@ -46,6 +46,15 @@ init_config:
       # ones you enumerated under `network_ids`
       # check_all_networks: true
 
+      #IDs of Projects (aka Tenants) to monitor
+      project_ids:
+          - 2f60042a0d464023905aaebf23a350ff
+
+      # Enable this option to list all projects (tenants) and check each one
+      # Note: this option supersedes `project_ids` above i.e. all project_ids will be monitored regardless of which
+      # ones you enumerated under `project_ids`
+      # check_all_projects: true
+
 # No need to change this. No instance-level config
 instances:
     [{}]


### PR DESCRIPTION
This update will query keystone to get the list of available projects (tenants) and then iterate through the list and get the limits (quotas) for each. Alternatively you can specify the project_ids you want to check if you only want to check certain ones. If for some reason it isn't able to get the limits for a project it will simply move on to the next one in the list.

If you want to get the list of all projects, you will need to update the keystone policy.json to allow the role access to this api call.

```
"identity:list_projects": "rule:admin_required or role:datadog_monitoring",
"identity:list_user_projects": "rule:admin_or_owner or role:datadog_monitoring",
```

I'm not entirely sure, but I think that the nova policy.json may also need to be updated for access to the admin limits too.

```
"compute_extension:used_limits_for_admin": "rule:admin_api or role:datadog_monitoring",
```

@talwai 
