### PR TITLE
[jmxfetch] Allow adding custom jars to JMXFetch's classpath

### DIFF
--- a/conf.d/jmx.yaml.example
+++ b/conf.d/jmx.yaml.example
@@ -8,9 +8,15 @@ instances:
   #   port: 7199
   #   user: username
   #   password: password
-  #   process_name_regex: .*process_name.* # Instead of specifying a host, and port. The agent can connect using the attach api.
+
+  #   # If the agent needs to connect to a non-default JMX URL, specify it here instead of a host and a port
+  #   # If you use this you need to specify a 'name' for the instance, below
+  #   jmx_url: "service:jmx:rmi:///jndi/rmi://myhost.host:9999/custompath"
+
+  #   process_name_regex: .*process_name.* # Instead of specifying a host and port or jmx_url, the agent can connect using the attach api.
   #                                        # This requires the JDK to be installed and the path to tools.jar to be set below.
   #   tools_jar_path: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar # To be set when process_name_regex is set
+
   #   name: jmx_instance
   #   # java_bin_path: /path/to/java # Optional, should be set if the agent cannot find your java executable
   #   # java_options: "-Xmx200m -Xms50m" # Optional, Java JVM options

--- a/conf.d/jmx.yaml.example
+++ b/conf.d/jmx.yaml.example
@@ -1,4 +1,7 @@
 init_config:
+  # custom_jar_paths: # Optional, allows specifying custom jars that will be added to the classpath of the agent's JVM
+  #   - /path/to/custom/jarfile.jar
+  #   - /path/to/another/custom/jarfile2.jar
 
 instances:
   # - host: localhost

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -353,9 +353,15 @@ class JMXFetch(object):
 
                 # Support for attach api using a process name regex
                 proc_regex = inst.get('process_name_regex')
+                # Support for a custom jmx URL
+                jmx_url = inst.get('jmx_url')
+                name = inst.get('name')
 
                 if proc_regex is not None:
                     is_attach_api = True
+                elif jmx_url is not None:
+                    if name is None:
+                        raise InvalidJMXConfiguration("A name must be specified when using a jmx_url")
                 else:
                     if host is None:
                         raise InvalidJMXConfiguration("A host must be specified")

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -108,7 +108,8 @@ class JMXFetch(object):
         if clean_status_file:
             JMXFiles.clean_status_file()
 
-        self.jmx_checks, self.invalid_checks, self.java_bin_path, self.java_options, self.tools_jar_path = \
+        self.jmx_checks, self.invalid_checks, self.java_bin_path, self.java_options, \
+            self.tools_jar_path, self.custom_jar_paths = \
             self.get_configuration(self.confd_path, checks_list=checks_list)
 
     def should_run(self):
@@ -143,7 +144,7 @@ class JMXFetch(object):
 
             if len(self.jmx_checks) > 0:
                 return self._start(self.java_bin_path, self.java_options, self.jmx_checks,
-                                   command, reporter, self.tools_jar_path, redirect_std_streams)
+                                   command, reporter, self.tools_jar_path, self.custom_jar_paths, redirect_std_streams)
             else:
                 # We're exiting purposefully, so exit with zero (supervisor's expected
                 # code). HACK: Sleep a little bit so supervisor thinks we've started cleanly
@@ -184,6 +185,7 @@ class JMXFetch(object):
         java_bin_path = None
         java_options = None
         tools_jar_path = None
+        custom_jar_paths = []
         invalid_checks = {}
 
         for conf in glob.glob(os.path.join(confd_path, '*.yaml')):
@@ -202,7 +204,7 @@ class JMXFetch(object):
                     continue
 
                 try:
-                    is_jmx, check_java_bin_path, check_java_options, check_tools_jar_path = \
+                    is_jmx, check_java_bin_path, check_java_options, check_tools_jar_path, check_custom_jar_paths = \
                         cls._is_jmx_check(check_config, check_name, checks_list)
                     if is_jmx:
                         jmx_checks.append(filename)
@@ -212,15 +214,17 @@ class JMXFetch(object):
                             java_options = check_java_options
                         if tools_jar_path is None and check_tools_jar_path is not None:
                             tools_jar_path = check_tools_jar_path
+                        if check_custom_jar_paths:
+                            custom_jar_paths.extend(check_custom_jar_paths)
                 except InvalidJMXConfiguration, e:
                     log.error("%s check does not have a valid JMX configuration: %s" % (check_name, e))
                     # Make sure check_name is a string - Fix issues with Windows
                     check_name = check_name.encode('ascii', 'ignore')
                     invalid_checks[check_name] = str(e)
 
-        return (jmx_checks, invalid_checks, java_bin_path, java_options, tools_jar_path)
+        return (jmx_checks, invalid_checks, java_bin_path, java_options, tools_jar_path, custom_jar_paths)
 
-    def _start(self, path_to_java, java_run_opts, jmx_checks, command, reporter, tools_jar_path, redirect_std_streams):
+    def _start(self, path_to_java, java_run_opts, jmx_checks, command, reporter, tools_jar_path, custom_jar_paths, redirect_std_streams):
         statsd_port = self.agentConfig.get('dogstatsd_port', "8125")
         if reporter is None:
             reporter = "statsd:%s" % str(statsd_port)
@@ -232,10 +236,11 @@ class JMXFetch(object):
             path_to_jmxfetch = self._get_path_to_jmxfetch()
             path_to_status_file = JMXFiles.get_status_file_path()
 
-            if tools_jar_path is None:
-                classpath = path_to_jmxfetch
-            else:
-                classpath = r"%s:%s" % (tools_jar_path, path_to_jmxfetch)
+            classpath = path_to_jmxfetch
+            if tools_jar_path is not None:
+                classpath = r"%s:%s" % (tools_jar_path, classpath)
+            if custom_jar_paths:
+                classpath = r"%s:%s" % (':'.join(custom_jar_paths), classpath)
 
             subprocess_args = [
                 path_to_java,  # Path to the java bin
@@ -319,6 +324,7 @@ class JMXFetch(object):
         is_jmx = False
         is_attach_api = False
         tools_jar_path = init_config.get("tools_jar_path")
+        custom_jar_paths = init_config.get("custom_jar_paths")
 
         if init_config is None:
             init_config = {}
@@ -407,7 +413,14 @@ class JMXFetch(object):
             else:
                 tools_jar_path = None
 
-        return is_jmx, java_bin_path, java_options, tools_jar_path
+            if custom_jar_paths:
+                if isinstance(custom_jar_paths, basestring):
+                    custom_jar_paths = [custom_jar_paths]
+                for custom_jar_path in custom_jar_paths:
+                    if not os.path.isfile(custom_jar_path):
+                        raise InvalidJMXConfiguration("Unable to find custom jar at %s" % custom_jar_path)
+
+        return is_jmx, java_bin_path, java_options, tools_jar_path, custom_jar_paths
 
     def _get_path_to_jmxfetch(self):
         if not Platform.is_windows():


### PR DESCRIPTION
Will allow JMXFetch to connect to JMX servers with unusual setups, for instance JBoss applications (which use JMX Remoting instead of the usual RMI protocol) and Tomcat applications that use `JmxRemoteLifecycleListener `.

I'm going to update our docs to specify which JARs to use for these known cases.