### PR TITLE
Relocatable procfs for process check

### DIFF
--- a/checks.d/gunicorn.py
+++ b/checks.d/gunicorn.py
@@ -68,7 +68,7 @@ class GUnicornCheck(AgentCheck):
         for proc in worker_procs:
             # cpu time is the sum of user + system time.
             try:
-                cpu_time_by_pid[proc.pid] = sum(proc.get_cpu_times())
+                cpu_time_by_pid[proc.pid] = sum(proc.cpu_times())
             except psutil.NoSuchProcess:
                 self.warning('Process %s disappeared while scanning' % proc.name)
                 continue
@@ -83,7 +83,7 @@ class GUnicornCheck(AgentCheck):
                 # The process is not running anymore, we didn't collect initial cpu times
                 continue
             try:
-                cpu_time = sum(proc.get_cpu_times())
+                cpu_time = sum(proc.cpu_times())
             except Exception:
                 # couldn't collect cpu time. assume it's dead.
                 self.log.debug("Couldn't collect cpu time for %s" % proc)

--- a/checks.d/process.py
+++ b/checks.d/process.py
@@ -61,6 +61,12 @@ class ProcessCheck(AgentCheck):
             )
         )
 
+        if Platform.is_linux():
+            psutil.PROCFS_PATH = init_config.get(
+                'procfs_path',
+                '/proc'
+            )
+
         # Process cache, indexed by instance
         self.process_cache = defaultdict(dict)
 

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -33,7 +33,7 @@ if Platform.is_windows():
 log = logging.getLogger(__name__)
 
 # Default methods run when collecting info about the agent in developer mode
-DEFAULT_PSUTIL_METHODS = ['get_memory_info', 'get_io_counters']
+DEFAULT_PSUTIL_METHODS = ['memory_info', 'io_counters']
 
 AGENT_METRICS_CHECK_NAME = 'agent_metrics'
 

--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -187,9 +187,9 @@ class Cpu(Check):
 
         cpu_percent = psutil.cpu_times()
 
-        self.save_sample('system.cpu.user', 100 * cpu_percent.user / psutil.NUM_CPUS)
-        self.save_sample('system.cpu.idle', 100 * cpu_percent.idle / psutil.NUM_CPUS)
-        self.save_sample('system.cpu.system', 100 * cpu_percent.system / psutil.NUM_CPUS)
+        self.save_sample('system.cpu.user', 100 * cpu_percent.user / psutil.cpu_count())
+        self.save_sample('system.cpu.idle', 100 * cpu_percent.idle / psutil.cpu_count())
+        self.save_sample('system.cpu.system', 100 * cpu_percent.system / psutil.cpu_count())
 
         return self.get_metrics()
 

--- a/conf.d/agent_metrics.yaml.default
+++ b/conf.d/agent_metrics.yaml.default
@@ -1,15 +1,15 @@
 init_config:
     process_metrics:
-        - name: get_memory_info
+        - name: memory_info
           type: gauge
           active: yes
-        - name: get_io_counters
+        - name: io_counters
           type: rate
           active: yes
-        - name: get_num_threads
+        - name: num_threads
           type: gauge
           active: yes
-        - name: get_connections
+        - name: connections
           type: gauge
           active: no
 

--- a/conf.d/process.yaml.example
+++ b/conf.d/process.yaml.example
@@ -3,6 +3,9 @@ init_config:
   # except if it detects a change before. You might want to set it
   # low if you want to alert on process service checks.
   # pid_cache_duration: 120
+  #
+  # used to override the default procfs path, e.g. for docker containers with the outside fs mounted at /host/proc
+  # procfs_path: /proc
 
 instances:
 # The `system.processes.cpu.pct` metric sent by this check is only accurate for processes that live

--- a/conf.d/tomcat.yaml.example
+++ b/conf.d/tomcat.yaml.example
@@ -66,17 +66,19 @@ init_config:
             metric_type: counter
     - include:
         type: Cache
-        accessCount:
-          alias: tomcat.cache.access_count
-          metric_type: counter
-        hitsCounts:
-          alias: tomcat.cache.hits_count
-          metric_type: counter
+        attribute:
+          accessCount:
+            alias: tomcat.cache.access_count
+            metric_type: counter
+          hitsCounts:
+            alias: tomcat.cache.hits_count
+            metric_type: counter
     - include:
         type: JspMonitor
-        jspCount:
-          alias: tomcat.jsp.count
-          metric_type: counter
-        jspReloadCount:
-          alias: tomcat.jsp.reload_count
-          metric_type: counter
+        attribute:
+          jspCount:
+            alias: tomcat.jsp.count
+            metric_type: counter
+          jspReloadCount:
+            alias: tomcat.jsp.reload_count
+            metric_type: counter

--- a/packaging/datadog-agent/source/agent
+++ b/packaging/datadog-agent/source/agent
@@ -3,7 +3,6 @@ BASEDIR=$(dirname $0)
 cd "$BASEDIR/.."
 
 PATH=$BASEDIR/../venv/bin:$PATH
-EMBEDDED_BIN_PATH="/opt/datadog-agent/embedded/bin"
 
 SUPERVISOR_NOT_RUNNING="Supervisor is not running"
 SUPERVISOR_CONF_FILE='supervisord/supervisord.conf'
@@ -109,7 +108,7 @@ case $action in
         ;;
 
     reload)
-        $EMBEDDED_BIN_PATH/kill -HUP `cat $COLLECTOR_PIDFILE`
+        kill -HUP `cat $COLLECTOR_PIDFILE`
         exit $?
         ;;
 

--- a/packaging/osx/datadog-agent
+++ b/packaging/osx/datadog-agent
@@ -4,7 +4,6 @@ DESC="Datadog Agent"
 AGENTPATH="/opt/datadog-agent/agent/agent.py"
 FORWARDERPATH="/opt/datadog-agent/agent/ddagent.py"
 DOGSTATSDPATH="/opt/datadog-agent/agent/dogstatsd.py"
-KILL_PATH="/opt/datadog-agent/embedded/bin/kill"
 AGENTCONF="/opt/datadog-agent/etc/datadog.conf"
 SUPERVISOR_PIDFILE="/opt/datadog-agent/run/datadog-supervisord.pid"
 SUPERVISOR_CONF_FILE="/opt/datadog-agent/etc/supervisor.conf"
@@ -98,7 +97,7 @@ case $1 in
         ;;
 
     reload)
-        $KILL_PATH -HUP `cat $COLLECTOR_PIDFILE`
+        kill -HUP `cat $COLLECTOR_PIDFILE`
         exit $?
         ;;
 

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -9,7 +9,7 @@ pycurl==7.19.5.1
 # checks.d/gunicorn.py
 # checks.d/btrfs.py
 # checks.d/system_core.py
-psutil==2.1.1
+psutil==3.3.0
 
 # checks.d/snmp.py
 # Require a compiler because pycrypto is a dep

--- a/tests/checks/mock/test_agent_metrics.py
+++ b/tests/checks/mock/test_agent_metrics.py
@@ -9,12 +9,12 @@ MOCK_CONFIG = {
     'instances': [
         {'process_metrics': [
             {
-                'name': 'get_memory_info',
+                'name': 'memory_info',
                 'type': 'gauge',
                 'active': 'yes'
             },
             {
-                'name': 'get_cpu_times',
+                'name': 'cpu_times',
                 'type': 'rate',
                 'active': 'yes'
             },
@@ -26,7 +26,7 @@ MOCK_CONFIG_2 = {
     'instances': [
         {'process_metrics': [
             {
-                'name': 'get_memory_info',
+                'name': 'memory_info',
                 'type': 'gauge',
                 'active': 'yes'
             },

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -89,6 +89,7 @@ def find_cgroup_filename_pattern(mountpoints, container_id):
         stat_file_path_coreos = os.path.join(mountpoint, "system.slice")
         stat_file_path_kubernetes = os.path.join(mountpoint, container_id)
         stat_file_path_kubernetes_docker = os.path.join(mountpoint, "system", "docker", container_id)
+        stat_file_path_docker_daemon = os.path.join(mountpoint, "docker-daemon", "docker", container_id)
 
         if os.path.exists(stat_file_path_lxc):
             return os.path.join('%(mountpoint)s/lxc/%(id)s/%(file)s')
@@ -100,6 +101,9 @@ def find_cgroup_filename_pattern(mountpoints, container_id):
             return os.path.join('%(mountpoint)s/%(id)s/%(file)s')
         elif os.path.exists(stat_file_path_kubernetes_docker):
             return os.path.join('%(mountpoint)s/system/docker/%(id)s/%(file)s')
+        elif os.path.exists(stat_file_path_docker_daemon):
+            return os.path.join('%(mountpoint)s/docker-daemon/docker/%(id)s/%(file)s')
+
 
     raise MountException("Cannot find Docker cgroup directory. Be sure your system is supported.")
 


### PR DESCRIPTION
When running the datadog agent as a container, we need to point psutils at a different procfs to gather metrics on processes outside the current namespace.

Note that this PR requires a hefty version bump for psutils; I'm not quite sure how best to check everything's working but so far it seems fine.