### PR TITLE
Add slab, page tables and cached swap.

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -318,7 +318,10 @@ class Collector(object):
                     'memSwapTotal': memory.get('swapTotal'),
                     'memCached': memory.get('physCached'),
                     'memBuffers': memory.get('physBuffers'),
-                    'memShared': memory.get('physShared')
+                    'memShared': memory.get('physShared'),
+                    'memSlab': memory.get('physSlab'),
+                    'memPageTables': memory.get('physPageTables'),
+                    'memSwapCached': memory.get('swapCached')
                 }
                 payload.update(memstats)
 

--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -368,6 +368,8 @@ class Memory(Check):
                 memData['physBuffers'] = int(meminfo.get('Buffers', 0)) / 1024
                 memData['physCached'] = int(meminfo.get('Cached', 0)) / 1024
                 memData['physShared'] = int(meminfo.get('Shmem', 0)) / 1024
+                memData['physSlab'] = int(meminfo.get('Slab', 0)) / 1024
+                memData['physPageTables'] = int(meminfo.get('PageTables', 0)) / 1024
                 memData['physUsed'] = memData['physTotal'] - memData['physFree']
 
                 if 'MemAvailable' in meminfo:
@@ -386,6 +388,7 @@ class Memory(Check):
             try:
                 memData['swapTotal'] = int(meminfo.get('SwapTotal', 0)) / 1024
                 memData['swapFree'] = int(meminfo.get('SwapFree', 0)) / 1024
+                memData['swapCached'] = int(meminfo.get('SwapCached', 0)) / 1024
 
                 memData['swapUsed'] = memData['swapTotal'] - memData['swapFree']
 


### PR DESCRIPTION
# What's this PR do?

Adds some new memory metrics:
* Slab:  The total amount of memory, in kilobytes, used by the kernel to cache data structures for its own use.
* PageTables: The total amount of memory, in kilobytes, dedicated to the lowest page table level.
* SwapCached: The amount of swap, in kilobytes, used as cache memory.

# Motivation

This is data we have in our existing munin + graphite setup. It's also stuff we've seen have a production impact during a nasty outage caused by a huge amount of VM pressure from slab allocation due to a weird problem we created by running a `find` across all of `/proc`. :P

# Notes

I still am not sure how this metric gets turned in to `system.memory.*`. Is this all I need to do? Will do some testing. :smile: 