### PR TITLE
[windows][requests] Bundle default CA certs of `requests`

### DIFF
--- a/config.py
+++ b/config.py
@@ -620,6 +620,26 @@ def set_win32_cert_path():
     log.info("Windows certificate path: %s" % crt_path)
     tornado.simple_httpclient._DEFAULT_CA_CERTS = crt_path
 
+
+def set_win32_requests_ca_bundle_path():
+    """In order to allow `requests` to validate SSL requests with the packaged .exe on Windows,
+    we need to override the default certificate location which is based on the location of the
+    requests or certifi libraries.
+
+    We override the path directly in requests.adapters so that the override works even when the
+    `requests` lib has already been imported
+    """
+    import requests.adapters
+    if hasattr(sys, 'frozen'):
+        # we're frozen - from py2exe
+        prog_path = os.path.dirname(sys.executable)
+        ca_bundle_path = os.path.join(prog_path, 'cacert.pem')
+        requests.adapters.DEFAULT_CA_BUNDLE_PATH = ca_bundle_path
+
+    log.info("Default CA bundle path of the requests library: {0}"
+             .format(requests.adapters.DEFAULT_CA_BUNDLE_PATH))
+
+
 def get_confd_path(osname=None):
     if not osname:
         osname = get_os()

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import sys
 
 # 3p
 from setuptools import find_packages, setup
+from requests.certs import where
 
 # project
 from config import get_version
@@ -116,7 +117,8 @@ if sys.platform == 'win32':
         'data_files': [
             ("Microsoft.VC90.CRT", glob(r'C:\Python27\redist\*.*')),
             ('jmxfetch', [r'checks\libs\%s' % JMX_FETCH_JAR_NAME]),
-            ('gohai', [r'gohai\gohai.exe'])
+            ('gohai', [r'gohai\gohai.exe']),
+            ('', [where()]),  # CA certificates bundled with `requests`
         ],
     }
 

--- a/win32/agent.py
+++ b/win32/agent.py
@@ -22,6 +22,7 @@ from config import (
     load_check_directory,
     PathNotFound,
     set_win32_cert_path,
+    set_win32_requests_ca_bundle_path,
 )
 from ddagent import Application
 import dogstatsd
@@ -198,6 +199,7 @@ class DDAgent(multiprocessing.Process):
         from config import initialize_logging
         initialize_logging('windows_collector')
         log.debug("Windows Service - Starting collector")
+        set_win32_requests_ca_bundle_path()
         emitters = self.get_emitters()
         systemStats = get_system_stats()
         self.collector = Collector(self.config, emitters, systemStats, self.hostname)

--- a/win32/shell.py
+++ b/win32/shell.py
@@ -1,8 +1,9 @@
 import traceback
 
 def shell():
-    from config import get_version
+    from config import get_version, set_win32_requests_ca_bundle_path
 
+    set_win32_requests_ca_bundle_path()
     print """
 Datadog Agent v%s - Python Shell
 


### PR DESCRIPTION
py2exe only includes the python files of the python packages in the
`library` zipped file. This causes the `requests` library to be shipped
without CA certs, so all the https requests made with it fail (unless
SSL cert validation is explicitely disabled).

This fixes the issue by:
1. shipping the default certificates of `requests` with the Windows
agent as an extra data file
2. overriding the path to the default CA bundle that `requests` uses
(which is done in quite an ugly way, but I haven't found any better
way)

Notes:
- we already ship CA certs for `tornado`, but to be as close as possible to the agent's behavior on other platforms I've used the default CA certs provided by `requests`/`certifi`
- this doesn't fix SSL cert validation on the `http_check` on Windows, because the check uses default paths that are only valid on unix platforms: see https://github.com/DataDog/dd-agent/blob/8fed4c926e8abbb2f16ebec47670f9f2a5ef8a61/checks.d/http_check.py#L127-L131 (unless the user sets a valid path in the check's config)