### PR TITLE
Rebased pr #1770: gather stats from zookeeper mntr command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ env:
     - TRAVIS_FLAVOR=tomcat # JMX testing machine / need the other ones before
     - TRAVIS_FLAVOR=varnish FLAVOR_VERSION=3.0.7
     - TRAVIS_FLAVOR=varnish FLAVOR_VERSION=4.0.3
-    - TRAVIS_FLAVOR=zookeeper FLAVOR_VERSION=3.4.6
+    - TRAVIS_FLAVOR=zookeeper FLAVOR_VERSION=3.4.7
     - TRAVIS_FLAVOR=zookeeper FLAVOR_VERSION=3.3.6
 
 # Override travis defaults with empty jobs

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,8 @@ env:
     - TRAVIS_FLAVOR=tomcat # JMX testing machine / need the other ones before
     - TRAVIS_FLAVOR=varnish FLAVOR_VERSION=3.0.7
     - TRAVIS_FLAVOR=varnish FLAVOR_VERSION=4.0.3
-    - TRAVIS_FLAVOR=zookeeper
+    - TRAVIS_FLAVOR=zookeeper FLAVOR_VERSION=3.4.6
+    - TRAVIS_FLAVOR=zookeeper FLAVOR_VERSION=3.3.6
 
 # Override travis defaults with empty jobs
 before_install: echo "OVERRIDING TRAVIS STEPS"

--- a/checks.d/zk.py
+++ b/checks.d/zk.py
@@ -106,7 +106,7 @@ class ZookeeperCheck(AgentCheck):
         cx_args = (host, port, timeout)
         sc_tags = ["host:{0}".format(host), "port:{0}".format(port)]
         hostname = get_hostname(self.agentConfig)
-        report_instance_mode = instance.get("report_instance_mode", False)
+        report_instance_mode = instance.get("report_instance_mode", True)
 
         zk_version = None # parse_stat will parse and set version string
 

--- a/ci/resources/zookeeper/zoo.cfg
+++ b/ci/resources/zookeeper/zoo.cfg
@@ -1,3 +1,3 @@
 tickTime=2000
-dataDir=VOLATILE_DIR/zookeeper
+dataDir=/tmp/zookeeper
 clientPort=2181

--- a/ci/zookeeper.rb
+++ b/ci/zookeeper.rb
@@ -1,7 +1,7 @@
 require './ci/common'
 
 def zk_version
-  ENV['FLAVOR_VERSION'] || '3.4.6'
+  ENV['FLAVOR_VERSION'] || '3.4.7'
 end
 
 def zk_rootdir

--- a/conf.d/zk.yaml.example
+++ b/conf.d/zk.yaml.example
@@ -7,8 +7,13 @@ instances:
     # tags:
     #   - optional_tag1
     #   - optional_tag2
-    
+
     # If `expected_mode` is defined we'll send a service check where the
     # status is determined by whether the current mode matches the expected.
     # Options: leader, follower, standalone
     # expected_mode: leader
+
+    # Whether to report the current instance mode as a 0/1 gauge
+    # For example if the current instance mode is `observer` - `zookeeper.instances.observer` reports as 1
+    # and `zookeeper.instances.(leader|follower|standalone|etc.)` reports as 0
+    # report_instance_mode: true

--- a/tests/checks/integration/test_zk.py
+++ b/tests/checks/integration/test_zk.py
@@ -1,4 +1,6 @@
 # stdlib
+import os
+from distutils.version import LooseVersion
 from nose.plugins.attrib import attr
 
 # project
@@ -48,19 +50,19 @@ class ZooKeeperTestCase(AgentCheckTest):
     ]
 
     MNTR_METRICS = [
-        'zookeeper.packets.sent',
-        'zookeeper.approximate.data.size',
-        'zookeeper.num.alive.connections',
-        'zookeeper.open.file.descriptor.count',
-        'zookeeper.avg.latency',
-        'zookeeper.znode.count',
-        'zookeeper.outstanding.requests',
-        'zookeeper.min.latency',
-        'zookeeper.ephemerals.count',
-        'zookeeper.watch.count',
-        'zookeeper.max.file.descriptor.count',
-        'zookeeper.packets.received',
-        'zookeeper.max.latency',
+        'zookeeper.packets_sent',
+        'zookeeper.approximate_data_size',
+        'zookeeper.num_alive_connections',
+        'zookeeper.open_file_descriptor_count',
+        'zookeeper.avg_latency',
+        'zookeeper.znode_count',
+        'zookeeper.outstanding_requests',
+        'zookeeper.min_latency',
+        'zookeeper.ephemerals_count',
+        'zookeeper.watch_count',
+        'zookeeper.max_file_descriptor_count',
+        'zookeeper.packets_received',
+        'zookeeper.max_latency',
     ]
 
     STATUS_TYPES = [
@@ -86,20 +88,19 @@ class ZooKeeperTestCase(AgentCheckTest):
         for mname in self.STAT_METRICS:
             self.assertMetric(mname, tags=["mode:standalone", "mytag"], count=1)
 
-        for mname in self.MNTR_METRICS:
-            self.assertMetric(mname, tags=["mode:standalone", "mytag"], count=1)
+        zk_version = os.environ.get("FLAVOR_VERSION")
+
+        if zk_version and LooseVersion(zk_version) > LooseVersion("3.4.0"):
+            for mname in self.MNTR_METRICS:
+                self.assertMetric(mname, tags=["mode:standalone", "mytag"], count=1)
 
         # Test service checks
         self.assertServiceCheck("zookeeper.ruok", status=AgentCheck.OK)
         self.assertServiceCheck("zookeeper.mode", status=AgentCheck.OK)
 
         expected_mode = self.CONFIG['expected_mode']
-        for t in self.STATUS_TYPES:
-            expected_value = 0
-            if t == expected_mode:
-                expected_value = 1
-            mname = "zookeeper.instances." + t
-            self.assertMetric(mname, value=expected_value, count=1)
+        mname = "zookeeper.instances." + expected_mode
+        self.assertMetric(mname, value=1, count=1)
 
         self.coverage_report()
 
@@ -134,9 +135,5 @@ class ZooKeeperTestCase(AgentCheckTest):
         self.assertMetric("zookeeper.instances", tags=["mode:down"], count=1)
 
         expected_mode = self.CONNECTION_FAILURE_CONFIG['expected_mode']
-        for t in self.STATUS_TYPES:
-            expected_value = 0
-            if t == expected_mode:
-                expected_value = 1
-            mname = "zookeeper.instances." + t
-            self.assertMetric(mname, value=expected_value, count=1)
+        mname = "zookeeper.instances." + expected_mode
+        self.assertMetric(mname, value=1, count=1)


### PR DESCRIPTION
This is a rebased and slightly modified version of @jpittis #1770 
The addition puts the `zookeeper.instances.*` gauges behind an instance-level configuration flag (defaults to `True`). Users can flag this off if they prefer to rely solely on the `expected_mode` service check to monitor instance status