### PR TITLE
Add counter support for go_expvar.

### DIFF
--- a/checks.d/go_expvar.py
+++ b/checks.d/go_expvar.py
@@ -16,12 +16,14 @@ TAGS = "tags"
 
 GAUGE = "gauge"
 RATE = "rate"
+COUNTER = "counter"
 DEFAULT_TYPE = GAUGE
 
 
 SUPPORTED_TYPES = {
     GAUGE: AgentCheck.gauge,
     RATE: AgentCheck.rate,
+    COUNTER: AgentCheck.increment,
 }
 
 DEFAULT_METRIC_NAMESPACE = "go_expvar"

--- a/conf.d/go_expvar.yaml.example
+++ b/conf.d/go_expvar.yaml.example
@@ -3,6 +3,10 @@ init_config:
 instances:
   # Most memstats metrics are exported by default
   # See http://godoc.org/runtime#MemStats for their explanation
+  # Note that you can specify a `type` for the metrics. One of:
+  #  * counter
+  #  * gauge (the default)
+  #  * rate (note that this will show up as a gauge in Datadog that is meant to be seen as a "per second rate")
 
   - expvar_url: http://localhost:8080/debug/vars
     # namespace: examplenamespace         # The default metric namespace is 'go_expvar', define your own
@@ -20,9 +24,9 @@ instances:
     #       - "metric_tag2:tag_value2"
     #   - path: memstats/Alloc            # metric will be reported as a gauge by default
     #   - path: memstats/Lookups
-    #     type: rate
+    #     type: rate                      # metric should be reported as a rate instead of the default gauge
     #   - path: memstats/Mallocs          # with no name specified, the metric name will default to a path based name
-    #     type: rate
+    #     type: counter                   # report as a counter instead of the default gauge
     #   - path: memstats/Frees
     #     type: rate
     #   - path: memstats/BySize/1/Mallocs # You can get nested values by separating them with "/"


### PR DESCRIPTION
# What's this PR do?

Adds support for counters by way of `increment` to the go_expvar check.

# Motivation

I'm unsure why the existing integration does not support counters and only rate. I feel like maybe I'm missing something here. In our use a rate will often do what I want, but it seems odd to convert to a rate when the full counter value is available. Also someone might want to alert on a raw total instead of a rate?