### PR TITLE
[mysql] add mysql.replication.slave_running service check

### DIFF
--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -190,9 +190,14 @@ class MySql(AgentCheck):
             if slave_running is not None:
                 if slave_running.lower().strip() == 'on':
                     slave_running = 1
+                    slave_running_status = AgentCheck.OK
                 else:
                     slave_running = 0
+                    slave_running_status = AgentCheck.CRITICAL
+                # deprecated in favor of service_check("mysql.replication.slave_running")
                 self.gauge("mysql.replication.slave_running", slave_running, tags=tags)
+            self.service_check("mysql.replication.slave_running", slave_running_status, tags=tags)
+
             self._collect_dict(
                 GAUGE,
                 {"Seconds_behind_master": "mysql.replication.seconds_behind_master"},

--- a/tests/checks/integration/test_mysql.py
+++ b/tests/checks/integration/test_mysql.py
@@ -123,6 +123,9 @@ class TestMySql(AgentCheckTest):
         self.assertServiceCheck('mysql.can_connect', status=AgentCheck.OK,
                                 tags=self.SC_TAGS, count=1)
 
+        self.assertServiceCheck('mysql.replication.slave_running', status=AgentCheck.CRITICAL,
+                                tags=self.METRIC_TAGS, count=1)
+
         # Test metrics
         for mname in (self.INNODB_METRICS + self.SYSTEM_METRICS + self.REPLICATION_METRICS +
                       self.KEY_CACHE + self.COMMON_GAUGES + self.COMMON_RATES):


### PR DESCRIPTION
The mysql.replication.slave_running metric is boolean and is thus more suitable exposed as a service check (if I understand the concepts correctly).

This PR adds a new service check but keeps the old metric for backwards compatibility.