### PR TITLE
[packaging][windows] force-include 'wmi' module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ if sys.platform == 'win32':
     # Modules to force-include in the exe
     include_modules = [
         # 3p
+        'wmi',
         'win32service',
         'win32serviceutil',
         'win32event',


### PR DESCRIPTION
The module was previously dynamically imported from the [Windows System check](https://github.com/DataDog/dd-agent/blob/5.5.x/checks/system/win32.py#L10-L14) and needs to be manually included now.