### PR TITLE
[docker_daemon] add docker storage driver metrics

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -5,7 +5,7 @@ import requests
 import time
 import socket
 import urllib2
-from collections import defaultdict, Counter, deque
+from collections import defaultdict, deque
 
 # project
 from checks import AgentCheck
@@ -264,8 +264,8 @@ class DockerDaemon(AgentCheck):
         must_query_size = self.collect_container_size and self._latest_size_query == 0
         self._latest_size_query = (self._latest_size_query + 1) % SIZE_REFRESH_RATE
 
-        running_containers_count = Counter()
-        all_containers_count = Counter()
+        running_containers_count = defaultdict(int)
+        all_containers_count = defaultdict(int)
 
         try:
             containers = self.client.containers(all=True, size=must_query_size)

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -58,6 +58,14 @@ instances:
     #
     # collect_image_size: false
 
+    # Collect daemon stats with docker.info.data.* and docker.info.metadata.* metrics.
+    # Each of those metrics include the sub metrics of total, free, used, and in_use which work the same as the system.disk versions.
+    # The data is collect with the `docker info` command.
+    # Requires collect_deamon_stats to be enabled.
+    # Defaults to false.
+    #
+    # collect_daemon_stats: false 
+
 
     # Exclude containers based on their tags
     # An excluded container will be completely ignored. The rule is a regex on the tags.

--- a/tests/checks/mock/test_docker_daemon.py
+++ b/tests/checks/mock/test_docker_daemon.py
@@ -1,0 +1,38 @@
+from tests.checks.common import AgentCheckTest
+MOCK_CONFIG = {
+    "init_config": {},
+    "instances": [{
+        "url": "unix://var/run/docker.sock",
+        "collect_daemon_stats": True,
+    },
+    ],
+}
+
+class TestCheckDockerDaemon(AgentCheckTest):
+    CHECK_NAME = 'docker_daemon'
+
+    def mock_get_daemon_info(self):
+        return {
+            'DriverStatus': [
+                ['Data Space Used', '1 GB'],
+                ['Data Space Available', '9 GB'],
+                ['Data Space Total', '10 GB'],
+                ['Metadata Space Used', '1 MB'],
+                ['Metadata Space Available', '9 MB'],
+                ['Metadata Space Total', '10 MB'],
+            ],
+        }
+
+    def test_devicemapper_storage_driver(self):
+        mocks = {
+            '_get_daemon_info': self.mock_get_daemon_info,
+        }
+        self.run_check(MOCK_CONFIG, mocks=mocks)
+        self.assertMetric('docker.info.data.free', value=9e9)
+        self.assertMetric('docker.info.data.used', value=1e9)
+        self.assertMetric('docker.info.data.total', value=10e9)
+        self.assertMetric('docker.info.data.in_use', value=0.1)
+        self.assertMetric('docker.info.metadata.free', value=9e6)
+        self.assertMetric('docker.info.metadata.used', value=1e6)
+        self.assertMetric('docker.info.metadata.total', value=10e6)
+        self.assertMetric('docker.info.metadata.in_use', value=0.1)

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -52,7 +52,6 @@ def set_docker_settings(init_config, instance):
 def get_client():
     return Client(**_docker_client_settings)
 
-
 def find_cgroup(hierarchy, docker_root):
         """Find the mount point for a specified cgroup hierarchy.
 


### PR DESCRIPTION
Added the docker storage driver metrics for the devicemapper storage driver (used by CentOS/RHEL) using the docker info API.

The unit test shows the metrics names which are patterned after the system.disk.* metrics.