### PR TITLE
Gauge delta support

### DIFF
--- a/aggregator.py
+++ b/aggregator.py
@@ -63,13 +63,14 @@ class Gauge(Metric):
         # This is a known oversight of the protocol
         try:
             if len(str(value)) > 0 and str(value)[0] in ('+'):
-                if self.value is None: self.value = 0
+                if self.value is None:
+                    self.value = 0
                 self.value += float(value)
             else:
                 self.value = float(value)
         except ValueError:
             log.warn("Cannot parse gauge value: %s" % value)
- 
+
         self.last_sample_time = time()
         self.timestamp = timestamp
 

--- a/aggregator.py
+++ b/aggregator.py
@@ -57,7 +57,16 @@ class Gauge(Metric):
         self.timestamp = time()
 
     def sample(self, value, sample_rate, timestamp=None):
-        self.value = value
+        # Parse optional leading + or - which means gauge delta
+        try:
+            if str(value)[0] in ('+', '-'):
+                if self.value is None: self.value = 0
+                self.value += int(value)
+            else:
+                self.value = value
+        except ValueError:
+            log.warn("Cannot parse gauge value: %s" % value)
+ 
         self.last_sample_time = time()
         self.timestamp = timestamp
 
@@ -392,7 +401,7 @@ class Aggregator(object):
     Abstract metric aggregator class.
     """
     # Types of metrics that allow strings
-    ALLOW_STRINGS = ['s', ]
+    ALLOW_STRINGS = ['s', 'g']
 
     def __init__(self, hostname, interval=1.0, expiry_seconds=300,
             formatter=None, recent_point_threshold=None,

--- a/aggregator.py
+++ b/aggregator.py
@@ -57,13 +57,16 @@ class Gauge(Metric):
         self.timestamp = time()
 
     def sample(self, value, sample_rate, timestamp=None):
-        # Parse optional leading + or - which means gauge delta
+        # Parse optional leading +which means gauge delta
+        # Note that we deviate from the statsd implementation by allowing negative values
+        # for gauges, rather than treating -N as a negative delta
+        # This is a known oversight of the protocol
         try:
-            if str(value)[0] in ('+', '-'):
+            if len(str(value)) > 0 and str(value)[0] in ('+'):
                 if self.value is None: self.value = 0
-                self.value += int(value)
+                self.value += float(value)
             else:
-                self.value = value
+                self.value = float(value)
         except ValueError:
             log.warn("Cannot parse gauge value: %s" % value)
  

--- a/tests/core/test_bucket_aggregator.py
+++ b/tests/core/test_bucket_aggregator.py
@@ -451,7 +451,7 @@ class TestUnitMetricsBucketAggregator(unittest.TestCase):
         stats.submit_packets('my.gauge.delta:-11|g')
         self.sleep_for_interval_length(ag_interval)
         # == -11 and not -1
-        
+
         metrics = self.sort_metrics(stats.flush())
         nt.assert_equals(len(metrics), 1)
         first = metrics[0]

--- a/tests/core/test_bucket_aggregator.py
+++ b/tests/core/test_bucket_aggregator.py
@@ -425,6 +425,39 @@ class TestUnitMetricsBucketAggregator(unittest.TestCase):
         nt.assert_equals(second['metric'], 'my.second.gauge')
         nt.assert_equals(second['points'][0][1], 1.5)
 
+    def test_gauge_delta(self):
+        ag_interval = 2
+        stats = MetricsBucketAggregator('myhost', interval=ag_interval)
+        self.wait_for_bucket_boundary(ag_interval)
+
+        # Submit a few gauge deltas
+        stats.submit_packets('my.gauge.delta:+1|g')
+        stats.submit_packets('my.gauge.delta:+2|g')
+        stats.submit_packets('my.gauge.delta:+3|g')
+        stats.submit_packets('my.gauge.delta:+4|g')
+        # == 10
+
+        # Ensure that gauges roll up correctly.
+        metrics = self.sort_metrics(stats.flush())
+        nt.assert_equals(len(metrics), 1)
+        first = metrics[0]
+
+        nt.assert_equals(first['metric'], 'my.gauge.delta')
+        nt.assert_equals(first['points'][0][1], 10)
+        nt.assert_equals(first['host'], 'myhost')
+
+        self.sleep_for_interval_length(ag_interval)
+        stats.submit_packets('my.gauge.delta:-11|g')
+        # == 0
+        
+        metrics = self.sort_metrics(stats.flush())
+        nt.assert_equals(len(metrics), 1)
+        first = metrics[0]
+
+        nt.assert_equals(first['metric'], 'my.gauge.delta')
+        nt.assert_equals(first['points'][0][1], -1)
+        nt.assert_equals(first['host'], 'myhost')
+
     def test_sets(self):
         stats = MetricsBucketAggregator('myhost', interval=self.interval)
         stats.submit_packets('my.set:10|s')

--- a/tests/core/test_bucket_aggregator.py
+++ b/tests/core/test_bucket_aggregator.py
@@ -438,6 +438,7 @@ class TestUnitMetricsBucketAggregator(unittest.TestCase):
         # == 10
 
         # Ensure that gauges roll up correctly.
+        self.sleep_for_interval_length(ag_interval)
         metrics = self.sort_metrics(stats.flush())
         nt.assert_equals(len(metrics), 1)
         first = metrics[0]
@@ -446,16 +447,17 @@ class TestUnitMetricsBucketAggregator(unittest.TestCase):
         nt.assert_equals(first['points'][0][1], 10)
         nt.assert_equals(first['host'], 'myhost')
 
-        self.sleep_for_interval_length(ag_interval)
+        self.wait_for_bucket_boundary(ag_interval)
         stats.submit_packets('my.gauge.delta:-11|g')
-        # == 0
+        self.sleep_for_interval_length(ag_interval)
+        # == -11 and not -1
         
         metrics = self.sort_metrics(stats.flush())
         nt.assert_equals(len(metrics), 1)
         first = metrics[0]
 
         nt.assert_equals(first['metric'], 'my.gauge.delta')
-        nt.assert_equals(first['points'][0][1], -1)
+        nt.assert_equals(first['points'][0][1], -11)
         nt.assert_equals(first['host'], 'myhost')
 
     def test_sets(self):


### PR DESCRIPTION
To fix #573.

Note that we don't exactly follow the statsd implementation, which treats negative gauge values as gauge deltas (instead of using e.g. a new metric type). The canonical implementation for negative values then forces a reset of the value to 0 before the transmission of a negative delta.

Here we take the opposite view. There are as many negative numbers as there are positive numbers so we treat them as first class citizens and limit gauge deltas to increasing numbers.