### PR TITLE
[Service Discovery] First version

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -10,7 +10,7 @@
     (C) Datadog, Inc. 2010-2014 all rights reserved
 '''
 # set up logging before importing any other components
-from config import get_version, initialize_logging # noqa
+from config import get_version, initialize_logging  # noqa
 initialize_logging('collector')
 
 # stdlib
@@ -43,6 +43,9 @@ from utils.flare import configcheck, Flare
 from utils.jmx import jmx_command
 from utils.pidfile import PidFile
 from utils.profile import AgentProfiler
+from utils.service_discovery.configcheck import sd_configcheck
+from utils.service_discovery.config_stores import get_config_store, TRACE_CONFIG
+from utils.service_discovery.sd_backend import get_sd_backend
 
 # Constants
 PID_NAME = "dd-agent"
@@ -74,6 +77,7 @@ class Agent(Daemon):
         self.collector_profile_interval = DEFAULT_COLLECTOR_PROFILE_INTERVAL
         self.check_frequency = None
         self.configs_reloaded = False
+        self.sd_backend = None
 
     def _handle_sigterm(self, signum, frame):
         """Handles SIGTERM and SIGINT, which gracefully stops the agent."""
@@ -143,6 +147,10 @@ class Agent(Daemon):
         systemStats = get_system_stats()
         emitters = self._get_emitters()
 
+        # Initialize service discovery
+        if self._agentConfig.get('service_discovery'):
+            self.sd_backend = get_sd_backend(self._agentConfig)
+
         # Load the checks.d checks
         self._checksd = load_check_directory(self._agentConfig, hostname)
 
@@ -181,8 +189,33 @@ class Agent(Daemon):
             self.collector.run(checksd=self._checksd,
                                start_event=self.start_event,
                                configs_reloaded=self.configs_reloaded)
-            if self.configs_reloaded:
-                self.configs_reloaded = False
+
+            # This flag is used to know if the check configs have been reloaded at the current
+            # run of the agent yet or not. It's used by the collector to know if it needs to
+            # look for the AgentMetrics check and pop it out.
+            # See: https://github.com/DataDog/dd-agent/blob/5.6.x/checks/collector.py#L265-L272
+            self.configs_reloaded = False
+
+            # Look for change in the config template store.
+            # The self.sd_backend.reload_check_configs flag is set
+            # to True if a config reload is needed.
+            if self._agentConfig.get('service_discovery') and self.sd_backend and \
+               not self.sd_backend.reload_check_configs:
+                try:
+                    self.sd_backend.reload_check_configs = get_config_store(
+                        self._agentConfig).crawl_config_template()
+                except Exception as e:
+                    log.warn('Something went wrong while looking for config template changes: %s' % str(e))
+
+            # Check if we should run service discovery
+            # The `reload_check_configs` flag can be set through the docker_daemon check or
+            # using ConfigStore.crawl_config_template
+            if self._agentConfig.get('service_discovery') and self.sd_backend and \
+               self.sd_backend.reload_check_configs:
+                self.reload_configs()
+                self.configs_reloaded = True
+                self.sd_backend.reload_check_configs = False
+
             if profiled:
                 if collector_profiled_runs >= self.collector_profile_interval:
                     try:
@@ -366,6 +399,19 @@ def main():
 
     elif 'configcheck' == command or 'configtest' == command:
         configcheck()
+
+        if agentConfig.get('service_discovery', False):
+            # set the TRACE_CONFIG flag to True to make load_check_directory return
+            # the source of config objects.
+            # Then call load_check_directory here and pass the result to sd_configcheck
+            # to avoid circular imports
+            agentConfig[TRACE_CONFIG] = True
+            configs = {
+                # check_name: (config_source, config)
+            }
+            print("\nLoading check configurations...\n\n")
+            configs = load_check_directory(agentConfig, hostname)
+            sd_configcheck(agentConfig, configs)
 
     elif 'jmx' == command:
         jmx_command(args[1:], agentConfig)

--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -2,7 +2,6 @@
 import os
 import re
 import requests
-import time
 import socket
 import urllib2
 from collections import defaultdict, Counter, deque
@@ -10,10 +9,10 @@ from collections import defaultdict, Counter, deque
 # project
 from checks import AgentCheck
 from config import _is_affirmative
-from utils.dockerutil import find_cgroup, find_cgroup_filename_pattern, get_client, MountException, \
-    set_docker_settings, image_tag_extractor, container_name_extractor
-from utils.kubeutil import get_kube_labels
+from utils.dockerutil import DockerUtil, MountException
+from utils.kubeutil import KubeUtil
 from utils.platform import Platform
+from utils.service_discovery.sd_backend import get_sd_backend
 
 
 EVENT_TYPE = 'docker'
@@ -97,10 +96,10 @@ DEFAULT_IMAGE_TAGS = [
 
 TAG_EXTRACTORS = {
     "docker_image": lambda c: [c["Image"]],
-    "image_name": lambda c: image_tag_extractor(c, 0),
-    "image_tag": lambda c: image_tag_extractor(c, 1),
+    "image_name": lambda c: DockerUtil.image_tag_extractor(c, 0),
+    "image_tag": lambda c: DockerUtil.image_tag_extractor(c, 1),
     "container_command": lambda c: [c["Command"]],
-    "container_name": container_name_extractor,
+    "container_name": DockerUtil.container_name_extractor,
 }
 
 CONTAINER = "container"
@@ -108,12 +107,6 @@ PERFORMANCE = "performance"
 FILTERED = "filtered"
 IMAGE = "image"
 
-
-def get_mountpoints(docker_root):
-    mountpoints = {}
-    for metric in CGROUP_METRICS:
-        mountpoints[metric["cgroup"]] = find_cgroup(metric["cgroup"], docker_root)
-    return mountpoints
 
 def get_filters(include, exclude):
     # The reasoning is to check exclude first, so we can skip if there is no exclude
@@ -146,27 +139,27 @@ class DockerDaemon(AgentCheck):
 
         self.init_success = False
         self.init()
+        self._service_discovery = agentConfig.get('service_discovery') and \
+            agentConfig.get('service_discovery_backend') == 'docker'
 
     def is_k8s(self):
-        return self.is_check_enabled("kubernetes")
+        return 'KUBERNETES_PORT' in os.environ
 
     def init(self):
         try:
+            instance = self.instances[0]
+
             # We configure the check with the right cgroup settings for this host
             # Just needs to be done once
-            instance = self.instances[0]
-            set_docker_settings(self.init_config, instance)
-
-            self.client = get_client()
-            self._docker_root = self.init_config.get('docker_root', '/')
-            self._mountpoints = get_mountpoints(self._docker_root)
+            self.docker_util = DockerUtil()
+            self.docker_client = self.docker_util.client
+            if self.is_k8s():
+                self.kubeutil = KubeUtil()
+            self._mountpoints = self.docker_util.get_mountpoints(CGROUP_METRICS)
             self.cgroup_listing_retries = 0
             self._latest_size_query = 0
             self._filtered_containers = set()
             self._disable_net_metrics = False
-
-            # At first run we'll just collect the events from the latest 60 secs
-            self._last_event_collection_ts = int(time.time()) - 60
 
             # Set tagging options
             self.custom_tags = instance.get("tags", [])
@@ -180,7 +173,6 @@ class DockerDaemon(AgentCheck):
                 CONTAINER: instance.get("container_tags", DEFAULT_CONTAINER_TAGS),
                 PERFORMANCE: performance_tags,
                 IMAGE: instance.get('image_tags', DEFAULT_IMAGE_TAGS)
-
             }
 
             # Set filtering settings
@@ -194,7 +186,6 @@ class DockerDaemon(AgentCheck):
                 exclude = instance.get("exclude", [])
                 self._exclude_patterns, self._include_patterns, _filtered_tag_names = get_filters(include, exclude)
                 self.tag_names[FILTERED] = _filtered_tag_names
-
 
             # Other options
             self.collect_image_stats = _is_affirmative(instance.get('collect_images_stats', False))
@@ -231,7 +222,7 @@ class DockerDaemon(AgentCheck):
 
         if self.is_k8s():
             try:
-                self.kube_labels = get_kube_labels()
+                self.kube_labels = self.kubeutil.get_kube_labels()
             except Exception as e:
                 self.log.warning('Could not retrieve kubernetes labels: %s' % str(e))
                 self.kube_labels = {}
@@ -240,15 +231,15 @@ class DockerDaemon(AgentCheck):
         containers_by_id = self._get_and_count_containers()
         containers_by_id = self._crawl_container_pids(containers_by_id)
 
+        # Send events from Docker API
+        if self.collect_events or self._service_discovery:
+            self._process_events(containers_by_id)
+
         # Report performance container metrics (cpu, mem, net, io)
         self._report_performance_metrics(containers_by_id)
 
         if self.collect_container_size:
             self._report_container_size(containers_by_id)
-
-        # Send events from Docker API
-        if self.collect_events:
-            self._process_events(containers_by_id)
 
         # Collect disk stats from Docker info command
         if self.collect_disk_stats:
@@ -257,9 +248,9 @@ class DockerDaemon(AgentCheck):
     def _count_and_weigh_images(self):
         try:
             tags = self._get_tags()
-            active_images = self.client.images(all=False)
+            active_images = self.docker_client.images(all=False)
             active_images_len = len(active_images)
-            all_images_len = len(self.client.images(quiet=True, all=True))
+            all_images_len = len(self.docker_client.images(quiet=True, all=True))
             self.gauge("docker.images.available", active_images_len, tags=tags)
             self.gauge("docker.images.intermediate", (all_images_len - active_images_len), tags=tags)
 
@@ -281,7 +272,7 @@ class DockerDaemon(AgentCheck):
         all_containers_count = Counter()
 
         try:
-            containers = self.client.containers(all=True, size=must_query_size)
+            containers = self.docker_client.containers(all=True, size=must_query_size)
         except Exception, e:
             message = "Unable to list Docker containers: {0}".format(e)
             self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
@@ -297,7 +288,7 @@ class DockerDaemon(AgentCheck):
         containers_by_id = {}
 
         for container in containers:
-            container_name = container_name_extractor(container)[0]
+            container_name = DockerUtil.container_name_extractor(container)[0]
 
             container_status_tags = self._get_tags(container, CONTAINER)
 
@@ -387,7 +378,6 @@ class DockerDaemon(AgentCheck):
                 if kube_tags:
                     tags.extend(list(kube_tags))
 
-
         return tags
 
     def _extract_tag_value(self, entity, tag_name):
@@ -408,7 +398,7 @@ class DockerDaemon(AgentCheck):
         return entity["_tag_values"][tag_name]
 
     def refresh_ecs_tags(self):
-        ecs_config = self.client.inspect_container('ecs-agent')
+        ecs_config = self.docker_client.inspect_container('ecs-agent')
         ip = ecs_config.get('NetworkSettings', {}).get('IPAddress')
         ports = ecs_config.get('NetworkSettings', {}).get('Ports')
         port = ports.keys()[0].split('/')[0] if ports else None
@@ -430,7 +420,7 @@ class DockerDaemon(AgentCheck):
         for container in containers:
             container_tags = self._get_tags(container, FILTERED)
             if self._are_tags_filtered(container_tags):
-                container_name = container_name_extractor(container)[0]
+                container_name = DockerUtil.container_name_extractor(container)[0]
                 self._filtered_containers.add(container_name)
                 self.log.debug("Container {0} is filtered".format(container["Names"][0]))
 
@@ -454,7 +444,7 @@ class DockerDaemon(AgentCheck):
 
         Requires _filter_containers to run first.
         """
-        container_name = container_name_extractor(container)[0]
+        container_name = DockerUtil.container_name_extractor(container)[0]
         return container_name in self._filtered_containers
 
     def _report_container_size(self, containers_by_id):
@@ -493,7 +483,7 @@ class DockerDaemon(AgentCheck):
             tags = self._get_tags(container, PERFORMANCE)
             self._report_cgroup_metrics(container, tags)
             if "_proc_root" not in container:
-                containers_without_proc_root.append(container_name_extractor(container)[0])
+                containers_without_proc_root.append(DockerUtil.container_name_extractor(container)[0])
                 continue
             self._report_net_metrics(container, tags)
 
@@ -505,7 +495,6 @@ class DockerDaemon(AgentCheck):
             else:
                 # On kubernetes, this is kind of expected. Network metrics will be collected by the kubernetes integration anyway
                 self.log.debug(message)
-
 
     def _report_cgroup_metrics(self, container, tags):
         try:
@@ -567,6 +556,10 @@ class DockerDaemon(AgentCheck):
             self.warning("Failed to report IO metrics from file {0}. Exception: {1}".format(proc_net_file, e))
 
     def _process_events(self, containers_by_id):
+        if self.collect_events is False:
+            # Crawl events for service discovery only
+            self._get_events()
+            return
         try:
             api_events = self._get_events()
             aggregated_events = self._pre_aggregate_events(api_events, containers_by_id)
@@ -576,7 +569,7 @@ class DockerDaemon(AgentCheck):
             return
         except Exception, e:
             self.warning("Unexpected exception when collecting events: {0}. "
-                "Events will be missing".format(e))
+                         "Events will be missing".format(e))
             return
 
         for ev in events:
@@ -585,14 +578,9 @@ class DockerDaemon(AgentCheck):
 
     def _get_events(self):
         """Get the list of events."""
-        now = int(time.time())
-        events = []
-        event_generator = self.client.events(since=self._last_event_collection_ts,
-            until=now, decode=True)
-        for event in event_generator:
-            if event != '':
-                events.append(event)
-        self._last_event_collection_ts = now
+        events, should_reload_conf = self.docker_util.get_events()
+        if should_reload_conf and self._service_discovery:
+            get_sd_backend(self.agentConfig).reload_check_configs = True
         return events
 
     def _pre_aggregate_events(self, api_events, containers_by_id):
@@ -623,7 +611,7 @@ class DockerDaemon(AgentCheck):
                 container_name = event['id'][:11]
                 if event['id'] in containers_by_id:
                     cont = containers_by_id[event['id']]
-                    container_name = container_name_extractor(cont)[0]
+                    container_name = DockerUtil.container_name_extractor(cont)[0]
                     container_tags.update(self._get_tags(cont, PERFORMANCE))
                     container_tags.add('container_name:%s' % container_name)
 
@@ -663,7 +651,7 @@ class DockerDaemon(AgentCheck):
             'total': None,
             'free': None
         }
-        info = self.client.info()
+        info = self.docker_client.info()
         driver_status = info.get('DriverStatus', [])
         for metric in driver_status:
             if metric[0] == 'Data Space Used':
@@ -702,7 +690,7 @@ class DockerDaemon(AgentCheck):
             "file": filename,
         }
 
-        return find_cgroup_filename_pattern(self._mountpoints, container_id) % (params)
+        return DockerUtil.find_cgroup_filename_pattern(self._mountpoints, container_id) % (params)
 
     def _parse_cgroup_file(self, stat_file):
         """Parse a cgroup pseudo file for key/values."""
@@ -733,7 +721,7 @@ class DockerDaemon(AgentCheck):
     # proc files
     def _crawl_container_pids(self, container_dict):
         """Crawl `/proc` to find container PIDs and add them to `containers_by_id`."""
-        proc_path = os.path.join(self._docker_root, 'proc')
+        proc_path = os.path.join(self.docker_util._docker_root, 'proc')
         pid_dirs = [_dir for _dir in os.listdir(proc_path) if _dir.isdigit()]
 
         if len(pid_dirs) == 0:

--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -2,11 +2,11 @@
 Collects metrics from cAdvisor instance
 """
 # stdlib
-import numbers
+from collections import defaultdict
 from fnmatch import fnmatch
+import numbers
 import re
 import simplejson as json
-from collections import defaultdict
 
 # 3rd party
 import requests
@@ -14,8 +14,8 @@ import requests
 # project
 from checks import AgentCheck
 from config import _is_affirmative
-from utils.kubeutil import set_kube_settings, get_kube_settings, extract_kube_labels
 from utils.http import retrieve_json
+from utils.kubeutil import KubeUtil
 
 NAMESPACE = "kubernetes"
 DEFAULT_MAX_DEPTH = 10
@@ -52,7 +52,7 @@ class Kubernetes(AgentCheck):
         if instances is not None and len(instances) > 1:
             raise Exception('Kubernetes check only supports one configured instance.')
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
-        self.kube_settings = set_kube_settings(instances[0])
+        self.kubeutil = KubeUtil()
 
     def _perform_kubelet_checks(self, url):
         service_check_base = NAMESPACE + '.kubelet.check'
@@ -80,7 +80,7 @@ class Kubernetes(AgentCheck):
         except Exception, e:
             self.log.warning('kubelet check failed: %s' % str(e))
             self.service_check(service_check_base, AgentCheck.CRITICAL,
-                message='Kubelet check failed: %s' % str(e))
+                               message='Kubelet check failed: %s' % str(e))
 
         else:
             if is_ok:
@@ -100,7 +100,7 @@ class Kubernetes(AgentCheck):
                 tags = ["minion_name:{0}".format(minion_name)]
                 if cond != 'Ready':
                     self.service_check(service_check_name, AgentCheck.CRITICAL,
-                        tags=tags, message=cond)
+                                       tags=tags, message=cond)
                 else:
                     self.service_check(service_check_name, AgentCheck.OK, tags=tags)
         except Exception, e:
@@ -109,8 +109,7 @@ class Kubernetes(AgentCheck):
             raise
 
     def check(self, instance):
-        kube_settings = get_kube_settings()
-        if not kube_settings.get("host"):
+        if not self.kubeutil.host:
             raise Exception('Unable to get default router and host parameter is not set')
 
         self.max_depth = instance.get('max_depth', DEFAULT_MAX_DEPTH)
@@ -126,16 +125,14 @@ class Kubernetes(AgentCheck):
 
         # master health checks
         if instance.get('enable_master_checks', False):
-            master_url = kube_settings["master_url_nodes"]
-            self._perform_master_checks(master_url)
+            self._perform_master_checks(self.kubeutil.master_url_nodes)
 
         # kubelet health checks
         if instance.get('enable_kubelet_checks', True):
-            kube_health_url = kube_settings["kube_health_url"]
-            self._perform_kubelet_checks(kube_health_url)
+            self._perform_kubelet_checks(self.kubeutil.kube_health_url)
 
         # kubelet metrics
-        self._update_metrics(instance, kube_settings)
+        self._update_metrics(instance)
 
     def _publish_raw_metrics(self, metric, dat, tags, depth=0):
         if depth >= self.max_depth:
@@ -149,7 +146,7 @@ class Kubernetes(AgentCheck):
                 self.publish_gauge(self, metric, float(dat), tags)
 
         elif isinstance(dat, dict):
-            for k,v in dat.iteritems():
+            for k, v in dat.iteritems():
                 self._publish_raw_metrics(metric + '.%s' % k.lower(), v, tags, depth + 1)
 
         elif isinstance(dat, list):
@@ -161,7 +158,7 @@ class Kubernetes(AgentCheck):
         return re.sub('([0-9a-fA-F]{64,})', lambda x: x.group(1)[0:12], name)
 
     def _update_container_metrics(self, instance, subcontainer, kube_labels):
-        tags = instance.get('tags', []) # add support for custom tags
+        tags = instance.get('tags', [])  # add support for custom tags
 
         if len(subcontainer.get('aliases', [])) >= 1:
             # The first alias seems to always match the docker container name
@@ -174,7 +171,7 @@ class Kubernetes(AgentCheck):
 
         pod_name_set = False
         try:
-            for label_name,label in subcontainer['spec']['labels'].iteritems():
+            for label_name, label in subcontainer['spec']['labels'].iteritems():
                 label_name = label_name.replace('io.kubernetes.pod.name', 'pod_name')
                 if label_name == "pod_name":
                     pod_name_set = True
@@ -219,14 +216,10 @@ class Kubernetes(AgentCheck):
     def _retrieve_metrics(self, url):
         return retrieve_json(url)
 
-    def _retrieve_pods_list(self):
-        kube_settings = get_kube_settings()
-        return retrieve_json(kube_settings["pods_list_url"])
-
-    def _update_metrics(self, instance, kube_settings):
-        pods_list = self._retrieve_pods_list()
-        metrics = self._retrieve_metrics(kube_settings["metrics_url"])
-        kube_labels = extract_kube_labels(pods_list)
+    def _update_metrics(self, instance):
+        pods_list = self.kubeutil.retrieve_pods_list()
+        metrics = self._retrieve_metrics(self.kubeutil.metrics_url)
+        kube_labels = self.kubeutil.extract_kube_labels(pods_list)
 
         if not metrics:
             raise Exception('No metrics retrieved cmd=%s' % self.metrics_cmd)

--- a/checks.d/ntp.py
+++ b/checks.d/ntp.py
@@ -1,9 +1,9 @@
-# 3p
+# std
 import ntplib
 
 # project
 from checks import AgentCheck
-from utils.ntp import get_ntp_args, set_user_ntp_settings
+from utils.ntp import NTPUtil
 
 DEFAULT_OFFSET_THRESHOLD = 60  # in seconds
 
@@ -20,9 +20,7 @@ class NtpCheck(AgentCheck):
         except (TypeError, ValueError):
             raise Exception('Must specify an integer value for offset_threshold. Configured value is %s' % repr(offset_threshold))
 
-        set_user_ntp_settings(dict(instance))
-
-        req_args = get_ntp_args()
+        req_args = NTPUtil().args
 
         self.log.debug("Using ntp host: {0}".format(req_args['host']))
 

--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -22,7 +22,7 @@ import config
 from config import _is_affirmative, _windows_commondata_path, get_config
 from util import plural
 from utils.jmx import JMXFiles
-from utils.ntp import get_ntp_args, set_user_ntp_settings
+from utils.ntp import NTPUtil
 from utils.pidfile import PidFile
 from utils.platform import Platform
 from utils.profile import pretty_statistics
@@ -103,8 +103,7 @@ def logger_info():
 
 
 def get_ntp_info():
-    set_user_ntp_settings()
-    req_args = get_ntp_args()
+    req_args = NTPUtil().args
     ntp_offset = ntplib.NTPClient().request(**req_args).offset
     if abs(ntp_offset) > NTP_OFFSET_THRESHOLD:
         ntp_styles = ['red', 'bold']
@@ -165,7 +164,7 @@ class AgentStatus(object):
         # Don't indent the header
         lines = self._title_lines()
         if self.created_seconds_ago() > 120:
-            styles = ['red','bold']
+            styles = ['red', 'bold']
         else:
             styles = []
         # We color it in red if the status is too old
@@ -212,7 +211,6 @@ class AgentStatus(object):
             ""
         ]
         return "\n".join(lines)
-
 
     @classmethod
     def remove_latest_status(cls):
@@ -371,7 +369,7 @@ class CollectorStatus(AgentStatus):
         if cs.init_failed_error:
             check_lines.append("    - initialize check class [%s]: %s" %
                                (style(STATUS_ERROR, 'red'),
-                               repr(cs.init_failed_error)))
+                                repr(cs.init_failed_error)))
             if cs.init_failed_traceback:
                 check_lines.extend('      ' + line for line in
                                    cs.init_failed_traceback.split('\n'))
@@ -399,12 +397,12 @@ class CollectorStatus(AgentStatus):
                         if not len(warn):
                             continue
                         check_lines.append(u"        %s: %s" %
-                            (style("Warning", 'yellow'), warn[0]))
+                                           (style("Warning", 'yellow'), warn[0]))
                         check_lines.extend(u"        %s" % l for l in
-                                    warn[1:])
+                                           warn[1:])
                 if s.traceback is not None:
                     check_lines.extend('      ' + line for line in
-                                   s.traceback.split('\n'))
+                                       s.traceback.split('\n'))
 
             check_lines += [
                 "    - Collected %s metric%s, %s event%s & %s service check%s" % (
@@ -516,7 +514,7 @@ class CollectorStatus(AgentStatus):
                 if cs.init_failed_error:
                     check_lines.append("    - initialize check class [%s]: %s" %
                                        (style(STATUS_ERROR, 'red'),
-                                       repr(cs.init_failed_error)))
+                                        repr(cs.init_failed_error)))
                     if self.verbose and cs.init_failed_traceback:
                         check_lines.extend('      ' + line for line in
                                            cs.init_failed_traceback.split('\n'))
@@ -544,12 +542,12 @@ class CollectorStatus(AgentStatus):
                                 if not len(warn):
                                     continue
                                 check_lines.append(u"        %s: %s" %
-                                    (style("Warning", 'yellow'), warn[0]))
+                                                   (style("Warning", 'yellow'), warn[0]))
                                 check_lines.extend(u"        %s" % l for l in
-                                            warn[1:])
+                                                   warn[1:])
                         if self.verbose and s.traceback is not None:
                             check_lines.extend('      ' + line for line in
-                                           s.traceback.split('\n'))
+                                               s.traceback.split('\n'))
 
                     check_lines += [
                         "    - Collected %s metric%s, %s event%s & %s service check%s" % (
@@ -718,7 +716,7 @@ class DogstatsdStatus(AgentStatus):
     NAME = 'Dogstatsd'
 
     def __init__(self, flush_count=0, packet_count=0, packets_per_second=0,
-            metric_count=0, event_count=0, service_check_count=0):
+                 metric_count=0, event_count=0, service_check_count=0):
         AgentStatus.__init__(self)
         self.flush_count = flush_count
         self.packet_count = packet_count
@@ -759,7 +757,7 @@ class ForwarderStatus(AgentStatus):
     NAME = 'Forwarder'
 
     def __init__(self, queue_length=0, queue_size=0, flush_count=0, transactions_received=0,
-            transactions_flushed=0):
+                 transactions_flushed=0):
         AgentStatus.__init__(self)
         self.queue_length = queue_length
         self.queue_size = queue_size
@@ -873,7 +871,7 @@ def get_jmx_status():
         if os.path.exists(java_status_path):
             java_jmx_stats = yaml.load(file(java_status_path))
 
-            status_age = time.time() - java_jmx_stats.get('timestamp')/1000 # JMX timestamp is saved in milliseconds
+            status_age = time.time() - java_jmx_stats.get('timestamp')/1000  # JMX timestamp is saved in milliseconds
             jmx_checks = java_jmx_stats.get('checks', {})
 
             if status_age > 60:
@@ -920,7 +918,6 @@ def get_jmx_status():
             jmx_checks = python_jmx_stats.get('invalid_checks', {})
             for check_name, excep in jmx_checks.iteritems():
                 check_statuses.append(CheckStatus(check_name, [], init_failed_error=excep))
-
 
         return check_statuses
 

--- a/conf.d/auto_conf/apache.yaml
+++ b/conf.d/auto_conf/apache.yaml
@@ -1,0 +1,7 @@
+docker_images:
+  - httpd
+
+init_config:
+
+instances:
+  - apache_status_url: http://%%host%%/server-status?auto

--- a/conf.d/auto_conf/consul.yaml
+++ b/conf.d/auto_conf/consul.yaml
@@ -1,0 +1,10 @@
+docker_images:
+  - consul
+
+init_config:
+
+instances:
+  - url: "http://%%host%%:%%port%%"
+    catalog_checks: yes
+    new_leader_checks: yes
+    # service_whitelist:

--- a/conf.d/auto_conf/couch.yaml
+++ b/conf.d/auto_conf/couch.yaml
@@ -1,0 +1,7 @@
+docker_images:
+  - couchdb
+
+init_config:
+
+instances:
+  - server: http://%%host%%:%%port%%

--- a/conf.d/auto_conf/couchbase.yaml
+++ b/conf.d/auto_conf/couchbase.yaml
@@ -1,0 +1,9 @@
+docker_images:
+  - couchbase
+
+init_config:
+
+instances:
+  - server: http://%%host%%:%%port%%
+    user: Administrator
+    password: password

--- a/conf.d/auto_conf/elastic.yaml
+++ b/conf.d/auto_conf/elastic.yaml
@@ -1,0 +1,7 @@
+docker_images:
+  - elasticsearch
+
+init_config:
+
+instances:
+  - url: "http://%%host%%:%%port%%"

--- a/conf.d/auto_conf/etcd.yaml
+++ b/conf.d/auto_conf/etcd.yaml
@@ -1,0 +1,7 @@
+docker_images:
+  - etcd
+
+init_config:
+
+instances:
+  - url: "http://%%host%%:%%port_0%%"

--- a/conf.d/auto_conf/kyototycoon.yaml
+++ b/conf.d/auto_conf/kyototycoon.yaml
@@ -1,0 +1,7 @@
+docker_images:
+  - kyototycoon
+
+init_config:
+
+instances:
+  - report_url: http://%%host%%:%%port%%/rpc/report

--- a/conf.d/auto_conf/mcache.yaml
+++ b/conf.d/auto_conf/mcache.yaml
@@ -1,0 +1,8 @@
+docker_images:
+  - memcached
+
+init_config:
+
+instances:
+  - url: "%%host%%"
+    port: "%%port%%"

--- a/conf.d/auto_conf/redisdb.yaml
+++ b/conf.d/auto_conf/redisdb.yaml
@@ -1,0 +1,8 @@
+docker_images:
+  - redis
+
+init_config:
+
+instances:
+  - host: "%%host%%"
+    port: "%%port%%"

--- a/conf.d/auto_conf/riak.yaml
+++ b/conf.d/auto_conf/riak.yaml
@@ -1,0 +1,7 @@
+docker_images:
+  - riak
+
+init_config:
+
+instances:
+  - url: http://%%host%%:%%port%%/stats

--- a/config.py
+++ b/config.py
@@ -18,18 +18,17 @@ import sys
 import traceback
 from urlparse import urlparse
 
-# 3p
-import yaml
-
 # project
-from util import get_os, yLoader
+from util import check_yaml, get_os
 from utils.platform import Platform
 from utils.proxy import get_proxy
+from utils.service_discovery.config import extract_agent_config
+from utils.service_discovery.config_stores import CONFIG_FROM_FILE, TRACE_CONFIG
+from utils.service_discovery.sd_backend import get_sd_backend, AUTO_CONFIG_DIR, SD_BACKENDS
 from utils.subprocess_output import (
     get_subprocess_output,
     SubprocessOutputEmptyError,
 )
-
 
 # CONSTANTS
 AGENT_VERSION = "5.8.0"
@@ -43,7 +42,7 @@ log = logging.getLogger(__name__)
 
 OLD_STYLE_PARAMETERS = [
     ('apache_status_url', "apache"),
-    ('cacti_mysql_server' , "cacti"),
+    ('cacti_mysql_server', "cacti"),
     ('couchdb_server', "couchdb"),
     ('elasticsearch', "elasticsearch"),
     ('haproxy_url', "haproxy"),
@@ -120,6 +119,7 @@ def get_url_endpoint(default_url, endpoint_type='app'):
             get_version().replace(".", "-"),
             endpoint_type))
 
+
 def skip_leading_wsp(f):
     "Works on a file, returns a file-like object"
     return StringIO("\n".join(map(string.strip, f.readlines())))
@@ -137,9 +137,9 @@ def _windows_commondata_path():
 
     _SHGetFolderPath = windll.shell32.SHGetFolderPathW
     _SHGetFolderPath.argtypes = [wintypes.HWND,
-                                ctypes.c_int,
-                                wintypes.HANDLE,
-                                wintypes.DWORD, wintypes.LPCWSTR]
+                                 ctypes.c_int,
+                                 wintypes.HANDLE,
+                                 wintypes.DWORD, wintypes.LPCWSTR]
 
     path_buf = wintypes.create_unicode_buffer(wintypes.MAX_PATH)
     _SHGetFolderPath(0, CSIDL_COMMON_APPDATA, 0, 0, path_buf)
@@ -252,7 +252,8 @@ def get_config_path(cfg_path=None, os_name=None):
             bad_path = e.args[0]
 
     # If all searches fail, exit the agent with an error
-    sys.stderr.write("Please supply a configuration file at %s or in the directory where the Agent is currently deployed.\n" % bad_path)
+    sys.stderr.write("Please supply a configuration file at %s or in the directory where "
+                     "the Agent is currently deployed.\n" % bad_path)
     sys.exit(3)
 
 
@@ -287,6 +288,7 @@ def get_histogram_aggregates(configstr=None):
 
     return result
 
+
 def get_histogram_percentiles(configstr=None):
     if configstr is None:
         return None
@@ -302,16 +304,17 @@ def get_histogram_percentiles(configstr=None):
                     raise ValueError
                 if len(val) > 4:
                     log.warning("Histogram percentiles are rounded to 2 digits: {0} rounded"
-                        .format(floatval))
+                                .format(floatval))
                 result.append(float(val[0:4]))
             except ValueError:
                 log.warning("Bad histogram percentile value {0}, must be float in ]0;1[, skipping"
-                    .format(val))
+                            .format(val))
     except Exception:
         log.exception("Error when parsing histogram percentiles, skipping")
         return None
 
     return result
+
 
 def get_config(parse_args=True, cfg_path=None, options=None):
     if parse_args:
@@ -392,6 +395,15 @@ def get_config(parse_args=True, cfg_path=None, options=None):
             agentConfig['use_dogstatsd'] = config.get('Main', 'use_dogstatsd').lower() in ("yes", "true")
         else:
             agentConfig['use_dogstatsd'] = True
+
+        # Service discovery
+        if config.has_option('Main', 'service_discovery_backend'):
+            try:
+                additional_config = extract_agent_config(config)
+                agentConfig.update(additional_config)
+            except:
+                log.error('Failed to load the agent configuration related to '
+                          'service discovery. It will not be used.')
 
         # Concerns only Windows
         if config.has_option('Main', 'use_web_info_page'):
@@ -618,7 +630,7 @@ def set_win32_cert_path():
     else:
         cur_path = os.path.dirname(__file__)
         crt_path = os.path.join(cur_path, 'packaging', 'datadog-agent', 'win32',
-                'install_files', 'ca-certificates.crt')
+                                'install_files', 'ca-certificates.crt')
     import tornado.simple_httpclient
     log.info("Windows certificate path: %s" % crt_path)
     tornado.simple_httpclient._DEFAULT_CA_CERTS = crt_path
@@ -678,6 +690,11 @@ def get_checksd_path(osname=None):
         return _unix_checksd_path()
 
 
+def get_auto_confd_path(osname=None):
+    """Used for service discovery which only works for Unix"""
+    return os.path.join(get_confd_path(osname), AUTO_CONFIG_DIR)
+
+
 def get_win32service_file(osname, filename):
     # This file is needed to log in the event viewer for windows
     if osname == 'windows':
@@ -720,67 +737,101 @@ def get_ssl_certificate(osname, filename):
         if os.path.exists(path):
             return path
 
-
     log.info("Certificate file NOT found at %s" % str(path))
     return None
 
-def check_yaml(conf_path):
-    with open(conf_path) as f:
-        check_config = yaml.load(f.read(), Loader=yLoader)
-        assert 'init_config' in check_config, "No 'init_config' section found"
-        assert 'instances' in check_config, "No 'instances' section found"
 
-        valid_instances = True
-        if check_config['instances'] is None or not isinstance(check_config['instances'], list):
-            valid_instances = False
-        else:
-            for i in check_config['instances']:
-                if not isinstance(i, dict):
-                    valid_instances = False
-                    break
-        if not valid_instances:
-            raise Exception('You need to have at least one instance defined in the YAML file for this check')
-        else:
-            return check_config
+def get_checks_paths(agentConfig, osname):
+    # this can happen if check.d is not found
+    '''Return the checks paths or None if che
+    log.error'Checks directory not found, exiting.')cks.d is not found.'''
+    checks_paths = [glob.glob(os.path.join(agentConfig['additional_checksd'], '*.py'))]
+    try:
+        checksd_path = get_checksd_path(osname)
+        checks_paths.append(glob.glob(os.path.join(checksd_path, '*.py')))
+    except PathNotFound, e:
+        log.error(e.args[0])
+        return None
+    return checks_paths
+
+
+def get_check_class(check_name, check, init_failed_checks={}):
+    '''Return the corresponding check class for a check name if available.'''
+    from checks import AgentCheck
+    check_class = None
+    try:
+        check_module = imp.load_source('checksd_%s' % check_name, check)
+    except Exception, e:
+        traceback_message = traceback.format_exc()
+        # There is a configuration file for that check but the module can't be imported
+        log.exception('Unable to import check module %s.py from checks.d' % check_name)
+        return {'error': e, 'traceback': traceback_message}
+
+    # We make sure that there is an AgentCheck class defined
+    check_class = None
+    classes = inspect.getmembers(check_module, inspect.isclass)
+    for _, clsmember in classes:
+        if clsmember == AgentCheck:
+            continue
+        if issubclass(clsmember, AgentCheck):
+            check_class = clsmember
+            if AgentCheck in clsmember.__bases__:
+                continue
+            else:
+                break
+    return check_class
+
 
 def load_check_directory(agentConfig, hostname):
     ''' Return the initialized checks from checks.d, and a mapping of checks that failed to
     initialize. Only checks that have a configuration
     file in conf.d will be returned. '''
-    from checks import AgentCheck, AGENT_METRICS_CHECK_NAME
+
+    from checks import AGENT_METRICS_CHECK_NAME
 
     initialized_checks = {}
     init_failed_checks = {}
     deprecated_checks = {}
     agentConfig['checksd_hostname'] = hostname
 
-    deprecated_configs_enabled = [v for k,v in OLD_STYLE_PARAMETERS if len([l for l in agentConfig if l.startswith(k)]) > 0]
+    # the TRACE_CONFIG flag is used by the configcheck to trace config object loading and
+    # where they come from (service discovery, auto configuration or configuration file).
+    if agentConfig.get(TRACE_CONFIG):
+        configs_and_sources = {
+            # check_name: (config_source, config)
+        }
+    deprecated_configs_enabled = [v for k, v in OLD_STYLE_PARAMETERS if len([l for l in agentConfig if l.startswith(k)]) > 0]
     for deprecated_config in deprecated_configs_enabled:
         msg = "Configuring %s in datadog.conf is not supported anymore. Please use conf.d" % deprecated_config
         deprecated_checks[deprecated_config] = {'error': msg, 'traceback': None}
         log.error(msg)
 
     osname = get_os()
-    checks_paths = [glob.glob(os.path.join(agentConfig['additional_checksd'], '*.py'))]
-
-    try:
-        checksd_path = get_checksd_path(osname)
-        checks_paths.append(glob.glob(os.path.join(checksd_path, '*.py')))
-    except PathNotFound, e:
-        log.error(e.args[0])
+    checks_paths = get_checks_paths(agentConfig, osname)
+    # this can happen if check.d is not found
+    if checks_paths is None:
+        log.error('Check directory not found, exiting. The agent is likely misconfigured.')
         sys.exit(3)
 
     try:
         confd_path = get_confd_path(osname)
     except PathNotFound, e:
-        log.error("No conf.d folder found at '%s' or in the directory where the Agent is currently deployed.\n" % e.args[0])
+        log.error("No conf.d folder found at '%s' or in the directory where "
+                  "the Agent is currently deployed.\n" % e.args[0])
         sys.exit(3)
+
+    if agentConfig.get('service_discovery') and agentConfig.get('service_discovery_backend') in SD_BACKENDS:
+        sd_backend = get_sd_backend(agentConfig=agentConfig)
+        service_disco_configs = sd_backend.get_configs()
+    else:
+        service_disco_configs = {}
 
     # We don't support old style configs anymore
     # So we iterate over the files in the checks.d directory
     # If there is a matching configuration file in the conf.d directory
     # then we import the check
     for check in itertools.chain(*checks_paths):
+        sd_init_config, sd_instances, skip_config_lookup = None, None, False
         check_name = os.path.basename(check).split('.')[0]
         check_config = None
         if check_name in initialized_checks or check_name in init_failed_checks:
@@ -794,67 +845,73 @@ def load_check_directory(agentConfig, hostname):
         if os.path.exists(conf_path):
             conf_exists = True
         else:
-            log.debug("No configuration file for %s. Looking for defaults" % check_name)
+            log.debug("No configuration file for %s. Looking for auto config or defaults" % check_name)
 
             # Default checks read their config from the "[CHECKNAME].yaml.default" file
             default_conf_path = os.path.join(confd_path, '%s.yaml.default' % check_name)
             if not os.path.exists(default_conf_path):
-                log.debug("Default configuration file {0} is missing. Skipping check".format(default_conf_path))
-                continue
-            conf_path = default_conf_path
-            conf_exists = True
-
-        if conf_exists:
-            try:
-                check_config = check_yaml(conf_path)
-            except Exception, e:
-                log.exception("Unable to parse yaml config in %s" % conf_path)
-                traceback_message = traceback.format_exc()
-                init_failed_checks[check_name] = {'error': str(e), 'traceback': traceback_message}
-                continue
-        else:
-            # Compatibility code for the Nagios checks if it's still configured
-            # in datadog.conf
-            # FIXME: 6.x, should be removed
-            if check_name == 'nagios':
-                if any([nagios_key in agentConfig for nagios_key in NAGIOS_OLD_CONF_KEYS]):
-                    log.warning("Configuring Nagios in datadog.conf is deprecated "
-                                "and will be removed in a future version. "
-                                "Please use conf.d")
-                    check_config = {'instances':[dict((key, agentConfig[key]) for key in agentConfig if key in NAGIOS_OLD_CONF_KEYS)]}
+                if check_name not in service_disco_configs:
+                    log.debug("Default configuration file {0} is missing. "
+                              "Skipping check".format(default_conf_path))
+                    continue
                 else:
+                    # flag set by the configcheck command to track where all configs come from
+                    # if it's set, service_disco_configs will look like:
+                    # 'check_name': (config_src, (sd_init_config, sd_instances)) instead
+                    if agentConfig.get(TRACE_CONFIG):
+                        sd_init_config, sd_instances = service_disco_configs[check_name][1]
+                        configs_and_sources[check_name] = (
+                            service_disco_configs[check_name][0],
+                            {'init_config': sd_init_config, 'instances': sd_instances})
+                    else:
+                        sd_init_config, sd_instances = service_disco_configs[check_name]
+                    check_config = {'init_config': sd_init_config, 'instances': sd_instances}
+                    skip_config_lookup = True
+
+            else:
+                conf_path = default_conf_path
+                conf_exists = True
+
+        if not skip_config_lookup:
+            if conf_exists:
+                try:
+                    check_config = check_yaml(conf_path)
+                    if agentConfig.get(TRACE_CONFIG):
+                        configs_and_sources[check_name] = (CONFIG_FROM_FILE, check_config)
+                except Exception, e:
+                    log.exception("Unable to parse yaml config in %s" % conf_path)
+                    traceback_message = traceback.format_exc()
+                    init_failed_checks[check_name] = {'error': str(e), 'traceback': traceback_message}
                     continue
             else:
-                log.debug("No configuration file for %s" % check_name)
-                continue
+                # Compatibility code for the Nagios checks if it's still configured
+                # in datadog.conf
+                # FIXME: 6.x, should be removed
+                if check_name == 'nagios':
+                    if any([nagios_key in agentConfig for nagios_key in NAGIOS_OLD_CONF_KEYS]):
+                        log.warning("Configuring Nagios in datadog.conf is deprecated "
+                                    "and will be removed in a future version. "
+                                    "Please use conf.d")
+                        check_config = {'instances': [dict((key, agentConfig[key]) for key in agentConfig if key in NAGIOS_OLD_CONF_KEYS)]}
+                        if agentConfig.get(TRACE_CONFIG):
+                            configs_and_sources[check_name] = (CONFIG_FROM_FILE, check_config)
+                    else:
+                        continue
+                else:
+                    log.debug("No configuration file for %s" % check_name)
+                    continue
 
         # If we are here, there is a valid matching configuration file.
         # Let's try to import the check
-        try:
-            check_module = imp.load_source('checksd_%s' % check_name, check)
-        except Exception, e:
-            traceback_message = traceback.format_exc()
-            # There is a configuration file for that check but the module can't be imported
-            init_failed_checks[check_name] = {'error':e, 'traceback':traceback_message}
-            log.exception('Unable to import check module %s.py from checks.d' % check_name)
-            continue
-
-        # We make sure that there is an AgentCheck class defined
-        check_class = None
-        classes = inspect.getmembers(check_module, inspect.isclass)
-        for _, clsmember in classes:
-            if clsmember == AgentCheck:
-                continue
-            if issubclass(clsmember, AgentCheck):
-                check_class = clsmember
-                if AgentCheck in clsmember.__bases__:
-                    continue
-                else:
-                    break
-
+        check_class = get_check_class(check_name, check, init_failed_checks)
         if not check_class:
             log.error('No check class (inheriting from AgentCheck) found in %s.py' % check_name)
             continue
+        # this means we are actually looking at a load failure
+        elif isinstance(check_class, dict):
+            init_failed_checks[check_name] = check_class
+        else:
+            pass
 
         # Look for the per-check config, which *must* exist
         if not check_config.get('instances'):
@@ -882,7 +939,7 @@ def load_check_directory(agentConfig, hostname):
         except Exception, e:
             log.exception('Unable to initialize check %s' % check_name)
             traceback_message = traceback.format_exc()
-            init_failed_checks[check_name] = {'error':e, 'traceback':traceback_message}
+            init_failed_checks[check_name] = {'error': e, 'traceback': traceback_message}
         else:
             initialized_checks[check_name] = c
 
@@ -898,8 +955,12 @@ def load_check_directory(agentConfig, hostname):
     init_failed_checks.update(deprecated_checks)
     log.info('initialized checks.d checks: %s' % [k for k in initialized_checks.keys() if k != AGENT_METRICS_CHECK_NAME])
     log.info('initialization failed checks.d checks: %s' % init_failed_checks.keys())
-    return {'initialized_checks':initialized_checks.values(),
-            'init_failed_checks':init_failed_checks,
+
+    if agentConfig.get(TRACE_CONFIG):
+        return configs_and_sources
+
+    return {'initialized_checks': initialized_checks.values(),
+            'init_failed_checks': init_failed_checks,
             }
 
 
@@ -1001,7 +1062,6 @@ def get_logging_config(cfg_path=None):
     return logging_config
 
 
-
 def initialize_logging(logger_name):
     try:
         logging_config = get_logging_config()
@@ -1052,7 +1112,7 @@ def initialize_logging(logger_name):
         if get_os() == 'windows' and logging_config['log_to_event_viewer']:
             try:
                 from logging.handlers import NTEventLogHandler
-                nt_event_handler = NTEventLogHandler(logger_name,get_win32service_file('windows', 'win32service.pyd'), 'Application')
+                nt_event_handler = NTEventLogHandler(logger_name, get_win32service_file('windows', 'win32service.pyd'), 'Application')
                 nt_event_handler.setFormatter(logging.Formatter(get_syslog_format(logger_name), get_log_date_format()))
                 nt_event_handler.setLevel(logging.ERROR)
                 app_log = logging.getLogger(logger_name)

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -89,6 +89,30 @@ use_mount: no
 # histogram_percentiles: 0.95
 
 # ========================================================================== #
+# Service Discovery                                                          #
+# See https://github.com/DataDog/dd-agent/wiki/Service-Discovery for details #
+# ========================================================================== #
+#
+# Service discovery allows the agent to look for running services
+# and load a configuration object for the one it recognizes.
+# This feature is disabled by default.
+# Uncomment this line to enable it (works for docker containers only for now).
+# service_discovery_backend: docker
+#
+# Define which key/value store must be used to look for configuration templates.
+# Default is etcd. Consul is also supported.
+# sd_config_backend: etcd
+#
+# Settings for connecting to the service discovery backend.
+# sd_backend_host: 127.0.0.1
+# sd_backend_port: 4001
+#
+# By default, the agent will look for the configuration templates under the
+# `/datadog/check_configs` key in the back-end. If you wish otherwise, uncomment this option
+# and modify its value.
+# sd_template_dir: /datadog/check_configs
+
+# ========================================================================== #
 # DogStatsd configuration                                                    #
 # ========================================================================== #
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,3 +72,7 @@ docker-py==1.3.1
 
 # checks.d/dns_check.py
 dnspython==1.12.0
+
+# utils/service_discovery/config_stores.py
+python-etcd==0.4.2
+python-consul==0.4.7

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -2,6 +2,7 @@
 import copy
 import inspect
 from itertools import product
+import imp
 import logging
 import os
 from pprint import pformat
@@ -58,10 +59,11 @@ def load_class(check_name, class_name):
 
 def load_check(name, config, agentConfig):
     checksd_path = get_checksd_path(get_os())
-    if checksd_path not in sys.path:
-        sys.path.append(checksd_path)
 
-    check_module = __import__(name)
+    # find (in checksd_path) and load the check module
+    fd, filename, desc = imp.find_module(name, [checksd_path])
+    check_module = imp.load_module(name, fd, filename, desc)
+
     check_class = None
     classes = inspect.getmembers(check_module, inspect.isclass)
     for _, clsmember in classes:
@@ -87,6 +89,7 @@ def load_check(name, config, agentConfig):
         raise Exception("Check is using old API, {0}".format(e))
     except Exception:
         raise
+
 
 class Fixtures(object):
     @staticmethod
@@ -198,7 +201,7 @@ class AgentCheckTest(unittest.TestCase):
                 self.service_metadata.append(metadata)
 
         if error is not None:
-            raise error # pylint: disable=E0702
+            raise error  # pylint: disable=E0702
 
     def print_current_state(self):
         log.debug("""++++++++ CURRENT STATE ++++++++

--- a/tests/checks/mock/test_disk.py
+++ b/tests/checks/mock/test_disk.py
@@ -120,7 +120,7 @@ class TestCheckDisk(AgentCheckTest):
 
         self.coverage_report()
 
-    @mock.patch('disk.get_subprocess_output',
+    @mock.patch('utils.subprocess_output.get_subprocess_output',
                 return_value=(Fixtures.read_file('debian-df-Tk'), "", 0))
     @mock.patch('os.statvfs', return_value=MockInodesMetrics())
     def test_no_psutil_debian(self, mock_df_output, mock_statvfs):
@@ -136,7 +136,7 @@ class TestCheckDisk(AgentCheckTest):
 
         self.coverage_report()
 
-    @mock.patch('disk.get_subprocess_output',
+    @mock.patch('utils.subprocess_output.get_subprocess_output',
                 return_value=(Fixtures.read_file('freebsd-df-Tk'), "", 0))
     @mock.patch('os.statvfs', return_value=MockInodesMetrics())
     def test_no_psutil_freebsd(self, mock_df_output, mock_statvfs):

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -16,7 +16,7 @@ from checks import (
 from checks.collector import Collector
 from tests.checks.common import load_check
 from util import get_hostname
-from utils.ntp import get_ntp_args
+from utils.ntp import NTPUtil
 from utils.proxy import get_proxy
 
 logger = logging.getLogger()
@@ -337,6 +337,9 @@ class TestCore(unittest.TestCase):
         self.assertTrue(len(metrics) > 0, metrics)
 
     def test_ntp_global_settings(self):
+        # Clear any existing ntp config
+        NTPUtil._drop()
+
         config = {'instances': [{
             "host": "foo.com",
             "port": "bar",
@@ -349,23 +352,29 @@ class TestCore(unittest.TestCase):
             'api_key': 'toto'
         }
 
+        # load this config in the ntp singleton
+        ntp_util = NTPUtil(config)
+
         # default min collection interval for that check was 20sec
         check = load_check('ntp', config, agentConfig)
         check.run()
 
-        ntp_args = get_ntp_args()
+        self.assertEqual(ntp_util.args["host"], "foo.com")
+        self.assertEqual(ntp_util.args["port"], "bar")
+        self.assertEqual(ntp_util.args["version"], 42)
+        self.assertEqual(ntp_util.args["timeout"], 13.37)
 
-        self.assertEqual(ntp_args["host"], "foo.com")
-        self.assertEqual(ntp_args["port"], "bar")
-        self.assertEqual(ntp_args["version"], 42)
-        self.assertEqual(ntp_args["timeout"], 13.37)
+        # Clear the singleton to prepare for next config
+        NTPUtil._drop()
 
         config = {'instances': [{}], 'init_config': {}}
-
         agentConfig = {
             'version': '0.1',
             'api_key': 'toto'
         }
+
+        # load the new config
+        ntp_util = NTPUtil(config)
 
         # default min collection interval for that check was 20sec
         check = load_check('ntp', config, agentConfig)
@@ -374,13 +383,12 @@ class TestCore(unittest.TestCase):
         except Exception:
             pass
 
-        ntp_args = get_ntp_args()
+        self.assertTrue(ntp_util.args["host"].endswith("datadog.pool.ntp.org"))
+        self.assertEqual(ntp_util.args["port"], "ntp")
+        self.assertEqual(ntp_util.args["version"], 3)
+        self.assertEqual(ntp_util.args["timeout"], 1.0)
 
-        self.assertTrue(ntp_args["host"].endswith("datadog.pool.ntp.org"))
-        self.assertEqual(ntp_args["port"], "ntp")
-        self.assertEqual(ntp_args["version"], 3)
-        self.assertEqual(ntp_args["timeout"], 1.0)
-
+        NTPUtil._drop()
 
 
 class TestAggregator(unittest.TestCase):

--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -1,0 +1,320 @@
+# stdlib
+import copy
+import mock
+import unittest
+
+# project
+from utils.service_discovery.config_stores import get_config_store
+from utils.service_discovery.consul_config_store import ConsulStore
+from utils.service_discovery.etcd_config_store import EtcdStore
+from utils.service_discovery.abstract_config_store import AbstractConfigStore
+from utils.service_discovery.sd_backend import get_sd_backend
+from utils.service_discovery.sd_docker_backend import SDDockerBackend
+
+
+def clear_singletons(agentConfig):
+    get_config_store(agentConfig)._drop()
+    get_sd_backend(agentConfig)._drop()
+
+
+class Response(object):
+    """Dummy response class for mocking purpose"""
+    def __init__(self, content):
+        self.content = content
+
+    def json(self):
+        return self.content
+
+    def raise_for_status(self):
+        pass
+
+
+def _get_container_inspect(c_id):
+    """Return a mocked container inspect dict from self.container_inspects."""
+    for co, _, _ in TestServiceDiscovery.container_inspects:
+        if co.get('Id') == c_id:
+            return co
+        return None
+
+
+def _get_conf_tpls(image_name, trace_config=False):
+    """Return a mocked configuration template from self.mock_templates."""
+    return copy.deepcopy(TestServiceDiscovery.mock_templates.get(image_name)[0])
+
+
+def _get_check_tpls(image_name, **kwargs):
+    if image_name in TestServiceDiscovery.mock_templates:
+        return [copy.deepcopy(TestServiceDiscovery.mock_templates.get(image_name)[0][0][0:3])]
+    elif image_name in TestServiceDiscovery.bad_mock_templates:
+        try:
+            return [copy.deepcopy(TestServiceDiscovery.bad_mock_templates.get(image_name))]
+        except Exception:
+            return None
+
+
+def client_read(path):
+    """Return a mocked string that would normally be read from a config store (etcd, consul...)."""
+    parts = path.split('/')
+    config_parts = ['check_names', 'init_configs', 'instances']
+    image, config_part = parts[-2], parts[-1]
+    return TestServiceDiscovery.mock_tpls.get(image)[0][config_parts.index(config_part)]
+
+
+class TestServiceDiscovery(unittest.TestCase):
+    docker_container_inspect = {
+        u'Id': u'69ff25598b2314d1cdb7752cc3a659fb1c1352b32546af4f1454321550e842c0',
+        u'Image': u'6ffc02088cb870652eca9ccd4c4fb582f75b29af2879792ed09bb46fd1c898ef',
+        u'Name': u'/nginx',
+        u'NetworkSettings': {u'IPAddress': u'172.17.0.21', u'Ports': {u'443/tcp': None, u'80/tcp': None}}
+    }
+    kubernetes_container_inspect = {
+        u'Id': u'389dc8a4361f3d6c866e9e9a7b6972b26a31c589c4e2f097375d55656a070bc9',
+        u'Image': u'de309495e6c7b2071bc60c0b7e4405b0d65e33e3a4b732ad77615d90452dd827',
+        u'Name': u'/k8s_sentinel.38057ab9_redis-master_default_27b84e1e-a81c-11e5-8347-42010af00002_f70875a1',
+        u'Config': {u'ExposedPorts': {u'6379/tcp': {}}},
+        u'NetworkSettings': {u'IPAddress': u'', u'Ports': None}
+    }
+    malformed_container_inspect = {
+        u'Id': u'69ff25598b2314d1cdb7752cc3a659fb1c1352b32546af4f1454321550e842c0',
+        u'Image': u'6ffc02088cb870652eca9ccd4c4fb582f75b29af2879792ed09bb46fd1c898ef',
+        u'Name': u'/nginx'
+    }
+    container_inspects = [
+        # (inspect_dict, expected_ip, expected_port)
+        (docker_container_inspect, '172.17.0.21', ['80', '443']),
+        (kubernetes_container_inspect, None, ['6379']),  # arbitrarily defined in the mocked pod_list
+        (malformed_container_inspect, None, KeyError)
+    ]
+
+    # templates with variables already extracted
+    mock_templates = {
+        # image_name: ([(check_name, init_tpl, instance_tpl, variables)], (expected_config_template))
+        'image_0': (
+            [('check_0', {}, {'host': '%%host%%'}, ['host'])],
+            ('check_0', {}, {'host': '127.0.0.1'})),
+        'image_1': (
+            [('check_1', {}, {'port': '%%port%%'}, ['port'])],
+            ('check_1', {}, {'port': '1337'})),
+        'image_2': (
+            [('check_2', {}, {'host': '%%host%%', 'port': '%%port%%'}, ['host', 'port'])],
+            ('check_2', {}, {'host': '127.0.0.1', 'port': '1337'})),
+    }
+
+    # raw templates coming straight from the config store
+    mock_tpls = {
+        # image_name: ('[check_name]', '[init_tpl]', '[instance_tpl]', expected_python_tpl_list)
+        'image_0': (
+            ('["check_0"]', '[{}]', '[{"host": "%%host%%"}]'),
+            [('check_0', {}, {"host": "%%host%%"})]),
+        'image_1': (
+            ('["check_1"]', '[{}]', '[{"port": "%%port%%"}]'),
+            [('check_1', {}, {"port": "%%port%%"})]),
+        'image_2': (
+            ('["check_2"]', '[{}]', '[{"host": "%%host%%", "port": "%%port%%"}]'),
+            [('check_2', {}, {"host": "%%host%%", "port": "%%port%%"})]),
+        'bad_image_0': ((['invalid template']), []),
+        'bad_image_1': (('invalid template'), []),
+        'bad_image_2': (None, [])
+    }
+
+    bad_mock_templates = {
+        'bad_image_0': ('invalid template'),
+        'bad_image_1': [('invalid template')],
+        'bad_image_2': None
+    }
+
+    def setUp(self):
+        self.etcd_agentConfig = {
+            'service_discovery': True,
+            'service_discovery_backend': 'docker',
+            'sd_template_dir': '/datadog/check_configs',
+            'sd_config_backend': 'etcd',
+            'sd_backend_host': '127.0.0.1',
+            'sd_backend_port': '2380'
+        }
+        self.consul_agentConfig = {
+            'service_discovery': True,
+            'service_discovery_backend': 'docker',
+            'sd_template_dir': '/datadog/check_configs',
+            'sd_config_backend': 'consul',
+            'sd_backend_host': '127.0.0.1',
+            'sd_backend_port': '8500'
+        }
+        self.auto_conf_agentConfig = {
+            'service_discovery': True,
+            'service_discovery_backend': 'docker',
+            'sd_template_dir': '/datadog/check_configs',
+            'additional_checksd': '/etc/dd-agent/checks.d/',
+        }
+        self.agentConfigs = [self.etcd_agentConfig, self.consul_agentConfig, self.auto_conf_agentConfig]
+
+    # sd_backend tests
+
+    @mock.patch('utils.http.requests.get')
+    @mock.patch('utils.kubeutil.check_yaml')
+    def test_get_host(self, mock_check_yaml, mock_get):
+        kubernetes_config = {'instances': [{'kubelet_port': 1337}]}
+        pod_list = {
+            'items': [{
+                'status': {
+                    'podIP': '127.0.0.1',
+                    'containerStatuses': [
+                        {'containerID': 'docker://389dc8a4361f3d6c866e9e9a7b6972b26a31c589c4e2f097375d55656a070bc9'}
+                    ]
+                }
+            }]
+        }
+
+        mock_check_yaml.return_value = kubernetes_config
+        mock_get.return_value = Response(pod_list)
+
+        for c_ins, expected_ip, _ in self.container_inspects:
+            with mock.patch.object(AbstractConfigStore, '__init__', return_value=None):
+                with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
+                    with mock.patch('utils.kubeutil.get_conf_path', return_value=None):
+                        sd_backend = get_sd_backend(agentConfig=self.auto_conf_agentConfig)
+                        self.assertEqual(sd_backend._get_host(c_ins), expected_ip)
+                        clear_singletons(self.auto_conf_agentConfig)
+
+    def test_get_ports(self):
+        with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
+            for c_ins, _, expected_ports in self.container_inspects:
+                sd_backend = get_sd_backend(agentConfig=self.auto_conf_agentConfig)
+                if isinstance(expected_ports, list):
+                    self.assertEqual(sd_backend._get_ports(c_ins), expected_ports)
+                else:
+                    self.assertRaises(expected_ports, sd_backend._get_ports, c_ins)
+                clear_singletons(self.auto_conf_agentConfig)
+
+    @mock.patch('docker.Client.inspect_container', side_effect=_get_container_inspect)
+    @mock.patch.object(SDDockerBackend, '_get_config_templates', side_effect=_get_conf_tpls)
+    def test_get_check_configs(self, mock_inspect_container, mock_get_conf_tpls):
+        """Test get_check_config with mocked container inspect and config template"""
+        with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
+            with mock.patch.object(SDDockerBackend, '_get_host', return_value='127.0.0.1'):
+                with mock.patch.object(SDDockerBackend, '_get_ports', return_value=['1337']):
+                    c_id = self.docker_container_inspect.get('Id')
+                    for image in self.mock_templates.keys():
+                        sd_backend = get_sd_backend(agentConfig=self.auto_conf_agentConfig)
+                        self.assertEquals(
+                            sd_backend._get_check_configs(c_id, image)[0],
+                            self.mock_templates[image][1])
+                        clear_singletons(self.auto_conf_agentConfig)
+
+    @mock.patch.object(AbstractConfigStore, 'get_check_tpls', side_effect=_get_check_tpls)
+    def test_get_config_templates(self, mock_get_check_tpls):
+        """Test _get_config_templates with mocked get_check_tpls"""
+        with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
+            with mock.patch.object(EtcdStore, 'get_client', return_value=None):
+                with mock.patch.object(ConsulStore, 'get_client', return_value=None):
+                    for agentConfig in self.agentConfigs:
+                        sd_backend = get_sd_backend(agentConfig=agentConfig)
+                        # normal cases
+                        for image in self.mock_templates.keys():
+                            template = sd_backend._get_config_templates(image)
+                            expected_template = self.mock_templates.get(image)[0]
+                            self.assertEquals(template, expected_template)
+                        # error cases
+                        for image in self.bad_mock_templates.keys():
+                            self.assertEquals(sd_backend._get_config_templates(image), None)
+                        clear_singletons(agentConfig)
+
+    def test_render_template(self):
+        """Test _render_template"""
+        valid_configs = [
+            (({}, {'host': '%%host%%'}, {'host': 'foo'}),
+             ({}, {'host': 'foo'})),
+            (({}, {'host': '%%host%%', 'port': '%%port%%'}, {'host': 'foo', 'port': '1337'}),
+             ({}, {'host': 'foo', 'port': '1337'})),
+            (({'foo': '%%bar%%'}, {}, {'bar': 'w00t'}),
+             ({'foo': 'w00t'}, {})),
+            (({'foo': '%%bar%%'}, {'host': '%%host%%'}, {'bar': 'w00t', 'host': 'localhost'}),
+             ({'foo': 'w00t'}, {'host': 'localhost'}))
+        ]
+
+        invalid_configs = [
+            ({}, {'host': '%%host%%'}, {}),  # no value to use
+            ({}, {'host': '%%host%%'}, {'port': 42}),  # the variable name doesn't match
+            ({'foo': '%%bar%%'}, {'host': '%%host%%'}, {'host': 'foo'})  # not enough value/no matching var name
+        ]
+
+        with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
+            for agentConfig in self.agentConfigs:
+                sd_backend = get_sd_backend(agentConfig=agentConfig)
+                for tpl, res in valid_configs:
+                    init, instance, variables = tpl
+                    config = sd_backend._render_template(init, instance, variables)
+                    self.assertEquals(config, res)
+                for init, instance, variables in invalid_configs:
+                    config = sd_backend._render_template(init, instance, variables)
+                    self.assertEquals(config, None)
+                    clear_singletons(agentConfig)
+
+    def test_fill_tpl(self):
+        """Test _fill_tpl with mock _get_ports"""
+        valid_configs = [
+            # ((inspect, instance_tpl, variables, tags), (expected_instance_tpl, expected_var_values))
+            (
+                ({}, {'host': 'localhost'}, [], None),
+                ({'host': 'localhost'}, {})
+            ),
+            (
+                ({'NetworkSettings': {'IPAddress': '127.0.0.1'}},
+                 {'host': '%%host%%', 'port': 1337}, ['host'], ['foo', 'bar:baz']),
+                ({'host': '%%host%%', 'port': 1337, 'tags': ['foo', 'bar:baz']}, {'host': '127.0.0.1'})
+            ),
+            (
+                ({'NetworkSettings': {'IPAddress': '127.0.0.1', 'Ports': {'42/tcp': None, '22/tcp': None}}},
+                 {'host': '%%host%%', 'port': '%%port_1%%', 'tags': ['env:test']},
+                 ['host', 'port_1'], ['foo', 'bar:baz']),
+                ({'host': '%%host%%', 'port': '%%port_1%%', 'tags': ['env:test', 'foo', 'bar:baz']},
+                 {'host': '127.0.0.1', 'port_1': '42'})
+            )
+        ]
+        with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
+            for ac in self.agentConfigs:
+                sd_backend = get_sd_backend(agentConfig=ac)
+                try:
+                    for co in valid_configs:
+                        inspect, tpl, variables, tags = co[0]
+                        instance_tpl, var_values = sd_backend._fill_tpl(inspect, tpl, variables, tags)
+                        for key in instance_tpl.keys():
+                            if isinstance(instance_tpl[key], list):
+                                self.assertEquals(len(instance_tpl[key]), len(co[1][0].get(key)))
+                                for elem in instance_tpl[key]:
+                                    self.assertTrue(elem in co[1][0].get(key))
+                            else:
+                                self.assertEquals(instance_tpl[key], co[1][0].get(key))
+                        self.assertEquals(var_values, co[1][1])
+                    clear_singletons(ac)
+                except Exception:
+                    clear_singletons(ac)
+                    raise
+
+    # config_stores tests
+
+    def test_get_auto_config(self):
+        """Test _get_auto_config"""
+        expected_tpl = {
+            'redis': ('redisdb', None, {"host": "%%host%%", "port": "%%port%%"}),
+            'consul': ('consul', None, {"url": "http://%%host%%:%%port%%", "catalog_checks": True, "service_whitelist": None, "new_leader_checks": True}),
+            'foobar': None
+        }
+
+        config_store = get_config_store(self.auto_conf_agentConfig)
+        for image in expected_tpl.keys():
+            config = config_store._get_auto_config(image)
+            self.assertEquals(config, expected_tpl.get(image))
+
+    @mock.patch.object(AbstractConfigStore, 'client_read', side_effect=client_read)
+    def test_get_check_tpls(self, mock_client_read):
+        """Test get_check_tpls"""
+        valid_config = ['image_0', 'image_1', 'image_2']
+        invalid_config = ['bad_image_0', 'bad_image_1']
+        config_store = get_config_store(self.auto_conf_agentConfig)
+        for image in valid_config:
+            tpl = self.mock_tpls.get(image)[1]
+            self.assertEquals(tpl, config_store.get_check_tpls(image))
+        for image in invalid_config:
+            tpl = self.mock_tpls.get(image)[1]
+            self.assertEquals(tpl, config_store.get_check_tpls(image))

--- a/util.py
+++ b/util.py
@@ -28,7 +28,7 @@ except ImportError:
 # if a user actually uses them in a custom check
 # If you're this user, please use utils.pidfile or utils.platform instead
 # FIXME: remove them at a point (6.x)
-from utils.dockerutil import get_hostname as get_docker_hostname, is_dockerized
+from utils.dockerutil import DockerUtil
 from utils.pidfile import PidFile  # noqa, see ^^^
 from utils.platform import Platform
 from utils.proxy import get_proxy
@@ -90,6 +90,7 @@ def headers(agentConfig):
         'Accept': 'text/html, */*',
     }
 
+
 def windows_friendly_colon_split(config_string):
     '''
     Perform a split by ':' on the config_string
@@ -100,6 +101,7 @@ def windows_friendly_colon_split(config_string):
         return COLON_NON_WIN_PATH.split(config_string)
     else:
         return config_string.split(':')
+
 
 def cast_metric_val(val):
     # ensure that the metric value is a numeric type
@@ -117,12 +119,15 @@ def cast_metric_val(val):
     return val
 
 _IDS = {}
+
+
 def get_next_id(name):
     global _IDS
     current_id = _IDS.get(name, 0)
     current_id += 1
     _IDS[name] = current_id
     return current_id
+
 
 def is_valid_hostname(hostname):
     if hostname.lower() in set([
@@ -140,6 +145,26 @@ def is_valid_hostname(hostname):
         log.warning("Hostname: %s is not complying with RFC 1123" % hostname)
         return False
     return True
+
+
+def check_yaml(conf_path):
+    with open(conf_path) as f:
+        check_config = yaml.load(f.read(), Loader=yLoader)
+        assert 'init_config' in check_config, "No 'init_config' section found"
+        assert 'instances' in check_config, "No 'instances' section found"
+
+        valid_instances = True
+        if check_config['instances'] is None or not isinstance(check_config['instances'], list):
+            valid_instances = False
+        else:
+            for i in check_config['instances']:
+                if not isinstance(i, dict):
+                    valid_instances = False
+                    break
+        if not valid_instances:
+            raise Exception('You need to have at least one instance defined in the YAML file for this check')
+        else:
+            return check_config
 
 
 def get_hostname(config=None):
@@ -171,8 +196,9 @@ def get_hostname(config=None):
                 return gce_hostname
 
     # Try to get the docker hostname
-    if hostname is None and is_dockerized():
-        docker_hostname = get_docker_hostname()
+    docker_util = DockerUtil()
+    if hostname is None and docker_util.is_dockerized():
+        docker_hostname = docker_util.get_hostname()
         if docker_hostname is not None and is_valid_hostname(docker_hostname):
             return docker_hostname
 

--- a/utils/checkfiles.py
+++ b/utils/checkfiles.py
@@ -1,0 +1,104 @@
+"""Helpers to work with check files (Python and YAML)."""
+# std
+import itertools
+import logging
+import os
+from urlparse import urljoin
+
+# project
+from util import check_yaml
+
+log = logging.getLogger(__name__)
+
+
+def get_conf_path(check_name):
+    """Return the yaml config file path for a given check name."""
+    from config import get_confd_path, PathNotFound
+    confd_path = ''
+
+    try:
+        confd_path = get_confd_path()
+    except PathNotFound:
+        log.error("Couldn't find the check configuration folder, this shouldn't happen.")
+        return None
+
+    conf_path = os.path.join(confd_path, '%s.yaml' % check_name)
+    if not os.path.exists(conf_path):
+        default_conf_path = os.path.join(confd_path, '%s.yaml.default' % check_name)
+        if not os.path.exists(default_conf_path):
+            log.error("Couldn't find any configuration file for the %s check." % check_name)
+            return None
+        else:
+            conf_path = default_conf_path
+    return conf_path
+
+
+def get_check_class(agentConfig, check_name):
+    """Return the class object for a given check name"""
+    from config import get_os, get_checks_paths, get_check_class
+
+    osname = get_os()
+    checks_paths = get_checks_paths(agentConfig, osname)
+    for check in itertools.chain(*checks_paths):
+        py_check_name = os.path.basename(check).split('.')[0]
+        if py_check_name == check_name:
+            check_class = get_check_class(check_name, check)
+            if isinstance(check_class, dict) or check_class is None:
+                log.warning('Failed to load the check class for %s.' % check_name)
+                return None
+            else:
+                return check_class
+
+
+def get_auto_conf(agentConfig, check_name):
+    """Return the yaml auto_config dict for a check name (None if it doesn't exist)."""
+    from config import PathNotFound, get_auto_confd_path
+
+    try:
+        auto_confd_path = get_auto_confd_path()
+    except PathNotFound:
+        log.error("Couldn't find the check auto-configuration folder, no auto configuration will be used.")
+        return None
+
+    auto_conf_path = os.path.join(auto_confd_path, '%s.yaml' % check_name)
+    if not os.path.exists(auto_conf_path):
+        log.error("Couldn't find any auto configuration file for the %s check." % check_name)
+        return None
+
+    try:
+        auto_conf = check_yaml(auto_conf_path)
+    except Exception as e:
+        log.error("Enable to load the auto-config, yaml file."
+                  "Auto-config will not work for this check.\n%s" % str(e))
+        return None
+
+    return auto_conf
+
+
+def get_auto_conf_images(agentConfig):
+    """Walk through the auto_config folder and build a dict of auto-configurable images."""
+    from config import PathNotFound, get_auto_confd_path
+    auto_conf_images = {
+        # image_name: check_name
+    }
+
+    try:
+        auto_confd_path = get_auto_confd_path()
+    except PathNotFound:
+        log.error("Couldn't find the check auto-configuration folder, no auto configuration will be used.")
+        return None
+
+    # walk through the auto-config dir
+    for yaml_file in os.listdir(auto_confd_path):
+        check_name = yaml_file.split('.')[0]
+        try:
+            # load the config file
+            auto_conf = check_yaml(urljoin(auto_confd_path, yaml_file))
+        except Exception as e:
+            log.error("Enable to load the auto-config, yaml file.\n%s" % str(e))
+            auto_conf = {}
+        # extract the supported image list
+        images = auto_conf.get('docker_images', [])
+        for image in images:
+            auto_conf_images[image] = check_name
+    return auto_conf_images

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -1,10 +1,15 @@
 # stdlib
 import logging
 import os
+import time
 
 # 3rd party
 from docker import Client
 from docker import tls
+
+# project
+from utils.singleton import Singleton
+
 
 class MountException(Exception):
     pass
@@ -13,167 +18,219 @@ class MountException(Exception):
 DEFAULT_TIMEOUT = 5
 DEFAULT_VERSION = 'auto'
 CHECK_NAME = 'docker_daemon'
+CONFIG_RELOAD_STATUS = ['start', 'die', 'stop', 'kill']  # used to trigger service discovery
 
 log = logging.getLogger(__name__)
-_docker_client_settings = {"version": DEFAULT_VERSION}
-
-def is_dockerized():
-    return os.environ.get("DOCKER_DD_AGENT") == "yes"
-
-def get_docker_settings():
-    global _docker_client_settings
-    return _docker_client_settings
 
 
-def reset_docker_settings():
-    global _docker_client_settings
-    _docker_client_settings = {"version": DEFAULT_VERSION}
+class DockerUtil():
+    __metaclass__ = Singleton
 
+    DEFAULT_SETTINGS = {"version": DEFAULT_VERSION}
 
-def set_docker_settings(init_config, instance):
-    global _docker_client_settings
-    _docker_client_settings = {
-        "version": init_config.get('api_version', DEFAULT_VERSION),
-        "base_url": instance.get("url"),
-        "timeout": int(init_config.get('timeout', DEFAULT_TIMEOUT)),
-    }
+    def __init__(self, **kwargs):
+        self._docker_root = None
 
-    if init_config.get('tls', False):
-        client_cert_path = init_config.get('tls_client_cert')
-        client_key_path = init_config.get('tls_client_key')
-        cacert = init_config.get('tls_cacert')
-        verify = init_config.get('tls_verify')
+        if 'init_config' in kwargs and 'instance' in kwargs:
+            init_config = kwargs.get('init_config')
+            instance = kwargs.get('instance')
+        else:
+            init_config, instance = self.get_check_config()
+        self.set_docker_settings(init_config, instance)
 
-        client_cert = None
-        if client_cert_path is not None and client_key_path is not None:
-            client_cert = (client_cert_path, client_key_path)
+        # At first run we'll just collect the events from the latest 60 secs
+        self._latest_event_collection_ts = int(time.time()) - 60
 
-        verify = verify if verify is not None else cacert
-        tls_config = tls.TLSConfig(client_cert=client_cert, verify=verify)
-        _docker_client_settings["tls"] = tls_config
+        # Try to detect if we are on ECS
+        self._is_ecs = False
+        try:
+            containers = self.client.containers()
+            for co in containers:
+                if '/ecs-agent' in co.get('Names', ''):
+                    self._is_ecs = True
+        except Exception:
+            pass
 
+    def get_check_config(self):
+        """Read the config from docker_daemon.yaml"""
+        from util import check_yaml
+        from utils.checkfiles import get_conf_path
+        init_config, instances = {}, []
+        conf_path = get_conf_path(CHECK_NAME)
 
-def get_client():
-    return Client(**_docker_client_settings)
+        if conf_path is not None and os.path.exists(conf_path):
+            try:
+                check_config = check_yaml(conf_path)
+                init_config, instances = check_config.get('init_config', {}), check_config['instances']
+                init_config = {} if init_config is None else init_config
+            except Exception:
+                log.exception('Docker check configuration file is invalid. The docker check and '
+                              'other Docker related components will not work.')
+                init_config, instances = {}, []
 
+        if len(instances) > 0:
+            instance = instances[0]
+        else:
+            instance = {}
+            log.error('No instance was found in the docker check configuration.'
+                      ' Docker related collection will not work.')
+        return init_config, instance
 
-def find_cgroup(hierarchy, docker_root):
-        """Find the mount point for a specified cgroup hierarchy.
+    def is_ecs(self):
+        return self._is_ecs
 
-        Works with old style and new style mounts.
-        """
-        with open(os.path.join(docker_root, "/proc/mounts"), 'r') as fp:
-            mounts = map(lambda x: x.split(), fp.read().splitlines())
-        cgroup_mounts = filter(lambda x: x[2] == "cgroup", mounts)
-        if len(cgroup_mounts) == 0:
-            raise Exception(
-                "Can't find mounted cgroups. If you run the Agent inside a container,"
-                " please refer to the documentation.")
-        # Old cgroup style
-        if len(cgroup_mounts) == 1:
-            return os.path.join(docker_root, cgroup_mounts[0][1])
+    def get_events(self):
+        self.events = []
+        should_reload_conf = False
+        now = int(time.time())
 
-        candidate = None
-        for _, mountpoint, _, opts, _, _ in cgroup_mounts:
-            if hierarchy in opts:
-                if mountpoint.startswith("/host/"):
-                    return os.path.join(docker_root, mountpoint)
-                candidate = mountpoint
+        event_generator = self.client.events(since=self._latest_event_collection_ts,
+                                             until=now, decode=True)
+        self._latest_event_collection_ts = now
+        for event in event_generator:
+            if event != '':
+                self.events.append(event)
+            if event.get('status') in CONFIG_RELOAD_STATUS:
+                should_reload_conf = True
+        return (self.events, should_reload_conf)
 
-        if candidate is not None:
-            return os.path.join(docker_root, candidate)
-        raise Exception("Can't find mounted %s cgroups." % hierarchy)
+    def get_hostname(self):
+        """Return the `Name` param from `docker info` to use as the hostname"""
+        if self.is_dockerized():
+            try:
+                return self.client.info().get("Name")
+            except Exception:
+                log.critical("Unable to find docker host hostname")
 
-
-def find_cgroup_filename_pattern(mountpoints, container_id):
-    # We try with different cgroups so that it works even if only one is properly working
-    for mountpoint in mountpoints.itervalues():
-        stat_file_path_lxc = os.path.join(mountpoint, "lxc")
-        stat_file_path_docker = os.path.join(mountpoint, "docker")
-        stat_file_path_coreos = os.path.join(mountpoint, "system.slice")
-        stat_file_path_kubernetes = os.path.join(mountpoint, container_id)
-        stat_file_path_kubernetes_docker = os.path.join(mountpoint, "system", "docker", container_id)
-        stat_file_path_docker_daemon = os.path.join(mountpoint, "docker-daemon", "docker", container_id)
-
-        if os.path.exists(stat_file_path_lxc):
-            return os.path.join('%(mountpoint)s/lxc/%(id)s/%(file)s')
-        elif os.path.exists(stat_file_path_docker):
-            return os.path.join('%(mountpoint)s/docker/%(id)s/%(file)s')
-        elif os.path.exists(stat_file_path_coreos):
-            return os.path.join('%(mountpoint)s/system.slice/docker-%(id)s.scope/%(file)s')
-        elif os.path.exists(stat_file_path_kubernetes):
-            return os.path.join('%(mountpoint)s/%(id)s/%(file)s')
-        elif os.path.exists(stat_file_path_kubernetes_docker):
-            return os.path.join('%(mountpoint)s/system/docker/%(id)s/%(file)s')
-        elif os.path.exists(stat_file_path_docker_daemon):
-            return os.path.join('%(mountpoint)s/docker-daemon/docker/%(id)s/%(file)s')
-
-
-    raise MountException("Cannot find Docker cgroup directory. Be sure your system is supported.")
-
-
-def image_tag_extractor(entity, key):
-    if "Image" in entity:
-        split = entity["Image"].split(":")
-        if len(split) <= key:
-            return None
-        elif len(split) > 2:
-            # if the repo is in the image name and has the form 'docker.clearbit:5000'
-            # the split will be like [repo_url, repo_port/image_name, image_tag]. Let's avoid that
-            split = [':'.join(split[:-1]), split[-1]]
-        return [split[key]]
-    if "RepoTags" in entity:
-        splits = [el.split(":") for el in entity["RepoTags"]]
-        tags = set()
-        for split in splits:
-            if len(split) > 2:
-                split = [':'.join(split[:-1]), split[-1]]
-            if len(split) > key:
-                tags.add(split[key])
-        if len(tags) > 0:
-            return list(tags)
-    return None
-
-
-def container_name_extractor(co):
-    names = co.get('Names', [])
-    if names is not None:
-        # we sort the list to make sure that a docker API update introducing
-        # new names with a single "/" won't make us report dups.
-        names = sorted(names)
-        for name in names:
-            # the leading "/" is legit, if there's another one it means the name is actually an alias
-            if name.count('/') <= 1:
-                return [str(name).lstrip('/')]
-    return co.get('Id')[:11]
-
-
-def get_hostname():
-    """Return the `Name` param from `docker info` to use as the hostname"""
-    from config import get_confd_path, check_yaml, PathNotFound
-
-    confd_path = ''
-
-    try:
-        confd_path = get_confd_path()
-    except PathNotFound:
-        log.error("Couldn't find the check configuration folder, not using the docker hostname.")
         return None
 
-    conf_path = os.path.join(confd_path, '%s.yaml' % CHECK_NAME)
-    if not os.path.exists(conf_path):
-        default_conf_path = os.path.join(confd_path, '%s.yaml.default' % CHECK_NAME)
-        if not os.path.exists(default_conf_path):
-            log.error("Couldn't find any configuration file for the docker check."
-                      " Not using the docker hostname.")
-            return None
-        else:
-            conf_path = default_conf_path
+    @property
+    def client(self):
+        return Client(**self.settings)
 
-    check_config = check_yaml(conf_path)
-    init_config, instances = check_config.get('init_config', {}), check_config['instances']
-    init_config = {} if init_config is None else init_config
-    if len(instances) > 0:
-        set_docker_settings(init_config, instances[0])
-        return get_client().info().get("Name")
-    return None
+    def set_docker_settings(self, init_config, instance):
+        """Update docker settings"""
+        self._docker_root = init_config.get('docker_root', '/')
+        self.settings = {
+            "version": init_config.get('api_version', DEFAULT_VERSION),
+            "base_url": instance.get("url", ''),
+            "timeout": int(init_config.get('timeout', DEFAULT_TIMEOUT)),
+        }
+
+        if init_config.get('tls', False):
+            client_cert_path = init_config.get('tls_client_cert')
+            client_key_path = init_config.get('tls_client_key')
+            cacert = init_config.get('tls_cacert')
+            verify = init_config.get('tls_verify')
+
+            client_cert = None
+            if client_cert_path is not None and client_key_path is not None:
+                client_cert = (client_cert_path, client_key_path)
+
+            verify = verify if verify is not None else cacert
+            tls_config = tls.TLSConfig(client_cert=client_cert, verify=verify)
+            self.settings["tls"] = tls_config
+
+    @classmethod
+    def is_dockerized(cls):
+        return os.environ.get("DOCKER_DD_AGENT") == "yes"
+
+    def get_mountpoints(self, cgroup_metrics):
+        mountpoints = {}
+        for metric in cgroup_metrics:
+            mountpoints[metric["cgroup"]] = self.find_cgroup(metric["cgroup"])
+        return mountpoints
+
+    def find_cgroup(self, hierarchy):
+            """Find the mount point for a specified cgroup hierarchy.
+
+            Works with old style and new style mounts.
+            """
+            with open(os.path.join(self._docker_root, "/proc/mounts"), 'r') as fp:
+                mounts = map(lambda x: x.split(), fp.read().splitlines())
+            cgroup_mounts = filter(lambda x: x[2] == "cgroup", mounts)
+            if len(cgroup_mounts) == 0:
+                raise Exception(
+                    "Can't find mounted cgroups. If you run the Agent inside a container,"
+                    " please refer to the documentation.")
+            # Old cgroup style
+            if len(cgroup_mounts) == 1:
+                return os.path.join(self._docker_root, cgroup_mounts[0][1])
+
+            candidate = None
+            for _, mountpoint, _, opts, _, _ in cgroup_mounts:
+                if hierarchy in opts:
+                    if mountpoint.startswith("/host/"):
+                        return os.path.join(self._docker_root, mountpoint)
+                    candidate = mountpoint
+
+            if candidate is not None:
+                return os.path.join(self._docker_root, candidate)
+            raise Exception("Can't find mounted %s cgroups." % hierarchy)
+
+    @classmethod
+    def find_cgroup_filename_pattern(cls, mountpoints, container_id):
+        # We try with different cgroups so that it works even if only one is properly working
+        for mountpoint in mountpoints.itervalues():
+            stat_file_path_lxc = os.path.join(mountpoint, "lxc")
+            stat_file_path_docker = os.path.join(mountpoint, "docker")
+            stat_file_path_coreos = os.path.join(mountpoint, "system.slice")
+            stat_file_path_kubernetes = os.path.join(mountpoint, container_id)
+            stat_file_path_kubernetes_docker = os.path.join(mountpoint, "system", "docker", container_id)
+            stat_file_path_docker_daemon = os.path.join(mountpoint, "docker-daemon", "docker", container_id)
+
+            if os.path.exists(stat_file_path_lxc):
+                return os.path.join('%(mountpoint)s/lxc/%(id)s/%(file)s')
+            elif os.path.exists(stat_file_path_docker):
+                return os.path.join('%(mountpoint)s/docker/%(id)s/%(file)s')
+            elif os.path.exists(stat_file_path_coreos):
+                return os.path.join('%(mountpoint)s/system.slice/docker-%(id)s.scope/%(file)s')
+            elif os.path.exists(stat_file_path_kubernetes):
+                return os.path.join('%(mountpoint)s/%(id)s/%(file)s')
+            elif os.path.exists(stat_file_path_kubernetes_docker):
+                return os.path.join('%(mountpoint)s/system/docker/%(id)s/%(file)s')
+            elif os.path.exists(stat_file_path_docker_daemon):
+                return os.path.join('%(mountpoint)s/docker-daemon/docker/%(id)s/%(file)s')
+
+        raise MountException("Cannot find Docker cgroup directory. Be sure your system is supported.")
+
+    @classmethod
+    def image_tag_extractor(cls, entity, key):
+        if "Image" in entity:
+            split = entity["Image"].split(":")
+            if len(split) <= key:
+                return None
+            elif len(split) > 2:
+                # if the repo is in the image name and has the form 'docker.clearbit:5000'
+                # the split will be like [repo_url, repo_port/image_name, image_tag]. Let's avoid that
+                split = [':'.join(split[:-1]), split[-1]]
+            return [split[key]]
+        if "RepoTags" in entity:
+            splits = [el.split(":") for el in entity["RepoTags"]]
+            tags = set()
+            for split in splits:
+                if len(split) > 2:
+                    split = [':'.join(split[:-1]), split[-1]]
+                if len(split) > key:
+                    tags.add(split[key])
+            if len(tags) > 0:
+                return list(tags)
+        return None
+
+    @classmethod
+    def container_name_extractor(cls, co):
+        names = co.get('Names', [])
+        if names is not None:
+            # we sort the list to make sure that a docker API update introducing
+            # new names with a single "/" won't make us report dups.
+            names = sorted(names)
+            for name in names:
+                # the leading "/" is legit, if there's another one it means the name is actually an alias
+                if name.count('/') <= 1:
+                    return [str(name).lstrip('/')]
+        return [co.get('Id')[:12]]
+
+    @classmethod
+    def _drop(cls):
+        if cls in cls._instances:
+            del cls._instances[cls]

--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -1,86 +1,94 @@
 # stdlib
 import logging
+import os
 import socket
 import struct
 from urlparse import urljoin
 
 # project
+from util import check_yaml
+from utils.checkfiles import get_conf_path
 from utils.http import retrieve_json
-
-DEFAULT_METHOD = 'http'
-METRICS_PATH = '/api/v1.3/subcontainers/'
-PODS_LIST_PATH = '/pods/'
-DEFAULT_CADVISOR_PORT = 4194
-DEFAULT_KUBELET_PORT = 10255
-DEFAULT_MASTER_PORT = 8080
+from utils.singleton import Singleton
 
 log = logging.getLogger('collector')
-_kube_settings = {}
+
+KUBERNETES_CHECK_NAME = 'kubernetes'
 
 
-def get_kube_settings():
-    global _kube_settings
-    return _kube_settings
+def is_k8s():
+    return 'KUBERNETES_PORT' in os.environ
 
 
-def set_kube_settings(instance):
-    global _kube_settings
+class KubeUtil():
+    __metaclass__ = Singleton
 
-    host = instance.get("host") or _get_default_router()
-    cadvisor_port = instance.get('port', DEFAULT_CADVISOR_PORT)
-    method = instance.get('method', DEFAULT_METHOD)
-    metrics_url = urljoin('%s://%s:%d' % (method, host, cadvisor_port), METRICS_PATH)
-    kubelet_port = instance.get('kubelet_port', DEFAULT_KUBELET_PORT)
-    master_port = instance.get('master_port', DEFAULT_MASTER_PORT)
-    master_host = instance.get('master_host', host)
-    pods_list_url = urljoin('%s://%s:%d' % (method, host, kubelet_port), PODS_LIST_PATH)
+    DEFAULT_METHOD = 'http'
+    METRICS_PATH = '/api/v1.3/subcontainers/'
+    PODS_LIST_PATH = '/pods/'
+    DEFAULT_CADVISOR_PORT = 4194
+    DEFAULT_KUBELET_PORT = 10255
+    DEFAULT_MASTER_PORT = 8080
 
-    _kube_settings = {
-        "host": host,
-        "method": method,
-        "metrics_url": metrics_url,
-        "cadvisor_port": cadvisor_port,
-        "labels_url": '%s://%s:%d/pods' % (method, host, kubelet_port),
-        "master_url_nodes": '%s://%s:%d/api/v1/nodes' % (method, master_host, master_port),
-        "kube_health_url": '%s://%s:%d/healthz' % (method, host, kubelet_port),
-        "pods_list_url": pods_list_url
-    }
+    def __init__(self):
+        config_file_path = get_conf_path(KUBERNETES_CHECK_NAME)
+        try:
+            check_config = check_yaml(config_file_path)
+            instance = check_config['instances'][0]
+        except Exception:
+            log.error('Kubernetes configuration file is invalid. '
+                      'Trying connecting to kubelet with default settings anyway...')
+            instance = {}
 
-    return _kube_settings
+        self.method = instance.get('method', KubeUtil.DEFAULT_METHOD)
+        self.host = instance.get("host") or self._get_default_router()
+        self.master_host = instance.get('master_host', self.host)
 
+        self.cadvisor_port = instance.get('port', KubeUtil.DEFAULT_CADVISOR_PORT)
+        self.kubelet_port = instance.get('kubelet_port', KubeUtil.DEFAULT_KUBELET_PORT)
+        self.master_port = instance.get('master_port', KubeUtil.DEFAULT_MASTER_PORT)
 
-def get_kube_labels():
-    global _kube_settings
-    pods = retrieve_json(_kube_settings["labels_url"])
-    return extract_kube_labels(pods)
+        self.metrics_url = urljoin(
+            '%s://%s:%d' % (self.method, self.host, self.cadvisor_port), KubeUtil.METRICS_PATH)
+        self.pods_list_url = urljoin(
+            '%s://%s:%d' % (self.method, self.host, self.kubelet_port), KubeUtil.PODS_LIST_PATH)
 
+        self.master_url_nodes = '%s://%s:%d/api/v1/nodes' % (self.method, self.master_host, self.master_port)
+        self.kube_health_url = '%s://%s:%d/healthz' % (self.method, self.host, self.kubelet_port)
 
-def extract_kube_labels(pods_list):
-    """
-    Extract labels from a list of pods coming from
-    the kubelet API.
-    """
-    kube_labels = {}
-    for pod in pods_list["items"]:
-        metadata = pod.get("metadata", {})
-        name = metadata.get("name")
-        namespace = metadata.get("namespace")
-        labels = metadata.get("labels")
-        if name and labels and namespace:
-            key = "%s/%s" % (namespace, name)
-            kube_labels[key] = ["kube_%s:%s" % (k,v) for k,v in labels.iteritems()]
+    def get_kube_labels(self):
+        pods = retrieve_json(self.pods_list_url)
+        return self.extract_kube_labels(pods)
 
-    return kube_labels
+    def extract_kube_labels(self, pods_list):
+        """
+        Extract labels from a list of pods coming from
+        the kubelet API.
+        """
+        kube_labels = {}
+        for pod in pods_list["items"]:
+            metadata = pod.get("metadata", {})
+            name = metadata.get("name")
+            namespace = metadata.get("namespace")
+            labels = metadata.get("labels")
+            if name and labels and namespace:
+                key = "%s/%s" % (namespace, name)
+                kube_labels[key] = ["kube_%s:%s" % (k, v) for k, v in labels.iteritems()]
 
+        return kube_labels
 
-def _get_default_router():
-    try:
-        with open('/proc/net/route') as f:
-            for line in f.readlines():
-                fields = line.strip().split()
-                if fields[1] == '00000000':
-                    return socket.inet_ntoa(struct.pack('<L', int(fields[2], 16)))
-    except IOError, e:
-        log.error('Unable to open /proc/net/route: %s', e)
+    def retrieve_pods_list(self):
+        return retrieve_json(self.pods_list_url)
 
-    return None
+    @classmethod
+    def _get_default_router(cls):
+        try:
+            with open('/proc/net/route') as f:
+                for line in f.readlines():
+                    fields = line.strip().split()
+                    if fields[1] == '00000000':
+                        return socket.inet_ntoa(struct.pack('<L', int(fields[2], 16)))
+        except IOError, e:
+            log.error('Unable to open /proc/net/route: %s', e)
+
+        return None

--- a/utils/ntp.py
+++ b/utils/ntp.py
@@ -3,51 +3,41 @@ import os
 import random
 
 # project
-from config import check_yaml, get_confd_path
-
-user_ntp_settings = {}
-
-DEFAULT_VERSION = 3
-DEFAULT_TIMEOUT = 1 # in seconds
-DEFAULT_PORT = "ntp"
+from config import get_confd_path
+from util import check_yaml
+from utils.singleton import Singleton
 
 
-def set_user_ntp_settings(instance=None):
-    global user_ntp_settings
-    if instance is None:
+class NTPUtil():
+    __metaclass__ = Singleton
+
+    DEFAULT_VERSION = 3
+    DEFAULT_TIMEOUT = 1  # in seconds
+    DEFAULT_PORT = "ntp"
+
+    def __init__(self, config=None):
         try:
-            ntp_check_config = check_yaml(os.path.join(get_confd_path(), 'ntp.yaml'))
-            instance = ntp_check_config['instances'][0]
+            if config:
+                ntp_config = config
+            else:
+                ntp_config = check_yaml(os.path.join(get_confd_path(), 'ntp.yaml'))
+            settings = ntp_config['instances'][0]
         except Exception:
-            instance = {}
+            settings = {}
 
-    user_ntp_settings = instance
+        self.host = settings.get('host') or "{0}.datadog.pool.ntp.org".format(random.randint(0, 3))
+        self.version = int(settings.get("version") or NTPUtil.DEFAULT_VERSION)
+        self.port = settings.get('port') or NTPUtil.DEFAULT_PORT
+        self.timeout = float(settings.get('timeout') or NTPUtil.DEFAULT_TIMEOUT)
 
-def get_ntp_host(subpool=None):
-    """
-    Returns randomly a NTP hostname of our vendor pool. Or
-    a given subpool if given in input.
-    """
+        self.args = {
+            'host':    self.host,
+            'port':    self.port,
+            'version': self.version,
+            'timeout': self.timeout,
+        }
 
-    if user_ntp_settings.get('host') is not None:
-        return user_ntp_settings['host']
-
-    subpool = subpool or random.randint(0, 3)
-    return "{0}.datadog.pool.ntp.org".format(subpool)
-
-def get_ntp_port():
-    return user_ntp_settings.get('port') or DEFAULT_PORT
-
-def get_ntp_version():
-    return int(user_ntp_settings.get("version") or DEFAULT_VERSION)
-
-def get_ntp_timeout():
-    return float(user_ntp_settings.get('timeout') or DEFAULT_TIMEOUT)
-
-def get_ntp_args():
-    return {
-        'host':    get_ntp_host(),
-        'port':    get_ntp_port(),
-        'version': get_ntp_version(),
-        'timeout': get_ntp_timeout(),
-    }
+    @classmethod
+    def _drop(cls):
+        if cls in cls._instances:
+            del cls._instances[cls]

--- a/utils/platform.py
+++ b/utils/platform.py
@@ -2,7 +2,7 @@
 import sys
 
 # project
-from utils.dockerutil import get_client
+from utils.dockerutil import DockerUtil
 
 _is_ecs = None
 
@@ -68,20 +68,4 @@ class Platform(object):
 
     @staticmethod
     def is_ecs_instance():
-        """Return True if the agent is running in an ECS instance, False otherwise."""
-        global _is_ecs
-        if _is_ecs is not None:
-            return _is_ecs
-
-        try:
-            client = get_client()
-            containers = client.containers()
-            for co in containers:
-                if '/ecs-agent' in co.get('Names', ''):
-                    _is_ecs = True
-                    return True
-        except Exception:
-            pass
-
-        _is_ecs = False
-        return False
+        return DockerUtil().is_ecs()

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -1,0 +1,184 @@
+# std
+import logging
+import simplejson as json
+from os import path
+
+# 3p
+from urllib3.exceptions import TimeoutError
+
+# project
+from utils.checkfiles import get_check_class, get_auto_conf, get_auto_conf_images
+from utils.singleton import Singleton
+
+log = logging.getLogger(__name__)
+
+CONFIG_FROM_AUTOCONF = 'auto-configuration'
+CONFIG_FROM_FILE = 'YAML file'
+CONFIG_FROM_TEMPLATE = 'template'
+TRACE_CONFIG = 'trace_config'  # used for tracing config load by service discovery
+
+
+class KeyNotFound(Exception):
+    pass
+
+
+class AbstractConfigStore(object):
+    """Singleton for config stores"""
+    __metaclass__ = Singleton
+
+    previous_config_index = None
+
+    def __init__(self, agentConfig):
+        self.client = None
+        self.agentConfig = agentConfig
+        self.settings = self._extract_settings(agentConfig)
+        self.client = self.get_client()
+        self.sd_template_dir = agentConfig.get('sd_template_dir')
+        self.auto_conf_images = get_auto_conf_images(agentConfig)
+
+    @classmethod
+    def _drop(cls):
+        """Drop the config store instance. This is only used for testing."""
+        if cls in cls._instances:
+            del cls._instances[cls]
+
+    def _extract_settings(self, config):
+        raise NotImplementedError()
+
+    def get_client(self, reset=False):
+        raise NotImplementedError()
+
+    def client_read(self, path, **kwargs):
+        raise NotImplementedError()
+
+    def dump_directory(self, path, **kwargs):
+        raise NotImplementedError()
+
+    def _get_auto_config(self, image_name):
+        if image_name in self.auto_conf_images:
+            check_name = self.auto_conf_images[image_name]
+
+            # get the check class to verify it matches
+            check = get_check_class(self.agentConfig, check_name)
+            if check is None:
+                log.info("Could not find an auto configuration template for %s."
+                         " Leaving it unconfigured." % image_name)
+                return None
+
+            auto_conf = get_auto_conf(self.agentConfig, check_name)
+            init_config, instances = auto_conf.get('init_config', {}), auto_conf.get('instances', [])
+            return (check_name, init_config, instances[0] or {})
+
+        return None
+
+    def get_check_tpls(self, image, **kwargs):
+        """Retrieve template configs for an image from the config_store or auto configuration."""
+        # TODO: make mixing both sources possible
+        templates = []
+        trace_config = kwargs.get(TRACE_CONFIG, False)
+
+        # this flag is used when no valid configuration store was provided
+        # it makes the method skip directly to the auto_conf
+        if kwargs.get('auto_conf') is True:
+            auto_config = self._get_auto_config(image)
+            if auto_config is not None:
+                source = CONFIG_FROM_AUTOCONF
+                if trace_config:
+                    return [(source, auto_config)]
+                return [auto_config]
+            else:
+                log.debug('No auto config was found for image %s, leaving it alone.' % image)
+                return []
+        else:
+            config = self.read_config_from_store(image)
+            if config:
+                source, check_names, init_config_tpls, instance_tpls = config
+            else:
+                return []
+
+        if len(check_names) != len(init_config_tpls) or len(check_names) != len(instance_tpls):
+            log.error('Malformed configuration template: check_names, init_configs '
+                      'and instances are not all the same length. Image {0} '
+                      'will not be configured by the service discovery'.format(image))
+            return []
+
+        for idx, c_name in enumerate(check_names):
+            if trace_config:
+                templates.append((source, (c_name, init_config_tpls[idx], instance_tpls[idx])))
+            else:
+                templates.append((c_name, init_config_tpls[idx], instance_tpls[idx]))
+        return templates
+
+    def read_config_from_store(self, image):
+        """Try to read from the config store, falls back to auto-config in case of failure."""
+        try:
+            check_names = json.loads(
+                self.client_read(path.join(self.sd_template_dir, image, 'check_names').lstrip('/')))
+            init_config_tpls = json.loads(
+                self.client_read(path.join(self.sd_template_dir, image, 'init_configs').lstrip('/')))
+            instance_tpls = json.loads(
+                self.client_read(path.join(self.sd_template_dir, image, 'instances').lstrip('/')))
+            source = CONFIG_FROM_TEMPLATE
+        except (KeyNotFound, TimeoutError, json.JSONDecodeError) as ex:
+            # first case is kind of expected, it means that no template was provided for this container
+            if isinstance(ex, KeyNotFound):
+                log.debug("Could not find directory {0} in the config store, "
+                          "trying to auto-configure a check...".format(image))
+            # this case is not expected, the agent can't reach the config store
+            elif isinstance(ex, TimeoutError):
+                log.warning("Connection to the config backend timed out. Is it reachable?\n"
+                            "Trying to auto-configure a check for the image %s..." % image)
+            # the template is reachable but invalid
+            elif isinstance(ex, json.JSONDecodeError):
+                log.error('Could not decode the JSON configuration template. '
+                          'Trying to auto-configure a check for the image %s...' % image)
+            # In any case cases we try to read from auto-config templates
+            auto_config = self._get_auto_config(image)
+            if auto_config is not None:
+                # create list-format config based on an autoconf template
+                check_names, init_config_tpls, instance_tpls = map(lambda x: [x], auto_config)
+                source = CONFIG_FROM_AUTOCONF
+            else:
+                log.debug('No auto config was found for image %s, leaving it alone.' % image)
+                return []
+        except Exception as ex:
+            log.warning(
+                'Fetching the value for {0} in the config store failed, this check '
+                'will not be configured by the service discovery. Error: {1}'.format(image, str(ex)))
+            return []
+        return source, check_names, init_config_tpls, instance_tpls
+
+    def crawl_config_template(self):
+        """Return whether or not configuration templates have changed since the previous crawl"""
+        try:
+            config_index = self.client_read(self.sd_template_dir.lstrip('/'), recursive=True, watch=True)
+        except KeyNotFound:
+            log.debug('Config template not found (normal if running on auto-config alone).'
+                      ' Not Triggering a config reload.')
+            return False
+        except TimeoutError:
+            msg = 'Request for the configuration template timed out.'
+            raise Exception(msg)
+        # Initialize the config index reference
+        if self.previous_config_index is None:
+            self.previous_config_index = config_index
+            return False
+        # Config has been modified since last crawl
+        if config_index != self.previous_config_index:
+            log.info('Detected an update in config template, reloading check configs...')
+            self.previous_config_index = config_index
+            return True
+        return False
+
+
+class StubStore(AbstractConfigStore):
+    """Used when no valid config store was found. Allow to use auto_config."""
+    def _extract_settings(self, config):
+        pass
+
+    def get_client(self):
+        pass
+
+    def crawl_config_template(self):
+        # There is no user provided templates in auto_config mode
+        return False

--- a/utils/service_discovery/abstract_sd_backend.py
+++ b/utils/service_discovery/abstract_sd_backend.py
@@ -1,0 +1,52 @@
+# std
+import logging
+import re
+
+# project
+from utils.singleton import Singleton
+
+log = logging.getLogger(__name__)
+
+
+class AbstractSDBackend(object):
+    """Singleton for service discovery backends"""
+    __metaclass__ = Singleton
+
+    PLACEHOLDER_REGEX = re.compile(r'%%.+?%%')
+
+    def __init__(self, agentConfig=None):
+        self.agentConfig = agentConfig
+        # this flag is used to know if check configs need to
+        # be reloaded at the end of the current collector run.
+        self.reload_check_configs = False
+
+    @classmethod
+    def _drop(cls):
+        if cls in cls._instances:
+            del cls._instances[cls]
+
+    def get_configs(self):
+        """Get the config for all docker containers running on the host."""
+        raise NotImplementedError()
+
+    def _render_template(self, init_config_tpl, instance_tpl, variables):
+        """Replace placeholders in a template with the proper values.
+           Return a tuple made of `init_config` and `instances`."""
+        config = (init_config_tpl, instance_tpl)
+        for tpl in config:
+            for key in tpl:
+                # iterate over template variables found in the templates
+                for var in self.PLACEHOLDER_REGEX.findall(str(tpl[key])):
+                    if var.strip('%') in variables and variables[var.strip('%')]:
+                        # if the variable is found in a list (for example {'tags': ['%%tags%%', 'env:prod']})
+                        # we need to iterate over its elements
+                        if isinstance(tpl[key], list):
+                            for idx, val in enumerate(tpl[key]):
+                                tpl[key][idx] = val.replace(var, variables[var.strip('%')])
+                        else:
+                            tpl[key] = tpl[key].replace(var, variables[var.strip('%')])
+                    else:
+                        log.warning('Failed to interpolate variable {0} for the {1} parameter.'
+                                    ' Dropping this configuration.'.format(var, key))
+                        return None
+        return config

--- a/utils/service_discovery/config.py
+++ b/utils/service_discovery/config.py
@@ -1,0 +1,38 @@
+# std
+import logging
+
+# project
+from utils.service_discovery.sd_backend import SD_BACKENDS
+from utils.service_discovery.config_stores import extract_sd_config, SD_CONFIG_BACKENDS
+
+log = logging.getLogger(__name__)
+
+
+def extract_agent_config(config):
+    # get merged into the real agentConfig
+    agentConfig = {}
+
+    backend = config.get('Main', 'service_discovery_backend')
+    agentConfig['service_discovery'] = True
+
+    conf_backend = None
+    if config.has_option('Main', 'sd_config_backend'):
+        conf_backend = config.get('Main', 'sd_config_backend')
+
+    if backend not in SD_BACKENDS:
+        log.error("The backend {0} is not supported. "
+                  "Service discovery won't be enabled.".format(backend))
+        agentConfig['service_discovery'] = False
+
+    if conf_backend is None:
+        log.warning('No configuration backend provided for service discovery. '
+                    'Only auto config templates will be used.')
+    elif conf_backend not in SD_CONFIG_BACKENDS:
+        log.error("The config backend {0} is not supported. "
+                  "Only auto config templates will be used.".format(conf_backend))
+        conf_backend = None
+    agentConfig['sd_config_backend'] = conf_backend
+
+    additional_config = extract_sd_config(config)
+    agentConfig.update(additional_config)
+    return agentConfig

--- a/utils/service_discovery/config_stores.py
+++ b/utils/service_discovery/config_stores.py
@@ -1,0 +1,53 @@
+# project
+from utils.service_discovery.abstract_config_store import AbstractConfigStore
+from utils.service_discovery.abstract_config_store import CONFIG_FROM_AUTOCONF, CONFIG_FROM_FILE, CONFIG_FROM_TEMPLATE, TRACE_CONFIG  # noqa imported somewhere else
+
+from utils.service_discovery.etcd_config_store import EtcdStore
+from utils.service_discovery.consul_config_store import ConsulStore
+
+
+SD_CONFIG_BACKENDS = ['etcd', 'consul']  # noqa: used somewhere else
+SD_TEMPLATE_DIR = '/datadog/check_configs'
+
+
+def get_config_store(agentConfig):
+    if agentConfig.get('sd_config_backend') == 'etcd':
+        return EtcdStore(agentConfig)
+    elif agentConfig.get('sd_config_backend') == 'consul':
+        return ConsulStore(agentConfig)
+    elif agentConfig.get('sd_config_backend') is None:
+        return StubStore(agentConfig)
+
+
+def extract_sd_config(config):
+    """Extract configuration about service discovery for the agent"""
+    sd_config = {}
+    if config.has_option('Main', 'sd_config_backend'):
+        sd_config['sd_config_backend'] = config.get('Main', 'sd_config_backend')
+    else:
+        sd_config['sd_config_backend'] = None
+    if config.has_option('Main', 'sd_template_dir'):
+        sd_config['sd_template_dir'] = config.get(
+            'Main', 'sd_template_dir')
+    else:
+        sd_config['sd_template_dir'] = SD_TEMPLATE_DIR
+    if config.has_option('Main', 'sd_backend_host'):
+        sd_config['sd_backend_host'] = config.get(
+            'Main', 'sd_backend_host')
+    if config.has_option('Main', 'sd_backend_port'):
+        sd_config['sd_backend_port'] = config.get(
+            'Main', 'sd_backend_port')
+    return sd_config
+
+
+class StubStore(AbstractConfigStore):
+    """Used when no valid config store was found. Allow to use auto_config."""
+    def _extract_settings(self, config):
+        pass
+
+    def get_client(self):
+        pass
+
+    def crawl_config_template(self):
+        # There is no user provided templates in auto_config mode
+        return False

--- a/utils/service_discovery/configcheck.py
+++ b/utils/service_discovery/configcheck.py
@@ -1,0 +1,55 @@
+# project
+from utils.dockerutil import DockerUtil
+from utils.service_discovery.config_stores import get_config_store, SD_CONFIG_BACKENDS
+
+
+def sd_configcheck(agentConfig, configs):
+    """Trace how the configuration objects are loaded and from where.
+        Also print containers detected by the agent and templates from the config store."""
+    print("\nSource of the configuration objects built by the agent:\n")
+    for check_name, config in configs.iteritems():
+        print('Check "%s":\n  source --> %s\n  config --> %s\n' % (check_name, config[0], config[1]))
+
+    try:
+        print_containers()
+    except Exception:
+        print("Failed to collect containers info.")
+
+    try:
+        print_templates(agentConfig)
+    except Exception:
+        print("Failed to collect configuration templates.")
+
+
+def print_containers():
+    containers = DockerUtil().client.containers()
+    print("\nContainers info:\n")
+    print("Number of containers found: %s" % len(containers))
+    for co in containers:
+        c_id = 'ID: %s' % co.get('Id')[:12]
+        c_image = 'image: %s' % co.get('Image')
+        c_name = 'name: %s' % DockerUtil.container_name_extractor(co)[0]
+        print("\t- %s %s %s" % (c_id, c_image, c_name))
+    print('\n')
+
+
+def print_templates(agentConfig):
+    if agentConfig.get('sd_config_backend') in SD_CONFIG_BACKENDS:
+        print("Configuration templates:\n")
+        templates = {}
+        sd_template_dir = agentConfig.get('sd_template_dir')
+        config_store = get_config_store(agentConfig)
+        try:
+            templates = config_store.dump_directory(sd_template_dir)
+        except Exception as ex:
+            print("Failed to extract configuration templates from the backend:\n%s" % str(ex))
+
+        for img, tpl in templates.iteritems():
+            print(
+                "- Image %s:\n\tcheck name: %s\n\tinit_config: %s\n\tinstance: %s" % (
+                    img,
+                    tpl.get('check_names'),
+                    tpl.get('init_configs'),
+                    tpl.get('instances'),
+                )
+            )

--- a/utils/service_discovery/consul_config_store.py
+++ b/utils/service_discovery/consul_config_store.py
@@ -1,0 +1,74 @@
+# project
+from consul import Consul
+from utils.service_discovery.abstract_config_store import AbstractConfigStore, KeyNotFound
+
+
+DEFAULT_CONSUL_HOST = '127.0.0.1'
+DEFAULT_CONSUL_PORT = 8500
+DEFAULT_CONSUL_TOKEN = None
+DEFAULT_CONSUL_SCHEME = 'http'
+DEFAULT_CONSUL_CONSISTENCY = 'default'
+DEFAULT_CONSUL_DATACENTER = None
+DEFAULT_CONSUL_VERIFY = True
+
+
+class ConsulStore(AbstractConfigStore):
+    """Implementation of a config store client for consul"""
+    def _extract_settings(self, config):
+        """Extract settings from a config object"""
+        settings = {
+            'host': config.get('sd_backend_host', DEFAULT_CONSUL_HOST),
+            'port': int(config.get('sd_backend_port', DEFAULT_CONSUL_PORT)),
+            # all these are set to their default value for now
+            'token': config.get('consul_token', None),
+            'scheme': config.get('consul_scheme', DEFAULT_CONSUL_SCHEME),
+            'consistency': config.get('consul_consistency', DEFAULT_CONSUL_CONSISTENCY),
+            'verify': config.get('consul_verify', DEFAULT_CONSUL_VERIFY),
+        }
+        return settings
+
+    def get_client(self, reset=False):
+        """Return a consul client, create it if needed"""
+        if self.client is None or reset is True:
+            self.client = Consul(
+                host=self.settings.get('host'),
+                port=self.settings.get('port'),
+                token=self.settings.get('token'),
+                scheme=self.settings.get('scheme'),
+                consistency=self.settings.get('consistency'),
+                verify=self.settings.get('verify'),
+            )
+        return self.client
+
+    def client_read(self, path, **kwargs):
+        """Retrieve a value from a consul key."""
+        recurse = kwargs.get('recursive', False)
+        res = self.client.kv.get(path, recurse=recurse)
+        if kwargs.get('watch', False) is True:
+            return res[0]
+        else:
+            if res[1] is not None:
+                return res[1].get('Value') if not recurse else res[1]
+            else:
+                raise KeyNotFound("The key %s was not found in consul" % path)
+
+    def dump_directory(self, path, **kwargs):
+        """Return a dict made of all image names and their corresponding check info"""
+        templates = {}
+        path = path.lstrip('/')
+        try:
+            directory = self.client_read(
+                path,
+                recursive=True,
+            )
+        except KeyNotFound:
+            raise KeyNotFound("The key %s was not found in consul" % path)
+        for leaf in directory:
+            image = leaf.get('Key').split('/')[-2]
+            param = leaf.get('Key').split('/')[-1]
+            value = leaf.get('Value')
+            if image not in templates:
+                templates[image] = {}
+            templates[image][param] = value
+
+        return templates

--- a/utils/service_discovery/etcd_config_store.py
+++ b/utils/service_discovery/etcd_config_store.py
@@ -1,0 +1,74 @@
+from urllib3.exceptions import TimeoutError
+
+from etcd import EtcdKeyNotFound
+from etcd import Client as etcd_client
+from utils.service_discovery.abstract_config_store import AbstractConfigStore, KeyNotFound
+
+DEFAULT_ETCD_HOST = '127.0.0.1'
+DEFAULT_ETCD_PORT = 4001
+DEFAULT_ETCD_PROTOCOL = 'http'
+DEFAULT_RECO = True
+DEFAULT_TIMEOUT = 5
+
+
+class EtcdStore(AbstractConfigStore):
+    """Implementation of a config store client for etcd"""
+    def _extract_settings(self, config):
+        """Extract settings from a config object"""
+        settings = {
+            'host': config.get('sd_backend_host', DEFAULT_ETCD_HOST),
+            'port': int(config.get('sd_backend_port', DEFAULT_ETCD_PORT)),
+            # these two are always set to their default value for now
+            'allow_reconnect': config.get('etcd_allow_reconnect', DEFAULT_RECO),
+            'protocol': config.get('etcd_protocol', DEFAULT_ETCD_PROTOCOL),
+        }
+        return settings
+
+    def get_client(self, reset=False):
+        if self.client is None or reset is True:
+            self.client = etcd_client(
+                host=self.settings.get('host'),
+                port=self.settings.get('port'),
+                allow_reconnect=self.settings.get('allow_reconnect'),
+                protocol=self.settings.get('protocol'),
+            )
+        return self.client
+
+    def client_read(self, path, **kwargs):
+        """Retrieve a value from a etcd key."""
+        try:
+            res = self.client.read(
+                path,
+                timeout=kwargs.get('timeout', DEFAULT_TIMEOUT),
+                recursive=kwargs.get('recursive', False))
+            if kwargs.get('watch', False) is True:
+                return res.etcd_index
+            else:
+                return res.value
+        except EtcdKeyNotFound:
+            raise KeyNotFound("The key %s was not found in etcd" % path)
+        except TimeoutError, e:
+            raise e
+
+    def dump_directory(self, path, **kwargs):
+        """Return a dict made of all image names and their corresponding check info"""
+        templates = {}
+        try:
+            directory = self.client.read(
+                path,
+                recursive=True,
+                timeout=kwargs.get('timeout', DEFAULT_TIMEOUT),
+            )
+        except EtcdKeyNotFound:
+            raise KeyNotFound("The key %s was not found in etcd" % path)
+        except TimeoutError, e:
+            raise e
+        for leaf in directory.leaves:
+            image = leaf.key.split('/')[-2]
+            param = leaf.key.split('/')[-1]
+            value = leaf.value
+            if image not in templates:
+                templates[image] = {}
+            templates[image][param] = value
+
+        return templates

--- a/utils/service_discovery/sd_backend.py
+++ b/utils/service_discovery/sd_backend.py
@@ -1,0 +1,17 @@
+# std
+import logging
+
+# project
+from utils.service_discovery.sd_docker_backend import SDDockerBackend
+
+log = logging.getLogger(__name__)
+
+AUTO_CONFIG_DIR = 'auto_conf/'
+SD_BACKENDS = ['docker']
+
+
+def get_sd_backend(agentConfig):
+    if agentConfig.get('service_discovery_backend') == 'docker':
+        return SDDockerBackend(agentConfig)
+    else:
+        log.error("Service discovery backend not supported. This feature won't be enabled")

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -1,0 +1,275 @@
+# std
+import logging
+import simplejson as json
+
+# project
+from utils.dockerutil import DockerUtil
+from utils.kubeutil import KubeUtil, is_k8s
+from utils.service_discovery.abstract_sd_backend import AbstractSDBackend
+from utils.service_discovery.config_stores import get_config_store, TRACE_CONFIG
+
+log = logging.getLogger(__name__)
+
+
+class SDDockerBackend(AbstractSDBackend):
+    """Docker-based service discovery"""
+
+    def __init__(self, agentConfig):
+        self.docker_client = DockerUtil().client
+        if is_k8s():
+            self.kubeutil = KubeUtil()
+
+        try:
+            self.config_store = get_config_store(agentConfig=agentConfig)
+        except Exception as e:
+            log.error('Failed to instantiate the config store client. '
+                      'Auto-config only will be used. %s' % str(e))
+            agentConfig['sd_config_backend'] = None
+            self.config_store = get_config_store(agentConfig=agentConfig)
+
+        self.VAR_MAPPING = {
+            'host': self._get_host,
+            'port': self._get_ports,
+            'tags': self._get_additional_tags,
+        }
+        AbstractSDBackend.__init__(self, agentConfig)
+
+    def _get_host(self, container_inspect):
+        """Extract the host IP from a docker inspect object, or the kubelet API."""
+        ip_addr = container_inspect.get('NetworkSettings', {}).get('IPAddress')
+        if not ip_addr:
+            if not is_k8s():
+                return
+            # kubernetes case
+            log.debug("Didn't find the IP address for container %s (%s), using the kubernetes way." %
+                      (container_inspect.get('Id', '')[:12], container_inspect.get('Config', {}).get('Image', '')))
+            pod_list = self.kubeutil.retrieve_pods_list().get('items', [])
+            c_id = container_inspect.get('Id')
+            for pod in pod_list:
+                pod_ip = pod.get('status', {}).get('podIP')
+                if pod_ip is None:
+                    continue
+                else:
+                    c_statuses = pod.get('status', {}).get('containerStatuses', [])
+                    for status in c_statuses:
+                        # compare the container id with those of containers in the current pod
+                        if c_id == status.get('containerID', '').split('//')[-1]:
+                            ip_addr = pod_ip
+
+        return ip_addr
+
+    def _get_ports(self, container_inspect):
+        """Extract a list of available ports from a docker inspect object. Sort them numerically."""
+        c_id = container_inspect.get('Id', '')
+        try:
+            ports = map(lambda x: x.split('/')[0], container_inspect['NetworkSettings']['Ports'].keys())
+        except (IndexError, KeyError, AttributeError):
+            log.debug("Didn't find the port for container %s (%s), trying the kubernetes way." %
+                      (c_id[:12], container_inspect.get('Config', {}).get('Image', '')))
+            # first we try to get it from the docker API
+            # it works if the image has an EXPOSE instruction
+            ports = map(lambda x: x.split('/')[0], container_inspect['Config'].get('ExposedPorts', {}).keys())
+            # if it failed, try with the kubernetes API
+            if not ports and is_k8s():
+                co_statuses = self._get_kube_config(c_id, 'status').get('containerStatuses', [])
+                c_name = None
+                for co in co_statuses:
+                    if co.get('containerID', '').split('//')[-1] == c_id:
+                        c_name = co.get('name')
+                        break
+                containers = self._get_kube_config(c_id, 'spec').get('containers', [])
+                for co in containers:
+                    if co.get('name') == c_name:
+                        ports = map(lambda x: str(x.get('containerPort')), co.get('ports', []))
+        ports = sorted(ports, key=lambda x: int(x))
+        return ports
+
+    def get_tags(self, c_inspect):
+        """Extract useful tags from docker or platform APIs. These are collected by default."""
+        tags = []
+        if is_k8s():
+            pod_metadata = self._get_kube_config(c_inspect.get('Id'), 'metadata')
+
+            if pod_metadata is None:
+                log.warning("Failed to fetch pod metadata for container %s."
+                            " Kubernetes tags may be missing." % c_inspect.get('Id', '')[:12])
+                return []
+            # get labels
+            kube_labels = pod_metadata.get('labels', {})
+            for label, value in kube_labels.iteritems():
+                tags.append('%s:%s' % (label, value))
+
+            # get replication controller
+            created_by = json.loads(pod_metadata.get('annotations', {}).get('kubernetes.io/created-by', '{}'))
+            if created_by.get('reference', {}).get('kind') == 'ReplicationController':
+                tags.append('kube_replication_controller:%s' % created_by.get('reference', {}).get('name'))
+
+            # get kubernetes namespace
+            tags.append('kube_namespace:%s' % pod_metadata.get('namespace'))
+
+        return tags
+
+    def _get_additional_tags(self, container_inspect):
+        tags = []
+        if is_k8s():
+            pod_metadata = self._get_kube_config(container_inspect.get('Id'), 'metadata')
+            pod_spec = self._get_kube_config(container_inspect.get('Id'), 'spec')
+            tags.append('node_name:%s' % pod_spec.get('nodeName'))
+            tags.append('pod_name:%s' % pod_metadata.get('name'))
+        return tags
+
+    def _get_kube_config(self, c_id, key):
+        """Get a part of a pod config from the kubernetes API"""
+        pods = self.kubeutil.retrieve_pods_list().get('items', [])
+        for pod in pods:
+            c_statuses = pod.get('status', {}).get('containerStatuses', [])
+            for status in c_statuses:
+                if c_id == status.get('containerID', '').split('//')[-1]:
+                    return pod.get(key, {})
+
+    def get_configs(self):
+        """Get the config for all docker containers running on the host."""
+        configs = {}
+        containers = [(
+            container.get('Image').split(':')[0].split('/')[-1],
+            container.get('Id'), container.get('Labels')
+        ) for container in self.docker_client.containers()]
+
+        # used by the configcheck agent command to trace where check configs come from
+        trace_config = self.agentConfig.get(TRACE_CONFIG, False)
+
+        for image, cid, labels in containers:
+            try:
+                check_configs = self._get_check_configs(cid, image, trace_config=trace_config) or []
+                for conf in check_configs:
+                    if trace_config and conf is not None:
+                        source, conf = conf
+
+                    check_name, init_config, instance = conf
+                    # build instances list if needed
+                    if configs.get(check_name) is None:
+                        if trace_config:
+                            configs[check_name] = (source, (init_config, [instance]))
+                        else:
+                            configs[check_name] = (init_config, [instance])
+                    else:
+                        conflict_init_msg = 'Different versions of `init_config` found for check {0}. ' \
+                            'Keeping the first one found.'
+                        if trace_config:
+                            if configs[check_name][1][0] != init_config:
+                                log.warning(conflict_init_msg.format(check_name))
+                            configs[check_name][1][1].append(instance)
+                        else:
+                            if configs[check_name][0] != init_config:
+                                log.warning(conflict_init_msg.format(check_name))
+                            configs[check_name][1].append(instance)
+            except Exception:
+                log.exception('Building config for container %s based on image %s using service'
+                              ' discovery failed, leaving it alone.' % (cid[:12], image))
+        return configs
+
+    def _get_check_configs(self, c_id, image, trace_config=False):
+        """Retrieve configuration templates and fill them with data pulled from docker and tags."""
+        inspect = self.docker_client.inspect_container(c_id)
+        config_templates = self._get_config_templates(image, trace_config=trace_config)
+        if not config_templates:
+            log.debug('No config template for container %s with image %s. '
+                      'It will be left unconfigured.' % (c_id[:12], image))
+            return None
+
+        check_configs = []
+        tags = self.get_tags(inspect)
+        for config_tpl in config_templates:
+            if trace_config:
+                source, config_tpl = config_tpl
+            check_name, init_config_tpl, instance_tpl, variables = config_tpl
+
+            # insert tags in instance_tpl and process values for template variables
+            instance_tpl, var_values = self._fill_tpl(inspect, instance_tpl, variables, tags)
+
+            tpl = self._render_template(init_config_tpl or {}, instance_tpl or {}, var_values)
+            if tpl and len(tpl) == 2:
+                if trace_config and len(tpl[1]) == 2:
+                    source, (init_config, instance) = tpl
+                    check_configs.append((source, (check_name, init_config, instance)))
+                elif not trace_config:
+                    init_config, instance = tpl
+                    check_configs.append((check_name, init_config, instance))
+
+        return check_configs
+
+    def _get_config_templates(self, image_name, trace_config=False):
+        """Extract config templates for an image from a K/V store and returns it as a dict object."""
+        config_backend = self.agentConfig.get('sd_config_backend')
+        templates = []
+        if config_backend is None:
+            auto_conf = True
+            log.warning('No supported configuration backend was provided, using auto-config only.')
+        else:
+            auto_conf = False
+
+        # format: [('image', {init_tpl}, {instance_tpl})] without trace_config
+        # or      [(source, ('image', {init_tpl}, {instance_tpl}))] with trace_config
+        raw_tpls = self.config_store.get_check_tpls(image_name, auto_conf=auto_conf, trace_config=trace_config)
+        for tpl in raw_tpls:
+            if trace_config and tpl is not None:
+                # each template can come from either auto configuration or user-supplied templates
+                source, tpl = tpl
+            if tpl is not None and len(tpl) == 3:
+                check_name, init_config_tpl, instance_tpl = tpl
+            else:
+                log.debug('No template was found for image %s, leaving it alone.' % image_name)
+                return None
+            try:
+                # build a list of all variables to replace in the template
+                variables = self.PLACEHOLDER_REGEX.findall(str(init_config_tpl)) + \
+                    self.PLACEHOLDER_REGEX.findall(str(instance_tpl))
+                variables = map(lambda x: x.strip('%'), variables)
+                if not isinstance(init_config_tpl, dict):
+                    init_config_tpl = json.loads(init_config_tpl or '{}')
+                if not isinstance(instance_tpl, dict):
+                    instance_tpl = json.loads(instance_tpl or '{}')
+            except json.JSONDecodeError:
+                log.exception('Failed to decode the JSON template fetched for check {0}. Its configuration'
+                              ' by service discovery failed for {1}.'.format(check_name, image_name))
+                return None
+
+            if trace_config:
+                templates.append((source, (check_name, init_config_tpl, instance_tpl, variables)))
+            else:
+                templates.append((check_name, init_config_tpl, instance_tpl, variables))
+
+        return templates
+
+    def _fill_tpl(self, inspect, instance_tpl, variables, tags=None):
+        """Add container tags to instance templates and build a """
+        """dict from template variable names and their values."""
+        var_values = {}
+
+        # add default tags to the instance
+        if tags:
+            tags += instance_tpl.get('tags', [])
+            instance_tpl['tags'] = list(set(tags))
+
+        for v in variables:
+            # variables can be suffixed with an index in case a list is found
+            var_parts = v.split('_')
+            if var_parts[0] in self.VAR_MAPPING:
+                try:
+                    res = self.VAR_MAPPING[var_parts[0]](inspect)
+                    if not res:
+                        raise ValueError("Invalid value for variable %s." % var_parts[0])
+                    # if an index is found in the variable, use it to select a value
+                    if len(var_parts) > 1 and isinstance(res, list) and int(var_parts[-1]) < len(res):
+                        var_values[v] = res[int(var_parts[-1])]
+                    # if no valid index was found but we have a list, return the last element
+                    elif isinstance(res, list):
+                        var_values[v] = res[-1]
+                    else:
+                        var_values[v] = res
+                except Exception as ex:
+                    log.error("Could not find a value for the template variable %s: %s" % (v, str(ex)))
+            else:
+                log.error("No method was found to interpolate template variable %s." % v)
+
+        return instance_tpl, var_values

--- a/utils/singleton.py
+++ b/utils/singleton.py
@@ -1,0 +1,9 @@
+
+class Singleton(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]


### PR DESCRIPTION
## What does this PR do?

The goal of this PR is to create a basic and generic service discovery feature for the agent that will be easy to improve and extend.

## How does it work

Users need to write configuration templates and store them in a key-value store (for now etcd or consul) that any node where the agent is running can access. These templates will then be used by the agent to generate check configurations on the fly using data (container IP address, service ports, tags, etc.) about the current running containers extracted from docker and platforms like Kubernetes, Docker Swarm and Amazon ECS.
The service discovery runs every 30 seconds or so. Configuration reload happens if relevant docker events (containers killed or started) happened between the current run and the previous one or if templates have been updated in the config store.

The feature also comes with auto-configuration for services where a simple configuration using default values is often enough.

## TO DO
- make the configuration reload smarter
- pull tags from more platform APIs
- support more K/V stores

## Related PRs
- https://github.com/DataDog/omnibus-software/pull/25

## Documentation
- https://github.com/DataDog/dd-agent/wiki/Service-discovery