### PR TITLE
[http_check] content-matching with unicode support

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -250,7 +250,7 @@ class HTTPCheck(NetworkCheck):
             # Check content matching is set
             if content_match:
                 content = r.content
-                if re.search(content_match, content):
+                if re.search(content_match, content, re.UNICODE):
                     self.log.debug("%s is found in return content" % content_match)
                     service_checks.append((
                         self.SC_STATUS, Status.UP, "UP"
@@ -322,12 +322,12 @@ class HTTPCheck(NetworkCheck):
                 if len(content) > 200:
                     content = content[:197] + '...'
 
-                msg = "%d %s\n\n%s" % (code, reason, content)
+                msg = u"%d %s\n\n%s" % (code, reason, content)
                 msg = msg.rstrip()
 
             title = "[Alert] %s reported that %s is down" % (self.hostname, name)
             alert_type = "error"
-            msg = "%s %s %s reported that %s (%s) failed %s time(s) within %s last attempt(s)."\
+            msg = u"%s %s %s reported that %s (%s) failed %s time(s) within %s last attempt(s)."\
                 " Last error: %s" % (notify_message, custom_message, self.hostname,
                                      name, url, nb_failures, nb_tries, msg)
             event_type = EventType.DOWN
@@ -335,7 +335,7 @@ class HTTPCheck(NetworkCheck):
         else:  # Status is UP
             title = "[Recovered] %s reported that %s is up" % (self.hostname, name)
             alert_type = "success"
-            msg = "%s %s %s reported that %s (%s) recovered" \
+            msg = u"%s %s %s reported that %s (%s) recovered" \
                 % (notify_message, custom_message, self.hostname, name, url)
             event_type = EventType.UP
 
@@ -367,7 +367,7 @@ class HTTPCheck(NetworkCheck):
                 if len(content) > 200:
                     content = content[:197] + '...'
 
-                msg = "%d %s\n\n%s" % (code, reason, content)
+                msg = u"%d %s\n\n%s" % (code, reason, content)
                 msg = msg.rstrip()
 
         self.service_check(sc_name,

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -554,7 +554,7 @@ class AgentCheck(object):
         if hostname is None:
             hostname = self.hostname
         if message is not None:
-            message = str(message)
+            message = unicode(message) # ascii converts to unicode but not viceversa
         self.service_checks.append(
             create_service_check(check_name, status, tags, timestamp,
                                  hostname, check_run_id, message)
@@ -570,7 +570,7 @@ class AgentCheck(object):
         :param value: metadata value
         :type value: string
         """
-        self._instance_metadata.append((meta_name, str(value)))
+        self._instance_metadata.append((meta_name, unicode(value)))
 
     def has_events(self):
         """

--- a/tests/checks/integration/test_http_check.py
+++ b/tests/checks/integration/test_http_check.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 # stdlibb
 import time
 
@@ -47,6 +49,12 @@ CONFIG = {
         'timeout': 1,
         'check_certificate_expiration': False,
         'content_match': '(thereisnosuchword|github)'
+    }, {
+        'name': 'cnt_match_unicode',
+        'url': 'http://www.inter-locale.com/whitepaper/learn/learn-to-test.html',
+        'timeout': 1,
+        'check_certificate_expiration': False,
+        'content_match': 'ぶびばぱぴ'
     }
     ]
 }
@@ -169,7 +177,6 @@ class HTTPCheckTest(AgentCheckTest):
 
         # HTTP connection error
         tags = ['url:https://thereisnosuchlink.com', 'instance:conn_error']
-
         self.assertServiceCheckCritical("http.can_connect", tags=tags)
 
         # Wrong HTTP response status code
@@ -187,6 +194,9 @@ class HTTPCheckTest(AgentCheckTest):
         self.assertServiceCheckCritical("http.can_connect", tags=tags)
         self.assertServiceCheckOK("http.can_connect", tags=tags, count=0)
         tags = ['url:https://github.com', 'instance:cnt_match']
+        self.assertServiceCheckOK("http.can_connect", tags=tags)
+        tags = ['url:http://www.inter-locale.com/whitepaper/learn/learn-to-test.html',
+                'instance:cnt_match_unicode']
         self.assertServiceCheckOK("http.can_connect", tags=tags)
 
         self.coverage_report()


### PR DESCRIPTION
Also - AgentCheck messages could be unicode, so changed it there as well.