### PR TITLE
[core] Set agent pid file and path from constant

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -46,6 +46,7 @@ from utils.profile import AgentProfiler
 
 # Constants
 PID_NAME = "dd-agent"
+PID_DIR = None
 WATCHDOG_MULTIPLIER = 10
 RESTART_INTERVAL = 4 * 24 * 60 * 60  # Defaults to 4 days
 START_COMMANDS = ['start', 'restart', 'foreground']
@@ -290,7 +291,7 @@ def main():
         deprecate_old_command_line_tools()
 
     if command in COMMANDS_AGENT:
-        agent = Agent(PidFile('dd-agent').get_path(), autorestart, in_developer_mode=in_developer_mode)
+        agent = Agent(PidFile(PID_NAME, PID_DIR).get_path(), autorestart, in_developer_mode=in_developer_mode)
 
     if command in START_COMMANDS:
         log.info('Agent version %s' % get_version())

--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -46,6 +46,9 @@ requests_log.propagate = True
 
 log = logging.getLogger('dogstatsd')
 
+PID_NAME = "dogstatsd"
+PID_DIR = None
+
 # Dogstatsd constants in seconds
 DOGSTATSD_FLUSH_INTERVAL = 10
 DOGSTATSD_AGGREGATOR_BUCKET_SIZE = 10
@@ -439,7 +442,7 @@ def main(config_path=None):
 
     if not args or args[0] in COMMANDS_START_DOGSTATSD:
         reporter, server, cnf = init(config_path, use_watchdog=True, use_forwarder=opts.use_forwarder, args=args)
-        daemon = Dogstatsd(PidFile('dogstatsd').get_path(), server, reporter,
+        daemon = Dogstatsd(PidFile(PID_NAME, PID_DIR).get_path(), server, reporter,
                            cnf.get('autorestart', False))
 
     # If no args were passed in, run the server in the foreground.


### PR DESCRIPTION
I'm working on FreeBSD port for dd-agent and I notice PID_FILE constant not being used. I also add option to set a path for pid file. I can change PID_DIR to '/tmp' and update to correct dir in FreeBSD port.