### PR TITLE
[process] Relocatable procfs for process check

### DIFF
--- a/checks.d/process.py
+++ b/checks.d/process.py
@@ -61,6 +61,11 @@ class ProcessCheck(AgentCheck):
             )
         )
 
+        if Platform.is_linux():
+            procfs_path = init_config.get('procfs_path')
+            if procfs_path:
+                psutil.PROCFS_PATH = procfs_path
+
         # Process cache, indexed by instance
         self.process_cache = defaultdict(dict)
 

--- a/conf.d/process.yaml.example
+++ b/conf.d/process.yaml.example
@@ -3,6 +3,9 @@ init_config:
   # except if it detects a change before. You might want to set it
   # low if you want to alert on process service checks.
   # pid_cache_duration: 120
+  #
+  # used to override the default procfs path, e.g. for docker containers with the outside fs mounted at /host/proc
+  # procfs_path: /proc
 
 instances:
 # The `system.processes.cpu.pct` metric sent by this check is only accurate for processes that live


### PR DESCRIPTION
When running the datadog agent as a container, we need to point
psutils at a different procfs to gather metrics on processes
outside the current namespace.

-- 
Based on #2124