### PR TITLE
[kubernets] Kubelet check failing shouldn't stop metrics collection

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -548,7 +548,7 @@ class AgentCheck(object):
         :param hostname: (optional) str, host that generated the service
                           check. Defaults to the host_name of the agent
         :param check_run_id: (optional) int, id used for logging and tracing
-                             purposes. Don't need to be unique. If not
+                             purposes. Doesn't need to be unique. If not
                              specified, one will be generated.
         """
         if hostname is None:

--- a/conf.d/kubernetes.yaml.example
+++ b/conf.d/kubernetes.yaml.example
@@ -22,10 +22,6 @@ instances:
   #
    use_histogram: True
   #
-  # Getting the master checks
-  # master_host: localhost
-  # master_port: 8080
-  #
   # Kubelet checks
   # enable_kubelet_checks: true
   # kubelet_port: 10255

--- a/tests/checks/mock/test_kubernetes.py
+++ b/tests/checks/mock/test_kubernetes.py
@@ -35,8 +35,7 @@ class TestKubernetes(AgentCheckTest):
         }
 
         # Can't use run_check_twice due to specific metrics
-        with self.assertRaises(Exception):
-            self.run_check(config, mocks=mocks, force_reload=True)
+        self.run_check(config, mocks=mocks, force_reload=True)
         self.assertServiceCheck("kubernetes.kubelet.check", status=AgentCheck.CRITICAL)
         self.coverage_report()
 


### PR DESCRIPTION
Also fix service check messages