### PR TITLE
[http_check] Renamed ssl_expire to check_certificate_expiration in comment.

### DIFF
--- a/conf.d/http_check.yaml.example
+++ b/conf.d/http_check.yaml.example
@@ -70,7 +70,7 @@ instances:
     #
     # ca_certs: /etc/ssl/certs/ca-certificates.crt
 
-    # The (optional) ssl_expire will instruct the check
+    # The (optional) check_certificate_expiration will instruct the check
     # to create a service check that checks the expiration of the
     # ssl certificate. Allow for a warning to occur when x days are
     # left in the certificate.


### PR DESCRIPTION
The comment explaining SSL expiration check references a option name `ssl_expire`. But in the exmaple after (and in [code](https://github.com/DataDog/dd-agent/blob/eb0154dc4a0fa921d5f517efc2834a363292151b/checks.d/http_check.py#L165)) the option is named `check_certificate_expiration`.