### PR TITLE
[check_consul] add SSL support to Consul checks.

### DIFF
--- a/checks.d/consul.py
+++ b/checks.d/consul.py
@@ -40,7 +40,19 @@ class ConsulCheck(AgentCheck):
     def consul_request(self, instance, endpoint):
         url = urljoin(instance.get('url'), endpoint)
         try:
-            resp = requests.get(url)
+
+            clientcertfile = instance.get('client_cert_file', self.init_config.get('client_cert_file', False))
+            privatekeyfile = instance.get('private_key_file', self.init_config.get('private_key_file', False))
+            cabundlefile = instance.get('ca_bundle_file', self.init_config.get('ca_bundle_file', True))
+
+            if clientcertfile:
+                if privatekeyfile:
+                    resp = requests.get(url, cert=(clientcertfile,privatekeyfile), verify=cabundlefile)
+                else:
+                    resp = requests.get(url, cert=clientcertfile, verify=cabundlefile)
+            else:
+                resp = requests.get(url, verify=cabundlefile)
+
         except requests.exceptions.Timeout:
             self.log.exception('Consul request to {0} timed out'.format(url))
             raise

--- a/conf.d/consul.yaml.example
+++ b/conf.d/consul.yaml.example
@@ -3,7 +3,22 @@ init_config:
 
 instances:
     # Where your Consul HTTP Server Lives
+    # Remind to use https instead of http if your Consul setup is configured to do so.
     - url: http://localhost:8500
+
+      # If Consul setup uses SSL, you might need to set the following options as well.
+
+      # You can specify a local cert to use as client side certificate
+      # as a single file (containing the private key and the certificate concatenated)
+      # client_cert_file: '/path/to/client.concatenated.pem'
+
+      # Or as two separate files (for certificate and key):
+      # client_cert_file: '/path/to/client.cert.pem'
+      # private_key_file: '/path/to/private.key.pem'
+
+      # Whether to verifiy SSL certificates for HTTPS requests.
+      # Possible values: True, False or '/path/to/your/trusted_ca_bundle_file'
+      # ca_bundle_file: '/path/to/trusted_ca_bundle_file'
 
       # Whether to perform checks against the Consul service Catalog
       catalog_checks: yes


### PR DESCRIPTION
This PR is supposed to enable Consul check over SSL, when a client certificate or a specific trusted CA might be needed.