### PR TITLE
[snmp] customisable `oid_batch_size` batch size

### DIFF
--- a/checks.d/snmp.py
+++ b/checks.d/snmp.py
@@ -33,7 +33,7 @@ SNMP_GAUGES = frozenset([
     snmp_type.Integer.__name__,
     snmp_type.Integer32.__name__])
 
-OID_BATCH_SIZE = 10
+DEFAULT_OID_BATCH_SIZE = 10
 
 
 def reply_invalid(oid):
@@ -61,6 +61,9 @@ class SnmpCheck(AgentCheck):
 
         # Create SNMP command generator and aliases
         self.create_command_generator(mibs_path, ignore_nonincreasing_oid)
+
+        # Set OID batch size
+        self.oid_batch_size = int(init_config.get("oid_batch_size", DEFAULT_OID_BATCH_SIZE))
 
     def snmp_logger(self, func):
         """
@@ -184,11 +187,11 @@ class SnmpCheck(AgentCheck):
             error_indication, error_status, error_index, var_binds = self.snmpget(
                 auth_data,
                 transport_target,
-                *(oids[first_oid:first_oid + OID_BATCH_SIZE]),
+                *(oids[first_oid:first_oid + self.oid_batch_size]),
                 lookupValues=lookup_names,
                 lookupNames=lookup_names)
 
-            first_oid = first_oid + OID_BATCH_SIZE
+            first_oid = first_oid + self.oid_batch_size
 
             # Raise on error_indication
             self.raise_on_error_indication(error_indication, instance)


### PR DESCRIPTION
Here is a **5.5.2 candidate**

### Context
For an unindentified reason (need more investigation ?), some OIDs do not return when pulled in a batch query. By default, the SNMP AgentCheck attemps to query up to 10 OID at the same time to speed up the crawling runtime. 

### Example
```
Running SNMP command nextCmd on OIDS ('1.3.6.1.4.1.39538.3.1.3.1.1.7', '1.3.6.1.4.1.39538.3.1.3.3.1.11') 
Returned vars: [[(ObjectName('1.3.6.1.4.1.39538.3.1.3.1.1.7.0'), Integer(7)), (ObjectName('1.3.6.1.6.3.1.1.6.1.0'), Integer(1694833796))]]
```
*(Note the unrelated '1.3.6.1.6.3.1.1.6.1.0' returned :open_mouth: )*

versus

```
Running SNMP command nextCmd on (CommunityData(communityIndex='s1542604247011267360', communityName=<COMMUNITY>, mpModel=1, contextEngineId=None, contextName='', tag='', securityName='s1542604247011267360'), UdpTransportTarget(('127.0.0.1', 161), timeout=1, retries=5, tagList=''), '1.3.6.1.4.1.39538.3.1.3.3.1.11') | {'lookupValues': False, 'lookupNames': False}
Returned vars: (None, Integer('noError', NamedValues(('noError', 0), ('tooBig', 1), ('noSuchName', 2), ('badValue', 3), ('readOnly', 4), ('genErr', 5), ('noAccess', 6), ('wrongType', 7), ('wrongLength', 8), ('wrongEncoding', 9), ('wrongValue', 10), ('noCreation', 11), ('inconsistentValue', 12), ('resourceUnavailable', 13), ('commitFailed', 14), ('undoFailed', 15), ('authorizationError', 16), ('notWritable', 17), ('inconsistentName', 18))), Integer(0, subtypeSpec=ConstraintsIntersection(ConstraintsIntersection(), ValueRangeConstraint(0, Integer(2147483647)))), [[(ObjectName('1.3.6.1.4.1.39538.3.1.3.3.1.11.0'), Integer(3))]])
```

### Changes
Make the OID batch size configurable. Create a 'hidden' `oid_batch_size` option in the `init_config` section of the check YAML configuration file (default to 10).
Helpful to troubleshoot and workaround batch query related cases.