### PR TITLE
Skip Containers when Names is None

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -308,6 +308,13 @@ class DockerDaemon(AgentCheck):
         containers_by_id = {}
 
         for container in containers:
+
+            # Docker may report 'Dead' containers with None vs an empty list, skip them
+            # as they are dead anyways.
+            # https://github.com/docker/docker/issues/16706
+            if container['Names'] == None:
+                continue
+
             container_name = container_name_extractor(container)[0]
 
             container_status_tags = self._get_tags(container, CONTAINER)

--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -312,7 +312,7 @@ class DockerDaemon(AgentCheck):
             # Docker may report 'Dead' containers with None vs an empty list, skip them
             # as they are dead anyways.
             # https://github.com/docker/docker/issues/16706
-            if container['Names'] == None:
+            if container['Names'] is None:
                 continue
 
             container_name = container_name_extractor(container)[0]


### PR DESCRIPTION
Due to a bug in docker, dead images listed may have 'Names' set to None rather than and empty list.
See: https://github.com/docker/docker/issues/16706
This will cause the dd-agent to bail real early and not report and metrics.

File "/opt/datadog-agent/agent/checks/__init__.py", line 745, in run
   self.check(copy.deepcopy(instance))
 File "/opt/datadog-agent/agent/checks.d/docker_daemon.py", line 255, in check
   containers_by_id = self._get_and_count_containers()
 File "/opt/datadog-agent/agent/checks.d/docker_daemon.py", line 311, in _get_and_count_containers
   container_name = container_name_extractor(container)[0]
 File "/opt/datadog-agent/agent/checks.d/docker_daemon.py", line 110, in container_name_extractor
   names = sorted(c.get('Names', []))
TypeError: 'NoneType' object is not iterable

Skip any container where names are "None" type, since they are dead anyways.