### PR TITLE
[vsphere] Add SSL config options for certs

### DIFF
--- a/conf.d/vsphere.yaml.example
+++ b/conf.d/vsphere.yaml.example
@@ -19,6 +19,15 @@ instances:
     username: datadog-readonly@vsphere.local
     password: mypassword
 
+    # Set to false to disable SSL verification, when connecting to vCenter
+    # optional
+    # ssl_verify: true
+
+    # Set to the absolute file path of a directory containing CA certificates
+    # in PEM format
+    # optional
+    # ssl_capath: "/path/to/directory"
+
     # Use a regex like this if you want only the check
     # to fetch metrics for these ESXi hosts and the VMs
     # running on it

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ python-memcached==1.53
 redis==2.10.3
 
 # checks.d/vsphere.py
-pyvmomi==5.5.0.2014.1.1
+pyvmomi==6.0.0
 
 # checks.d/hdfs.py
 snakebite==1.3.11


### PR DESCRIPTION
As it stands, the vsphere check does not allow customization of SSL verification procedures in any way. This PR seeks to allow the ability to disable SSL verification, and to specify your own CA certificates.