### PR TITLE
[nginx] report nginx.server_zone.response.* as count

### DIFF
--- a/checks.d/nginx.py
+++ b/checks.d/nginx.py
@@ -42,7 +42,8 @@ class Nginx(AgentCheck):
 
         funcs = {
             'gauge': self.gauge,
-            'rate': self.rate
+            'rate': self.rate,
+            'count': self.count
         }
         for row in metrics:
             try:
@@ -173,6 +174,9 @@ class Nginx(AgentCheck):
             output.append((metric_base, val, tags, 'gauge'))
 
         elif isinstance(val, (int, float)):
-            output.append((metric_base, val, tags, 'gauge'))
+            if metric_base.startswith('nginx.server_zone.responses.'):
+                output.append((metric_base, val, tags, 'count'))
+            else:
+                output.append((metric_base, val, tags, 'gauge'))
 
         return output


### PR DESCRIPTION
Asked by a user. After investigation I think it could also make sense for other metrics, let's discuss it.
