### PR TITLE
[riak] add custom tags to service checks tags

### DIFF
--- a/checks.d/riak.py
+++ b/checks.d/riak.py
@@ -61,7 +61,7 @@ class Riak(AgentCheck):
         default_timeout = self.init_config.get('default_timeout', 5)
         timeout = float(instance.get('timeout', default_timeout))
         tags = instance.get('tags', [])
-        service_check_tags = ['url:%s' % url]
+        service_check_tags = tags + ['url:%s' % url]
 
         try:
             h = Http(timeout=timeout)


### PR DESCRIPTION
Fix https://github.com/DataDog/dd-agent/issues/1482
Revert https://github.com/DataDog/dd-agent/pull/1527 (backend wasn't able to
deal with custom service checks tags at that time)