### PR TITLE
[packaging] Fix config reload on osx and source install

### DIFF
--- a/packaging/datadog-agent/source/agent
+++ b/packaging/datadog-agent/source/agent
@@ -3,7 +3,6 @@ BASEDIR=$(dirname $0)
 cd "$BASEDIR/.."
 
 PATH=$BASEDIR/../venv/bin:$PATH
-EMBEDDED_BIN_PATH="/opt/datadog-agent/embedded/bin"
 
 SUPERVISOR_NOT_RUNNING="Supervisor is not running"
 SUPERVISOR_CONF_FILE='supervisord/supervisord.conf'
@@ -109,7 +108,7 @@ case $action in
         ;;
 
     reload)
-        $EMBEDDED_BIN_PATH/kill -HUP `cat $COLLECTOR_PIDFILE`
+        kill -HUP `cat $COLLECTOR_PIDFILE`
         exit $?
         ;;
 

--- a/packaging/osx/datadog-agent
+++ b/packaging/osx/datadog-agent
@@ -4,7 +4,6 @@ DESC="Datadog Agent"
 AGENTPATH="/opt/datadog-agent/agent/agent.py"
 FORWARDERPATH="/opt/datadog-agent/agent/ddagent.py"
 DOGSTATSDPATH="/opt/datadog-agent/agent/dogstatsd.py"
-KILL_PATH="/opt/datadog-agent/embedded/bin/kill"
 AGENTCONF="/opt/datadog-agent/etc/datadog.conf"
 SUPERVISOR_PIDFILE="/opt/datadog-agent/run/datadog-supervisord.pid"
 SUPERVISOR_CONF_FILE="/opt/datadog-agent/etc/supervisor.conf"
@@ -98,7 +97,7 @@ case $1 in
         ;;
 
     reload)
-        $KILL_PATH -HUP `cat $COLLECTOR_PIDFILE`
+        kill -HUP `cat $COLLECTOR_PIDFILE`
         exit $?
         ;;
 


### PR DESCRIPTION
We don't package our own `kill` bin with the osx and source installs, so use the command provided by the OS for these install methods.

The cross-platform compatibility of the HUP signal seems to be good, so we can expect this to work well on most platforms.

Tested on OSX and FreeBSD.
