### PR TITLE
[consul] more accurate nodes_* and services_* gauges

### DIFF
--- a/checks.d/consul.py
+++ b/checks.d/consul.py
@@ -23,6 +23,7 @@ class ConsulCheck(AgentCheck):
     MAX_SERVICES = 50 # cap on distinct Consul ServiceIDs to interrogate
 
     STATUS_SC = {
+        'up': AgentCheck.OK,
         'passing': AgentCheck.OK,
         'warning': AgentCheck.WARNING,
         'critical': AgentCheck.CRITICAL,
@@ -290,7 +291,8 @@ class ConsulCheck(AgentCheck):
                             node_status['passing'] += 1
                             nodes_to_service_status[node_id]["passing"] += 1
 
-                for status_key, status_value in node_status.items():
+                for status_key in self.STATUS_SC:
+                    status_value = node_status[status_key]
                     self.gauge(
                         '{0}.nodes_{1}'.format(self.CONSUL_CATALOG_CHECK, status_key),
                         status_value,
@@ -309,7 +311,8 @@ class ConsulCheck(AgentCheck):
                            len(services),
                            tags=main_tags+node_tags)
 
-                for status_key, status_value in service_status.items():
+                for status_key in self.STATUS_SC:
+                    status_value = service_status[status_key]
                     self.gauge(
                         '{0}.services_{1}'.format(self.CONSUL_CATALOG_CHECK, status_key),
                         status_value,

--- a/checks.d/consul.py
+++ b/checks.d/consul.py
@@ -267,7 +267,13 @@ class ConsulCheck(AgentCheck):
                                tags=main_tags+node_tags)
 
                 for n in nodes_up:
-                    node_id = n.get('Node', {}).get('Node') or None
+                    node = n.get('Node') or None
+
+                    if not node:
+                        continue
+
+                    # The node_id is n['Node']['Node']
+                    node_id = node.get('Node') or None
 
                     if not node_id:
                         continue

--- a/conf.d/consul.yaml.example
+++ b/conf.d/consul.yaml.example
@@ -32,7 +32,7 @@ instances:
       # The default settings query up to 50 services. So if you have more than
       # this many in your Consul service catalog, you will want to fill in the
       # whitelist
-      service_whitelist:
-        - zookeeper
-        - gunicorn
-        - redis
+      # service_whitelist:
+      #   - zookeeper
+      #   - gunicorn
+      #   - redis

--- a/tests/checks/mock/test_consul.py
+++ b/tests/checks/mock/test_consul.py
@@ -121,15 +121,31 @@ class TestCheckConsul(AgentCheckTest):
 
         return [
             {
-                "Address": _get_random_ip(),
-                "Node": "node-1",
-                "ServiceAddress": "",
-                "ServiceID": service,
-                "ServiceName": service,
-                "ServicePort": 80,
-                "ServiceTags": [
-                    "az-us-east-1a"
-                ]
+                "Checks": [
+                    {
+                        "CheckID": "serfHealth",
+                        "Name": "Serf Health Status",
+                        "Node": "node-1",
+                        "Notes": "",
+                        "Output": "Agent alive and reachable",
+                        "ServiceID": "",
+                        "ServiceName": "",
+                        "Status": "passing"
+                    }
+                ],
+                "Node": {
+                    "Address": _get_random_ip(),
+                    "Node": "node-1"
+                },
+                "Service": {
+                    "Address": "",
+                    "ID": service,
+                    "Port": 80,
+                    "Service": service,
+                    "Tags": [
+                        "az-us-east-1a"
+                    ]
+                }
             }
         ]
 

--- a/tests/checks/mock/test_consul.py
+++ b/tests/checks/mock/test_consul.py
@@ -41,6 +41,10 @@ MOCK_BAD_CONFIG = {
     }]
 }
 
+def _get_random_ip():
+    rand_int = int(15 * random.random()) + 10
+    return "10.0.2.{0}".format(rand_int)
+
 class TestCheckConsul(AgentCheckTest):
     CHECK_NAME = 'consul'
 
@@ -115,9 +119,6 @@ class TestCheckConsul(AgentCheckTest):
 
 
     def mock_get_nodes_with_service(self, instance, service):
-        def _get_random_ip():
-            rand_int = int(15 * random.random()) + 10
-            return "10.0.2.{0}".format(rand_int)
 
         return [
             {
@@ -131,6 +132,111 @@ class TestCheckConsul(AgentCheckTest):
                         "ServiceID": "",
                         "ServiceName": "",
                         "Status": "passing"
+                    },
+                    {
+                        "CheckID": "service:{0}".format(service),
+                        "Name": "service check {0}".format(service),
+                        "Node": "node-1",
+                        "Notes": "",
+                        "Output": "Service {0} alive".format(service),
+                        "ServiceID": service,
+                        "ServiceName": "",
+                        "Status": "passing"
+                    }
+                ],
+                "Node": {
+                    "Address": _get_random_ip(),
+                    "Node": "node-1"
+                },
+                "Service": {
+                    "Address": "",
+                    "ID": service,
+                    "Port": 80,
+                    "Service": service,
+                    "Tags": [
+                        "az-us-east-1a"
+                    ]
+                }
+            }
+        ]
+
+    def mock_get_nodes_with_service_warning(self, instance, service):
+
+        return [
+            {
+                "Checks": [
+                    {
+                        "CheckID": "serfHealth",
+                        "Name": "Serf Health Status",
+                        "Node": "node-1",
+                        "Notes": "",
+                        "Output": "Agent alive and reachable",
+                        "ServiceID": "",
+                        "ServiceName": "",
+                        "Status": "passing"
+                    },
+                    {
+                        "CheckID": "service:{0}".format(service),
+                        "Name": "service check {0}".format(service),
+                        "Node": "node-1",
+                        "Notes": "",
+                        "Output": "Service {0} alive".format(service),
+                        "ServiceID": service,
+                        "ServiceName": "",
+                        "Status": "warning"
+                    }
+                ],
+                "Node": {
+                    "Address": _get_random_ip(),
+                    "Node": "node-1"
+                },
+                "Service": {
+                    "Address": "",
+                    "ID": service,
+                    "Port": 80,
+                    "Service": service,
+                    "Tags": [
+                        "az-us-east-1a"
+                    ]
+                }
+            }
+        ]
+
+
+    def mock_get_nodes_with_service_critical(self, instance, service):
+
+        return [
+            {
+                "Checks": [
+                    {
+                        "CheckID": "serfHealth",
+                        "Name": "Serf Health Status",
+                        "Node": "node-1",
+                        "Notes": "",
+                        "Output": "Agent alive and reachable",
+                        "ServiceID": "",
+                        "ServiceName": "",
+                        "Status": "passing"
+                    },
+                    {
+                        "CheckID": "service:{0}".format(service),
+                        "Name": "service check {0}".format(service),
+                        "Node": "node-1",
+                        "Notes": "",
+                        "Output": "Service {0} alive".format(service),
+                        "ServiceID": service,
+                        "ServiceName": "",
+                        "Status": "warning"
+                    },
+                    {
+                        "CheckID": "service:{0}".format(service),
+                        "Name": "service check {0}".format(service),
+                        "Node": "node-1",
+                        "Notes": "",
+                        "Output": "Service {0} alive".format(service),
+                        "ServiceID": service,
+                        "ServiceName": "",
+                        "Status": "critical"
                     }
                 ],
                 "Node": {
@@ -170,6 +276,41 @@ class TestCheckConsul(AgentCheckTest):
     def test_get_nodes_with_service(self):
         self.run_check(MOCK_CONFIG, mocks=self._get_consul_mocks())
         self.assertMetric('consul.catalog.nodes_up', value=1, tags=['consul_datacenter:dc1', 'consul_service_id:service-1'])
+        self.assertMetric('consul.catalog.nodes_passing', value=1, tags=['consul_datacenter:dc1', 'consul_service_id:service-1'])
+        self.assertMetric('consul.catalog.nodes_warning', value=0, tags=['consul_datacenter:dc1', 'consul_service_id:service-1'])
+        self.assertMetric('consul.catalog.nodes_critical', value=0, tags=['consul_datacenter:dc1', 'consul_service_id:service-1'])
+        self.assertMetric('consul.catalog.services_up', value=6, tags=['consul_datacenter:dc1', 'consul_node_id:node-1'])
+        self.assertMetric('consul.catalog.services_passing', value=6, tags=['consul_datacenter:dc1', 'consul_node_id:node-1'])
+        self.assertMetric('consul.catalog.services_warning', value=0, tags=['consul_datacenter:dc1', 'consul_node_id:node-1'])
+        self.assertMetric('consul.catalog.services_critical', value=0, tags=['consul_datacenter:dc1', 'consul_node_id:node-1'])
+
+    def test_get_nodes_with_service_warning(self):
+        my_mocks = self._get_consul_mocks()
+        my_mocks['get_nodes_with_service'] = self.mock_get_nodes_with_service_warning
+
+        self.run_check(MOCK_CONFIG, mocks=my_mocks)
+        self.assertMetric('consul.catalog.nodes_up', value=1, tags=['consul_datacenter:dc1', 'consul_service_id:service-1'])
+        self.assertMetric('consul.catalog.nodes_passing', value=0, tags=['consul_datacenter:dc1', 'consul_service_id:service-1'])
+        self.assertMetric('consul.catalog.nodes_warning', value=1, tags=['consul_datacenter:dc1', 'consul_service_id:service-1'])
+        self.assertMetric('consul.catalog.nodes_critical', value=0, tags=['consul_datacenter:dc1', 'consul_service_id:service-1'])
+        self.assertMetric('consul.catalog.services_up', value=6, tags=['consul_datacenter:dc1', 'consul_node_id:node-1'])
+        self.assertMetric('consul.catalog.services_passing', value=0, tags=['consul_datacenter:dc1', 'consul_node_id:node-1'])
+        self.assertMetric('consul.catalog.services_warning', value=6, tags=['consul_datacenter:dc1', 'consul_node_id:node-1'])
+        self.assertMetric('consul.catalog.services_critical', value=0, tags=['consul_datacenter:dc1', 'consul_node_id:node-1'])
+
+    def test_get_nodes_with_service_critical(self):
+        my_mocks = self._get_consul_mocks()
+        my_mocks['get_nodes_with_service'] = self.mock_get_nodes_with_service_critical
+
+        self.run_check(MOCK_CONFIG, mocks=my_mocks)
+        self.assertMetric('consul.catalog.nodes_up', value=1, tags=['consul_datacenter:dc1', 'consul_service_id:service-1'])
+        self.assertMetric('consul.catalog.nodes_passing', value=0, tags=['consul_datacenter:dc1', 'consul_service_id:service-1'])
+        self.assertMetric('consul.catalog.nodes_warning', value=0, tags=['consul_datacenter:dc1', 'consul_service_id:service-1'])
+        self.assertMetric('consul.catalog.nodes_critical', value=1, tags=['consul_datacenter:dc1', 'consul_service_id:service-1'])
+        self.assertMetric('consul.catalog.services_up', value=6, tags=['consul_datacenter:dc1', 'consul_node_id:node-1'])
+        self.assertMetric('consul.catalog.services_passing', value=0, tags=['consul_datacenter:dc1', 'consul_node_id:node-1'])
+        self.assertMetric('consul.catalog.services_warning', value=0, tags=['consul_datacenter:dc1', 'consul_node_id:node-1'])
+        self.assertMetric('consul.catalog.services_critical', value=6, tags=['consul_datacenter:dc1', 'consul_node_id:node-1'])
 
     def test_get_peers_in_cluster(self):
         mocks = self._get_consul_mocks()
@@ -183,11 +324,6 @@ class TestCheckConsul(AgentCheckTest):
         # When node is follower
         self.run_check(MOCK_CONFIG, mocks=mocks)
         self.assertMetric('consul.peers', value=3, tags=['consul_datacenter:dc1', 'mode:follower'])
-
-
-    def test_get_services_on_node(self):
-        self.run_check(MOCK_CONFIG, mocks=self._get_consul_mocks())
-        self.assertMetric('consul.catalog.services_up', value=6, tags=['consul_datacenter:dc1', 'consul_node_id:node-1'])
 
     def test_cull_services_list(self):
         self.check = load_check(self.CHECK_NAME, MOCK_CONFIG_LEADER_CHECK, self.DEFAULT_AGENT_CONFIG)


### PR DESCRIPTION
This is a rebased and slightly modified version of #2018 . It queries for cluster status via the `/v1/health/service/<service>` endpoint, which allows us to split the coarse-grained `consul.catalog.nodes_up` and `consul.catalog.services_up` metrics into the following
-  `consul.catalog.nodes_passing` tagged by `consul_service_id`
-  `consul.catalog.nodes_warning` tagged by `consul_service_id`
-  `consul.catalog.nodes_critical` tagged by `consul_service_id`
-  `consul.catalog.services_passing` tagged by `consul_node_id`
-  `consul.catalog.services_warning` tagged by `consul_node_id`
-  `consul.catalog.services_critical` tagged by `consul_node_id`

The `consul.catalog.nodes_up` and `consul.catalog.services_up` metrics are preserved with their original values, but will likely be removed or renamed in a future version of the check.

Additionally `consul.check` service checks are now tagged by `consul_service_id` rather than `service-id` to keep consistent with the `consul.catalog.*` tagging scheme

TODOs:
- [x] Add tests for `consul.catalog.services_*` functionality

cc @mtougeron 
