### PR TITLE
Enable running multiple datadog agents on the same machine.

### DIFF
--- a/config.py
+++ b/config.py
@@ -221,6 +221,14 @@ def get_config_path(cfg_path=None, os_name=None):
     if cfg_path is not None and os.path.exists(cfg_path):
         return cfg_path
 
+    # Check if there's a config stored in the current agent directory
+    try:
+        path = os.path.realpath(__file__)
+        path = os.path.dirname(path)
+        return _config_path(path)
+    except PathNotFound, e:
+        pass
+
     if os_name is None:
         os_name = get_os()
 
@@ -236,14 +244,6 @@ def get_config_path(cfg_path=None, os_name=None):
     except PathNotFound, e:
         if len(e.args) > 0:
             bad_path = e.args[0]
-
-    # Check if there's a config stored in the current agent directory
-    try:
-        path = os.path.realpath(__file__)
-        path = os.path.dirname(path)
-        return _config_path(path)
-    except PathNotFound, e:
-        pass
 
     # If all searches fail, exit the agent with an error
     sys.stderr.write("Please supply a configuration file at %s or in the directory where the Agent is currently deployed.\n" % bad_path)
@@ -619,6 +619,12 @@ def set_win32_cert_path():
     tornado.simple_httpclient._DEFAULT_CA_CERTS = crt_path
 
 def get_confd_path(osname=None):
+    try:
+        cur_path = os.path.dirname(os.path.realpath(__file__))
+        return _confd_path(cur_path)
+    except PathNotFound, e:
+        pass
+
     if not osname:
         osname = get_os()
     bad_path = ''
@@ -632,12 +638,6 @@ def get_confd_path(osname=None):
     except PathNotFound, e:
         if len(e.args) > 0:
             bad_path = e.args[0]
-
-    try:
-        cur_path = os.path.dirname(os.path.realpath(__file__))
-        return _confd_path(cur_path)
-    except PathNotFound, e:
-        pass
 
     raise PathNotFound(bad_path)
 


### PR DESCRIPTION
I needed to apply this patch so that I could configure a datadog agent install from source that ran alongside the system/ubuntu based install. Without this patch, if a set of configs is found in `/etc/...`, then they override the configs in the local directory tree even when installed from source.