### PR TITLE
[integration] [openstack] Add project limit collection and implement agent scoping

### DIFF
--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -634,7 +634,8 @@ class OpenStackCheck(AgentCheck):
                         self.get_stats_for_single_server(sid, tags=server_tags)
 
                     self.get_stats_for_single_hypervisor(hyp, host_tags=host_tags)
-                    self.get_stats_for_single_project(project)
+                    if project:
+                        self.get_stats_for_single_project(project)
                 else:
                     # Legacy behavior: monitor everything reachable
                     # as enumerated by the user
@@ -659,9 +660,9 @@ class OpenStackCheck(AgentCheck):
         hyp = self.get_all_hypervisor_ids(filter_by_host=host)
         return hyp[0]
 
-    def get_local_project(self):
+    def get_scoped_project(self):
         if self._tenant_id:
-            return self._tenant_id
+            return {"id": self._tenant_id}
 
         if not (self._project_name and self._domain_id):
             # sets auth state for future use
@@ -680,7 +681,7 @@ class OpenStackCheck(AgentCheck):
         except Exception as e:
             self.warning('Unable to get the list of all project ids: {0}'.format(str(e)))
 
-        return projects[0]
+        return None
 
     def get_my_hostname(self):
         return socket.gethostname()

--- a/conf.d/openstack.yaml.example
+++ b/conf.d/openstack.yaml.example
@@ -23,6 +23,7 @@ init_config:
           #         id: default
 
       # Password is the only auth method supported right now
+      # The user identity should resolve to a structure like {'password': 'my_password', 'name': 'my_name', 'domain': {'id': 'my_domain_id'}}
       user:
           password: my_password
           name: datadog
@@ -30,56 +31,31 @@ init_config:
               id: default
 
       # IDs of Nova Hypervisors to monitor
+      # This is only required when nova_api_version is set to `v2` since
+      # indexing hypervsiors is restricted to `admin`s in Compute API v2
+      # With v2.1, the check will intelligently discover the locally running
+      # hypervisor, based on the hypervisor_hostname
+
       # hypervisor_ids:
       #    - 1
-
-      # Enable this option to list all hypervisors and check each one.
-      # Note: this option supersedes `hypervisor_ids` above i.e. all hypervisors will be monitored regardless of which
-      # ones you enumerated under `hypervisor_ids`
-      # check_all_hypervisors: true
-
-      # IDs of hypervisors to exclude from monitoring (only significant when `check_all_hypervisors` is enabled)
-      # exclude_hypervisor_ids:
-      #     - 2
-
-      # IDs of Nova Servers to monitor
-      # server_ids:
-      #    - 68d6a5f3-cc08-4a9f-aafd-150d8ee9e695
-      #    - cfc98054-0b25-4182-a77a-c7f4bf5e574d
-
-
-      # Enable this option to list all servers and check each one
-      # Note: this option supersedes `server_ids` above i.e. all server_ids will be monitored regardless of which
-      # ones you enumerated under `server_ids`
-      # check_all_servers: true
-
-      # IDs of servers to exclude from monitoring (only significant when `check_all_servers` is enabled)
-      # exclude_server_ids:
-
-      # IDs of Neutron networks to monitor
-      # network_ids:
-      #    - 2f60042a-0d46-4023-905a-aebf23a350ff
-
-      # Enable this option to list all networks and check each one
-      # Note: this option supersedes `network_ids` above i.e. all network_ids will be monitored regardless of which
-      # ones you enumerated under `network_ids`
-      # check_all_networks: true
-
-      # IDs of networks to exclude from monitoring (only significant when `check_all_networks` is enabled)
-      # exclude_network_ids:
 
       # Whether to enable SSL certificate verification for HTTP requests. Defaults to true, you may
       # need to set to False when using self-signed certs
       # ssl_verify: true
 
-      #IDs of Projects (aka Tenants) to monitor
-      # project_ids:
-      #    - 2f60042a0d464023905aaebf23a350ff
+      # In some cases, the nova url is returned without the tenant id suffixed
+      # e.g. http://172.0.0.1:8774 rather than http://172.0.0.1:8774/<tenant_id>
+      # The user can set append_tenant_id` to true manually add this suffix for downstream requests
+      # append_tenant_id: false
 
-      # Enable this option to list all projects (tenants) and check each one
-      # Note: this option supersedes `project_ids` above i.e. all project_ids will be monitored regardless of which
-      # ones you enumerated under `project_ids`
-      # check_all_projects: true
+      # IDs of servers to exclude from monitoring (by default the agent will collect metrics from all guest servers running on the host)
+      # exclude_server_ids:
+      #    - server_1
+      #    - server_2
+
+      # IDs of networks to exclude from monitoring (by default the agent will collect metrics from networks returned by the neutron:get_networks operation)
+      # exclude_network_ids:
+      #    - network_1
 
 # No need to change this. No instance-level config
 instances:

--- a/conf.d/openstack.yaml.example
+++ b/conf.d/openstack.yaml.example
@@ -1,23 +1,33 @@
 init_config:
-       # Where your identity server lives (please omit the trailing slash). Note the server must support Identity API v3
+      # All directives prefixed with a '#' sign are optional and will default to sane values when omitted
+
+      # Where your identity server lives (please omit the trailing slash). Note that the server must support Identity API v3
       keystone_server_url: "https://my-keystone-server.com"
 
       # Nova API version to use - this check supports v2 and v2.1 (default)
-      #nova_api_version: 'v2.1'
+      # nova_api_version: 'v2.1'
 
       # The authorization scope that will be used to request a token from Identity API v3
+      # The auth scope must resolve to 1 of the following structures:
+      # {'project': {'name': 'my_project', 'domain': 'my_domain} OR {'project': {'id': 'my_project_id'}}
+
       auth_scope:
           project:
-              name: my_project_name
-              #domain:
-              #    id: default
+              id: my_project_id
+
+          # Alternately
+
+          # project:
+          #     name: my_project_name
+          #     domain:
+          #         id: default
 
       # Password is the only auth method supported right now
       user:
           password: my_password
           name: datadog
-          #domain:
-          #    id: default
+          domain:
+              id: default
 
       # IDs of Nova Hypervisors to monitor
       # hypervisor_ids:

--- a/conf.d/openstack.yaml.example
+++ b/conf.d/openstack.yaml.example
@@ -62,6 +62,15 @@ init_config:
       # need to set to False when using self-signed certs
       # ssl_verify: true
 
+      #IDs of Projects (aka Tenants) to monitor
+      project_ids:
+          - 2f60042a0d464023905aaebf23a350ff
+
+      # Enable this option to list all projects (tenants) and check each one
+      # Note: this option supersedes `project_ids` above i.e. all project_ids will be monitored regardless of which
+      # ones you enumerated under `project_ids`
+      # check_all_projects: true
+
 # No need to change this. No instance-level config
 instances:
     [{}]

--- a/conf.d/openstack.yaml.example
+++ b/conf.d/openstack.yaml.example
@@ -63,8 +63,8 @@ init_config:
       # ssl_verify: true
 
       #IDs of Projects (aka Tenants) to monitor
-      project_ids:
-          - 2f60042a0d464023905aaebf23a350ff
+      # project_ids:
+      #    - 2f60042a0d464023905aaebf23a350ff
 
       # Enable this option to list all projects (tenants) and check each one
       # Note: this option supersedes `project_ids` above i.e. all project_ids will be monitored regardless of which


### PR DESCRIPTION
This PR is a rebased and updated version of @mtougeron's PR #1966 
It also incorporates a few other miscellaneous changes and fixes (apologies to reviewers for shoddy commits)

It adds the following:
- Collection of project-level metrics related to limits and quotas, courtesy @mtougeron
- Caching of host aggregates, which change infrequently, in between check runs. This allows us to query 
for `os-aggregates` only every `CACHE_TTL` seconds, rather than at the standard interval of 15s
- Proper failover of endpoints in the service catalog - we now correctly accept `internal` endpoints for 
Nova and Neutron when `public` endpoints are not present
- **IMPT - a new default** for the metric collection - local-only scoping. This is to handle the tricky case of ensuring that no two agents running in the same cluster accidentally duplicate the same metrics. This default ensures that the agent will collect metrics local to its `(physical_host, hypervisor, project)` along with guest servers contained in that scope. Any external servers / hypervisors / projects previously captured by the `check_all_*` directives will cease to be monitored. This is to ensure a manageable workload for the agent and allows it to run with fewer global permissions. The prior behavior can still be maintained by setting `local_only: false` in the `init_config` for this check.
- Also ensures that metrics from local-only servers / hypervisors as collected in the default scenario, have host-level tags propagated to them to allow for better aggregation on the backend

cc @mtougeron , let me know what you think!

