### PR TITLE
Add the main_tags to the consul service_check tags

### DIFF
--- a/checks.d/consul.py
+++ b/checks.d/consul.py
@@ -188,7 +188,7 @@ class ConsulCheck(AgentCheck):
                 if check["ServiceID"]:
                     tags.append("service-id:{0}".format(check["ServiceID"]))
 
-                self.service_check(self.HEALTH_CHECK, status, tags=tags)
+                self.service_check(self.HEALTH_CHECK, status, tags=main_tags+tags)
 
         except Exception as e:
             self.service_check(self.CONSUL_CHECK, AgentCheck.CRITICAL,


### PR DESCRIPTION
Add the main_tags to the service_check tags. This will include the consul_datacenter tag in the health checks. This is needed for when you have the same service name in multiple datacenters