### PR TITLE
[docker_daemon] Remove spurious proc root container warnings

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -485,8 +485,9 @@ class DockerDaemon(AgentCheck):
                 continue
             self._report_net_metrics(container, tags)
 
-        self.warning("Couldn't find pid directory for container: {0}. They'll be missing network metrics".format(
-            ",".join(containers_without_proc_root)))
+        if containers_without_proc_root:
+            self.warning("Couldn't find pid directory for container: {0}. They'll be missing network metrics".format(
+                ",".join(containers_without_proc_root)))
 
     def _report_cgroup_metrics(self, container, tags):
         try:


### PR DESCRIPTION
With 5.6.0, this happens on every cycle:

```
2015-11-05 19:20:27 UTC | WARNING | dd.collector | checks.docker_daemon(__init__.py:649) | Couldn't find pid directory for container: . They'll be missing network metrics
```