### PR TITLE
[core] Normalize exit code of fallback `status` command

### DIFF
--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -178,6 +178,9 @@ case "$1" in
             echo "${RED}Warning: Known bug in Linux Kernel 3.18+ causes 'status' to fail.${NC}"
             echo "Calling 'info', instead..."
             service datadog-agent info
+            if [ $? -ne 0 ]; then
+                exit 1
+            fi
         else
             check_status
         fi

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -145,6 +145,9 @@ case "$1" in
             echo "${RED}Warning: Known bug in Linux Kernel 3.18+ causes 'status' to fail.${NC}"
             echo "Calling 'info', instead..."
             service datadog-agent info
+            if [ $? -ne 0 ]; then
+                exit 1
+            fi
         else
             check_status
         fi


### PR DESCRIPTION
The exit code of the `status` command has to be one of 0, 1, 2, 3, 4,
69 to be correctly understood by Ansible, but was returning `253`
when the agent was not running on linux kernel versions 3.18+

Normalize the exit code to 0 or 1 to avoid the issue.

See https://github.com/ansible/ansible-modules-core/blob/cbbb20b6bf0d82fdc92f064c9e4d18c04f203da6/system/service.py#L590

Fixes #1976

More generally we could try to stick more closely to the [LSB specs](http://refspecs.linuxbase.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/iniscrptact.html) for the exit code of the `status` command.