### PR TITLE
Update the mirror urls to use Apache archives for ZK tests

### DIFF
--- a/ci/zookeeper.rb
+++ b/ci/zookeeper.rb
@@ -1,7 +1,7 @@
 require './ci/common'
 
 def zk_version
-  ENV['FLAVOR_VERSION'] || '3.4.6'
+  ENV['FLAVOR_VERSION'] || '3.4.7'
 end
 
 def zk_rootdir
@@ -16,7 +16,7 @@ namespace :ci do
       unless Dir.exist? File.expand_path(zk_rootdir)
         sh %(curl -s -L\
              -o $VOLATILE_DIR/zookeeper-#{zk_version}.tar.gz\
-             http://mirror.cogentco.com/pub/apache/zookeeper/zookeeper-#{zk_version}/zookeeper-#{zk_version}.tar.gz)
+            http://archive.apache.org/dist/zookeeper/zookeeper-#{zk_version}/zookeeper-#{zk_version}.tar.gz)
         sh %(mkdir -p #{zk_rootdir})
         sh %(tar zxf $VOLATILE_DIR/zookeeper-#{zk_version}.tar.gz\
              -C #{zk_rootdir} --strip-components=1)


### PR DESCRIPTION
Update the mirror urls to use Apache.org archives, the previously used cogent mirror only includes the latest release. As such each time apache releases a new version the url we had here previously would begin returning 404 and fail tests.

Also start testing against 3.4.7, rather than 3.4.6.