### PR TITLE
[packaging][rpm] Use HTTP for yum on RedHat <= 5

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -98,7 +98,17 @@ if [ $OS = "RedHat" ]; then
     else
         ARCHI="x86_64"
     fi
-    $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://yum.datadoghq.com/rpm/$ARCHI/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public' > /etc/yum.repos.d/datadog.repo"
+
+    # Versions of yum on RedHat 5 and lower embed M2Crypto with SSL that doesn't support TLS1.2
+    if [ -f /etc/redhat-release ]; then
+        REDHAT_MAJOR_VERSION=$(grep -Eo "[0-9].[0-9]{1,2}" /etc/redhat-release | head -c 1)
+    fi
+    if [ -n "$REDHAT_MAJOR_VERSION" ] && [ "$REDHAT_MAJOR_VERSION" -le "5" ]; then
+        PROTOCOL="http"
+    else
+        PROTOCOL="https"
+    fi
+    $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = $PROTOCOL://yum.datadoghq.com/rpm/$ARCHI/\nenabled=1\ngpgcheck=1\npriority=1\ngpgkey=$PROTOCOL://yum.datadoghq.com/DATADOG_RPM_KEY.public' > /etc/yum.repos.d/datadog.repo"
 
     printf "\033[34m* Installing the Datadog Agent package\n\033[0m\n"
 


### PR DESCRIPTION
yum on RedHat <= 5 doesn't support TLS1.2 so it can't use
our https repo. Use http instead.

See https://github.com/DataDog/chef-datadog/pull/240 for a detailed description of the issue.