### PR TITLE
[redis] Optionally collect redis INFO COMMANDSTATS as metrics.

### DIFF
--- a/conf.d/redisdb.yaml.example
+++ b/conf.d/redisdb.yaml.example
@@ -39,3 +39,6 @@ instances:
     # set the value here.
     # Warning: It may impact the performance of your redis instance
     # slowlog-max-len: 128
+
+    # Collect INFO COMMANDSTATS output as metrics.
+    # command_stats: False

--- a/tests/checks/integration/test_redisdb.py
+++ b/tests/checks/integration/test_redisdb.py
@@ -5,7 +5,9 @@ import random
 import time
 
 # 3p
+from distutils.version import StrictVersion
 from nose.plugins.attrib import attr
+from nose.plugins.skip import SkipTest
 import redis
 
 # project
@@ -305,6 +307,50 @@ class TestRedis(AgentCheckTest):
         # payload, as specified in the above agent configuration
         self.assertMetric("redis.slowlog.micros.count", tags=["command:SORT",
             "redis_host:localhost", "redis_port:{0}".format(port)], value=1.0)
+
+    def test_redis_command_stats(self):
+        port = NOAUTH_PORT
+
+        instance = {
+            'host': 'localhost',
+            'port': port,
+            'command_stats': True
+        }
+
+        db = redis.Redis(port=port, db=14)  # Datadog's test db
+
+        r = load_check('redisdb', {}, {})
+        r.check(instance)
+
+        version = db.info().get('redis_version')
+        if StrictVersion(version) < StrictVersion('2.6.0'):
+            raise SkipTest("Command stats only works with Redis >= 2.6.0")
+
+        metrics = self._sort_metrics(r.get_metrics())
+        assert metrics, "No metrics returned"
+        command_stat_metrics = ['redis.command.calls', 'redis.command.usec', 'redis.command.usec_per_call']
+        command_metrics = [m for m in metrics if m[0] in command_stat_metrics]
+
+        # Assert we have values, timestamps and tags for each metric.
+        for m in command_metrics:
+            assert isinstance(m[1], int)    # timestamp
+            assert isinstance(m[2], (int, float, long))  # value
+            tags = m[3]["tags"]
+            expected_tags = ["redis_host:localhost", "redis_port:%s" % port]
+            for e in expected_tags:
+                assert e in tags
+
+        # Check the command stats for INFO, since we know we've called it
+        info_metrics = self._sort_metrics(
+            [m for m in command_metrics if "command:info" in m[3]["tags"]])
+        # There should be one value for each metric for the info command
+        self.assertEquals(2, len(info_metrics))
+
+        self.assertEquals('redis.command.calls', info_metrics[0][0])
+        assert info_metrics[0][2] > 0, "Number of INFO calls should be >0"
+
+        self.assertEquals('redis.command.usec_per_call', info_metrics[1][0])
+        assert info_metrics[1][2] > 0, "Usec per INFO call should be >0"
 
     def _sort_metrics(self, metrics):
         def sort_by(m):


### PR DESCRIPTION
The redis [INFO](http://redis.io/commands/INFO) COMMANDSTATS command returns:
* The number of times each command has been called.
* The amount of time spent on calling this command
* The average time per call of each command.

This parses that data into three gauges, tagged by command:
* `redis.command.calls`
* `redis.command.usec`
* `redis.command.usec_per_call`

These metrics are only collected if the `command_stats` flag is set to true for the instance, as there are 3 new metrics for every command run on a redis instance.