### PR TITLE
Obfuscates passwords encoded in URI's

### DIFF
--- a/tests/core/fixtures/flare/password_uri.yaml
+++ b/tests/core/fixtures/flare/password_uri.yaml
@@ -1,0 +1,10 @@
+init_config:
+
+instances:
+    -   server: mongodb://datadog:V3pZC7ghx1ne82XkyqLnOW36@localhost:27017/admin
+        tags:
+            - foo
+
+#   -   server: mongodb://datadog:V3pZC7ghx1ne82XkyqLnOW36@localhost:27017/movies
+#        tags:
+#            - bar

--- a/tests/core/test_flare.py
+++ b/tests/core/test_flare.py
@@ -1,6 +1,7 @@
 # stdlib
 import os.path
 import unittest
+import re
 
 # 3p
 import mock
@@ -27,6 +28,16 @@ def get_mocked_temp():
         'fixtures',
         'flare'
     )
+
+mock_cfgs = {
+    'uri_password' : 'password_uri.yaml',
+}
+
+password_tests = {
+    'uri_password' : '      -   server: mongodb://datadog:V3pZC7ghx1ne82XkyqLnOW36@localhost:27017/admin',
+    'uri_password_2' : '      -   server: mongodb://datadog:V3!pZC7ghx1ne8#-2XkyqLnOW36!?@localhost:27017/admin',
+    'uri_password_expected' : '      -   server: mongodb://datadog:********@localhost:27017/admin',
+}
 
 
 def mocked_strftime(t):
@@ -121,3 +132,33 @@ class FlareTest(unittest.TestCase):
             raise Exception('Should fail before')
         except Exception, e:
             self.assertEqual(str(e), "Your request is incorrect: Invalid inputs: 'API key unknown'")
+
+    @attr(requires='core_integration')
+    @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
+    @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
+    @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
+    def test_uri_password(self, mock_config, mock_tempdir, mock_strftime):
+        f = Flare()
+        _, password_found = f._strip_password(os.path.join(get_mocked_temp(), mock_cfgs['uri_password']))
+        self.assertEqual(
+            password_found,
+            " - this file contains a password in a uri which has been removed in the version collected"
+        )
+
+    @attr(requires='core_integration')
+    @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
+    @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
+    @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
+    def test_uri_password_regex(self, mock_config, mock_tempdir, mock_strftime):
+        f = Flare()
+        line = re.sub(f.URI_REGEX, r'\1://\2:********@', password_tests['uri_password'])
+        self.assertEqual(
+            line,
+            password_tests['uri_password_expected']
+        )
+
+        line = re.sub(f.URI_REGEX, r'\1://\2:********@', password_tests['uri_password_2'])
+        self.assertEqual(
+            line,
+            password_tests['uri_password_expected']
+        )

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -75,6 +75,7 @@ class Flare(object):
 
     DATADOG_SUPPORT_URL = '/support/flare'
     PASSWORD_REGEX = re.compile('( *(\w|_)*pass(word)?:).+')
+    URI_REGEX = re.compile('(.*\ [A-Za-z0-9]+)\:\/\/([A-Za-z0-9]+)\:(.+)\@')
     COMMENT_REGEX = re.compile('^ *#.*')
     APIKEY_REGEX = re.compile('^api_key: *\w+(\w{5})$')
     REPLACE_APIKEY = r'api_key: *************************\1'
@@ -362,6 +363,10 @@ class Flare(object):
                     if self.PASSWORD_REGEX.match(line):
                         line = re.sub(self.PASSWORD_REGEX, r'\1 ********', line)
                         password_found = ' - this file contains a password which '\
+                                         'has been removed in the version collected'
+                    if self.URI_REGEX.match(line):
+                        line = re.sub(self.URI_REGEX, r'\1://\2:********@', line)
+                        password_found = ' - this file contains a password in a uri which '\
                                          'has been removed in the version collected'
                     if not self.COMMENT_REGEX.match(line):
                         temp_file.write(line)


### PR DESCRIPTION
For lines including passwords in the URI of the form `fooproto://bar_user:somepass@somewhere....` this regex will strip somepass and substitute for asterisks.