### PR TITLE
[dev] install deps from requirements-test.txt during `rake setup_env`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -64,6 +64,7 @@ task 'setup_env' do
   `wget -O venv/get-pip.py https://raw.github.com/pypa/pip/master/contrib/get-pip.py`
   `venv/bin/python venv/get-pip.py`
   `venv/bin/pip install -r requirements.txt`
+  `venv/bin/pip install -r requirements-test.txt`
   # These deps are not really needed, so we ignore failures
   ENV['PIP_COMMAND'] = 'venv/bin/pip'
   `./utils/pip-allow-failures.sh requirements-opt.txt`


### PR DESCRIPTION
Now that `rake setup_env` installs the linting and testing dependencies in
addition to the runtime ones, all of the setup instructions in the readme now
work correctly from start to finish on a clean machine.