### PR TITLE
[resources] Catch and log exceptions from the resources checks

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -361,18 +361,21 @@ class Collector(object):
         if not Platform.is_windows():
             has_resource = False
             for resources_check in self._resources_checks:
-                resources_check.check()
-                snaps = resources_check.pop_snapshots()
-                if snaps:
-                    has_resource = True
-                    res_value = {
-                        'snaps': snaps,
-                        'format_version': resources_check.get_format_version()
-                    }
-                    res_format = resources_check.describe_format_if_needed()
-                    if res_format is not None:
-                        res_value['format_description'] = res_format
-                    payload['resources'][resources_check.RESOURCE_KEY] = res_value
+                try:
+                    resources_check.check()
+                    snaps = resources_check.pop_snapshots()
+                    if snaps:
+                        has_resource = True
+                        res_value = {
+                            'snaps': snaps,
+                            'format_version': resources_check.get_format_version()
+                        }
+                        res_format = resources_check.describe_format_if_needed()
+                        if res_format is not None:
+                            res_value['format_description'] = res_format
+                        payload['resources'][resources_check.RESOURCE_KEY] = res_value
+                except Exception:
+                    log.exception("Error running resource check %s" % resources_check.RESOURCE_KEY)
 
             if has_resource:
                 payload['resources']['meta'] = {

--- a/resources/processes.py
+++ b/resources/processes.py
@@ -38,9 +38,9 @@ class Processes(ResourcePlugin):
                 ps_arg = 'auxww'
             output, _, _ = get_subprocess_output(['ps', ps_arg], self.log)
             processLines = output.splitlines()  # Also removes a trailing empty line
-        except Exception, e:
+        except Exception:
             self.log.exception('Cannot get process list')
-            return False
+            raise
 
         del processLines[0]  # Removes the headers
 


### PR DESCRIPTION
They shouldn't make the collector exit when they raise an exception.

Also, raise an exception in the processes resource check instead of
returning False.