### PR TITLE
[core][transaction] Use utcnow instead of now

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -752,6 +752,7 @@ class Collector(object):
             pass
 
         metadata["hostname"] = self.hostname
+        metadata["timezones"] = time.tzname
 
         # Add cloud provider aliases
         host_aliases = GCE.get_host_aliases(self.agentConfig)

--- a/tests/core/test_transaction.py
+++ b/tests/core/test_transaction.py
@@ -102,9 +102,9 @@ class TestTransaction(unittest.TestCase):
             trManager.append(tr)
 
         # Try to flush them, time it
-        before = datetime.now()
+        before = datetime.utcnow()
         trManager.flush()
-        after = datetime.now()
+        after = datetime.utcnow()
         self.assertTrue((after - before) > 3 * THROTTLING_DELAY - timedelta(microseconds=100000),
                         "before = %s after = %s" % (before, after))
 

--- a/transaction.py
+++ b/transaction.py
@@ -20,7 +20,7 @@ class Transaction(object):
 
         self._id = None
         self._error_count = 0
-        self._next_flush = datetime.now()
+        self._next_flush = datetime.utcnow()
         self._size = None
 
     def get_id(self):
@@ -52,10 +52,10 @@ class Transaction(object):
         if td > max_delay:
             td = max_delay
 
-        newdate = datetime.now() + td
+        newdate = datetime.utcnow() + td
         self._next_flush = newdate.replace(microsecond=0)
 
-    def time_to_flush(self,now = datetime.now()):
+    def time_to_flush(self,now = datetime.utcnow()):
         return self._next_flush < now
 
     def flush(self):
@@ -84,7 +84,7 @@ class TransactionManager(object):
         self._counter = 0
 
         self._trs_to_flush = None # Current transactions being flushed
-        self._last_flush = datetime.now() # Last flush (for throttling)
+        self._last_flush = datetime.utcnow() # Last flush (for throttling)
 
         # Track an initial status message.
         ForwarderStatus().persist()
@@ -138,7 +138,7 @@ class TransactionManager(object):
 
         to_flush = []
         # Do we have something to do ?
-        now = datetime.now()
+        now = datetime.utcnow()
         for tr in self._transactions:
             if tr.time_to_flush(now):
                 to_flush.append(tr)
@@ -175,7 +175,7 @@ class TransactionManager(object):
 
         if len(self._trs_to_flush) > 0:
 
-            td = self._last_flush + self._THROTTLING_DELAY - datetime.now()
+            td = self._last_flush + self._THROTTLING_DELAY - datetime.utcnow()
             # Python 2.7 has this built in, python < 2.7 don't...
             if hasattr(td,'total_seconds'):
                 delay = td.total_seconds()
@@ -184,7 +184,7 @@ class TransactionManager(object):
 
             if delay <= 0:
                 tr = self._trs_to_flush.pop()
-                self._last_flush = datetime.now()
+                self._last_flush = datetime.utcnow()
                 log.debug("Flushing transaction %d" % tr.get_id())
                 try:
                     tr.flush()


### PR DESCRIPTION
If the server is configured in a local timezone that follows DST, the
forwarder can get stuck if we use .now instead of .utcnow as it will
think that there is already a transaction in progress.