### PR TITLE
[vsphere] Added option to disable strict SSL checks of vCenter server

### DIFF
--- a/checks.d/vsphere.py
+++ b/checks.d/vsphere.py
@@ -6,6 +6,7 @@ from Queue import Empty, Queue
 import re
 import time
 import traceback
+import ssl
 
 # 3p
 from pyVim import connect
@@ -430,6 +431,13 @@ class VSphereCheck(AgentCheck):
         ]
 
         if i_key not in self.server_instances:
+            if (instance.get('strict_ssl') is False):
+                try:
+                    _create_unverified_https_context = ssl._create_unverified_context
+                except AttributeError:
+                    pass
+                else:
+                    ssl._create_default_https_context = _create_unverified_https_context
             try:
                 server_instance = connect.SmartConnect(
                     host=instance.get('host'),

--- a/conf.d/vsphere.yaml.example
+++ b/conf.d/vsphere.yaml.example
@@ -19,6 +19,9 @@ instances:
     username: datadog-readonly@vsphere.local
     password: mypassword
 
+    # Enable or disable strict checking of SSL certificates of vCenter server
+    # strict_ssl: true
+
     # Use a regex like this if you want only the check
     # to fetch metrics for these ESXi hosts and the VMs
     # running on it


### PR DESCRIPTION
We ran into a problem using the vSphere check - if our vCenter server had a self-signed SSL certificate, dd-agent 5.6+ couldn't connect to it as there was no certification chain. This workaround allows for someone to disable the strict SSL check when connecting to a vCenter server if they are in a similar situation.

There's a better way to do this, but it would require updating pyvmomi to 6.0.0 so that SmartConnect will accept a ssl context parameter. The commit below was tested on Python 2.7.11 but should work on earlier versions as well.