### PR TITLE
[windows] log + timeout WMI queries after 10 seconds

### DIFF
--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -39,12 +39,6 @@ class Processes(Check):
                              ' No process metrics will be returned.')
             return
 
-        try:
-            cpu = w.Win32_PerfFormattedData_PerfOS_Processor(name="_Total")[0]
-        except AttributeError:
-            self.logger.info('Missing Win32_PerfFormattedData_PerfOS_Processor WMI class.'
-                             ' No process metrics will be returned.')
-            return
         if os.ProcessorQueueLength is not None:
             self.save_sample('system.proc.queue_length', os.ProcessorQueueLength)
         if os.Processes is not None:

--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -1,5 +1,6 @@
-# project
+# datadog
 from checks import Check
+from utils.debug import logged
 
 # 3rd party
 try:
@@ -9,6 +10,10 @@ except ImportError:
 
 try:
     import wmi
+
+    # Log DEBUG WMI queries
+    wmi._wmi_namespace.__getattr__ = logged(wmi._wmi_namespace.__getattr__)
+
     w = wmi.WMI()
 except Exception:
     wmi, w = None, None
@@ -19,6 +24,7 @@ class DriveType(object):
     UNKNOWN, NOROOT, REMOVEABLE, LOCAL, NETWORK, CD, RAM = (0, 1, 2, 3, 4, 5, 6)
 B2MB = float(1048576)
 KB2MB = B2KB = float(1024)
+
 
 def should_ignore_disk(name, blacklist_re):
     # blacklist_re is a compiled regex, compilation done at config loading time

--- a/tests/core/test_timeout.py
+++ b/tests/core/test_timeout.py
@@ -1,0 +1,98 @@
+# stdlib
+import unittest
+import time
+
+# datadog
+from utils.timeout import _thread_by_func, timeout, TimeoutException
+
+count = 0
+
+
+class SomeException(Exception):
+    """A generic exception"""
+
+
+@timeout(0.2)
+def make_sum(a, b, sleep=0, raise_exception=False):
+    """Sleep, sum and return `a` with `b`"""
+    global count
+    count += 1
+    time.sleep(sleep)
+    if raise_exception:
+        raise SomeException()
+    return a + b
+
+
+class TestTimeout(unittest.TestCase):
+    """
+    Test timeout decorator logic.
+    """
+
+    def setUp(self):
+        global count
+        count = 0
+
+    def tearDown(self):
+        """
+        Wait for all threads to end to avoid contamination between each tests.
+        """
+        for key, worker in _thread_by_func.iteritems():
+            while worker.is_alive():
+                time.sleep(0.2)
+        for key in _thread_by_func.keys():
+            del _thread_by_func[key]
+
+    def test_preserve(self):
+        """
+        Preserve function name and docstring.
+        """
+        self.assertEquals(make_sum.__name__, "make_sum")
+        self.assertEquals(make_sum.__doc__, "Sleep, sum and return `a` with `b`")
+
+    def test_no_timeout(self):
+        """
+        Return the result when the method runtime does not exceed the limit set.
+        """
+        self.assertEquals(make_sum(1, 2), 3)
+
+    def test_exception_propagation(self):
+        """
+        Propagate exceptions.
+        """
+        self.assertRaises(SomeException, make_sum, 1, 2, raise_exception=True)
+
+    def test_raise_on_timeout(self):
+        """
+        Raise `TimeoutException` on timeouts.
+        """
+        self.assertRaises(TimeoutException, make_sum, 1, 2, sleep=0.5)
+
+    def test_refetch_thread(self):
+        """
+        Refetch an existing thread when it exists.
+        """
+        #  This should create a thread
+        self.assertRaises(TimeoutException, make_sum, 1, 2, sleep=0.5)
+        self.assertEquals(count, 1)
+
+        time.sleep(0.5)
+
+        # This should refetch the existing thread
+        self.assertEquals(make_sum(1, 2, sleep=0.5), 3)
+        self.assertEquals(count, 1)
+
+        # This should create a new thread
+        self.assertRaises(TimeoutException, make_sum, 1, 2, sleep=0.5)
+        self.assertEquals(count, 2)
+
+    def test_multiple_threads(self):
+        """
+        Create one thread per function call.
+        """
+        # Create one thread
+        self.assertRaises(TimeoutException, make_sum, 1, 2, sleep=0.5)
+
+        #  ... and a second one
+        self.assertRaises(TimeoutException, make_sum, 2, 3, sleep=0.5)
+
+        self.assertEquals(count, 2)

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -50,6 +50,7 @@ def run_check(name, path=None):
     Test custom checks on Windows.
     """
     from config import get_confd_path
+    from util import get_os
 
     # Read the config file
     confd_path = path or os.path.join(get_confd_path(get_os()), '%s.yaml' % name)

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -2,12 +2,12 @@
 from functools import wraps
 from pprint import pprint
 import inspect
+import logging
 import os
 import sys
 
-# datadog
-from config import get_checksd_path, get_confd_path
-from util import get_os
+
+log = logging.getLogger(__name__)
 
 
 def log_exceptions(logger):
@@ -30,13 +30,28 @@ def log_exceptions(logger):
     return decorator
 
 
+def logged(func):
+    """
+    Add DEBUG logging to a function.
+    """
+    @wraps(func)
+    def wrapper(*params, **kwargs):
+        fc = "%s(%s)" % (func.__name__, ', '.join(
+            [a.__repr__() for a in params] +
+            ["%s = %s" % (a, b) for a, b in kwargs.items()]
+        ))
+        log.debug("%s called" % fc)
+        return func(*params, **kwargs)
+    return wrapper
+
 
 def run_check(name, path=None):
     """
     Test custom checks on Windows.
     """
-    # Read the config file
+    from config import get_confd_path
 
+    # Read the config file
     confd_path = path or os.path.join(get_confd_path(get_os()), '%s.yaml' % name)
 
     try:
@@ -62,6 +77,8 @@ def run_check(name, path=None):
 
 def get_check(name, config_str):
     from checks import AgentCheck
+    from config import get_checksd_path
+    from util import get_os
 
     checksd_path = get_checksd_path(get_os())
     if checksd_path not in sys.path:

--- a/utils/subprocess_output.py
+++ b/utils/subprocess_output.py
@@ -4,6 +4,10 @@ import logging
 import subprocess
 import tempfile
 
+# datadog
+from utils.debug import logged
+
+
 log = logging.getLogger(__name__)
 
 
@@ -27,18 +31,4 @@ def get_subprocess_output(command, log):
     return output
 
 
-def log_subprocess(func):
-    """
-    Wrapper around subprocess to log.debug commands.
-    """
-    @wraps(func)
-    def wrapper(*params, **kwargs):
-        fc = "%s(%s)" % (func.__name__, ', '.join(
-            [a.__repr__() for a in params] +
-            ["%s = %s" % (a, b) for a, b in kwargs.items()]
-        ))
-        log.debug("%s called" % fc)
-        return func(*params, **kwargs)
-    return wrapper
-
-subprocess.Popen = log_subprocess(subprocess.Popen)
+subprocess.Popen = logged(subprocess.Popen)

--- a/utils/subprocess_output.py
+++ b/utils/subprocess_output.py
@@ -1,5 +1,4 @@
 # stdlib
-from functools import wraps
 import logging
 import subprocess
 import tempfile

--- a/utils/timeout.py
+++ b/utils/timeout.py
@@ -1,0 +1,70 @@
+from threading import Thread
+import functools
+
+_thread_by_func = {}
+
+
+class TimeoutException(Exception):
+    """
+    Raised when a function runtime exceeds the limit set.
+    """
+    pass
+
+
+class ThreadMethod(Thread):
+    """
+    Descendant of `Thread` class.
+
+    Run the specified target method with the specified arguments.
+    Store result and exceptions.
+
+    From: https://code.activestate.com/recipes/440569/
+    """
+    def __init__(self, target, args, kwargs):
+        Thread.__init__(self)
+        self.setDaemon(True)
+        self.target, self.args, self.kwargs = target, args, kwargs
+        self.start()
+
+    def run(self):
+        try:
+            self.result = self.target(*self.args, **self.kwargs)
+        except Exception, e:
+            self.exception = e
+        else:
+            self.exception = None
+
+
+def timeout(timeout):
+    """
+    A decorator to timeout a function. Decorated method calls are executed in a separate new thread
+    with a specified timeout.
+    Also check if a thread for the same function already exists before creating a new one.
+
+    Note: Compatible with Windows (thread based).
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            key = "{0}:{1}:{2}".format(func.__name__, args, kwargs)
+
+            if key in _thread_by_func:
+                # A thread for the same function already exists.
+                worker = _thread_by_func[key]
+            else:
+                worker = ThreadMethod(func, args, kwargs)
+                _thread_by_func[key] = worker
+                worker.join(timeout)
+
+            if worker.is_alive():
+                raise TimeoutException()
+
+            del _thread_by_func[key]
+
+            if worker.exception:
+                raise worker.exception
+            else:
+                return worker.result
+
+        return wrapper
+    return decorator


### PR DESCRIPTION
## Context
On Windows, the collector sometimes spends an abnormally high amount of time collecting system metrics, causing the agent to restart.
System metric are collected through WMI, using the `wmi` Python package. It is unfortunately known to cause us a lot of issues... In particular, most of the WMI queries, here, use Win32_PerfFormattedData_* which are slow !

## Changes
### `log_subprocess` → `logged`
Make `log_subprocess` decorator more generic:
 * Rename it `logged`
 * Move it to `utils/debug`

### WMI activity logging
Log DEBUG WMI queries among Windows system check.

###  Decorator to timeout a function
Create a decorator to timeout a function. Decorated method calls are executed in a separate new thread with a specified timeout.
Also check if a thread for the same function already exists before creating a new one.

__Note__: Compatible with Windows (thread based).

#### Timeout WMI queries after 10 seconds
Timeout WMI queries after 10 seconds among Windows system check.

## Milestone

Seems like a good 5.5.2 candidate.
