### PR TITLE
[win32_event_log] Allow optional tagging by event_id

### DIFF
--- a/checks.d/win32_event_log.py
+++ b/checks.d/win32_event_log.py
@@ -61,7 +61,8 @@ class Win32EventLog(AgentCheck):
         # Save any events returned to the payload as Datadog events
         for ev in events:
             log_ev = LogEvent(ev, self.agentConfig.get('api_key', ''),
-                              self.hostname, tags, notify)
+                              self.hostname, tags, notify,
+                              self.init_config.get('tag_event_id', False))
 
             # Since WQL only compares on the date and NOT the time, we have to
             # do a secondary check to make sure events are after the last
@@ -98,7 +99,7 @@ class EventLogQuery(object):
     def to_wql(self):
         ''' Return this query as a WQL string. '''
         wql = """
-        SELECT Message, SourceName, TimeGenerated, Type, User, InsertionStrings
+        SELECT Message, SourceName, TimeGenerated, Type, User, InsertionStrings, EventCode
         FROM Win32_NTLogEvent
         WHERE TimeGenerated >= "%s"
         """ % (self._dt_to_wmi(self.start_ts))
@@ -150,11 +151,11 @@ class EventLogQuery(object):
 
 
 class LogEvent(object):
-    def __init__(self, ev, api_key, hostname, tags, notify_list):
+    def __init__(self, ev, api_key, hostname, tags, notify_list, tag_event_id):
         self.event = ev
         self.api_key = api_key
         self.hostname = hostname
-        self.tags = tags
+        self.tags = self._tags(tags, ev.EventCode) if tag_event_id else tags
         self.notify_list = notify_list
         self.timestamp = self._wmi_to_ts(self.event.TimeGenerated)
 
@@ -189,6 +190,15 @@ class LogEvent(object):
         dt = datetime(year=year, month=month, day=day, hour=hour, minute=minute,
                       second=second, microsecond=microsecond) + tz_delta
         return int(calendar.timegm(dt.timetuple()))
+
+    def _tags(self, tags, event_code):
+        ''' Inject additional tags into the list already supplied to LogEvent.
+        '''
+        tags_list = []
+        if tags is not None:
+            tags_list += list(tags)
+        tags_list.append("event_id:{event_id}".format(event_id=event_code))
+        return tags_list
 
     def _msg_title(self, event):
         return '%s/%s' % (event.Logfile, event.SourceName)

--- a/conf.d/win32_event_log.yaml.example
+++ b/conf.d/win32_event_log.yaml.example
@@ -1,4 +1,7 @@
 init_config:
+    # The (optional) tag_event_id setting will add an event id tag to each
+    # event sent from this check. Defaults to false.
+    # tag_event_id: false
 
 instances:
   # Each Event Log instance lets you define the type of events you want to


### PR DESCRIPTION
Add config option for allowing the user to have events tagged by event_id of the form `event_id:<num>`.