### PR TITLE
[installation script] Add custom provided hostname to dd-agent config

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -36,6 +36,10 @@ solve your problem.\n\033[0m\n"
 }
 trap on_error ERR
 
+if [ -n "$DD_HOSTNAME" ]; then
+    dd_hostname=$DD_HOSTNAME
+fi
+
 if [ -n "$DD_API_KEY" ]; then
     apikey=$DD_API_KEY
 fi
@@ -49,6 +53,10 @@ fi
 if [ ! $apikey ]; then
     printf "\033[31mAPI key not available in DD_API_KEY environment variable.\033[0m\n"
     exit 1;
+fi
+
+if [ $dd_hostname ]; then
+    printf "\033[31mHOSTNAME is force installed.\033[0m\n"
 fi
 
 # OS/Distro Detection
@@ -150,6 +158,10 @@ if [ -e /etc/dd-agent/datadog.conf ]; then
 else
     printf "\033[34m\n* Adding your API key to the Agent configuration: /etc/dd-agent/datadog.conf\n\033[0m\n"
     $sudo_cmd sh -c "sed 's/api_key:.*/api_key: $apikey/' /etc/dd-agent/datadog.conf.example > /etc/dd-agent/datadog.conf"
+    if [ $dd_hostname ]; then
+        printf "\033[34m\n* Adding your HOSTNAME to the Agent configuration: /etc/dd-agent/datadog.conf\n\033[0m\n"
+        $sudo_cmd sh -c "sed 's/#hostname:.*/hostname: $dd_hostname/' /etc/dd-agent/datadog.conf > /etc/dd-agent/datadog.conf"
+    fi
     $sudo_cmd chown dd-agent:root /etc/dd-agent/datadog.conf
     $sudo_cmd chmod 640 /etc/dd-agent/datadog.conf
 fi

--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -160,7 +160,7 @@ else
     $sudo_cmd sh -c "sed 's/api_key:.*/api_key: $apikey/' /etc/dd-agent/datadog.conf.example > /etc/dd-agent/datadog.conf"
     if [ $dd_hostname ]; then
         printf "\033[34m\n* Adding your HOSTNAME to the Agent configuration: /etc/dd-agent/datadog.conf\n\033[0m\n"
-        $sudo_cmd sh -c "sed 's/#hostname:.*/hostname: $dd_hostname/' /etc/dd-agent/datadog.conf > /etc/dd-agent/datadog.conf"
+        $sudo_cmd sh -c "sed -i 's|#hostname:.*|hostname: $dd_hostname|' /etc/dd-agent/datadog.conf"
     fi
     $sudo_cmd chown dd-agent:root /etc/dd-agent/datadog.conf
     $sudo_cmd chmod 640 /etc/dd-agent/datadog.conf


### PR DESCRIPTION
Add posibility to provide custom datadog-agent hostname.

Works same way as DD_API_KEY. If DD_HOSTNAME variable is not defined works with old logic.

DD_HOSTNAME=test.example.com DD_API_KEY=testapihash bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/install_agent.sh)"