### PR TITLE
[tests] remove misleading nosetests error message

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -25,7 +25,6 @@ import modules
 from util import (
     EC2,
     GCE,
-    get_hostname,
     get_os,
     get_uuid,
     Timer,
@@ -751,7 +750,7 @@ class Collector(object):
         except Exception:
             pass
 
-        metadata["hostname"] = get_hostname()
+        metadata["hostname"] = self.hostname
 
         # Add cloud provider aliases
         host_aliases = GCE.get_host_aliases(self.agentConfig)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -19,7 +19,8 @@ class TestConfig(unittest.TestCase):
         """Leading whitespace confuse ConfigParser
         """
         agentConfig = get_config(cfg_path=os.path.join(os.path.dirname(os.path.realpath(__file__)),
-                                                       'fixtures', 'badconfig.conf'))
+                                                       'fixtures', 'badconfig.conf'),
+                                 parse_args=False)
         self.assertEquals(agentConfig["dd_url"], "https://app.datadoghq.com")
         self.assertEquals(agentConfig["api_key"], "1234")
         self.assertEquals(agentConfig["nagios_log"], "/var/log/nagios3/nagios.log")


### PR DESCRIPTION
Problem
-------
When running `rake ci:run` we can see `nosetests: error: no such option:
-s` for some specific tests.

It's caused by calls to `get_config` (from config.py) with `parse_args=True`,
which calls `OptionParser`, which tries to parse the `nosetests` command line,
and fails because `dd-agent` doesn't have a `-s` option. (but has a `-A` and
`-v`). Source of the error: https://github.com/DataDog/dd-agent/blob/4907d1178a0eb38558cfa2cc644be769835a7b92/config.py#L88

Solution
--------
One of the concerned tests was directly calling `get_config`, the
`parse_args=False` arg was added.

The others are using a `Collector` which calls `get_hostname` (itself calling
`get_config` with `parse_args=True`) in `_get_hostname_metadata`:
https://github.com/DataDog/dd-agent/blob/4907d1178a0eb38558cfa2cc644be769835a7b92/checks/collector.py#L754

However the `Collector` already stores the agent config in `self.agentConfig`,
so this is used to avoid the useless `get_config` (not called if a config is
provided).

This fixes https://github.com/DataDog/dd-agent/issues/1957.