### PR TITLE
[mysql] Flavored mysql test

### DIFF
--- a/ci/mysql.rb
+++ b/ci/mysql.rb
@@ -1,20 +1,68 @@
 require './ci/common'
 
-# FIXME: use our own brew of MySQL like other flavors
+def mysql_version
+  ENV['FLAVOR_VERSION'] || '5.7.9'
+end
+
+
+def mysql_rootdir
+  "#{ENV['INTEGRATIONS_DIR']}/mysql_#{mysql_version}"
+end
 
 namespace :ci do
   namespace :mysql do |flavor|
     task before_install: ['ci:common:before_install']
 
-    task install: ['ci:common:install']
+    task install: ['ci:common:install'] do
+      # Downloads
+      # https://github.com/postgres/postgres/archive/#{pg_version}.tar.gz
+      unless Dir.exist? File.expand_path(mysql_rootdir)
+        if `uname`.strip == 'Darwin'
+          target = 'osx10.10'
+        else
+          target = 'linux-glibc2.5'
+        end
+        sh %(curl -s -L\
+             -o $VOLATILE_DIR/mysql-#{mysql_version}.tar.gz \
+             https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-#{mysql_version}-#{target}-x86_64.tar.gz)
+
+             #https://s3.amazonaws.com/dd-agent-tarball-mirror/#{pg_version}.tar.gz)
+        sh %(mkdir -p #{mysql_rootdir})
+        sh %(tar zxf $VOLATILE_DIR/mysql-#{mysql_version}.tar.gz\
+               -C #{mysql_rootdir} --strip-components=1)
+      end
+    end
 
     task before_script: ['ci:common:before_script'] do
-      sh %(mysql -e "create user 'dog'@'localhost' identified by 'dog'" -uroot)
-      sh %(mysql -e "CREATE DATABASE testdb;" -uroot)
-      sh %(mysql -e "CREATE TABLE testdb.users (name VARCHAR(20), age INT);" -uroot)
-      sh %(mysql -e "GRANT SELECT ON testdb.users TO 'dog'@'localhost';" -uroot)
-      sh %(mysql -e "INSERT INTO testdb.users (name,age) VALUES('Alice',25);" -uroot)
-      sh %(mysql -e "INSERT INTO testdb.users (name,age) VALUES('Bob',20);" -uroot)
+      # does travis have any mysql instance already running? :X
+      # use another port?
+      sh %(mkdir -p #{mysql_rootdir}/data)
+      sh %(mkdir -p #{mysql_rootdir}/data_replica)
+      sh %(#{mysql_rootdir}/bin/mysqld --no-defaults --initialize-insecure --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data --log-error=#{mysql_rootdir}/data/mysql.err --socket=#{mysql_rootdir}/data/mysql.sock --pid-file=#{mysql_rootdir}/data/mysqld_safe.pid --performance-schema)
+      sh %(#{mysql_rootdir}/bin/mysqld --no-defaults --initialize-insecure --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data_replica --log-error=#{mysql_rootdir}/data_replica/mysql.err --socket=#{mysql_rootdir}/data_replica/mysql.sock --pid-file=#{mysql_rootdir}/data_replica/mysqld_safe.pid --performance-schema)
+      # let the init process complete
+      sleep_for 2
+      sh %(#{mysql_rootdir}/bin/mysqld --no-defaults --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data --plugin-dir=#{mysql_rootdir}/lib/plugin --log-error=#{mysql_rootdir}/data/mysql.err --socket=#{mysql_rootdir}/data/mysql.sock --pid-file=#{mysql_rootdir}/data/mysqld_safe.pid --port=3308 --log-bin=mysql-bin --server-id=1 --performance-schema --daemonize >/dev/null 2>&1)
+      sh %(#{mysql_rootdir}/bin/mysqld --no-defaults --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data_replica --plugin-dir=#{mysql_rootdir}/lib/plugin --log-error=#{mysql_rootdir}/data_replica/mysql.err --socket=#{mysql_rootdir}/data_replica/mysql.sock --pid-file=#{mysql_rootdir}/data_replica/mysqld_safe.pid --port=3310 --server-id=2 --performance-schema --daemonize >/dev/null 2>&1)
+      Wait.for 33_08, 10
+      Wait.for 33_10, 10
+      # set-up replication
+      sh %(#{mysql_rootdir}/bin/mysql -e "CREATE USER 'repl'@'%' IDENTIFIED BY 'slavedog';" -u root --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "GRANT REPLICATION SLAVE ON *.* TO 'repl'@'%';" -u root --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "create user 'dog'@'localhost' identified by 'dog'" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "GRANT PROCESS, REPLICATION CLIENT ON *.* TO 'dog'@'localhost' WITH MAX_USER_CONNECTIONS 5;" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "CHANGE MASTER TO MASTER_HOST='localhost', MASTER_PORT=3309, MASTER_USER='repl', MASTER_PASSWORD='slavedog', MASTER_LOG_FILE='', MASTER_LOG_POS=4;" -uroot --socket=#{mysql_rootdir}/data_replica/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "START SLAVE;" -uroot --socket=#{mysql_rootdir}/data_replica/mysql.sock)
+      # lets add some data to our master.
+      sh %(#{mysql_rootdir}/bin/mysql -e "CREATE DATABASE testdb;" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "CREATE TABLE testdb.users (name VARCHAR(20), age INT);" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "GRANT SELECT ON testdb.users TO 'dog'@'localhost';" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "INSERT INTO testdb.users (name,age) VALUES('Alice',25);" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "INSERT INTO testdb.users (name,age) VALUES('Bob',20);" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "GRANT SELECT ON performance_schema.* TO 'dog'@'localhost';" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
+      # generate some performance metrics....
+      sh %(#{mysql_rootdir}/bin/mysql -e "USE testdb; SELECT * FROM users ORDER BY name;" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "SHOW /*!50000 ENGINE*/ INNODB STATUS;" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
     end
 
     task script: ['ci:common:script'] do
@@ -28,7 +76,21 @@ namespace :ci do
 
     task cache: ['ci:common:cache']
 
-    task cleanup: ['ci:common:cleanup']
+    task cleanup: ['ci:common:cleanup'] do
+      sh %(mysql -e "DROP USER 'dog'@'localhost';" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(mysql -e "DROP DATABASE testdb;" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
+      `pgrep -f "#{mysql_rootdir}/bin/mysqld" `.split("\n").each do |spid|
+          begin
+              p = spid.to_i
+              puts "Stopping #{p}"
+              Process.kill "TERM", p
+          rescue Errno::ESRCH
+              next
+          end
+      end
+      sh %(rm -rf #{mysql_rootdir}/data)
+      sh %(rm -rf #{mysql_rootdir}/data_replica)
+    end
 
     task :execute do
       exception = nil

--- a/ci/mysql.rb
+++ b/ci/mysql.rb
@@ -62,7 +62,6 @@ namespace :ci do
       sh %(#{mysql_rootdir}/bin/mysql -e "GRANT SELECT ON performance_schema.* TO 'dog'@'localhost';" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
       # generate some performance metrics....
       sh %(#{mysql_rootdir}/bin/mysql -e "USE testdb; SELECT * FROM users ORDER BY name;" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
-      sh %(#{mysql_rootdir}/bin/mysql -e "SHOW /*!50000 ENGINE*/ INNODB STATUS;" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
     end
 
     task script: ['ci:common:script'] do

--- a/ci/mysql.rb
+++ b/ci/mysql.rb
@@ -4,14 +4,13 @@ def mysql_version
   ENV['FLAVOR_VERSION'] || '5.7.9'
 end
 
-
 def mysql_rootdir
   "#{ENV['INTEGRATIONS_DIR']}/mysql_#{mysql_version}"
 end
 
 namespace :ci do
   namespace :mysql do |flavor|
-    @ld_path="#{mysql_rootdir}/ld_deps/"
+    @ld_path = "#{mysql_rootdir}/ld_deps/"
     task before_install: ['ci:common:before_install']
 
     task install: ['ci:common:install'] do
@@ -27,16 +26,16 @@ namespace :ci do
              -o $VOLATILE_DIR/mysql-#{mysql_version}.tar.gz \
              https://dev.mysql.com/get/Downloads/MySQL-5.7/mysql-#{mysql_version}-#{target}-x86_64.tar.gz)
 
-             #https://s3.amazonaws.com/dd-agent-tarball-mirror/#{pg_version}.tar.gz)
+        # https://s3.amazonaws.com/dd-agent-tarball-mirror/#{pg_version}.tar.gz)
         sh %(mkdir -p #{mysql_rootdir}/ld_deps)
         sh %(tar zxf $VOLATILE_DIR/mysql-#{mysql_version}.tar.gz\
                -C #{mysql_rootdir} --strip-components=1)
-        if target.include? "linux"
-            libaio_url = `apt-cache show libaio1 | grep "Filename:" | cut -f 2 -d " "`
-            sh %(curl -s -L\
-                 -o $VOLATILE_DIR/libaio.deb \
-                 http://archive.ubuntu.com/ubuntu/#{libaio_url})
-            sh %(dpkg-deb -x $VOLATILE_DIR/libaio.deb #{mysql_rootdir}/ld_deps)
+        if target.include? 'linux'
+          libaio_url = `apt-cache show libaio1 | grep "Filename:" | cut -f 2 -d " "`
+          sh %(curl -s -L\
+               -o $VOLATILE_DIR/libaio.deb \
+               http://archive.ubuntu.com/ubuntu/#{libaio_url})
+          sh %(dpkg-deb -x $VOLATILE_DIR/libaio.deb #{mysql_rootdir}/ld_deps)
         end
       end
     end
@@ -45,25 +44,40 @@ namespace :ci do
       # does travis have any mysql instance already running? :X
       # use another port?
       if `uname`.strip != 'Darwin'
-          @ld_path = @ld_path + "lib/x86_64-linux-gnu/"
+        @ld_path += "lib/x86_64-linux-gnu/"
       end
       sh %(mkdir -p #{mysql_rootdir}/data)
       sh %(mkdir -p #{mysql_rootdir}/data_replica)
-      puts "Initializing MySQL instances.".yellow
-      system({"LD_LIBRARY_PATH" => @ld_path}, "#{mysql_rootdir}/bin/mysqld --no-defaults --initialize-insecure --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data --log-error=#{mysql_rootdir}/data/mysql.err --socket=#{mysql_rootdir}/data/mysql.sock --pid-file=#{mysql_rootdir}/data/mysqld_safe.pid --performance-schema")
-      system({"LD_LIBRARY_PATH" => @ld_path}, "#{mysql_rootdir}/bin/mysqld --no-defaults --initialize-insecure --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data_replica --log-error=#{mysql_rootdir}/data_replica/mysql.err --socket=#{mysql_rootdir}/data_replica/mysql.sock --pid-file=#{mysql_rootdir}/data_replica/mysqld_safe.pid --performance-schema")
+      puts 'Initializing MySQL instances.'.yellow
+      system({ 'LD_LIBRARY_PATH' => @ld_path },
+             "#{mysql_rootdir}/bin/mysqld --no-defaults --initialize-insecure --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data" \
+             "--log-error=#{mysql_rootdir}/data/mysql.err --socket=#{mysql_rootdir}/data/mysql.sock --pid-file=#{mysql_rootdir}/data/mysqld_safe.pid" \
+             "--performance-schema")
+      system({ 'LD_LIBRARY_PATH' => @ld_path },
+             "#{mysql_rootdir}/bin/mysqld --no-defaults --initialize-insecure --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data_replica" \
+             "--log-error=#{mysql_rootdir}/data_replica/mysql.err --socket=#{mysql_rootdir}/data_replica/mysql.sock --pid-file=#{mysql_rootdir}/data_replica/mysqld_safe.pid" \
+             "--performance-schema")
       # let the init process complete
       sleep_for 2
-      system({"LD_LIBRARY_PATH" => @ld_path}, "#{mysql_rootdir}/bin/mysqld --no-defaults --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data --plugin-dir=#{mysql_rootdir}/lib/plugin --log-error=#{mysql_rootdir}/data/mysql.err --socket=#{mysql_rootdir}/data/mysql.sock --pid-file=#{mysql_rootdir}/data/mysqld_safe.pid --port=3308 --log-bin=mysql-bin --server-id=1 --performance-schema --daemonize >/dev/null 2>&1")
-      system({"LD_LIBRARY_PATH" => @ld_path}, "#{mysql_rootdir}/bin/mysqld --no-defaults --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data_replica --plugin-dir=#{mysql_rootdir}/lib/plugin --log-error=#{mysql_rootdir}/data_replica/mysql.err --socket=#{mysql_rootdir}/data_replica/mysql.sock --pid-file=#{mysql_rootdir}/data_replica/mysqld_safe.pid --port=3310 --server-id=2 --performance-schema --daemonize >/dev/null 2>&1")
+      system({ 'LD_LIBRARY_PATH' => @ld_path },
+             "#{mysql_rootdir}/bin/mysqld --no-defaults --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data --plugin-dir=#{mysql_rootdir}/lib/plugin" \
+             "--log-error=#{mysql_rootdir}/data/mysql.err --socket=#{mysql_rootdir}/data/mysql.sock --pid-file=#{mysql_rootdir}/data/mysqld_safe.pid --port=3308" \
+             "--log-bin=mysql-bin --server-id=1 --performance-schema --daemonize >/dev/null 2>&1")
+      system({ 'LD_LIBRARY_PATH' => @ld_path },
+             "#{mysql_rootdir}/bin/mysqld --no-defaults --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data_replica --plugin-dir=#{mysql_rootdir}/lib/plugin" \
+             "--log-error=#{mysql_rootdir}/data_replica/mysql.err --socket=#{mysql_rootdir}/data_replica/mysql.sock --pid-file=#{mysql_rootdir}/data_replica/mysqld_safe.pid" \
+             "--port=3310 --server-id=2 --performance-schema --daemonize >/dev/null 2>&1")
       Wait.for 33_08, 10
       Wait.for 33_10, 10
       # set-up replication
       sh %(#{mysql_rootdir}/bin/mysql -e "CREATE USER 'repl'@'%' IDENTIFIED BY 'slavedog';" -u root --socket=#{mysql_rootdir}/data/mysql.sock)
-      sh %(#{mysql_rootdir}/bin/mysql -e "GRANT REPLICATION SLAVE ON *.* TO 'repl'@'%';" -u root --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "GRANT REPLICATION SLAVE ON *.* TO 'repl'@'%';" \
+           -u root --socket=#{mysql_rootdir}/data/mysql.sock)
       sh %(#{mysql_rootdir}/bin/mysql -e "create user 'dog'@'localhost' identified by 'dog'" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
-      sh %(#{mysql_rootdir}/bin/mysql -e "GRANT PROCESS, REPLICATION CLIENT ON *.* TO 'dog'@'localhost' WITH MAX_USER_CONNECTIONS 5;" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
-      sh %(#{mysql_rootdir}/bin/mysql -e "CHANGE MASTER TO MASTER_HOST='localhost', MASTER_PORT=3309, MASTER_USER='repl', MASTER_PASSWORD='slavedog', MASTER_LOG_FILE='', MASTER_LOG_POS=4;" -uroot --socket=#{mysql_rootdir}/data_replica/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "GRANT PROCESS, REPLICATION CLIENT ON *.* TO 'dog'@'localhost' WITH MAX_USER_CONNECTIONS 5;" \
+           -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "CHANGE MASTER TO MASTER_HOST='localhost', MASTER_PORT=3309, MASTER_USER='repl', MASTER_PASSWORD='slavedog', MASTER_LOG_FILE='', MASTER_LOG_POS=4;" \
+           -uroot --socket=#{mysql_rootdir}/data_replica/mysql.sock)
       sh %(#{mysql_rootdir}/bin/mysql -e "START SLAVE;" -uroot --socket=#{mysql_rootdir}/data_replica/mysql.sock)
       # lets add some data to our master.
       sh %(#{mysql_rootdir}/bin/mysql -e "CREATE DATABASE testdb;" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
@@ -91,15 +105,15 @@ namespace :ci do
       sh %(mysql -e "DROP USER 'dog'@'localhost';" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
       sh %(mysql -e "DROP DATABASE testdb;" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
       `pgrep -f "#{mysql_rootdir}/bin/mysqld" `.split("\n").each do |spid|
-          begin
-              p = spid.to_i
-              puts "Stopping #{p}"
-              Process.kill "TERM", p
-          rescue Errno::ESRCH
-              next
-          end
+        begin
+          p = spid.to_i
+          puts "Stopping #{p}"
+          Process.kill 'TERM', p
+        rescue Errno::ESRCH
+          next
+        end
       end
-      puts "Waiting for MySQL instances to shutdown.".yellow
+      puts 'Waiting for MySQL instances to shutdown.'.yellow
       sleep_for 2
       sh %(rm -rf #{mysql_rootdir}/data)
       sh %(rm -rf #{mysql_rootdir}/data_replica)

--- a/ci/mysql.rb
+++ b/ci/mysql.rb
@@ -43,30 +43,46 @@ namespace :ci do
     task before_script: ['ci:common:before_script'] do
       # does travis have any mysql instance already running? :X
       # use another port?
-      if `uname`.strip != 'Darwin'
-        @ld_path += "lib/x86_64-linux-gnu/"
-      end
+      @ld_path += 'lib/x86_64-linux-gnu/' if `uname`.strip != 'Darwin'
+
+      puts "Using LD_LIBRARY_PATH=#{@ld_path}".yellow
       sh %(mkdir -p #{mysql_rootdir}/data)
       sh %(mkdir -p #{mysql_rootdir}/data_replica)
       puts 'Initializing MySQL instances.'.yellow
       system({ 'LD_LIBRARY_PATH' => @ld_path },
-             "#{mysql_rootdir}/bin/mysqld --no-defaults --initialize-insecure --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data" \
-             "--log-error=#{mysql_rootdir}/data/mysql.err --socket=#{mysql_rootdir}/data/mysql.sock --pid-file=#{mysql_rootdir}/data/mysqld_safe.pid" \
-             "--performance-schema")
+             "#{mysql_rootdir}/bin/mysqld --no-defaults "\
+             "--initialize-insecure --basedir=#{mysql_rootdir} "\
+             "--datadir=#{mysql_rootdir}/data "\
+             "--log-error=#{mysql_rootdir}/data/mysql.err "\
+             "--socket=#{mysql_rootdir}/data/mysql.sock "\
+             "--pid-file=#{mysql_rootdir}/data/mysqld_safe.pid --performance-schema")
       system({ 'LD_LIBRARY_PATH' => @ld_path },
-             "#{mysql_rootdir}/bin/mysqld --no-defaults --initialize-insecure --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data_replica" \
-             "--log-error=#{mysql_rootdir}/data_replica/mysql.err --socket=#{mysql_rootdir}/data_replica/mysql.sock --pid-file=#{mysql_rootdir}/data_replica/mysqld_safe.pid" \
-             "--performance-schema")
+             "#{mysql_rootdir}/bin/mysqld --no-defaults "\
+             "--initialize-insecure --basedir=#{mysql_rootdir} "\
+             "--datadir=#{mysql_rootdir}/data_replica "\
+             "--log-error=#{mysql_rootdir}/data_replica/mysql.err "\
+             "--socket=#{mysql_rootdir}/data_replica/mysql.sock"\
+             "--pid-file=#{mysql_rootdir}/data_replica/mysqld_safe.pid --performance-schema")
       # let the init process complete
       sleep_for 2
       system({ 'LD_LIBRARY_PATH' => @ld_path },
-             "#{mysql_rootdir}/bin/mysqld --no-defaults --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data --plugin-dir=#{mysql_rootdir}/lib/plugin" \
-             "--log-error=#{mysql_rootdir}/data/mysql.err --socket=#{mysql_rootdir}/data/mysql.sock --pid-file=#{mysql_rootdir}/data/mysqld_safe.pid --port=3308" \
-             "--log-bin=mysql-bin --server-id=1 --performance-schema --daemonize >/dev/null 2>&1")
+             "#{mysql_rootdir}/bin/mysqld --no-defaults "\
+             "--basedir=#{mysql_rootdir} "\
+             "--datadir=#{mysql_rootdir}/data "\
+             "--plugin-dir=#{mysql_rootdir}/lib/plugin "\
+             "--log-error=#{mysql_rootdir}/data/mysql.err --log-bin=mysql-bin "\
+             "--socket=#{mysql_rootdir}/data/mysql.sock "\
+             "--pid-file=#{mysql_rootdir}/data/mysqld_safe.pid "\
+             '--port=3308 --server-id=1 --performance-schema --daemonize >/dev/null 2>&1')
       system({ 'LD_LIBRARY_PATH' => @ld_path },
-             "#{mysql_rootdir}/bin/mysqld --no-defaults --basedir=#{mysql_rootdir} --datadir=#{mysql_rootdir}/data_replica --plugin-dir=#{mysql_rootdir}/lib/plugin" \
-             "--log-error=#{mysql_rootdir}/data_replica/mysql.err --socket=#{mysql_rootdir}/data_replica/mysql.sock --pid-file=#{mysql_rootdir}/data_replica/mysqld_safe.pid" \
-             "--port=3310 --server-id=2 --performance-schema --daemonize >/dev/null 2>&1")
+             "#{mysql_rootdir}/bin/mysqld --no-defaults "\
+             "--basedir=#{mysql_rootdir} "\
+             "--datadir=#{mysql_rootdir}/data_replica "\
+             "--plugin-dir=#{mysql_rootdir}/lib/plugin "\
+             "--log-error=#{mysql_rootdir}/data_replica/mysql.err "\
+             "--socket=#{mysql_rootdir}/data_replica/mysql.sock "\
+             "--pid-file=#{mysql_rootdir}/data_replica/mysqld_safe.pid "\
+             '--port=3310 --server-id=2 --performance-schema --daemonize >/dev/null 2>&1')
       Wait.for 33_08, 10
       Wait.for 33_10, 10
       # set-up replication
@@ -76,16 +92,19 @@ namespace :ci do
       sh %(#{mysql_rootdir}/bin/mysql -e "create user 'dog'@'localhost' identified by 'dog'" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
       sh %(#{mysql_rootdir}/bin/mysql -e "GRANT PROCESS, REPLICATION CLIENT ON *.* TO 'dog'@'localhost' WITH MAX_USER_CONNECTIONS 5;" \
            -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
-      sh %(#{mysql_rootdir}/bin/mysql -e "CHANGE MASTER TO MASTER_HOST='localhost', MASTER_PORT=3309, MASTER_USER='repl', MASTER_PASSWORD='slavedog', MASTER_LOG_FILE='', MASTER_LOG_POS=4;" \
-           -uroot --socket=#{mysql_rootdir}/data_replica/mysql.sock)
+      sql = "CHANGE MASTER TO MASTER_HOST='localhost', MASTER_PORT=3309, MASTER_USER='repl', MASTER_PASSWORD='slavedog', "
+      sql += "MASTER_LOG_FILE='', MASTER_LOG_POS=4;"
+      sh %(#{mysql_rootdir}/bin/mysql -e "#{sql}" -uroot --socket=#{mysql_rootdir}/data_replica/mysql.sock)
       sh %(#{mysql_rootdir}/bin/mysql -e "START SLAVE;" -uroot --socket=#{mysql_rootdir}/data_replica/mysql.sock)
       # lets add some data to our master.
       sh %(#{mysql_rootdir}/bin/mysql -e "CREATE DATABASE testdb;" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
       sh %(#{mysql_rootdir}/bin/mysql -e "CREATE TABLE testdb.users (name VARCHAR(20), age INT);" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
-      sh %(#{mysql_rootdir}/bin/mysql -e "GRANT SELECT ON testdb.users TO 'dog'@'localhost';" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "GRANT SELECT ON testdb.users TO 'dog'@'localhost'; "\
+           -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
       sh %(#{mysql_rootdir}/bin/mysql -e "INSERT INTO testdb.users (name,age) VALUES('Alice',25);" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
       sh %(#{mysql_rootdir}/bin/mysql -e "INSERT INTO testdb.users (name,age) VALUES('Bob',20);" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
-      sh %(#{mysql_rootdir}/bin/mysql -e "GRANT SELECT ON performance_schema.* TO 'dog'@'localhost';" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
+      sh %(#{mysql_rootdir}/bin/mysql -e "GRANT SELECT ON performance_schema.* TO 'dog'@'localhost';"\
+           -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
       # generate some performance metrics....
       sh %(#{mysql_rootdir}/bin/mysql -e "USE testdb; SELECT * FROM users ORDER BY name;" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
     end
@@ -102,8 +121,6 @@ namespace :ci do
     task cache: ['ci:common:cache']
 
     task cleanup: ['ci:common:cleanup'] do
-      sh %(mysql -e "DROP USER 'dog'@'localhost';" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
-      sh %(mysql -e "DROP DATABASE testdb;" -uroot --socket=#{mysql_rootdir}/data/mysql.sock)
       `pgrep -f "#{mysql_rootdir}/bin/mysqld" `.split("\n").each do |spid|
         begin
           p = spid.to_i
@@ -115,8 +132,8 @@ namespace :ci do
       end
       puts 'Waiting for MySQL instances to shutdown.'.yellow
       sleep_for 2
-      sh %(rm -rf #{mysql_rootdir}/data)
-      sh %(rm -rf #{mysql_rootdir}/data_replica)
+      # sh %(rm -rf #{mysql_rootdir}/data)
+      # sh %(rm -rf #{mysql_rootdir}/data_replica)
     end
 
     task :execute do

--- a/tests/checks/integration/test_mysql.py
+++ b/tests/checks/integration/test_mysql.py
@@ -126,7 +126,7 @@ class TestMySql(AgentCheckTest):
                                 tags=self.SC_TAGS, count=1)
 
         # Test metrics
-        for mname in (self.INNODB_METRICS + self.SYSTEM_METRICS + self.REPLICATION_METRICS +
+        for mname in (self.INNODB_METRICS + self.SYSTEM_METRICS + 
                       self.KEY_CACHE + self.COMMON_GAUGES + self.COMMON_RATES):
             self.assertMetric(mname, tags=self.METRIC_TAGS, count=1)
 

--- a/tests/checks/integration/test_mysql.py
+++ b/tests/checks/integration/test_mysql.py
@@ -11,12 +11,13 @@ class TestMySql(AgentCheckTest):
     CHECK_NAME = 'mysql'
 
     METRIC_TAGS = ['tag1', 'tag2']
-    SC_TAGS = ['host:localhost', 'port:0']
+    SC_TAGS = ['host:localhost', 'port:3308']
 
     MYSQL_CONFIG = [{
         'server': 'localhost',
         'user': 'dog',
         'pass': 'dog',
+        'port': 3308,
         'options': {'replication': True},
         'tags': METRIC_TAGS,
         'queries': [
@@ -39,6 +40,7 @@ class TestMySql(AgentCheckTest):
         'server': 'localhost',
         'user': 'unknown',
         'pass': 'dog',
+        'port': 3308,
     }]
 
     # Available by default on MySQL > 5.5

--- a/tests/checks/integration/test_mysql.py
+++ b/tests/checks/integration/test_mysql.py
@@ -126,7 +126,7 @@ class TestMySql(AgentCheckTest):
                                 tags=self.SC_TAGS, count=1)
 
         # Test metrics
-        for mname in (self.INNODB_METRICS + self.SYSTEM_METRICS + 
+        for mname in (self.INNODB_METRICS + self.SYSTEM_METRICS +
                       self.KEY_CACHE + self.COMMON_GAUGES + self.COMMON_RATES):
             self.assertMetric(mname, tags=self.METRIC_TAGS, count=1)
 


### PR DESCRIPTION
# Description
Adding a flavored test that will allow us to finally have a disposable environment for our MySQL tests. The new test brings up two MySQL instances, one for the master, and a second one for the slave, and we setup replication. 

## Improvable
* tarballs should probably be put in our S3
* we should get tarballs for multiple versions.
* replication seems to be working as the logs indicate, but replication test is failing - not sure if the problem is with the actual check and the newer 5.7.x STATUS tables - 'Slave_running' is definitely not there. We will know once we merge with the revamped MySQL check.

## Caveats
* `libaio1` is a dependency for mysqld, unavailable in the Travis executors. We therefore have to download manually, extract and employ `LD_LIBRARY_PATH` for the dynamic linking to work. Currently we download the deb from the ubuntu repos, and extract the `deb` to a directory of our choice. Not sure if the Travis executors will allow all necessary commands (namely: `apt-cache` and `dpkg-deb`) - we can always put a tarball in our S3 with the lib.

* test has to resort to system() instead of sh to start-up the mysql instances because sh won't allow prepending env variables in the call. There may be some other way, but I'm not aware of it currently. If init fails, we won't notice until the actual mysql client tries to connect to the DB's but that should work fine and take us to the clean-up code.

