### PR TITLE
[core] do not log API keys

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -29,7 +29,7 @@ from util import (
     get_uuid,
     Timer,
 )
-from utils.debug import log_exceptions
+from utils.logger import log_exceptions
 from utils.jmx import JMXFiles
 from utils.platform import Platform
 from utils.subprocess_output import get_subprocess_output

--- a/tests/core/test_utils_logger.py
+++ b/tests/core/test_utils_logger.py
@@ -1,0 +1,69 @@
+# stdlib
+import unittest
+
+# 3p
+from mock import Mock
+
+# datadog
+from utils.logger import log_exceptions, log_no_api_key
+
+
+class TestUtilsLogger(unittest.TestCase):
+
+    def test_log_exception(self):
+        """
+        Catch any exception and log it.
+        """
+        mock_logger = Mock()
+
+        @log_exceptions(mock_logger)
+        def raise_exception():
+            """
+            Raise an exception
+            """
+            raise Exception(u"Bad exception.")
+
+        self.assertRaises(Exception, raise_exception)
+        self.assertTrue(mock_logger.exception.called)
+
+    def test_log_no_api(self):
+        """
+        Log no API key in the method scope.
+        """
+        # Mock a logger
+        _logging = []
+        mock_logger = Mock(
+            _log=lambda level, msg, args, **kwargs: _logging.append(args),
+            get_logging=lambda: _logging.pop(),
+        )
+
+        #
+        def log_args(*args):
+            """
+            Log arguments and return logging.
+            """
+            level = 0
+            msg = u""
+
+            mock_logger._log(level, msg, *args)
+
+        log_arg_wo_api_keys = log_no_api_key(mock_logger)(log_args)
+
+        # Run tests
+        args_to_log = (
+            "Sending metrics to endpoint dd_url at https://x-x-x-app.agent.datadog.com/intake/?api_key=foobar",  # noqa
+            "200 POST /intake/?api_key=foobar (127.0.0.1) 67.70ms",
+            "Transaction 1 completed",
+        )
+
+        args_wo_api_keys = (
+            "Sending metrics to endpoint dd_url at https://x-x-x-app.agent.datadog.com/intake/?api_key=*************************oobar",  # noqa
+            "200 POST /intake/?api_key=*************************oobar (127.0.0.1) 67.70ms",
+            "Transaction 1 completed",
+        )
+
+        log_arg_wo_api_keys(args_to_log)
+        self.assertEquals(mock_logger.get_logging(), args_wo_api_keys)
+
+        log_args(args_to_log)
+        self.assertEquals(mock_logger.get_logging(), args_to_log)

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -1,5 +1,4 @@
 # stdlib
-from functools import wraps
 from pprint import pprint
 import inspect
 import os
@@ -8,27 +7,6 @@ import sys
 # datadog
 from config import get_checksd_path, get_confd_path
 from util import get_os
-
-
-def log_exceptions(logger):
-    """
-    A decorator that catches any exceptions thrown by the decorated function and
-    logs them along with a traceback.
-    """
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            try:
-                result = func(*args, **kwargs)
-            except Exception:
-                logger.exception(
-                    u"Uncaught exception while running {0}".format(func.__name__)
-                )
-                raise
-            return result
-        return wrapper
-    return decorator
-
 
 
 def run_check(name, path=None):

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,64 @@
+# stdlib
+from functools import wraps
+import re
+
+
+API_KEY_PATTERN = re.compile('api_key=*\w+(\w{5})')
+API_KEY_REPLACEMENT = r'api_key=*************************\1'
+
+
+def log_exceptions(logger):
+    """
+    A decorator that catches any exceptions thrown by the decorated function and
+    logs them along with a traceback.
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                result = func(*args, **kwargs)
+            except Exception:
+                logger.exception(
+                    u"Uncaught exception while running {0}".format(func.__name__)
+                )
+                raise
+            return result
+        return wrapper
+    return decorator
+
+
+def log_no_api_key(logger):
+    """
+    A decorator that patches a logger in a method scope to obfuscate API keys.
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            # Patch logger
+            tmp = logger._log
+            logger._log = _obfuscate_api_keys(logger._log)
+
+            # Run method
+            result = func(*args, **kwargs)
+
+            # Unpatch logger
+            logger._log = tmp
+
+            return result
+        return wrapper
+    return decorator
+
+
+def _obfuscate_api_keys(func):
+    """
+    A decorator that obfuscate API keys among the method arguments.
+    """
+    @wraps(func)
+    def wrapper(level, msg, args, **kwargs):
+        # Obfuscate API keys among logger arguments
+        sanitized_args = [re.sub(API_KEY_PATTERN, API_KEY_REPLACEMENT, arg)
+                          if isinstance(arg, basestring) else arg
+                          for arg in args]
+
+        return func(level, msg, tuple(sanitized_args), **kwargs)
+    return wrapper


### PR DESCRIPTION
Create a `utils.logger` module:
* Move `log_exceptions` from `utils.debug`
* `log_no_api_key` patches a logger in a method scope to obfuscate API
 keys

Apply `log_no_api_key` on some forwarder methods.