### PR TITLE
Lithium/elastic stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ embedded/*
 .cache
 dump.rdb
 tests/core/fixtures/flare/dd*
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,8 @@ env:
     - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.3.9
     - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.4.5
     - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.5.2
-    - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.6.0
+    - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.6.2
+    - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.7.4
     - TRAVIS_FLAVOR=etcd
     - TRAVIS_FLAVOR=fluentd
     - TRAVIS_FLAVOR=go_expvar

--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -98,6 +98,8 @@ class ESCheck(AgentCheck):
         "elasticsearch.search.fetch.total": ("gauge", "indices.search.fetch_total"),
         "elasticsearch.search.fetch.time": ("gauge", "indices.search.fetch_time_in_millis", lambda v: float(v)/1000),
         "elasticsearch.search.fetch.current": ("gauge", "indices.search.fetch_current"),
+        "elasticsearch.indices.segments.count": ("gauge", "indices.segments.count"),
+        "elasticsearch.indices.segments.memory_in_bytes": ("gauge", "indices.segments.memory_in_bytes"),
         "elasticsearch.merges.current": ("gauge", "indices.merges.current"),
         "elasticsearch.merges.current.docs": ("gauge", "indices.merges.current_docs"),
         "elasticsearch.merges.current.size": ("gauge", "indices.merges.current_size_in_bytes"),
@@ -158,6 +160,9 @@ class ESCheck(AgentCheck):
         "jvm.mem.non_heap_used": ("gauge", "jvm.mem.non_heap_used_in_bytes"),
         "jvm.threads.count": ("gauge", "jvm.threads.count"),
         "jvm.threads.peak_count": ("gauge", "jvm.threads.peak_count"),
+        "elasticsearch.fs.total.total_in_bytes": ("gauge", "fs.total.total_in_bytes"),
+        "elasticsearch.fs.total.free_in_bytes": ("gauge", "fs.total.free_in_bytes"),
+        "elasticsearch.fs.total.available_in_bytes": ("gauge", "fs.total.available_in_bytes"),
     }
 
     JVM_METRICS_POST_0_90_10 = {
@@ -191,6 +196,27 @@ class ESCheck(AgentCheck):
         "elasticsearch.cache.filter.count": ("gauge", "indices.cache.filter_count"),
         "elasticsearch.cache.filter.evictions": ("gauge", "indices.cache.filter_evictions"),
         "elasticsearch.cache.filter.size": ("gauge", "indices.cache.filter_size_in_bytes"),
+    }
+
+    ADDITIONAL_METRICS_POST_1_0_0 = {
+        "elasticsearch.indices.translog.size_in_bytes": ("gauge", "indices.translog.size_in_bytes"),
+        "elasticsearch.indices.translog.operations": ("gauge", "indices.translog.operations"),
+        "elasticsearch.fs.total.disk_reads": ("rate", "fs.total.disk_reads"),
+        "elasticsearch.fs.total.disk_writes": ("rate", "fs.total.disk_writes"),
+        "elasticsearch.fs.total.disk_io_op": ("rate", "fs.total.disk_io_op"),
+        "elasticsearch.fs.total.disk_read_size_in_bytes": ("gauge", "fs.total.disk_read_size_in_bytes"),
+        "elasticsearch.fs.total.disk_write_size_in_bytes": ("gauge", "fs.total.disk_write_size_in_bytes"),
+        "elasticsearch.fs.total.disk_io_size_in_bytes": ("gauge", "fs.total.disk_io_size_in_bytes"),
+    }
+
+    ADDITIONAL_METRICS_POST_1_3_0 = {
+        "elasticsearch.indices.segments.index_writer_memory_in_bytes": ("gauge", "indices.segments.index_writer_memory_in_bytes"),
+        "elasticsearch.indices.segments.version_map_memory_in_bytes": ("gauge", "indices.segments.version_map_memory_in_bytes"),
+    }
+
+    ADDITIONAL_METRICS_POST_1_4_0 = {
+        "elasticsearch.indices.segments.index_writer_max_memory_in_bytes": ("gauge", "indices.segments.index_writer_max_memory_in_bytes"),
+        "elasticsearch.indices.segments.fixed_bit_set_memory_in_bytes": ("gauge", "indices.segments.fixed_bit_set_memory_in_bytes"),
     }
 
     CLUSTER_HEALTH_METRICS = {
@@ -353,6 +379,8 @@ class ESCheck(AgentCheck):
         stats_metrics = dict(self.STATS_METRICS)
         stats_metrics.update(additional_metrics)
 
+
+        ### Additional Stats metrics ###
         if version >= [0, 90, 5]:
             # ES versions 0.90.5 and above
             additional_metrics = self.ADDITIONAL_METRICS_POST_0_90_5
@@ -361,6 +389,16 @@ class ESCheck(AgentCheck):
             additional_metrics = self.ADDITIONAL_METRICS_PRE_0_90_5
 
         stats_metrics.update(additional_metrics)
+
+        if version >= [1, 0, 0]:
+            stats_metrics.update(self.ADDITIONAL_METRICS_POST_1_0_0)
+
+        if version >= [1, 3, 0]:
+            stats_metrics.update(self.ADDITIONAL_METRICS_POST_1_3_0)
+
+        if version >= [1, 4, 0]:
+            # ES versions 1.4 and above
+            stats_metrics.update(self.ADDITIONAL_METRICS_POST_1_4_0)
 
         # Version specific stats metrics about the primary shards
         pshard_stats_metrics = dict(self.PRIMARY_SHARD_METRICS)

--- a/tests/checks/integration/test_elastic.py
+++ b/tests/checks/integration/test_elastic.py
@@ -74,6 +74,8 @@ STATS_METRICS = {  # Metrics that are common to all Elasticsearch versions
     "elasticsearch.search.fetch.total": ("gauge", "indices.search.fetch_total"),
     "elasticsearch.search.fetch.time": ("gauge", "indices.search.fetch_time_in_millis", lambda v: float(v)/1000),
     "elasticsearch.search.fetch.current": ("gauge", "indices.search.fetch_current"),
+    "elasticsearch.indices.segments.count": ("gauge", "indices.segments.count"),
+    "elasticsearch.indices.segments.memory_in_bytes": ("gauge", "indices.segments.memory_in_bytes"),
     "elasticsearch.merges.current": ("gauge", "indices.merges.current"),
     "elasticsearch.merges.current.docs": ("gauge", "indices.merges.current_docs"),
     "elasticsearch.merges.current.size": ("gauge", "indices.merges.current_size_in_bytes"),
@@ -134,6 +136,9 @@ STATS_METRICS = {  # Metrics that are common to all Elasticsearch versions
     "jvm.mem.non_heap_used": ("gauge", "jvm.mem.non_heap_used_in_bytes"),
     "jvm.threads.count": ("gauge", "jvm.threads.count"),
     "jvm.threads.peak_count": ("gauge", "jvm.threads.peak_count"),
+    "elasticsearch.fs.total.total_in_bytes": ("gauge", "fs.total.total_in_bytes"),
+    "elasticsearch.fs.total.free_in_bytes": ("gauge", "fs.total.free_in_bytes"),
+    "elasticsearch.fs.total.available_in_bytes": ("gauge", "fs.total.available_in_bytes"),
 }
 
 JVM_METRICS_POST_0_90_10 = {
@@ -167,6 +172,28 @@ ADDITIONAL_METRICS_PRE_0_90_5 = {
     "elasticsearch.cache.filter.count": ("gauge", "indices.cache.filter_count"),
     "elasticsearch.cache.filter.evictions": ("gauge", "indices.cache.filter_evictions"),
     "elasticsearch.cache.filter.size": ("gauge", "indices.cache.filter_size_in_bytes"),
+}
+
+ADDITIONAL_METRICS_POST_1_0_0 = {
+    "elasticsearch.indices.translog.size_in_bytes": ("gauge", "indices.translog.size_in_bytes"),
+    "elasticsearch.indices.translog.operations": ("gauge", "indices.translog.operations"),
+    # Currently has issues in test framework:
+    # "elasticsearch.fs.total.disk_reads": ("rate", "fs.total.disk_reads"),
+    # "elasticsearch.fs.total.disk_writes": ("rate", "fs.total.disk_writes"),
+    # "elasticsearch.fs.total.disk_io_op": ("rate", "fs.total.disk_io_op"),
+    # "elasticsearch.fs.total.disk_read_size_in_bytes": ("gauge", "fs.total.disk_read_size_in_bytes"),
+    # "elasticsearch.fs.total.disk_write_size_in_bytes": ("gauge", "fs.total.disk_write_size_in_bytes"),
+    # "elasticsearch.fs.total.disk_io_size_in_bytes": ("gauge", "fs.total.disk_io_size_in_bytes"),
+}
+
+ADDITIONAL_METRICS_POST_1_3_0 = {
+    "elasticsearch.indices.segments.index_writer_memory_in_bytes": ("gauge", "indices.segments.index_writer_memory_in_bytes"),
+    "elasticsearch.indices.segments.version_map_memory_in_bytes": ("gauge", "indices.segments.version_map_memory_in_bytes"),
+}
+
+ADDITIONAL_METRICS_POST_1_4_0 = {
+    "elasticsearch.indices.segments.index_writer_max_memory_in_bytes": ("gauge", "indices.segments.index_writer_max_memory_in_bytes"),
+    "elasticsearch.indices.segments.fixed_bit_set_memory_in_bytes": ("gauge", "indices.segments.fixed_bit_set_memory_in_bytes"),
 }
 
 CLUSTER_HEALTH_METRICS = {
@@ -243,6 +270,15 @@ class TestElastic(AgentCheckTest):
         else:
             expected_metrics.update(ADDITIONAL_METRICS_PRE_0_90_5)
             expected_metrics.update(JVM_METRICS_PRE_0_90_10)
+
+        if es_version >= [1, 0, 0]:
+            expected_metrics.update(ADDITIONAL_METRICS_POST_1_0_0)
+
+        if es_version >= [1, 3, 0]:
+            expected_metrics.update(ADDITIONAL_METRICS_POST_1_3_0)
+
+        if es_version >= [1, 4, 0]:
+            expected_metrics.update(ADDITIONAL_METRICS_POST_1_4_0)
 
         contexts = [
             (conf_hostname, default_tags + tags),


### PR DESCRIPTION
Adds additional important statistics that can be monitored by the datadog agent. 

I wasn't sure how to verify the version of introduction of these statistics to elasticsearch, so I made the assumption that they've always been available. If this is incorrect or if there's a place to be able to find this information, please let me know