### PR TITLE
[vsphere] Check metric type first to determine how to report

### DIFF
--- a/checks.d/vsphere.py
+++ b/checks.d/vsphere.py
@@ -15,6 +15,7 @@ from pyVmomi import vim
 from checks import AgentCheck
 from checks.libs.thread_pool import Pool
 from checks.libs.vmware.basic_metrics import BASIC_METRICS
+from checks.libs.vmware.all_metrics import ALL_METRICS
 from util import Timer
 
 SOURCE_TYPE = 'vsphere'
@@ -748,7 +749,13 @@ class VSphereCheck(AgentCheck):
                     continue
                 instance_name = result.id.instance or "none"
                 value = self._transform_value(instance, result.id.counterId, result.value[0])
-                self.gauge(
+
+                # Metric types are absolute, delta, and rate
+                if ALL_METRICS[self.metrics_metadata[i_key][result.id.counterId]['name']]['s_type'] == 'rate':
+                    record_metric = self.rate
+                else:
+                    record_metric = self.gauge
+                record_metric(
                     "vsphere.%s" % self.metrics_metadata[i_key][result.id.counterId]['name'],
                     value,
                     hostname=mor['hostname'],


### PR DESCRIPTION
Currently, all metrics from vsphere are reported as gauges. We should attempt to read the metric type from the VMware metrics module and call self.gauge or self.rate, etc. accordingly.

First came up in conversation with @LeoCavaille here: https://github.com/DataDog/dd-agent/pull/1824