### PR TITLE
[mongo] `pymongo==3.2` :heart: MongoDB 3.2

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -313,7 +313,7 @@ class MongoDb(AgentCheck):
             AgentCheck.OK,
             tags=service_check_tags)
 
-        status = db["$cmd"].find_one({"serverStatus": 1, "tcmalloc": collect_tcmalloc_metrics})
+        status = db.command('serverStatus', tcmalloc=collect_tcmalloc_metrics)
         if status['ok'] == 0:
             raise Exception(status['errmsg'].__str__())
 


### PR DESCRIPTION
MongoDB v3.2 instances throw the following exception with `pymongo==3.2`
and `db[$cmd].find_one(...)` command:
```
OperationFailure: Invalid collection name: admin.$cmd
```

Comply with `pymongo==3.2`, use `db.command('serverStatus')` instead.