### PR TITLE
[teamcity] Add ssl_validation flag to check

### DIFF
--- a/conf.d/teamcity.yaml.example
+++ b/conf.d/teamcity.yaml.example
@@ -22,6 +22,9 @@ instances:
     # rather than just that a successful build happened
     # is_deployment: true
 
+    # Optional, this turns off ssl certificate validation. Defaults to True.
+    # ssl_validation: false
+
     # Optional, any additional tags you'd like to add to the event
     # tags:
     #   - test


### PR DESCRIPTION
It would be helpful to have the ability to disable SSL validation in the teamcity check, same idea as issue #1782.

I went ahead and added a flag in with the same name as the nginx check. I did not try and write an integration test. Is a test needed for this?