### PR TITLE
[check] [network] Test if UDP metrics exist before trying to report them

### DIFF
--- a/checks.d/network.py
+++ b/checks.d/network.py
@@ -256,7 +256,8 @@ class Network(AgentCheck):
                 'SndbufErrors': 'system.net.udp.snd_buf_errors'
             }
             for key, metric in udp_metrics_name.iteritems():
-                self.rate(metric, self._parse_value(udp_metrics[key]))
+                if key in udp_metrics:
+                    self.rate(metric, self._parse_value(udp_metrics[key]))
 
         except IOError:
             # On Openshift, /proc/net/snmp is only readable by root


### PR DESCRIPTION
As @olivielpeau [mentioned](https://github.com/DataDog/dd-agent/pull/1974#issuecomment-149275279) on https://github.com/DataDog/dd-agent/pull/1974, some of these can be missing in old Linux versions.
We want to make sure we found them before submitting them.