### PR TITLE
Add StatsD integration.

### DIFF
--- a/checks.d/statsd.py
+++ b/checks.d/statsd.py
@@ -1,0 +1,80 @@
+# stdlib
+import re
+import socket
+from StringIO import StringIO
+
+# project
+from checks import AgentCheck
+
+SERVICE_CHECK_NAME = "statsd.can_connect"
+SERVICE_CHECK_NAME_HEALTH = "statsd.is_up"
+
+ENDER = re.compile("^(END|health: up|health: down)\n$", re.MULTILINE)
+BAD_ENDER = re.compile("^ERROR\n$", re.MULTILINE)
+
+class StatsCheck(AgentCheck):
+    def check(self, instance):
+        host = instance.get("host", "localhost")
+        port = instance.get("port", 8126)
+        tags = instance.get("tags", [])
+        tags = ["host:{0}".format(host), "port:{0}".format(port)] + tags
+
+        # Is it up?
+        health = self._send_command(host, port, "health", tags).getvalue().strip()
+        if health == "health: up":
+            self.service_check(
+                SERVICE_CHECK_NAME_HEALTH, AgentCheck.OK, tags
+            )
+        else:
+            self.service_check(
+                SERVICE_CHECK_NAME_HEALTH, AgentCheck.CRITICAL, tags
+            )
+
+        # Get general stats
+        stats = self._send_command(host, port, "stats", tags)
+        stats.seek(0)
+        for l in stats.readlines():
+            parts = l.strip().split(":")
+            if len(parts) == 2:
+                # Uptime isn't a gauge. Since we have only one exception, this
+                # seems fine. If we make more a lookup table might be best.
+                if parts[0] == "bad_lines_seen":
+                    self.monotonic_count("statsd.{0}".format(parts[0]), float(parts[1]), tags=tags)
+                else:
+                    self.gauge("statsd.{0}".format(parts[0]), float(parts[1]), tags=tags)
+
+        counters = len(self._send_command(host, port, "counters", tags).getvalue().splitlines()) - 1
+        self.gauge("statsd.counters.count", counters, tags=tags)
+
+        gauges = len(self._send_command(host, port, "gauges", tags).getvalue().splitlines()) - 1
+        self.gauge("statsd.gauges.count", gauges, tags=tags)
+
+        timers = len(self._send_command(host, port, "timers", tags).getvalue().splitlines()) - 1
+        self.gauge("statsd.timers.count", timers, tags=tags)
+
+    def _send_command(self, host, port, command, tags):
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.connect((host, port))
+
+            s.sendall("{0}\n".format(command))
+
+            buf = StringIO()
+
+            chunk = s.recv(1024)
+            buf.write(chunk)
+            while chunk:
+                if ENDER.search(chunk):
+                    break
+                if BAD_ENDER.search(chunk):
+                    raise Exception("Got an error issuing command: {0}".format(command))
+                chunk = s.recv(1024)
+                buf.write(chunk)
+            return buf
+        except Exception as e:
+            self.service_check(
+                SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags
+            )
+            raise Exception("Failed connection {0}".format(str(e)))
+        finally:
+            s.close()

--- a/conf.d/statsd.yaml.example
+++ b/conf.d/statsd.yaml.example
@@ -1,0 +1,8 @@
+init_config:
+
+instances:
+  - host: localhost
+    port: 8126
+    # tags:
+    #  - optional_tag1
+    #  - optional_tag2


### PR DESCRIPTION
# What's this PR do?

Adds a StatsD integration for collecting metrics and service checks using [StatsD's admin interface](https://github.com/etsy/statsd/blob/master/docs/admin_interface.md).

# Motivation

Even though Datadog provides DogStatsD some organizations may choose to run StatsD for one reason or another. They may also be migrating from an existing StatsD setup. Or maybe they are monitoring someone else's stuff that uses StatsD.

We're in the second group, migrating from an existing StatsD setup. Having the ability to get service checks and metrics from our existing StatsD gives us both monitoring of current infra until it's gone and a way to measure our progress in moving "legacy" clients when that comes to pass.

# Notes

* I can imagine this seeming odd since DogStatsD, but I hope I've justified it well.
* I'm running this in our QA environment and it works fine.
* As I often say, I'm not a native Pythoner so helping me with style or idiomatic shit is welcome.
* Suggestions for improvement are also welcome. I don't write a lot of socket code. :)
* I used two different service check names for failure and for "health". Is this ok?
* I used `gauge` for all the things, even though `uptime` and `messages.bad_lines_seen` will only increase unless StatsD restarts. Which metric type is appropriate here?

Thanks for taking a look!