### PR TITLE
[activemq_xml] add monitoring for standby hosts

### DIFF
--- a/conf.d/activemq_xml.yaml.example
+++ b/conf.d/activemq_xml.yaml.example
@@ -6,6 +6,7 @@ instances:
     # the agent check will append /admin/xml/queues.jsp to the url 
     # username: username
     # password: password
+    # suppress_errors: true # suppress connection errors if url is expected to be sometimes offline (eg standby host)
        
     #detailed_queues: # Optional. If you have more than 300 queues you need to list the ones you want to track
       # - queue1


### PR DESCRIPTION
ActiveMQ standby hosts (for HA) are running but do not allow connections until they are failed over to. When a failover occurs we need to start capturing metrics, but until then we should silently wait.
This adds a new config parameter which if used will treat a offline host as 0 successful metrics rather than logging exceptions and presenting an "agent error" in the datadog console interface.