### PR TITLE
[core] `supervisor.conf` to select Supervisor user

### DIFF
--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -104,7 +104,7 @@ start() {
     # no need to test for status before daemon,
     # the daemon function does the right thing
     echo -n "Starting Datadog Agent (using supervisord):"
-    daemon --user=$AGENTUSER --pidfile=$SUPERVISOR_PIDFILE $SUPERVISORD_PATH -c $SUPERVISOR_CONF > /dev/null
+    daemon --pidfile=$SUPERVISOR_PIDFILE $SUPERVISORD_PATH -c $SUPERVISOR_CONF > /dev/null
     # check if the agent is running once per second for 10 seconds
     retries=10
     while [ $retries -gt 1 ]; do

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -90,7 +90,7 @@ case "$1" in
 
 
         log_daemon_msg "Starting $DESC (using supervisord)" "$NAME"
-        PATH=$SYSTEM_PATH start-stop-daemon --chuid $AGENTUSER --start --quiet --oknodo --exec $SUPERVISORD_PATH -- -c $SUPERVISOR_FILE --pidfile $SUPERVISOR_PIDFILE
+        PATH=$SYSTEM_PATH start-stop-daemon --start --quiet --oknodo --exec $SUPERVISORD_PATH -- -c $SUPERVISOR_FILE --pidfile $SUPERVISOR_PIDFILE
         if [ $? -ne 0 ]; then
             log_end_msg 1
         fi
@@ -116,7 +116,7 @@ case "$1" in
     stop)
 
         log_daemon_msg "Stopping $DESC (stopping supervisord)" "$NAME"
-        start-stop-daemon --chuid $AGENTUSER --stop --retry 30 --quiet --oknodo --pidfile $SUPERVISOR_PIDFILE
+        start-stop-daemon --stop --retry 30 --quiet --oknodo --pidfile $SUPERVISOR_PIDFILE
 
         log_end_msg $?
 


### PR DESCRIPTION
By default, Supervisor runs with the given `user` in the `supervisord`
section of the `supervisor.conf` configuration file.

> If supervisord is run as the root user, switch users to this UNIX user
account before doing any meaningful processing. This value has no effect
if supervisord is not run as root.
(c.f
http://supervisord.org/configuration.html#supervisord-section-settings)

Thus, forcing Supervisor to run as `dd-agent` in the init script file is
simply an extra precaution. However, it makes impossible to change UNIX
users running the agent subprocesses via the `supervisor.conf`
configuration file only.
Drop this constraint.