### PR TITLE
[core][wmi] new WMI metric collection core

### DIFF
--- a/checks.d/wmi_check.py
+++ b/checks.d/wmi_check.py
@@ -1,132 +1,285 @@
-'''
-Windows Only.
-
-Generic WMI check. This check allows you to specify particular metrics that you
-want from WMI in your configuration. Check wmi_check.yaml.example in your conf.d
-directory for more details on configuration.
-'''
-# 3rd party
-import wmi
+# stdlib
+from collections import namedtuple
 
 # project
 from checks import AgentCheck
+from checks.libs.wmi.sampler import WMISampler
 
-UP_METRIC = 'Up'
-SEARCH_WILDCARD = '*'
+WMIMetric = namedtuple('WMIMetric', ['name', 'value', 'tags'])
+
+
+class InvalidWMIQuery(Exception):
+    """
+    Invalid WMI Query.
+    """
+    pass
+
+
+class MissingTagBy(Exception):
+    """
+    WMI query returned multiple rows but no `tag_by` value was given.
+    """
+    pass
+
+
+class TagQueryUniquenessFailure(Exception):
+    """
+    'Tagging query' did not return or returned multiple results.
+    """
+    pass
 
 
 class WMICheck(AgentCheck):
+    """
+    WMI check.
+
+    Windows only.
+    """
     def __init__(self, name, init_config, agentConfig, instances):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
-        self.wmi_conns = {}
-
-    def _get_wmi_conn(self, host, **kwargs):
-        key = "{0}:".format(host)
-        key += ":".join(str(v) for v in kwargs.values())
-        if key not in self.wmi_conns:
-            self.wmi_conns[key] = wmi.WMI(host, **kwargs)
-        return self.wmi_conns[key]
+        self.wmi_samplers = {}
+        self.wmi_props = {}
 
     def check(self, instance):
-        host = instance.get('host', None)
-        namespace = instance.get('namespace', None)
-        user = instance.get('username', None)
-        password = instance.get('password', None)
-        w = self._get_wmi_conn(host, namespace=namespace, user=user, password=password)
+        """
+        Fetch WMI metrics.
+        """
+        # Connection information
+        host = instance.get('host', "localhost")
+        namespace = instance.get('namespace', "root\\cimv2")
+        username = instance.get('username', "")
+        password = instance.get('password', "")
+
+        # WMI instance
         wmi_class = instance.get('class')
         metrics = instance.get('metrics')
         filters = instance.get('filters')
-        tag_by = instance.get('tag_by')
-        tag_queries = instance.get('tag_queries')
+        tag_by = instance.get('tag_by', "").lower()
+        tag_queries = instance.get('tag_queries', [])
         constant_tags = instance.get('constant_tags')
 
-        if not wmi_class:
-            raise Exception('WMI instance is missing a value for `class` in wmi_check.yaml')
+        # Create or retrieve an existing WMISampler
+        instance_key = self._get_instance_key(host, namespace, wmi_class)
 
-        # If there are filters, we need one query per filter.
-        if filters:
-            for f in filters:
-                prop = f.keys()[0]
-                search = f.values()[0]
-                if SEARCH_WILDCARD in search:
-                    search = search.replace(SEARCH_WILDCARD, '%')
-                    wql = "SELECT * FROM %s WHERE %s LIKE '%s'" \
-                        % (wmi_class, prop, search)
-                    results = w.query(wql)
-                else:
-                    results = getattr(w, wmi_class)(**f)
-                self._extract_metrics(results, metrics, tag_by, w, tag_queries, constant_tags)
-        else:
-            results = getattr(w, wmi_class)()
-            self._extract_metrics(results, metrics, tag_by, w, tag_queries, constant_tags)
+        metric_name_and_type_by_property, properties = \
+            self._get_wmi_properties(instance_key, metrics, tag_queries)
 
-    def _extract_metrics(self, results, metrics, tag_by, wmi, tag_queries, constant_tags):
-        if len(results) > 1 and tag_by is None:
-            raise Exception('WMI query returned multiple rows but no `tag_by` value was given. '
-                            'metrics=%s' % metrics)
+        wmi_sampler = self._get_wmi_sampler(
+            instance_key,
+            wmi_class, properties,
+            filters=filters,
+            host=host, namespace=namespace,
+            username=username, password=password
+        )
 
-        for res in results:
-            tags = []
+        # Sample, extract & submit metrics
+        wmi_sampler.sample()
+        metrics = self._extract_metrics(wmi_sampler, tag_by, tag_queries, constant_tags)
+        self._submit_metrics(metrics, metric_name_and_type_by_property)
 
-            # include any constant tags...
-            if constant_tags:
-                tags.extend(constant_tags)
+    def _format_tag_query(self, sampler, wmi_obj, tag_query):
+        """
+        Format `tag_query` or raise on incorrect parameters.
+        """
+        try:
+            link_source_property = int(wmi_obj[tag_query[0]])
+            target_class = tag_query[1]
+            link_target_class_property = tag_query[2]
+            target_property = tag_query[3]
+        except IndexError:
+            self.log.error(
+                u"Wrong `tag_queries` parameter format. "
+                "Please refer to the configuration file for more information.")
+            raise
+        except TypeError:
+            self.log.error(
+                u"Incorrect 'link source property' in `tag_queries` parameter:"
+                " `{wmi_property}` is not a property of `{wmi_class}`".format(
+                    wmi_property=tag_query[0],
+                    wmi_class=sampler.class_name,
+                )
+            )
+            raise
 
-            # if tag_queries is specified then get attributes from other classes and use as a tags
-            if tag_queries:
-                for query in tag_queries:
-                    link_source_property = int(getattr(res, query[0]))
-                    target_class = query[1]
-                    link_target_class_property = query[2]
-                    target_property = query[3]
+        return target_class, target_property, [{link_target_class_property: link_source_property}]
 
-                    link_results = \
-                        wmi.query("SELECT {0} FROM {1} WHERE {2} = {3}"
-                                  .format(target_property, target_class,
-                                          link_target_class_property, link_source_property))
+    def _raise_on_invalid_tag_query_result(self, sampler, wmi_obj, tag_query):
+        """
+        """
+        target_property = sampler.property_names[0]
+        target_class = sampler.class_name
 
-                    if len(link_results) != 1:
-                        self.log.warning("Failed to find {0} for {1} {2}. No metrics gathered"
-                                         .format(target_class, link_target_class_property,
-                                                 link_source_property))
-                        continue
+        if len(sampler) != 1:
+            message = "no result was returned"
+            if len(sampler):
+                message = "multiple results returned (one expected)"
 
-                    link_value = str(getattr(link_results[0], target_property)).lower()
-                    tags.append("{0}:{1}".format(target_property.lower(),
-                                "_".join(link_value.split())))
+            self.log.warning(
+                u"Failed to extract a tag from `tag_queries` parameter: {reason}."
+                " wmi_object={wmi_obj} - query={tag_query}".format(
+                    reason=message,
+                    wmi_obj=wmi_obj, tag_query=tag_query,
+                )
+            )
+            raise TagQueryUniquenessFailure
 
-            # Grab the tag from the result if there's a `tag_by` value (e.g.: "name:jenkins")
-            # Strip any #instance off the value when `tag_queries` is set (gives us unique tags)
-            if tag_by:
-                tag_value = str(getattr(res, tag_by)).lower()
-                if tag_queries and tag_value.find("#") > 0:
-                    tag_value = tag_value[:tag_value.find("#")]
-                tags.append('%s:%s' % (tag_by.lower(), tag_value))
+        if sampler[0][target_property] is None:
+            self.log.error(
+                u"Incorrect 'target property' in `tag_queries` parameter:"
+                " `{wmi_property}` is not a property of `{wmi_class}`".format(
+                    wmi_property=target_property,
+                    wmi_class=target_class,
+                )
+            )
+            raise TypeError
 
-            if len(tags) == 0:
-                tags = None
+    def _get_tag_query_tag(self, sampler, wmi_obj, tag_query):
+        """
+        Design a query based on the given WMIObject to extract a tag.
 
-            for wmi_property, name, mtype in metrics:
-                if wmi_property == UP_METRIC:
-                    # Special-case metric will just submit 1 for every value
-                    # returned in the result.
-                    val = 1
-                else:
-                    try:
-                        val = float(getattr(res, wmi_property))
-                    except (ValueError, TypeError):
-                        self.log.warning("When extracting metrics with WMI, found a non digit value"
-                                         " for property '{0}'.".format(wmi_property))
-                        continue
-                    except AttributeError:
-                        self.log.warning("'{0}' WMI class has no property '{1}'."
-                                         .format(res.__class__.__name__, wmi_property))
-                        continue
+        Returns: tag or TagQueryUniquenessFailure exception.
+        """
+        self.log.debug(
+            u"`tag_queries` parameter found."
+            " wmi_object={wmi_obj} - query={tag_query}".format(
+                wmi_obj=wmi_obj, tag_query=tag_query,
+            )
+        )
 
-                # Submit the metric to Datadog
+        # Extract query information
+        target_class, target_property, filters = \
+            self._format_tag_query(sampler, wmi_obj, tag_query)
+
+        # Create a specific sampler
+        connection = sampler.get_connection()
+        tag_query_sampler = WMISampler(
+            self.log,
+            target_class, [target_property],
+            filters=filters,
+            **connection
+        )
+
+        tag_query_sampler.sample()
+
+        # Extract tag
+        self._raise_on_invalid_tag_query_result(tag_query_sampler, wmi_obj, tag_query)
+
+        link_value = str(tag_query_sampler[0][target_property]).lower()
+
+        tag = "{tag_name}:{tag_value}".format(
+            tag_name=target_property.lower(),
+            tag_value="_".join(link_value.split())
+        )
+
+        self.log.debug(u"Extracted `tag_queries` tag: '{tag}'".format(tag=tag))
+        return tag
+
+    def _extract_metrics(self, wmi_sampler, tag_by, tag_queries, constant_tags):
+        """
+        Extract and tag metrics from the WMISampler.
+
+        Raise when multiple WMIObject were returned by the sampler with no `tag_by` specified.
+
+        Returns: List of WMIMetric
+        ```
+        [
+            WMIMetric("freemegabytes", 19742, ["name:_total"]),
+            WMIMetric("avgdiskbytesperwrite", 1536, ["name:c:"]),
+        ]
+        ```
+        """
+        if len(wmi_sampler) > 1 and not tag_by:
+            raise MissingTagBy(
+                u"WMI query returned multiple rows but no `tag_by` value was given."
+                " class={wmi_class} - properties={wmi_properties} - filters={filters}".format(
+                    wmi_class=wmi_sampler.class_name, wmi_properties=wmi_sampler.property_names,
+                    filters=wmi_sampler.filters,
+                )
+            )
+
+        metrics = []
+
+        for wmi_obj in wmi_sampler:
+            tags = list(constant_tags) if constant_tags else []
+
+            # Tag with `tag_queries` parameter
+            for query in tag_queries:
                 try:
-                    func = getattr(self, mtype)
-                except AttributeError:
-                    raise Exception('Invalid metric type: {0}'.format(mtype))
+                    tags.append(self._get_tag_query_tag(wmi_sampler, wmi_obj, query))
+                except TagQueryUniquenessFailure:
+                    continue
 
-                func(name, val, tags=tags)
+            for wmi_property, wmi_value in wmi_obj.iteritems():
+                # Tag with `tag_by` parameter
+                if wmi_property == tag_by:
+                    tag_value = str(wmi_value).lower()
+                    if tag_queries and tag_value.find("#") > 0:
+                        tag_value = tag_value[:tag_value.find("#")]
+
+                    tags.append(
+                        "{name}:{value}".format(
+                            name=tag_by.lower(), value=tag_value
+                        )
+                    )
+                    continue
+                try:
+                    metrics.append(WMIMetric(wmi_property, float(wmi_value), tags))
+                except ValueError:
+                    self.log.warning(u"When extracting metrics with WMI, found a non digit value"
+                                     " for property '{0}'.".format(wmi_property))
+                    continue
+                except TypeError:
+                    self.log.warning(u"When extracting metrics with WMI, found a missing property"
+                                     " '{0}'".format(wmi_property))
+                    continue
+        return metrics
+
+    def _submit_metrics(self, metrics, metric_name_and_type_by_property):
+        """
+        Resolve metric names and types and submit it.
+        """
+        for metric in metrics:
+            if metric.name not in metric_name_and_type_by_property:
+                # Only report the metrics that were specified in the configration
+                # Ignore added properties like 'Timestamp_Sys100NS', `Frequency_Sys100NS`, etc ...
+                continue
+
+            metric_name, metric_type = metric_name_and_type_by_property[metric.name]
+            try:
+                func = getattr(self, metric_type)
+            except AttributeError:
+                raise Exception(u"Invalid metric type: {0}".format(metric_type))
+
+            func(metric_name, metric.value, metric.tags)
+
+    def _get_instance_key(self, host, namespace, wmi_class):
+        """
+        Return an index key for a given instance. Usefull for caching.
+        """
+        return "{host}:{namespace}:{wmi_class}".format(
+            host=host, namespace=namespace, wmi_class=wmi_class,
+        )
+
+    def _get_wmi_sampler(self, instance_key, wmi_class, properties, **kwargs):
+        """
+        Create and cache a WMISampler for the given (class, properties)
+        """
+        if instance_key not in self.wmi_samplers:
+            wmi_sampler = WMISampler(self.log, wmi_class, properties, **kwargs)
+            self.wmi_samplers[instance_key] = wmi_sampler
+
+        return self.wmi_samplers[instance_key]
+
+    def _get_wmi_properties(self, instance_key, metrics, tag_queries):
+        """
+        Create and cache a (metric name, metric type) by WMI property map and a property list.
+        """
+        if instance_key not in self.wmi_props:
+            metric_name_by_property = dict(
+                (wmi_property.lower(), (metric_name, metric_type))
+                for wmi_property, metric_name, metric_type in metrics
+            )
+            properties = map(lambda x: x[0], metrics + tag_queries)
+            self.wmi_props[instance_key] = (metric_name_by_property, properties)
+
+        return self.wmi_props[instance_key]

--- a/checks/libs/wmi/counter_type.py
+++ b/checks/libs/wmi/counter_type.py
@@ -1,0 +1,139 @@
+"""
+Implementation of WMI calculators a few `CounterType`(s).
+
+
+Protocol.
+
+    Use MSDN to lookup the class, property and counter type to determine the
+    appropriate calculator.
+
+    For example, "Win32_PerfRawData_PerfOS_Memory" is located at:
+      https://msdn.microsoft.com/en-us/library/aa394314(v=vs.85).aspx
+    and the "CacheBytes" property has a CounterType = 65792 which
+    can be determined from:
+      https://msdn.microsoft.com/en-us/library/aa389383(v=vs.85).aspx
+    The CounterType 65792 (PERF_COUNTER_LARGE_RAWCOUNT) is defined here:
+      https://technet.microsoft.com/en-us/library/cc780300(v=ws.10).aspx
+
+    From: https://msdn.microsoft.com/en-us/library/aa389383(v=vs.85).aspx
+
+Original discussion thread: https://github.com/DataDog/dd-agent/issues/1952
+Credits to @TheCloudlessSky (https://github.com/TheCloudlessSky)
+"""
+
+_counter_type_calculators = {}
+
+
+class UndefinedCalculator(Exception):
+    """
+    No calculator is defined for the given CounterType.
+    """
+    pass
+
+
+def calculator(counter_type):
+    """
+    A decorator that assign a counter_type to its calculator.
+    """
+    def set_calculator(func):
+        _counter_type_calculators[counter_type] = func
+        return func
+    return set_calculator
+
+
+def get_calculator(counter_type):
+    """
+    Return the calculator associated with the counter_type when it exists.
+
+    Raise a UndefinedCalculator exception otherwise.
+    """
+    try:
+        return _counter_type_calculators[counter_type]
+    except KeyError:
+        raise UndefinedCalculator
+
+
+def get_raw(previous, current, property_name):
+    """
+    Returns the vanilla RAW property value.
+
+    Not associated with any counter_type. Used to fallback when no calculator
+    is defined for a given counter_type.
+    """
+    return current[property_name]
+
+
+@calculator(65536)
+def calculate_perf_counter_rawcount(previous, current, property_name):
+    """
+    PERF_COUNTER_RAWCOUNT
+
+    https://technet.microsoft.com/en-us/library/cc757032(v=ws.10).aspx
+    """
+    return current[property_name]
+
+
+@calculator(65792)
+def calculate_perf_counter_large_rawcount(previous, current, property_name):
+    """
+    PERF_COUNTER_LARGE_RAWCOUNT
+
+    https://technet.microsoft.com/en-us/library/cc780300(v=ws.10).aspx
+    """
+    return current[property_name]
+
+
+@calculator(542180608)
+def calculate_perf_100nsec_timer(previous, current, property_name):
+    """
+    PERF_100NSEC_TIMER
+
+    https://technet.microsoft.com/en-us/library/cc728274(v=ws.10).aspx
+    """
+    n0 = previous[property_name]
+    n1 = current[property_name]
+    d0 = previous["Timestamp_Sys100NS"]
+    d1 = current["Timestamp_Sys100NS"]
+
+    if n0 is None or n1 is None:
+        return
+
+    return (n1 - n0) / (d1 - d0) * 100
+
+
+@calculator(272696576)
+def calculate_perf_counter_bulk_count(previous, current, property_name):
+    """
+    PERF_COUNTER_BULK_COUNT
+
+    https://technet.microsoft.com/en-us/library/cc757486(v=ws.10).aspx
+    """
+    n0 = previous[property_name]
+    n1 = current[property_name]
+    d0 = previous["Timestamp_Sys100NS"]
+    d1 = current["Timestamp_Sys100NS"]
+    f = current["Frequency_Sys100NS"]
+
+    if n0 is None or n1 is None:
+        return
+
+    return (n1 - n0) / ((d1 - d0) / f)
+
+
+@calculator(272696320)
+def calculate_perf_counter_counter(previous, current, property_name):
+    """
+    PERF_COUNTER_COUNTER
+
+    https://technet.microsoft.com/en-us/library/cc740048(v=ws.10).aspx
+    """
+    n0 = previous[property_name]
+    n1 = current[property_name]
+    d0 = previous["Timestamp_Sys100NS"]
+    d1 = current["Timestamp_Sys100NS"]
+    f = current["Frequency_Sys100NS"]
+
+    if n0 is None or n1 is None:
+        return
+
+    return (n1 - n0) / ((d1 - d0) / f)

--- a/checks/libs/wmi/sampler.py
+++ b/checks/libs/wmi/sampler.py
@@ -89,6 +89,17 @@ class WMISampler(object):
         self.current_sample = None
         self.previous_sample = None
 
+    def get_connection(self):
+        """
+        A Getter to retrieve the sampler connection information.
+        """
+        return {
+            'host': self.host,
+            'namespace': self.namespace,
+            'username': self.username,
+            'password': self.password,
+        }
+
     @property
     def formatted_filters(self):
         """

--- a/checks/libs/wmi/sampler.py
+++ b/checks/libs/wmi/sampler.py
@@ -1,0 +1,379 @@
+"""
+A lightweight Python WMI module wrapper built on top of `pywin32` and `win32com` extensions.
+
+**Specifications**
+* Based on top of the `pywin32` and `win32com` third party extensions only
+* Compatible with `Raw`* and `Formatted` Performance Data classes
+    * Dynamically resolve properties' counter types
+    * Hold the previous/current `Raw` samples to compute/format new values*
+* Fast and lightweight
+    * Avoid queries overhead
+    * Cache connections and qualifiers
+    * Use `wbemFlagForwardOnly` flag to improve enumeration/memory performance
+
+*\* `Raw` data formatting relies on the avaibility of the corresponding calculator.
+Please refer to `checks.lib.wmi.counter_type` for more information*
+
+Original discussion thread: https://github.com/DataDog/dd-agent/issues/1952
+Credits to @TheCloudlessSky (https://github.com/TheCloudlessSky)
+"""
+
+# stdlib
+from copy import deepcopy
+from itertools import izip
+import pywintypes
+
+# 3p
+from win32com.client import Dispatch
+
+# project
+from checks.libs.wmi.counter_type import get_calculator, get_raw, UndefinedCalculator
+
+
+class CaseInsensitiveDict(dict):
+    def __setitem__(self, key, value):
+        super(CaseInsensitiveDict, self).__setitem__(key.lower(), value)
+
+    def __getitem__(self, key):
+        return super(CaseInsensitiveDict, self).__getitem__(key.lower())
+
+    def __contains__(self, key):
+        return super(CaseInsensitiveDict, self).__contains__(key.lower())
+
+    def get(self, key):
+        return super(CaseInsensitiveDict, self).get(key.lower())
+
+
+class WMISampler(object):
+    """
+    WMI Sampler.
+    """
+    _wmi_locators = {}
+    _wmi_connections = {}
+
+    def __init__(self, logger, class_name, property_names, filters="", host="localhost",
+                 namespace="root\\cimv2", username="", password=""):
+        self.logger = logger
+
+        # Connection information
+        self.host = host
+        self.namespace = namespace
+        self.username = username
+        self.password = password
+
+        self.is_raw_perf_class = "_PERFRAWDATA_" in class_name.upper()
+
+        # WMI class, properties, filters and counter types
+        # Include required properties for making calculations with raw
+        # performance counters:
+        # https://msdn.microsoft.com/en-us/library/aa394299(v=vs.85).aspx
+        if self.is_raw_perf_class:
+            property_names.extend([
+                "Timestamp_Sys100NS",
+                "Frequency_Sys100NS",
+                # IMPORTANT: To improve performance and since they're currently
+                # not needed, do not include the other Timestamp/Frequency
+                # properties:
+                #   - Timestamp_PerfTime
+                #   - Timestamp_Object
+                #   - Frequency_PerfTime
+                #   - Frequency_Object"
+            ])
+        self.class_name = class_name
+        self.property_names = property_names
+        self.filters = filters
+        self._formatted_filters = None
+        self.property_counter_types = None
+
+        # Samples
+        self.current_sample = None
+        self.previous_sample = None
+
+    @property
+    def formatted_filters(self):
+        """
+        Cache and return filters as a comprehensive WQL clause.
+        """
+        if not self._formatted_filters:
+            filters = deepcopy(self.filters)
+            self._formatted_filters = self._format_filter(filters)
+        return self._formatted_filters
+
+    def sample(self):
+        """
+        Compute new samples.
+        """
+        if self.is_raw_perf_class and not self.previous_sample:
+            self.logger.debug(u"Querying for initial sample for raw performance counter.")
+            self.current_sample = self._query()
+        self.previous_sample = self.current_sample
+
+        self.current_sample = self._query()
+
+        self.logger.debug(u"Sample: {0}".format(self.current_sample))
+
+    def __len__(self):
+        """
+        Return the number of WMI Objects in the current sample.
+        """
+        return len(self.current_sample)
+
+    def __iter__(self):
+        """
+        Iterate on the current sample's WMI Objects and format the property values.
+        """
+        if self.is_raw_perf_class:
+            # Format required
+            for previous_wmi_object, current_wmi_object in \
+                    izip(self.previous_sample, self.current_sample):
+                formatted_wmi_object = self._format_property_values(
+                    previous_wmi_object,
+                    current_wmi_object
+                )
+                yield formatted_wmi_object
+        else:
+            #  No format required
+            for wmi_object in self.current_sample:
+                yield wmi_object
+
+    def __getitem__(self, index):
+        """
+        Get the specified formatted WMI Object from the current sample.
+        """
+        if self.is_raw_perf_class:
+            previous_wmi_object = self.previous_sample[index]
+            current_wmi_object = self.current_sample[index]
+            formatted_wmi_object = self._format_property_values(
+                previous_wmi_object,
+                current_wmi_object
+            )
+            return formatted_wmi_object
+        else:
+            return self.current_sample[index]
+
+    def __eq__(self, other):
+        """
+        Equality operator is based on the current sample.
+        """
+        return self.current_sample == other
+
+    def __str__(self):
+        """
+        Stringify the current sample's WMI Objects.
+        """
+        return str(self.current_sample)
+
+    def _get_property_calculator(self, counter_type):
+        """
+        Return the calculator for the given `counter_type`.
+        Fallback with `get_raw`.
+        """
+        calculator = get_raw
+        try:
+            calculator = get_calculator(counter_type)
+        except UndefinedCalculator:
+            self.logger.warning(
+                u"Undefined WMI calculator for counter_type {counter_type}."
+                " Values are reported as RAW.".format(
+                    counter_type=counter_type
+                )
+            )
+
+        return calculator
+
+    def _format_property_values(self, previous, current):
+        """
+        Format WMI Object's RAW data based on the previous sample.
+
+        Do not override the original WMI Object !
+        """
+        formatted_wmi_object = CaseInsensitiveDict()
+
+        for property_name, property_raw_value in current.iteritems():
+            counter_type = self.property_counter_types.get(property_name)
+            property_formatted_value = property_raw_value
+
+            if counter_type:
+                calculator = self._get_property_calculator(counter_type)
+                property_formatted_value = calculator(previous, current, property_name)
+
+            formatted_wmi_object[property_name] = property_formatted_value
+
+        return formatted_wmi_object
+
+    def _get_connection(self):
+        """
+        Create and cache WMI connections.
+        """
+        connection_key = "{host}:{namespace}:{username}".format(
+            host=self.host,
+            namespace=self.namespace,
+            username=self.username
+        )
+
+        if connection_key in self._wmi_connections:
+            self.logger.debug(
+                u"Using cached connection "
+                u"(host={host}, namespace={namespace}, username={username}).".format(
+                    host=self.host,
+                    namespace=self.namespace,
+                    username=self.username
+                )
+            )
+            return self._wmi_connections[connection_key]
+
+        self.logger.debug(
+            u"Connecting to WMI server "
+            u"(host={host}, namespace={namespace}, username={username}).".format(
+                host=self.host,
+                namespace=self.namespace,
+                username=self.username
+            )
+        )
+
+        locator = Dispatch("WbemScripting.SWbemLocator")
+        self._wmi_locators[connection_key] = locator
+
+        connection = locator.ConnectServer(self.host, self.namespace, self.username, self.password)
+        self._wmi_connections[connection_key] = connection
+
+        return connection
+
+    @staticmethod
+    def _format_filter(filters):
+        """
+        Transform filters to a comprehensive WQL `WHERE` clause.
+        """
+        def build_where_clause(fltr):
+            """
+            Recursively build `WHERE` clause.
+            """
+            f = fltr.pop()
+            prop, value = f.popitem()
+
+            if len(fltr) == 0:
+                return "{property} = '{constant}'".format(
+                    property=prop,
+                    constant=value
+                )
+            return "{property} = '{constant}' AND {more}".format(
+                property=prop,
+                constant=value,
+                more=build_where_clause(fltr)
+            )
+
+        if not filters:
+            return ""
+
+        return " WHERE {clause}".format(clause=build_where_clause(filters))
+
+    def _query(self):
+        """
+        Query WMI using WMI Query Language (WQL) & parse the results.
+
+        Returns: List of WMI objects
+        """
+        formated_property_names = ",".join(self.property_names)
+        wql = "Select {property_names} from {class_name}{filters}".format(
+            property_names=formated_property_names,
+            class_name=self.class_name,
+            filters=self.formatted_filters,
+        )
+        self.logger.debug(u"Querying WMI: {0}".format(wql))
+
+        try:
+            # From: https://msdn.microsoft.com/en-us/library/aa393866(v=vs.85).aspx
+            flag_return_immediately = 0x10  # Default flag.
+            flag_forward_only = 0x20
+            flag_use_amended_qualifiers = 0x20000
+
+            query_flags = flag_return_immediately | flag_forward_only
+
+            # For the first query, cache the qualifiers to determine each
+            # propertie's "CounterType"
+            includes_qualifiers = self.is_raw_perf_class and self.property_counter_types is None
+            if includes_qualifiers:
+                self.property_counter_types = CaseInsensitiveDict()
+                query_flags |= flag_use_amended_qualifiers
+
+            raw_results = self._get_connection().ExecQuery(wql, "WQL", query_flags)
+            results = self._parse_results(raw_results, includes_qualifiers=includes_qualifiers)
+
+        except pywintypes.com_error as ex:
+            self.logger.warning(u"Failed to execute WMI query (%s)", wql, exc_info=True)
+            results = []
+
+        return results
+
+    def _parse_results(self, raw_results, includes_qualifiers):
+        """
+        Parse WMI query results in a more comprehensive form.
+
+        Returns: List of WMI objects
+        ```
+        [
+            {
+                'freemegabytes': 19742.0,
+                'name': 'C:',
+                'avgdiskbytesperwrite': 1536.0
+            }, {
+                'freemegabytes': 19742.0,
+                'name': 'D:',
+                'avgdiskbytesperwrite': 1536.0
+            }
+        ]
+        ```
+        """
+        results = []
+        for res in raw_results:
+            # Ensure all properties are available. Use case-insensitivity
+            # because some properties are returned with different cases.
+            item = CaseInsensitiveDict()
+            for prop_name in self.property_names:
+                item[prop_name] = None
+
+            for wmi_property in res.Properties_:
+                # IMPORTANT: To improve performance, only access the Qualifiers
+                # if the "CounterType" hasn't already been cached.
+                should_get_qualifier_type = (
+                    includes_qualifiers and
+                    wmi_property.Name not in self.property_counter_types
+                )
+
+                if should_get_qualifier_type:
+
+                    # Can't index into "Qualifiers_" for keys that don't exist
+                    # without getting an exception.
+                    qualifiers = dict((q.Name, q.Value) for q in wmi_property.Qualifiers_)
+
+                    # Some properties like "Name" and "Timestamp_Sys100NS" do
+                    # not have a "CounterType" (since they're not a counter).
+                    # Therefore, they're ignored.
+                    if "CounterType" in qualifiers:
+                        counter_type = qualifiers["CounterType"]
+                        self.property_counter_types[wmi_property.Name] = counter_type
+
+                        self.logger.debug(
+                            u"Caching property qualifier CounterType: "
+                            "{class_name}.{property_names} = {counter_type}"
+                            .format(
+                                class_name=self.class_name,
+                                property_names=wmi_property.Name,
+                                counter_type=counter_type,
+                            )
+                        )
+                    else:
+                        self.logger.debug(
+                            u"CounterType qualifier not found for {class_name}.{property_names}"
+                            .format(
+                                class_name=self.class_name,
+                                property_names=wmi_property.Name,
+                            )
+                        )
+
+                try:
+                    item[wmi_property.Name] = float(wmi_property.Value)
+                except ValueError:
+                    item[wmi_property.Name] = wmi_property.Value
+            results.append(item)
+        return results

--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -8,10 +8,13 @@ except ImportError:
     psutil = None
 
 try:
-    import wmi
-    w = wmi.WMI()
+    from checks.libs.wmi.sampler import WMISampler
 except Exception:
-    wmi, w = None, None
+    def WMISampler(*args, **kwargs):
+        """
+        Fallback with a 'None' callable object.
+        """
+        return
 
 
 # Device WMI drive types
@@ -19,6 +22,7 @@ class DriveType(object):
     UNKNOWN, NOROOT, REMOVEABLE, LOCAL, NETWORK, CD, RAM = (0, 1, 2, 3, 4, 5, 6)
 B2MB = float(1048576)
 KB2MB = B2KB = float(1024)
+
 
 def should_ignore_disk(name, blacklist_re):
     # blacklist_re is a compiled regex, compilation done at config loading time
@@ -28,27 +32,33 @@ def should_ignore_disk(name, blacklist_re):
 class Processes(Check):
     def __init__(self, logger):
         Check.__init__(self, logger)
+
+        # Sampler(s)
+        self.wmi_sampler = WMISampler(
+            logger,
+            "Win32_PerfRawData_PerfOS_System",
+            ["ProcessorQueueLength", "Processes"]
+        )
+
         self.gauge('system.proc.queue_length')
         self.gauge('system.proc.count')
 
     def check(self, agentConfig):
-        try:
-            os = w.Win32_PerfFormattedData_PerfOS_System()[0]
-        except AttributeError:
-            self.logger.info('Missing Win32_PerfFormattedData_PerfOS_System WMI class.'
+        self.wmi_sampler.sample()
+
+        if not (len(self.wmi_sampler)):
+            self.logger.info('Missing Win32_PerfRawData_PerfOS_System WMI class.'
                              ' No process metrics will be returned.')
             return
 
-        try:
-            cpu = w.Win32_PerfFormattedData_PerfOS_Processor(name="_Total")[0]
-        except AttributeError:
-            self.logger.info('Missing Win32_PerfFormattedData_PerfOS_Processor WMI class.'
-                             ' No process metrics will be returned.')
-            return
-        if os.ProcessorQueueLength is not None:
-            self.save_sample('system.proc.queue_length', os.ProcessorQueueLength)
-        if os.Processes is not None:
-            self.save_sample('system.proc.count', os.Processes)
+        os = self.wmi_sampler[0]
+        processor_queue_length = os.get('ProcessorQueueLength')
+        processes = os.get('Processes')
+
+        if processor_queue_length is not None:
+            self.save_sample('system.proc.queue_length', processor_queue_length)
+        if processes is not None:
+            self.save_sample('system.proc.count', processes)
 
         return self.get_metrics()
 
@@ -56,7 +66,18 @@ class Processes(Check):
 class Memory(Check):
     def __init__(self, logger):
         Check.__init__(self, logger)
-        self.logger = logger
+
+        # Sampler(s)
+        self.os_wmi_sampler = WMISampler(
+            logger,
+            "Win32_OperatingSystem",
+            ["TotalVisibleMemorySize", "FreePhysicalMemory"]
+        )
+        self.mem_wmi_sampler = WMISampler(
+            logger,
+            "Win32_PerfRawData_PerfOS_Memory",
+            ["CacheBytes", "CommittedBytes", "PoolPagedBytes", "PoolNonpagedBytes"])
+
         self.gauge('system.mem.free')
         self.gauge('system.mem.used')
         self.gauge('system.mem.total')
@@ -79,33 +100,52 @@ class Memory(Check):
         self.gauge('system.mem.pct_usable')
 
     def check(self, agentConfig):
-        try:
-            os = w.Win32_OperatingSystem()[0]
-        except AttributeError:
-            self.logger.info('Missing Win32_OperatingSystem. No memory metrics will be returned.')
+        self.os_wmi_sampler.sample()
+
+        if not (len(self.os_wmi_sampler)):
+            self.logger.info('Missing Win32_OperatingSystem WMI class.'
+                             ' No memory metrics will be returned.')
             return
+
+        os = self.os_wmi_sampler[0]
 
         total = 0
         free = 0
         cached = 0
 
-        if os.TotalVisibleMemorySize is not None and os.FreePhysicalMemory is not None:
-            total = int(os.TotalVisibleMemorySize) / KB2MB
-            free = int(os.FreePhysicalMemory) / KB2MB
+        total_visible_memory_size = os.get('TotalVisibleMemorySize')
+        free_physical_memory = os.get('FreePhysicalMemory')
+
+        if total_visible_memory_size is not None and free_physical_memory is not None:
+            total = int(total_visible_memory_size) / KB2MB
+            free = int(free_physical_memory) / KB2MB
             self.save_sample('system.mem.total', total)
             self.save_sample('system.mem.free', free)
             self.save_sample('system.mem.used', total - free)
 
-        mem = w.Win32_PerfFormattedData_PerfOS_Memory()[0]
-        if mem.CacheBytes is not None:
-            cached = int(mem.CacheBytes) / B2MB
+        self.mem_wmi_sampler.sample()
+
+        if not (len(self.mem_wmi_sampler)):
+            self.logger.info('Missing Win32_PerfRawData_PerfOS_Memory WMI class.'
+                             ' No memory metrics will be returned.')
+            return self.get_metrics()
+
+        mem = self.mem_wmi_sampler[0]
+
+        cache_bytes = mem.get('CacheBytes')
+        committed_bytes = mem.get('CommittedBytes')
+        pool_paged_bytes = mem.get('PoolPagedBytes')
+        pool_non_paged_bytes = mem.get('PoolNonpagedBytes')
+
+        if cache_bytes is not None:
+            cached = int(cache_bytes) / B2MB
             self.save_sample('system.mem.cached', cached)
-        if mem.CommittedBytes is not None:
-            self.save_sample('system.mem.committed', int(mem.CommittedBytes) / B2MB)
-        if mem.PoolPagedBytes is not None:
-            self.save_sample('system.mem.paged', int(mem.PoolPagedBytes) / B2MB)
-        if mem.PoolNonpagedBytes is not None:
-            self.save_sample('system.mem.nonpaged', int(mem.PoolNonpagedBytes) / B2MB)
+        if committed_bytes is not None:
+            self.save_sample('system.mem.committed', int(committed_bytes) / B2MB)
+        if pool_paged_bytes is not None:
+            self.save_sample('system.mem.paged', int(pool_paged_bytes) / B2MB)
+        if pool_non_paged_bytes is not None:
+            self.save_sample('system.mem.nonpaged', int(pool_non_paged_bytes) / B2MB)
 
         usable = free + cached
         self.save_sample('system.mem.usable', usable)
@@ -119,21 +159,29 @@ class Memory(Check):
 class Cpu(Check):
     def __init__(self, logger):
         Check.__init__(self, logger)
-        self.logger = logger
+
+        # Sampler(s)
+        self.wmi_sampler = WMISampler(
+            logger,
+            "Win32_PerfRawData_PerfOS_Processor",
+            ["Name", "PercentInterruptTime"]
+        )
+
         self.counter('system.cpu.user')
         self.counter('system.cpu.idle')
         self.gauge('system.cpu.interrupt')
         self.counter('system.cpu.system')
 
     def check(self, agentConfig):
-        try:
-            cpu = w.Win32_PerfFormattedData_PerfOS_Processor()
-        except AttributeError:
-            self.logger.info('Missing Win32_PerfFormattedData_PerfOS_Processor WMI class.'
-                             ' No CPU metrics will be returned.')
+
+        self.wmi_sampler.sample()
+
+        if not (len(self.wmi_sampler)):
+            self.logger.info('Missing Win32_PerfRawData_PerfOS_Processor WMI class.'
+                             ' No CPU metrics will be returned')
             return
 
-        cpu_interrupt = self._average_metric(cpu, 'PercentInterruptTime')
+        cpu_interrupt = self._average_metric(self.wmi_sampler, 'PercentInterruptTime')
         if cpu_interrupt is not None:
             self.save_sample('system.cpu.interrupt', cpu_interrupt)
 
@@ -145,20 +193,21 @@ class Cpu(Check):
 
         return self.get_metrics()
 
-    def _average_metric(self, wmi_class, wmi_prop):
+    def _average_metric(self, sampler, wmi_prop):
         ''' Sum all of the values of a metric from a WMI class object, excluding
             the value for "_Total"
         '''
         val = 0
         counter = 0
-        for wmi_object in wmi_class:
-            if wmi_object.Name == '_Total':
+        for wmi_object in sampler:
+            if wmi_object['Name'] == '_Total':
                 # Skip the _Total value
                 continue
 
-            if getattr(wmi_object, wmi_prop) is not None:
+            wmi_prop_value = wmi_object.get(wmi_prop)
+            if wmi_prop_value is not None:
                 counter += 1
-                val += float(getattr(wmi_object, wmi_prop))
+                val += float(wmi_prop_value)
 
         if counter > 0:
             return val / counter
@@ -169,25 +218,36 @@ class Cpu(Check):
 class Network(Check):
     def __init__(self, logger):
         Check.__init__(self, logger)
-        self.logger = logger
+
+        # Sampler(s)
+        self.wmi_sampler = WMISampler(
+            logger,
+            "Win32_PerfRawData_Tcpip_NetworkInterface",
+            ["Name", "BytesReceivedPerSec", "BytesSentPerSec"]
+        )
+
         self.gauge('system.net.bytes_rcvd')
         self.gauge('system.net.bytes_sent')
 
     def check(self, agentConfig):
-        try:
-            net = w.Win32_PerfFormattedData_Tcpip_NetworkInterface()
-        except AttributeError:
-            self.logger.info('Missing Win32_PerfFormattedData_Tcpip_NetworkInterface WMI class.'
+        self.wmi_sampler.sample()
+
+        if not (len(self.wmi_sampler)):
+            self.logger.info('Missing Win32_PerfRawData_Tcpip_NetworkInterface WMI class.'
                              ' No network metrics will be returned')
             return
 
-        for iface in net:
-            name = self.normalize_device_name(iface.name)
-            if iface.BytesReceivedPerSec is not None:
-                self.save_sample('system.net.bytes_rcvd', iface.BytesReceivedPerSec,
+        for iface in self.wmi_sampler:
+            name = iface.get('Name')
+            bytes_received_per_sec = iface.get('BytesReceivedPerSec')
+            bytes_sent_per_sec = iface.get('BytesSentPerSec')
+
+            name = self.normalize_device_name(name)
+            if bytes_received_per_sec is not None:
+                self.save_sample('system.net.bytes_rcvd', bytes_received_per_sec,
                                  device_name=name)
-            if iface.BytesSentPerSec is not None:
-                self.save_sample('system.net.bytes_sent', iface.BytesSentPerSec,
+            if bytes_sent_per_sec is not None:
+                self.save_sample('system.net.bytes_sent', bytes_sent_per_sec,
                                  device_name=name)
         return self.get_metrics()
 
@@ -195,7 +255,15 @@ class Network(Check):
 class IO(Check):
     def __init__(self, logger):
         Check.__init__(self, logger)
-        self.logger = logger
+
+        #  Sampler(s)
+        self.wmi_sampler = WMISampler(
+            logger,
+            "Win32_PerfRawData_PerfDisk_LogicalDisk",
+            ["Name", "DiskWriteBytesPerSec", "DiskWritesPerSec", "DiskReadBytesPerSec",
+             "DiskReadsPerSec", "CurrentDiskQueueLength"]
+        )
+
         self.gauge('system.io.wkb_s')
         self.gauge('system.io.w_s')
         self.gauge('system.io.rkb_s')
@@ -203,30 +271,38 @@ class IO(Check):
         self.gauge('system.io.avg_q_sz')
 
     def check(self, agentConfig):
-        try:
-            disk = w.Win32_PerfFormattedData_PerfDisk_LogicalDisk()
-        except AttributeError:
-            self.logger.info('Missing Win32_PerfFormattedData_PerfDisk_LogicalDiskUnable WMI class.'
+        self.wmi_sampler.sample()
+
+        if not (len(self.wmi_sampler)):
+            self.logger.info('Missing Win32_PerfRawData_PerfDisk_LogicalDiskUnable WMI class.'
                              ' No I/O metrics will be returned.')
             return
+
         blacklist_re = agentConfig.get('device_blacklist_re', None)
-        for device in disk:
-            name = self.normalize_device_name(device.name)
+        for device in self.wmi_sampler:
+            name = device.get('Name')
+            disk_write_bytes_per_sec = device.get('DiskWriteBytesPerSec')
+            disk_writes_per_sec = device.get('DiskWritesPerSec')
+            disk_read_bytes_per_sec = device.get('DiskReadBytesPerSec')
+            disk_reads_per_sec = device.get('DiskReadsPerSec')
+            current_disk_queue_length = device.get('CurrentDiskQueueLength')
+
+            name = self.normalize_device_name(name)
             if should_ignore_disk(name, blacklist_re):
                 continue
-            if device.DiskWriteBytesPerSec is not None:
-                self.save_sample('system.io.wkb_s', int(device.DiskWriteBytesPerSec) / B2KB,
-                    device_name=name)
-            if device.DiskWritesPerSec is not None:
-                self.save_sample('system.io.w_s', int(device.DiskWritesPerSec),
-                    device_name=name)
-            if device.DiskReadBytesPerSec is not None:
-                self.save_sample('system.io.rkb_s', int(device.DiskReadBytesPerSec) / B2KB,
-                    device_name=name)
-            if device.DiskReadsPerSec is not None:
-                self.save_sample('system.io.r_s', int(device.DiskReadsPerSec),
-                    device_name=name)
-            if device.CurrentDiskQueueLength is not None:
-                self.save_sample('system.io.avg_q_sz', device.CurrentDiskQueueLength,
-                    device_name=name)
+            if disk_write_bytes_per_sec is not None:
+                self.save_sample('system.io.wkb_s', int(disk_write_bytes_per_sec) / B2KB,
+                                 device_name=name)
+            if disk_writes_per_sec is not None:
+                self.save_sample('system.io.w_s', int(disk_writes_per_sec),
+                                 device_name=name)
+            if disk_read_bytes_per_sec is not None:
+                self.save_sample('system.io.rkb_s', int(disk_read_bytes_per_sec) / B2KB,
+                                 device_name=name)
+            if disk_reads_per_sec is not None:
+                self.save_sample('system.io.r_s', int(disk_reads_per_sec),
+                                 device_name=name)
+            if current_disk_queue_length is not None:
+                self.save_sample('system.io.avg_q_sz', current_disk_queue_length,
+                                 device_name=name)
         return self.get_metrics()

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -41,6 +41,20 @@ def get_check_class(name):
     return check_class
 
 
+def load_class(check_name, class_name):
+    """
+    Retrieve a class with the given name among the given check module.
+    """
+    checksd_path = get_checksd_path(get_os())
+    check_module = __import__(check_name)
+    classes = inspect.getmembers(check_module, inspect.isclass)
+    for name, clsmember in classes:
+        if name == class_name:
+            return clsmember
+
+    raise Exception(u"Unable to import class {0} from the check module.".format(class_name))
+
+
 def load_check(name, config, agentConfig):
     checksd_path = get_checksd_path(get_os())
     if checksd_path not in sys.path:
@@ -114,7 +128,7 @@ class Fixtures(object):
     @staticmethod
     def read_file(file_name):
         with open(Fixtures.file(file_name)) as f:
-            return f.read()
+            return f.read().decode('string-escape').decode("utf-8")
 
 
 class AgentCheckTest(unittest.TestCase):
@@ -137,6 +151,12 @@ class AgentCheckTest(unittest.TestCase):
     def load_check(self, config, agent_config=None):
         agent_config = agent_config or self.DEFAULT_AGENT_CONFIG
         self.check = load_check(self.CHECK_NAME, config, agent_config)
+
+    def load_class(self, name):
+        """
+        Retrieve a class with the given name among the check module.
+        """
+        return load_class(self.CHECK_NAME, name)
 
     # Helper function when testing rates
     def run_check_twice(self, config, agent_config=None, mocks=None,

--- a/tests/checks/fixtures/wmi/win32_perfformatteddata_perfdisk_logicaldisk
+++ b/tests/checks/fixtures/wmi/win32_perfformatteddata_perfdisk_logicaldisk
@@ -1,0 +1,2 @@
+AvgDiskBytesPerWrite 1536
+FreeMegabytes 19742

--- a/tests/checks/fixtures/wmi/win32_perfformatteddata_perfproc_process
+++ b/tests/checks/fixtures/wmi/win32_perfformatteddata_perfproc_process
@@ -1,0 +1,2 @@
+IOReadBytesPerSec 20455
+IDProcess 4036

--- a/tests/checks/fixtures/wmi/win32_perfformatteddata_perfproc_process_alt
+++ b/tests/checks/fixtures/wmi/win32_perfformatteddata_perfproc_process_alt
@@ -1,0 +1,2 @@
+IOReadBytesPerSec 20455
+ResultNotMatchingAnyTargetProperty 0

--- a/tests/checks/fixtures/wmi/win32_perfrawdata_perfos_system_current
+++ b/tests/checks/fixtures/wmi/win32_perfrawdata_perfos_system_current
@@ -1,0 +1,4 @@
+CounterRawCount 500 65536
+CounterCounter 500 272696320
+Timestamp_Sys100NS 52
+Frequency_Sys100NS 0.5

--- a/tests/checks/fixtures/wmi/win32_perfrawdata_perfos_system_previous
+++ b/tests/checks/fixtures/wmi/win32_perfrawdata_perfos_system_previous
@@ -1,0 +1,4 @@
+CounterRawCount 300 65536
+CounterCounter 300 272696320
+Timestamp_Sys100NS 50
+Frequency_Sys100NS 0.5

--- a/tests/checks/fixtures/wmi/win32_perfrawdata_perfos_system_unknown
+++ b/tests/checks/fixtures/wmi/win32_perfrawdata_perfos_system_unknown
@@ -1,0 +1,3 @@
+UnknownCounter 999 123456
+Timestamp_Sys100NS 52
+Frequency_Sys100NS 0.5

--- a/tests/checks/fixtures/wmi/win32_process
+++ b/tests/checks/fixtures/wmi/win32_process
@@ -1,0 +1,1 @@
+CommandLine C:\\ProgramFiles(x86)\\Google\\Chrome\\Application\\chrome.exe\

--- a/tests/core/test_wmi.py
+++ b/tests/core/test_wmi.py
@@ -22,7 +22,7 @@ WMISampler = None
 # Check the role of the flags
 
 
-def load_fixture(f, args):
+def load_fixture(f, args=None):
     """
     Build a WMI query result from a file and given parameters.
     """
@@ -55,8 +55,9 @@ def load_fixture(f, args):
         )
 
     # Append extra information
-    property_name, property_value = args
-    properties.append(Mock(Name=property_name, Value=property_value, Qualifiers_=[]))
+    if args:
+        property_name, property_value = args
+        properties.append(Mock(Name=property_name, Value=property_value, Qualifiers_=[]))
 
     return [Mock(Properties_=properties)]
 
@@ -137,6 +138,17 @@ class SWbemServices(object):
         if query == "Select UnknownCounter,MissingProperty,Timestamp_Sys100NS,Frequency_Sys100NS from Win32_PerfRawData_PerfOS_System":  # noqa
             results += load_fixture("win32_perfrawdata_perfos_system_unknown", ("Name", "C:"))
             results += load_fixture("win32_perfrawdata_perfos_system_unknown", ("Name", "D:"))
+
+        if query == "Select IOReadBytesPerSec,IDProcess from Win32_PerfFormattedData_PerfProc_Process WHERE Name = 'chrome'" \
+                or query == "Select IOReadBytesPerSec,UnknownProperty from Win32_PerfFormattedData_PerfProc_Process WHERE Name = 'chrome'":  # noqa
+            results += load_fixture("win32_perfformatteddata_perfproc_process")
+
+        if query == "Select IOReadBytesPerSec,ResultNotMatchingAnyTargetProperty from Win32_PerfFormattedData_PerfProc_Process WHERE Name = 'chrome'":  # noqa
+            results += load_fixture("win32_perfformatteddata_perfproc_process_alt")
+
+        if query == "Select CommandLine from Win32_Process WHERE Handle = '4036'" \
+                or query == "Select UnknownProperty from Win32_Process WHERE Handle = '4036'":
+            results += load_fixture("win32_process")
 
         return results
 

--- a/tests/core/test_wmi.py
+++ b/tests/core/test_wmi.py
@@ -1,0 +1,490 @@
+# stdlib
+from functools import partial
+import logging
+import unittest
+
+# 3rd
+from mock import Mock
+
+# project
+from tests.checks.common import Fixtures
+
+
+log = logging.getLogger(__name__)
+
+WMISampler = None
+
+
+# Thoughts
+# Log WMI activity
+# Mechanism to timeout
+# Check when pywintypes.com_error are raised
+# Check the role of the flags
+
+
+def load_fixture(f, args):
+    """
+    Build a WMI query result from a file and given parameters.
+    """
+    properties = []
+
+    def extract_line(line):
+        """
+        Extract a property name, value and the qualifiers from a fixture line.
+
+        Return (property name, property value, property qualifiers)
+        """
+        property_counter_type = ""
+
+        try:
+            property_name, property_value, property_counter_type = line.split(" ")
+        except ValueError:
+            property_name, property_value = line.split(" ")
+
+        property_qualifiers = [Mock(Name='CounterType', Value=int(property_counter_type))] \
+            if property_counter_type else []
+
+        return property_name, property_value, property_qualifiers
+
+    # Build from file
+    data = Fixtures.read_file(f)
+    for l in data.splitlines():
+        property_name, property_value, property_qualifiers = extract_line(l)
+        properties.append(
+            Mock(Name=property_name, Value=property_value, Qualifiers_=property_qualifiers)
+        )
+
+    # Append extra information
+    property_name, property_value = args
+    properties.append(Mock(Name=property_name, Value=property_value, Qualifiers_=[]))
+
+    return [Mock(Properties_=properties)]
+
+
+class Counter(object):
+    def __init__(self):
+        self.value = 0
+
+    def __iadd__(self, other):
+        self.value += other
+        return self
+
+    def __eq__(self, other):
+        return self.value == other
+
+    def __str__(self):
+        return str(self.value)
+
+    def reset(self):
+        self.value = 0
+
+
+class SWbemServices(object):
+    """
+    SWbemServices a.k.a. (mocked) WMI connection.
+    Save connection parameters so it can be tested.
+    """
+    _exec_query_call_count = Counter()
+
+    def __init__(self, wmi_conn_args):
+        super(SWbemServices, self).__init__()
+        self._wmi_conn_args = wmi_conn_args
+        self._last_wmi_query = None
+        self._last_wmi_flags = None
+
+    @classmethod
+    def reset(cls):
+        """
+        FIXME - Dirty patch to reset `SWbemServices.ExecQuery` to 0.
+        """
+        cls._exec_query_call_count.reset()
+
+    def get_conn_args(self):
+        """
+        Return parameters used to set up the WMI connection.
+        """
+        return self._wmi_conn_args
+
+    def get_last_wmi_query(self):
+        """
+        Return the last WMI query submitted via the WMI connection.
+        """
+        return self._last_wmi_query
+
+    def get_last_wmi_flags(self):
+        """
+        Return the last WMI flags submitted via the WMI connection.
+        """
+        return self._last_wmi_flags
+
+    def ExecQuery(self, query, query_language, flags):
+        SWbemServices._exec_query_call_count += 1
+        self._last_wmi_query = query
+        self._last_wmi_flags = flags
+        results = []
+
+        if query == "Select AvgDiskBytesPerWrite,FreeMegabytes from Win32_PerfFormattedData_PerfDisk_LogicalDisk":  # noqa
+            results += load_fixture("win32_perfformatteddata_perfdisk_logicaldisk", ("Name", "C:"))
+            results += load_fixture("win32_perfformatteddata_perfdisk_logicaldisk", ("Name", "D:"))
+
+        if query == "Select CounterRawCount,CounterCounter,Timestamp_Sys100NS,Frequency_Sys100NS from Win32_PerfRawData_PerfOS_System":  # noqa
+            # Mock a previous and a current sample
+            sample_file = "win32_perfrawdata_perfos_system_previous" if flags == 131120\
+                else "win32_perfrawdata_perfos_system_current"
+            results += load_fixture(sample_file, ("Name", "C:"))
+            results += load_fixture(sample_file, ("Name", "D:"))
+
+        if query == "Select UnknownCounter,MissingProperty,Timestamp_Sys100NS,Frequency_Sys100NS from Win32_PerfRawData_PerfOS_System":  # noqa
+            results += load_fixture("win32_perfrawdata_perfos_system_unknown", ("Name", "C:"))
+            results += load_fixture("win32_perfrawdata_perfos_system_unknown", ("Name", "D:"))
+
+        return results
+
+    ExecQuery.call_count = _exec_query_call_count
+
+
+class Dispatch(object):
+    """
+    Mock for win32com.client Dispatch class.
+    """
+    _connect_call_count = Counter()
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    @classmethod
+    def reset(cls):
+        """
+        FIXME - Dirty patch to reset `ConnectServer.call_count` to 0.
+        """
+        cls._connect_call_count.reset()
+
+    def ConnectServer(self, *args, **kwargs):
+        """
+        Return a WMI connection, a.k.a. a SWbemServices object.
+        """
+        Dispatch._connect_call_count += 1
+        wmi_conn_args = (args, kwargs)
+        return SWbemServices(wmi_conn_args)
+
+    ConnectServer.call_count = _connect_call_count
+
+
+class TestCommonWMI(unittest.TestCase):
+    """
+    Common toolbox for WMI unit testing.
+    """
+    def setUp(self):
+        """
+        Mock WMI related Python packages, so it can be tested on any environment.
+        """
+        import sys
+        global WMISampler
+
+        sys.modules['pywintypes'] = Mock()
+        sys.modules['win32com'] = Mock()
+        sys.modules['win32com.client'] = Mock(Dispatch=Dispatch)
+
+        from checks.libs.wmi import sampler
+        WMISampler = partial(sampler.WMISampler, log)
+
+    def tearDown(self):
+        """
+        Reset Mock counters, flush samplers and connections
+        """
+        # Reset counters
+        Dispatch.reset()
+        SWbemServices.reset()
+
+        # Flush cache
+        from checks.libs.wmi.sampler import WMISampler
+        WMISampler._wmi_locators = {}
+        WMISampler._wmi_connections = {}
+
+    def assertWMIConnWith(self, wmi_sampler, param):
+        """
+        Helper, assert that the WMI connection was established with the right parameter and value.
+        """
+        wmi_instance = wmi_sampler._get_connection()
+        wmi_conn_args, wmi_conn_kwargs = wmi_instance.get_conn_args()
+        if isinstance(param, tuple):
+            key, value = param
+            self.assertIn(key, wmi_conn_kwargs)
+            self.assertEquals(wmi_conn_kwargs[key], value)
+        else:
+            self.assertIn(param, wmi_conn_args)
+
+    def assertWMIQuery(self, wmi_sampler, query=None, flags=None):
+        """
+        Helper, assert that the given WMI query and flags were submitted.
+        """
+        wmi_instance = wmi_sampler._get_connection()
+
+        if query:
+            last_wmi_query = wmi_instance.get_last_wmi_query()
+            self.assertEquals(last_wmi_query, query)
+
+        if flags:
+            last_wmi_flags = wmi_instance.get_last_wmi_flags()
+            self.assertEquals(last_wmi_flags, flags)
+
+    def assertWMIObject(self, wmi_obj, property_names):
+        """
+        Assert the WMI object integrity.
+        """
+        for prop in property_names:
+            self.assertIn(prop, wmi_obj)
+
+    def assertIn(self, first, second):
+        """
+        Assert `first` in `second`.
+
+        Note: needs to be defined for Python 2.6
+        """
+        self.assertTrue(first in second, "{0} not in {1}".format(first, second))
+
+
+class TestUnitWMISampler(TestCommonWMI):
+    """
+    Unit tests for WMISampler.
+    """
+    def test_wmi_connection(self):
+        """
+        Establish a WMI connection to the specified host/namespace, with the right credentials.
+        """
+        wmi_sampler = WMISampler(
+            "Win32_PerfRawData_PerfOS_System",
+            ["ProcessorQueueLength"],
+            host="myhost",
+            namespace="some/namespace",
+            username="datadog",
+            password="password"
+        )
+        wmi_conn = wmi_sampler._get_connection()
+
+        # WMI connection is cached
+        self.assertIn('myhost:some/namespace:datadog', wmi_sampler._wmi_connections)
+
+        # Connection was established with the right parameters
+        self.assertWMIConnWith(wmi_sampler, "myhost")
+        self.assertWMIConnWith(wmi_sampler, "some/namespace")
+
+    def test_wmi_connection_pooling(self):
+        """
+        Share WMI connections among WMISampler objects.
+        """
+        from win32com.client import Dispatch
+
+        wmi_sampler_1 = WMISampler("Win32_PerfRawData_PerfOS_System", ["ProcessorQueueLength"])
+        wmi_sampler_2 = WMISampler("Win32_OperatingSystem", ["TotalVisibleMemorySize"])
+        wmi_sampler_3 = WMISampler("Win32_PerfRawData_PerfOS_System", ["ProcessorQueueLength"], host="myhost")  # noqa
+
+        wmi_sampler_1.sample()
+        wmi_sampler_2.sample()
+
+        self.assertEquals(Dispatch.ConnectServer.call_count, 1, Dispatch.ConnectServer.call_count)
+
+        wmi_sampler_3.sample()
+
+        self.assertEquals(Dispatch.ConnectServer.call_count, 2, Dispatch.ConnectServer.call_count)
+
+    def test_wql_filtering(self):
+        """
+        Format the filters to a comprehensive WQL `WHERE` clause.
+        """
+        from checks.libs.wmi import sampler
+        format_filter = sampler.WMISampler._format_filter
+
+        # Check `_format_filter` logic
+        no_filters = []
+        filters = [{'Name': "SomeName"}, {'Id': "SomeId"}]
+
+        self.assertEquals("", format_filter(no_filters))
+        self.assertEquals(" WHERE Id = 'SomeId' AND Name = 'SomeName'",
+                          format_filter(filters))
+
+    def test_wmi_query(self):
+        """
+        Query WMI using WMI Query Language (WQL).
+        """
+        # No filters
+        wmi_sampler = WMISampler("Win32_PerfFormattedData_PerfDisk_LogicalDisk",
+                                 ["AvgDiskBytesPerWrite", "FreeMegabytes"])
+        wmi_sampler.sample()
+
+        self.assertWMIQuery(
+            wmi_sampler,
+            "Select AvgDiskBytesPerWrite,FreeMegabytes"
+            " from Win32_PerfFormattedData_PerfDisk_LogicalDisk"
+        )
+
+        # Single filter
+        wmi_sampler = WMISampler("Win32_PerfFormattedData_PerfDisk_LogicalDisk",
+                                 ["AvgDiskBytesPerWrite", "FreeMegabytes"],
+                                 filters=[{'Name': "C:"}])
+        wmi_sampler.sample()
+
+        self.assertWMIQuery(
+            wmi_sampler,
+            "Select AvgDiskBytesPerWrite,FreeMegabytes"
+            " from Win32_PerfFormattedData_PerfDisk_LogicalDisk"
+            " WHERE Name = 'C:'"
+        )
+
+        # Multiple filters
+        wmi_sampler = WMISampler("Win32_PerfFormattedData_PerfDisk_LogicalDisk",
+                                 ["AvgDiskBytesPerWrite", "FreeMegabytes"],
+                                 filters=[{'Name': "C:"}, {'Id': "123"}])
+        wmi_sampler.sample()
+
+        self.assertWMIQuery(
+            wmi_sampler,
+            "Select AvgDiskBytesPerWrite,FreeMegabytes"
+            " from Win32_PerfFormattedData_PerfDisk_LogicalDisk"
+            " WHERE Id = '123' AND Name = 'C:'"
+        )
+
+    def test_wmi_parser(self):
+        """
+        Parse WMI objects from WMI query results.
+        """
+        wmi_sampler = WMISampler("Win32_PerfFormattedData_PerfDisk_LogicalDisk",
+                                 ["AvgDiskBytesPerWrite", "FreeMegabytes"])
+        wmi_sampler.sample()
+
+        # Assert `results`
+        expected_results = [
+            {
+                'freemegabytes': 19742.0,
+                'name': 'C:',
+                'avgdiskbytesperwrite': 1536.0
+            }, {
+                'freemegabytes': 19742.0,
+                'name': 'D:',
+                'avgdiskbytesperwrite': 1536.0
+            }
+        ]
+
+        self.assertEquals(wmi_sampler, expected_results, wmi_sampler)
+
+    def test_wmi_sampler_iterator_getter(self):
+        """
+        Iterate/Get on the WMISampler object iterates/gets on its current sample.
+        """
+        wmi_sampler = WMISampler("Win32_PerfFormattedData_PerfDisk_LogicalDisk",
+                                 ["AvgDiskBytesPerWrite", "FreeMegabytes"])
+        wmi_sampler.sample()
+
+        self.assertEquals(len(wmi_sampler), 2)
+
+        # Using an iterator
+        for wmi_obj in wmi_sampler:
+            self.assertWMIObject(wmi_obj, ["AvgDiskBytesPerWrite", "FreeMegabytes", "name"])
+
+        # Using an accessor
+        for index in xrange(0, 2):
+            self.assertWMIObject(wmi_sampler[index], ["AvgDiskBytesPerWrite", "FreeMegabytes", "name"])
+
+    def test_raw_perf_properties(self):
+        """
+        Extend the list of properties to query for RAW Performance classes.
+        """
+        # Formatted Performance class
+        wmi_sampler = WMISampler("Win32_PerfFormattedData_PerfOS_System", ["ProcessorQueueLength"])
+        self.assertEquals(len(wmi_sampler.property_names), 1)
+
+        # Raw Performance class
+        wmi_sampler = WMISampler("Win32_PerfRawData_PerfOS_System", ["CounterRawCount", "CounterCounter"])  # noqa
+        self.assertEquals(len(wmi_sampler.property_names), 4)
+
+    def test_raw_initial_sampling(self):
+        """
+        Query for initial sample for RAW Performance classes.
+        """
+        wmi_sampler = WMISampler("Win32_PerfRawData_PerfOS_System", ["CounterRawCount", "CounterCounter"])  # noqa
+        wmi_sampler.sample()
+
+        # 2 queries should have been made: one for initialization, one for sampling
+        self.assertEquals(SWbemServices.ExecQuery.call_count, 2, SWbemServices.ExecQuery.call_count)
+
+        # Repeat
+        wmi_sampler.sample()
+        self.assertEquals(SWbemServices.ExecQuery.call_count, 3, SWbemServices.ExecQuery.call_count)
+
+    def test_raw_cache_qualifiers(self):
+        """
+        Cache the qualifiers on the first query against RAW Performance classes.
+        """
+        # Append `flag_use_amended_qualifiers` flag on the first query
+        wmi_raw_sampler = WMISampler("Win32_PerfRawData_PerfOS_System", ["CounterRawCount", "CounterCounter"])  # noqa
+        wmi_raw_sampler._query()
+
+        self.assertWMIQuery(wmi_raw_sampler, flags=131120)
+
+        wmi_raw_sampler._query()
+        self.assertWMIQuery(wmi_raw_sampler, flags=48)
+
+        # Qualifiers are cached
+        self.assertTrue(wmi_raw_sampler.property_counter_types)
+        self.assertIn('CounterRawCount', wmi_raw_sampler.property_counter_types)
+        self.assertIn('CounterCounter', wmi_raw_sampler.property_counter_types)
+
+    def test_raw_properties_formatting(self):
+        """
+        WMI Object's RAW data are returned formatted.
+        """
+        wmi_raw_sampler = WMISampler("Win32_PerfRawData_PerfOS_System", ["CounterRawCount", "CounterCounter"])  # noqa
+        wmi_raw_sampler.sample()
+
+        self.assertEquals(len(wmi_raw_sampler), 2)
+
+        # Using an iterator
+        for wmi_obj in wmi_raw_sampler:
+            self.assertWMIObject(wmi_obj, ["CounterRawCount", "CounterCounter", "Timestamp_Sys100NS", "Frequency_Sys100NS", "name"])  # noqa
+            self.assertEquals(wmi_obj['CounterRawCount'], 500)
+            self.assertEquals(wmi_obj['CounterCounter'], 50)
+
+        # Using an accessor
+        for index in xrange(0, 2):
+            self.assertWMIObject(wmi_raw_sampler[index], ["CounterRawCount", "CounterCounter", "Timestamp_Sys100NS", "Frequency_Sys100NS", "name"])  # noqa
+            self.assertEquals(wmi_raw_sampler[index]['CounterRawCount'], 500)
+            self.assertEquals(wmi_raw_sampler[index]['CounterCounter'], 50)
+
+    def test_raw_properties_fallback(self):
+        """
+        Print a warning on RAW Performance classes if the calculator is undefined.
+
+        Returns the original RAW value.
+        """
+        from checks.libs.wmi.sampler import WMISampler
+        logger = Mock()
+        wmi_raw_sampler = WMISampler(logger, "Win32_PerfRawData_PerfOS_System", ["UnknownCounter", "MissingProperty"])  # noqa
+        wmi_raw_sampler.sample()
+
+        self.assertEquals(len(wmi_raw_sampler), 2)
+
+        for wmi_obj in wmi_raw_sampler:
+            self.assertWMIObject(wmi_obj, ["UnknownCounter", "Timestamp_Sys100NS", "Frequency_Sys100NS", "name"])  # noqa
+            self.assertEquals(wmi_obj['UnknownCounter'], 999)
+
+        self.assertTrue(logger.warning.called)
+
+    def test_missing_property(self):
+        """
+        Do not raise on missing properties.
+        """
+        wmi_raw_sampler = WMISampler("Win32_PerfRawData_PerfOS_System", ["UnknownCounter", "MissingProperty"])  # noqa
+        wmi_raw_sampler.sample()
+
+        self.assertEquals(len(wmi_raw_sampler), 2)
+
+        for wmi_obj in wmi_raw_sampler:
+            # Access a non existent property
+            self.assertFalse(wmi_obj['MissingProperty'])
+
+
+class TestIntegrationWMI(unittest.TestCase):
+    """
+    Integration tests for WMISampler.
+    """
+    pass

--- a/tests/core/test_wmi_calculator.py
+++ b/tests/core/test_wmi_calculator.py
@@ -1,0 +1,67 @@
+# stdlib
+import unittest
+
+# datadog
+from checks.libs.wmi.counter_type import calculator, get_calculator, UndefinedCalculator
+
+
+class TestWMICalculators(unittest.TestCase):
+    """
+    Unit testing for WMI calculators.
+    """
+    def setUp(self):
+        """
+        Defines two WMI object samples.
+        """
+        self.previous = {
+            'WMIPropertyName': 300,
+            'Timestamp_Sys100NS': 50,
+        }
+
+        self.current = {
+            'WMIPropertyName': 500,
+            'Timestamp_Sys100NS': 52,
+            'Frequency_Sys100NS': 0.5,
+        }
+
+    def assertPropertyValue(self, counter_type, value):
+        """
+        Handler to assert the value returned by the counter_type's calculator on the given sample.
+        """
+        calculator = get_calculator(counter_type)
+        self.assertEquals(value, calculator(self.previous, self.current, "WMIPropertyName"))
+
+    def test_calculator_decorator(self):
+        """
+        Asssign a calculator to a counter_type. Raise when the calculator is missing.
+        """
+        @calculator(123456)
+        def do_something():
+            """A function that does something."""
+            pass
+
+        self.assertEquals("do_something", do_something.__name__)
+        self.assertEquals("A function that does something.", do_something.__doc__)
+
+        self.assertTrue(get_calculator(123456))
+
+        self.assertRaises(UndefinedCalculator, get_calculator, 654321)
+
+    def test_calculator_values(self):
+        """
+        Check the computed values from calculators.
+        """
+        # PERF_COUNTER_RAWCOUNT
+        self.assertPropertyValue(65536, 500)
+
+        # PERF_COUNTER_LARGE_RAWCOUNT
+        self.assertPropertyValue(65792, 500)
+
+        # PERF_100NSEC_TIMER
+        self.assertPropertyValue(542180608, 10000)
+
+        # PERF_COUNTER_BULK_COUNT
+        self.assertPropertyValue(272696576, 50)
+
+        # PERF_COUNTER_COUNTER
+        self.assertPropertyValue(272696320, 50)


### PR DESCRIPTION
Original discussion thread: https://github.com/DataDog/dd-agent/issues/1952
Credits to @TheCloudlessSky (https://github.com/TheCloudlessSky) . Thanks a lot !!!

### WMI module + CounterType calculators
A lightweight Python WMI module wrapper built on top of `pywin32` and
`win32com` extensions.

**Specifications**
* Based on top of the `pywin32` and `win32com` third party extensions only
* Compatible with `Raw`* and `Formatted` Performance Data classes
    * Dynamically resolve properties' counter types
    * Hold the previous/current `Raw` samples to compute/format new values*
* Fast and lightweight
    * Avoid queries overhead
    * Cache connections and qualifiers
    * Use `wbemFlagForwardOnly` flag to improve enumeration/memory performance

*\* `Raw` data formatting relies on the avaibility of the corresponding calculator.
Please refer to `checks.lib.wmi.counter_type` for more information*

### Windows system check speedup
Speedup the Windows system check:
* Drop third party `wmi` Python package in favor of the local `checks.lib.wmi` module
* Use `PerfRawData` WMI Performance classes rather than `PerfFormattedData`

### WMI check speedup
Speedup the generic WMI check:
* Drop third party `wmi` Python package in favor of the local `checks.lib.wmi` module