### PR TITLE
[core] do not log API keys

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -29,7 +29,7 @@ from util import (
     get_uuid,
     Timer,
 )
-from utils.debug import log_exceptions
+from utils.logger import log_exceptions
 from utils.jmx import JMXFiles
 from utils.platform import Platform
 from utils.subprocess_output import get_subprocess_output

--- a/ddagent.py
+++ b/ddagent.py
@@ -56,7 +56,10 @@ from util import (
     json,
     Watchdog,
 )
+from utils.logger import RedactedLogRecord
 
+
+logging.LogRecord = RedactedLogRecord
 log = logging.getLogger('forwarder')
 log.setLevel(get_logging_config()['log_level'] or logging.INFO)
 
@@ -203,7 +206,10 @@ class AgentTransaction(Transaction):
     def flush(self):
         for endpoint in self._endpoints:
             url = self.get_url(endpoint)
-            log.debug("Sending %s to endpoint %s at %s" % (self._type, endpoint, url))
+            log.debug(
+                u"Sending %s to endpoint %s at %s",
+                self._type, endpoint, url
+            )
 
             # Getting proxy settings
             proxy_settings = self._application._agentConfig.get('proxy_settings', None)
@@ -410,9 +416,13 @@ class Application(tornado.web.Application):
             log_method = log.warning
         else:
             log_method = log.error
+
         request_time = 1000.0 * handler.request.request_time()
-        log_method("%d %s %.2fms", handler.get_status(),
-                   handler._request_summary(), request_time)
+        log_method(
+            u"%d %s %.2fms",
+            handler.get_status(),
+            handler._request_summary(), request_time
+        )
 
     def appendMetric(self, prefix, name, host, device, ts, value):
 

--- a/tests/core/test_utils_logger.py
+++ b/tests/core/test_utils_logger.py
@@ -1,0 +1,86 @@
+# stdlib
+import logging
+import unittest
+
+# 3p
+from mock import Mock
+
+# datadog
+from utils.logger import log_exceptions, RedactedLogRecord
+
+
+class MockLoggingHandler(logging.Handler, object):
+    """
+    Mock logging handler to check for expected logs.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(MockLoggingHandler, self).__init__(*args, **kwargs)
+        self.messages = []
+
+    def emit(self, record):
+        self.messages.append(record.getMessage())
+
+    def pop(self):
+        """
+        Return the last message logged.
+        """
+        if not self.messages:
+            return None
+
+        return self.messages.pop()
+
+
+class TestUtilsLogger(unittest.TestCase):
+
+    def test_log_exception(self):
+        """
+        Catch any exception and log it.
+        """
+        mock_logger = Mock()
+
+        @log_exceptions(mock_logger)
+        def raise_exception():
+            """
+            Raise an exception.
+            """
+            raise Exception(u"Bad exception.")
+
+        self.assertRaises(Exception, raise_exception)
+        self.assertTrue(mock_logger.exception.called)
+
+    def test_api_key_log_obfuscation(self):
+        """
+        `RedactedLogRecord` custom LogRecord obfuscates API key logging.
+        """
+        # Initialize a logger with `RedactedLogRecord` custom LogRecord
+        logging.LogRecord = RedactedLogRecord
+
+        logger = logging.getLogger()
+        handler = MockLoggingHandler()
+
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(handler)
+
+        # Attempt to log an API key
+        def log_api_key():
+            """
+            Log things, including an API key.
+            """
+            mtype = "metrics"
+            endpoint = "dd_url"
+            url = "https://x-x-x-app.agent.datadog.com/intake/?api_key=foobar"
+
+            logger.info(
+                u"Sending %s to endpoint %s at %s",
+                mtype, endpoint, url
+            )
+
+        log_api_key()
+
+        # API key is obfuscated
+        result = handler.pop()
+        expected_result = u"Sending metrics to endpoint dd_url at "\
+            "https://x-x-x-app.agent.datadog.com/intake/?api_key=*************************oobar"
+
+        self.assertEquals(result, expected_result)

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -1,5 +1,4 @@
 # stdlib
-from functools import wraps
 from pprint import pprint
 import inspect
 import os
@@ -8,27 +7,6 @@ import sys
 # datadog
 from config import get_checksd_path, get_confd_path
 from util import get_os
-
-
-def log_exceptions(logger):
-    """
-    A decorator that catches any exceptions thrown by the decorated function and
-    logs them along with a traceback.
-    """
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            try:
-                result = func(*args, **kwargs)
-            except Exception:
-                logger.exception(
-                    u"Uncaught exception while running {0}".format(func.__name__)
-                )
-                raise
-            return result
-        return wrapper
-    return decorator
-
 
 
 def run_check(name, path=None):

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,0 +1,37 @@
+# stdlib
+from functools import wraps
+from logging import LogRecord
+import re
+
+
+def log_exceptions(logger):
+    """
+    A decorator that catches any exceptions thrown by the decorated function and
+    logs them along with a traceback.
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                result = func(*args, **kwargs)
+            except Exception:
+                logger.exception(
+                    u"Uncaught exception while running {0}".format(func.__name__)
+                )
+                raise
+            return result
+        return wrapper
+    return decorator
+
+
+class RedactedLogRecord(LogRecord, object):
+    """
+    Custom LogRecord that obfuscates API key logging.
+    """
+    API_KEY_PATTERN = re.compile('api_key=*\w+(\w{5})')
+    API_KEY_REPLACEMENT = r'api_key=*************************\1'
+
+    def getMessage(self):
+        message = super(RedactedLogRecord, self).getMessage()
+
+        return re.sub(self.API_KEY_PATTERN, self.API_KEY_REPLACEMENT, message)


### PR DESCRIPTION
Create a `utils.logger` module:
* Move `log_exceptions` from `utils.debug`
* `NoAPIKeyLogRecord` is a custom `LogRecord` that obfuscates API keys
  logging