### PR TITLE
Add support for forced SNMP data types to help w/ buggy devices

### DIFF
--- a/conf.d/snmp.yaml.example
+++ b/conf.d/snmp.yaml.example
@@ -28,6 +28,16 @@ instances:
   #     - OID: 1.3.6.1.2.1.6.5
   #       name: tcpPassiveOpens
   #
+  #     # This monitor auto-detects OID data types from the remote agent's response.
+  #     # If you're dealing with a buggy agent that returns incorrect data types for OIDs,
+  #     # You can force the data type with the 'forced_type' parameter.  Valid options for
+  #     # this parameter are 'gauge' and 'counter'.
+  #     # Example: When a F5 Networks load balancer is queried for this OID, it will return
+  #     # it as a Counter64 when it should be a gauge.  So, we force the data type to gauge:
+  #     - OID: 1.3.6.1.4.1.3375.2.1.1.2.1.8.0
+  #       name: F5_TotalCurrentConnections
+  #       forced_type: gauge
+  #
   #     # You can also query a table and specify
   #     #   - which columns to report as value (symbols)
   #     #   - which columns / indexes to use as tags (metric_tags)

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -168,13 +168,13 @@ class AgentCheckTest(unittest.TestCase):
         self.run_check(config, agent_config, mocks)
 
     def run_check_n(self, config, agent_config=None, mocks=None,
-                    force_reload=False, repeat=1):
+                    force_reload=False, repeat=1, sleep=1):
         for i in xrange(repeat):
             if not i:
                 self.run_check(config, agent_config, mocks, force_reload)
             else:
                 self.run_check(config, agent_config, mocks)
-            time.sleep(1)
+            time.sleep(sleep)
 
     def run_check(self, config, agent_config=None, mocks=None, force_reload=False):
         # If not loaded already, do it!
@@ -325,7 +325,7 @@ WARNINGS
             raise
 
     def assertMetric(self, metric_name, value=None, tags=None, count=None,
-                     at_least=1, hostname=None, device_name=None):
+                     at_least=1, hostname=None, device_name=None, metric_type=None):
         candidates = []
         for m_name, ts, val, mdata in self.metrics:
             if m_name == metric_name:
@@ -336,6 +336,8 @@ WARNINGS
                 if hostname is not None and mdata['hostname'] != hostname:
                     continue
                 if device_name is not None and mdata['device_name'] != device_name:
+                    continue
+                if metric_type is not None and mdata['type'] != metric_type:
                     continue
 
                 candidates.append((m_name, ts, val, mdata))


### PR DESCRIPTION
This is just a minor touch-up to #1331 by @chrissnell - adding tests and raising an exception in the event of a bad `forced_type`.

PR summary by @chrissnell:

# Add support for forced SNMP data types to help w/ buggy devices

Some SNMP-enabled devices return incorrect data types when certain OIDs are queried. The F5 1600LTM load balancer is an example of such a device. This PR allows for the forcing of data types (to 'gauge' or 'counter') in the event of an incorrect response from the remote agent.

It adds a parameter to the metric definition on the YAML, 'forced_type'.

NOTE: The changes in this PR were tested in a back-ported version of this improved snmp check that Datadog provided me. The check patched here is from a newer version of the agent that I don't have any easy way to test right now. The changes are the same between the versions and it should work but I have no way to test.