### PR TITLE
[http_check] Adding a days_critical to the SSL certificate expiration feature

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -378,6 +378,7 @@ class HTTPCheck(NetworkCheck):
 
     def check_cert_expiration(self, instance, timeout, instance_ca_certs):
         warning_days = int(instance.get('days_warning', 14))
+        critical_days = int(instance.get('days_critical', 7))
         url = instance.get('url')
 
         o = urlparse(url)
@@ -401,6 +402,10 @@ class HTTPCheck(NetworkCheck):
 
         if days_left.days < 0:
             return Status.DOWN, "Expired by {0} days".format(days_left.days)
+
+        elif days_left.days < critical_days:
+            return Status.CRITICAL, "This cert TTL is critical: only {0} days before it expires"\
+                .format(days_left.days)
 
         elif days_left.days < warning_days:
             return Status.WARNING, "This cert is almost expired, only {0} days left"\

--- a/checks/network_checks.py
+++ b/checks/network_checks.py
@@ -18,6 +18,7 @@ FAILURE = "FAILURE"
 class Status:
     DOWN = "DOWN"
     WARNING = "WARNING"
+    CRITICAL = "CRITICAL"
     UP = "UP"
 
 
@@ -33,7 +34,8 @@ class NetworkCheck(AgentCheck):
     STATUS_TO_SERVICE_CHECK = {
         Status.UP  : AgentCheck.OK,
         Status.WARNING : AgentCheck.WARNING,
-        Status.DOWN : AgentCheck.CRITICAL
+        Status.CRITICAL : AgentCheck.CRITICAL,
+        Status.DOWN : AgentCheck.CRITICAL,
     }
 
     """

--- a/conf.d/http_check.yaml.example
+++ b/conf.d/http_check.yaml.example
@@ -73,12 +73,14 @@ instances:
     # The (optional) ssl_expire will instruct the check
     # to create a service check that checks the expiration of the
     # ssl certificate. Allow for a warning to occur when x days are
-    # left in the certificate.
+    # left in the certificate, and alternatively raise a critical
+    # warning if the certificate is y days from the expiration date.
     # The SSL certificate will always be validated for this additional
     # service check regardless of the value of disable_ssl_validation
     #
     # check_certificate_expiration: true
     # days_warning: 14
+    # days_critical: 7
 
     # The (optional) headers parameter allows you to send extra headers
     # with the request. This is useful for explicitly specifying the host

--- a/tests/checks/integration/test_http_check.py
+++ b/tests/checks/integration/test_http_check.py
@@ -57,19 +57,29 @@ CONFIG_SSL_ONLY = {
         'url': 'https://github.com:443',
         'timeout': 1,
         'check_certificate_expiration': True,
-        'days_warning': 14
+        'days_warning': 14,
+        'days_critical': 7
     }, {
         'name': 'cert_exp_soon',
         'url': 'https://google.com',
         'timeout': 1,
         'check_certificate_expiration': True,
-        'days_warning': 9999
+        'days_warning': 9999,
+        'days_critical': 7
+    }, {
+        'name': 'cert_critical',
+        'url': 'https://google.com',
+        'timeout': 1,
+        'check_certificate_expiration': True,
+        'days_warning': 9999,
+        'days_critical': 9999
     }, {
         'name': 'conn_error',
         'url': 'https://thereisnosuchlink.com',
         'timeout': 1,
         'check_certificate_expiration': True,
-        'days_warning': 14
+        'days_warning': 14,
+        'days_critical': 7
     }
     ]
 }
@@ -80,7 +90,8 @@ CONFIG_EXPIRED_SSL = {
         'url': 'https://github.com',
         'timeout': 1,
         'check_certificate_expiration': True,
-        'days_warning': 14
+        'days_warning': 14,
+        'days_critical': 7
     },
     ]
 }
@@ -91,7 +102,8 @@ CONFIG_UNORMALIZED_INSTANCE_NAME = {
         'url': 'https://github.com',
         'timeout': 1,
         'check_certificate_expiration': True,
-        'days_warning': 14
+        'days_warning': 14,
+        'days_critical': 7
     },
     ]
 }
@@ -202,6 +214,10 @@ class HTTPCheckTest(AgentCheckTest):
         tags = ['url:https://google.com', 'instance:cert_exp_soon']
         self.assertServiceCheckOK("http.can_connect", tags=tags)
         self.assertServiceCheckWarning("http.ssl_cert", tags=tags)
+
+        tags = ['url:https://google.com', 'instance:cert_critical']
+        self.assertServiceCheckOK("http.can_connect", tags=tags)
+        self.assertServiceCheckCritical("http.ssl_cert", tags=tags)
 
         tags = ['url:https://thereisnosuchlink.com', 'instance:conn_error']
         self.assertServiceCheckCritical("http.can_connect", tags=tags)


### PR DESCRIPTION
The check will now raise a critical warning if we're within the specified CRITICAL range before a certificate expires.