### PR TITLE
[core] Fix transaction test

### DIFF
--- a/tests/core/test_transaction.py
+++ b/tests/core/test_transaction.py
@@ -157,9 +157,9 @@ class TestTransaction(unittest.TestCase):
         MetricTransaction.set_application(app)
         MetricTransaction.set_endpoints()
 
-        transaction = MetricTransaction(None, {}, "msgtype")
+        transaction = MetricTransaction(None, {}, "")
         endpoints = [transaction.get_url(e) for e in transaction._endpoints]
-        expected = ['https://{0}-app.agent.datadoghq.com/intake/msgtype?api_key={1}'.format(
+        expected = ['https://{0}-app.agent.datadoghq.com/intake/?api_key={1}'.format(
             get_version().replace(".", "-"), api_key)]
         self.assertEqual(endpoints, expected, (endpoints, expected))
 


### PR DESCRIPTION
Propjoe doesn't support /intake/foo addresses as it's not needed. This is making the test to fail.