### PR TITLE
Add timeout for requests to get go expvar metrics.

### DIFF
--- a/checks.d/go_expvar.py
+++ b/checks.d/go_expvar.py
@@ -59,7 +59,7 @@ class GoExpvar(AgentCheck):
         self._last_gc_count = defaultdict(int)
 
     def _get_data(self, url):
-        r = requests.get(url)
+        r = requests.get(url, timeout=10)
         r.raise_for_status()
         return r.json()
 


### PR DESCRIPTION
# What's this PR do?
Adds a timeout for requests made to fetch go expvar metrics.

# Motivation
Locally we had a misbehaving app that never answered, causing the entire collector to be blocked and not getting metrics!

# Notes
Should this be configurable?

r? @antifuchs @remh 