### PR TITLE
[core][wmi] gracefully timeout WMI queries

### DIFF
--- a/checks.d/wmi_check.py
+++ b/checks.d/wmi_check.py
@@ -151,12 +151,11 @@ class WMICheck(AgentCheck):
             self._format_tag_query(sampler, wmi_obj, tag_query)
 
         # Create a specific sampler
-        connection = sampler.get_connection()
         tag_query_sampler = WMISampler(
             self.log,
             target_class, [target_property],
             filters=filters,
-            **connection
+            **sampler.connection
         )
 
         tag_query_sampler.sample()

--- a/ci/common.rb
+++ b/ci/common.rb
@@ -58,7 +58,7 @@ class Wait
     Timeout.timeout(0.5) do
       begin
         r = HTTParty.get(url)
-        return (200...300).include? r.code
+        return (200...300).cover? r.code
       rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
         return false
       end
@@ -93,11 +93,8 @@ class Wait
       n += 1
       sleep 0.25
     end
-    if status
-      puts 'Found!'
-    else
-      fail "Still not up after #{max_timeout}s"
-    end
+    fail "Still not up after #{max_timeout}s" unless status
+    puts 'Found!'
     status
   end
 end
@@ -180,17 +177,18 @@ namespace :ci do
     task :run_tests, :flavor do |t, attr|
       flavors = attr[:flavor]
       filter = ENV['NOSE_FILTER'] || '1'
-      if flavors.include?('default') || flavors.include?('checks_mock')
-        nose = "(not requires) and #{filter}"
-      else
-        nose = "(requires in ['#{flavors.join("','")}']) and #{filter}"
-      end
-      if flavors.include?('default') || flavors.include?('core_integration')
-        tests_directory = 'tests/core'
-      else
-        tests_directory = 'tests/checks'
-      end
 
+      nose = if flavors.include?('default') || flavors.include?('checks_mock')
+               "(not requires) and #{filter}"
+             else
+               "(requires in ['#{flavors.join("','")}']) and #{filter}"
+             end
+
+      tests_directory = if flavors.include?('default') || flavors.include?('core_integration')
+                          'tests/core'
+                        else
+                          'tests/checks'
+                        end
       # Rake on Windows doesn't support setting the var at the beginning of the
       # command
       path = ''

--- a/ci/etcd.rb
+++ b/ci/etcd.rb
@@ -17,7 +17,7 @@ namespace :ci do
         # Downloads:
         # https://github.com/coreos/etcd/releases/download/v#{etcd_version}/etcd-v#{etcd_version}-darwin-amd64.zip
         # https://github.com/coreos/etcd/releases/download/v#{etcd_version}/etcd-v#{etcd_version}-linux-amd64.tar.gz
-        if `uname -s`.strip.downcase == 'darwin'
+        if 'darwin'.casecmp(`uname -s`.strip)
           sh %(curl -s -L -o $VOLATILE_DIR/etcd.zip\
                 https://s3.amazonaws.com/dd-agent-tarball-mirror/etcd-v#{etcd_version}-darwin-amd64.zip)
           sh %(mkdir -p #{etcd_rootdir})

--- a/ci/haproxy.rb
+++ b/ci/haproxy.rb
@@ -24,11 +24,11 @@ namespace :ci do
         sh %(tar zxf $VOLATILE_DIR/haproxy-#{haproxy_version}.tar.gz\
              -C $VOLATILE_DIR/haproxy --strip-components=1)
 
-        if `uname`.strip == 'Darwin'
-          target = 'mac'
-        else
-          target = 'linux2628'
-        end
+        target = if `uname`.strip == 'Darwin'
+                   'mac'
+                 else
+                   'linux2628'
+                 end
         sh %(cd $VOLATILE_DIR/haproxy\
              && make -j $CONCURRENCY TARGET=#{target} USE_PCRE=1 USE_OPENSSL=1 USE_ZLIB=1)
         sh %(cp $VOLATILE_DIR/haproxy/haproxy #{haproxy_rootdir})

--- a/ci/mongo.rb
+++ b/ci/mongo.rb
@@ -16,11 +16,11 @@ namespace :ci do
       unless Dir.exist? File.expand_path(mongo_rootdir)
         # Downloads
         # https://fastdl.mongodb.org/linux/mongodb-#{target}-x86_64-#{mongo_version}.tgz
-        if `uname`.strip == 'Darwin'
-          target = 'osx'
-        else
-          target = 'linux'
-        end
+        target = if `uname`.strip == 'Darwin'
+                   'osx'
+                 else
+                   'linux'
+                 end
         sh %(curl -s -L\
              -o $VOLATILE_DIR/mongodb-#{target}-x86_64-#{mongo_version}.tgz\
              https://s3.amazonaws.com/dd-agent-tarball-mirror/mongodb-#{target}-x86_64-#{mongo_version}.tgz)

--- a/ci/resources/cache.rb
+++ b/ci/resources/cache.rb
@@ -31,15 +31,15 @@ require './ci/resources/cache/aws4_signature'
 class Cache
   MSGS = {
     config_missing: 'Worker S3 config missing: %s'
-  }
+  }.freeze
 
   VALIDATE = {
     bucket:            'bucket name',
     access_key_id:     'access key id',
     secret_access_key: 'secret access key'
-  }
+  }.freeze
 
-  CURL_FORMAT = <<-EOF
+  CURL_FORMAT = "<<-EOF
      time_namelookup:  %{time_namelookup} s
         time_connect:  %{time_connect} s
      time_appconnect:  %{time_appconnect} s
@@ -50,7 +50,7 @@ class Cache
        url_effective:  %{url_effective}
                      ----------
           time_total:  %{time_total} s
-  EOF
+  EOF".freeze
 
   KeyPair = Struct.new(:id, :secret)
 
@@ -60,9 +60,9 @@ class Cache
     end
   end
 
-  CASHER_URL = 'https://raw.githubusercontent.com/DataDog/casher/%s/bin/casher'
-  USE_RUBY   = '1.9.3'
-  BIN_PATH   = '$DD_CASHER_DIR/bin/casher'
+  CASHER_URL = 'https://raw.githubusercontent.com/DataDog/casher/%s/bin/casher'.freeze
+  USE_RUBY   = '1.9.3'.freeze
+  BIN_PATH   = '$DD_CASHER_DIR/bin/casher'.freeze
 
   attr_reader :data, :slug, :start, :msgs
   attr_accessor :directories

--- a/tests/checks/mock/test_wmi_check.py
+++ b/tests/checks/mock/test_wmi_check.py
@@ -103,8 +103,8 @@ class WMITestCase(AgentCheckTest, TestCommonWMI):
         wmi_sampler = self.check.wmi_samplers["myhost:some/namespace:Win32_OperatingSystem"]
 
         # Connection was established with the right parameters
-        self.assertWMIConnWith(wmi_sampler, "myhost")
-        self.assertWMIConnWith(wmi_sampler, "some/namespace")
+        self.assertWMIConn(wmi_sampler, "myhost")
+        self.assertWMIConn(wmi_sampler, "some/namespace")
 
     def test_wmi_sampler_initialization(self):
         """

--- a/tests/core/test_timeout.py
+++ b/tests/core/test_timeout.py
@@ -1,0 +1,126 @@
+# stdlib
+import unittest
+import time
+
+# datadog
+from utils.timeout import _thread_by_func, timeout, TimeoutException
+
+count = 0
+
+
+class SomeException(Exception):
+    """A generic exception"""
+
+
+@timeout(0.2)
+def make_sum(a, b, sleep=0, raise_exception=False):
+    """Sleep, sum and return `a` with `b`"""
+    global count
+    count += 1
+    time.sleep(sleep)
+    if raise_exception:
+        raise SomeException()
+    return a + b
+
+
+class MyClass(object):
+    """
+    A simple class example.
+    """
+    def __init__(self):
+        """
+        Decorate `make_sum`.
+        """
+        self.make_sum = timeout(0.2)(self.make_sum)
+
+    def make_sum(self, a, b, sleep=0, raise_exception=False):
+        """Sleep, sum and return `a` with `b`"""
+        global count
+        count += 1
+        time.sleep(sleep)
+
+
+class TestTimeout(unittest.TestCase):
+    """
+    Test timeout decorator logic.
+    """
+
+    def setUp(self):
+        global count
+        count = 0
+
+    def tearDown(self):
+        """
+        Wait for all threads to end to avoid contamination between each tests.
+        """
+        for key, worker in _thread_by_func.iteritems():
+            while worker.is_alive():
+                time.sleep(0.2)
+        for key in _thread_by_func.keys():
+            del _thread_by_func[key]
+
+    def test_preserve(self):
+        """
+        Preserve function name and docstring.
+        """
+        self.assertEquals(make_sum.__name__, "make_sum")
+        self.assertEquals(make_sum.__doc__, "Sleep, sum and return `a` with `b`")
+
+    def test_no_timeout(self):
+        """
+        Return the result when the method runtime does not exceed the limit set.
+        """
+        self.assertEquals(make_sum(1, 2), 3)
+
+    def test_exception_propagation(self):
+        """
+        Propagate exceptions.
+        """
+        self.assertRaises(SomeException, make_sum, 1, 2, raise_exception=True)
+
+    def test_raise_on_timeout(self):
+        """
+        Raise `TimeoutException` on timeouts.
+        """
+        self.assertRaises(TimeoutException, make_sum, 1, 2, sleep=0.5)
+
+    def test_refetch_thread(self):
+        """
+        Refetch an existing thread when it exists.
+        """
+        #  This should create a thread
+        self.assertRaises(TimeoutException, make_sum, 1, 2, sleep=0.5)
+        self.assertEquals(count, 1)
+
+        time.sleep(0.5)
+
+        # This should refetch the existing thread
+        self.assertEquals(make_sum(1, 2, sleep=0.5), 3)
+        self.assertEquals(count, 1)
+
+        # This should create a new thread
+        self.assertRaises(TimeoutException, make_sum, 1, 2, sleep=0.5)
+        self.assertEquals(count, 2)
+
+    def test_multiple_threads(self):
+        """
+        Create one thread per function call.
+        """
+        # Create one thread
+        self.assertRaises(TimeoutException, make_sum, 1, 2, sleep=0.5)
+
+        #  ... and a second one
+        self.assertRaises(TimeoutException, make_sum, 2, 3, sleep=0.5)
+
+        self.assertEquals(count, 2)
+
+    def test_multiple_instances(self):
+        """
+        Same method within different instances = different threads
+        """
+        # Create one thread
+        self.assertRaises(TimeoutException, MyClass().make_sum, 1, 2, sleep=0.5)
+
+        # Different instance = new thread
+        self.assertRaises(TimeoutException, MyClass().make_sum, 1, 2, sleep=0.5)
+        self.assertEquals(count, 2)

--- a/tests/core/test_wmi.py
+++ b/tests/core/test_wmi.py
@@ -1,4 +1,5 @@
 # stdlib
+from collections import defaultdict
 from functools import partial
 import logging
 import time
@@ -223,34 +224,41 @@ class TestCommonWMI(unittest.TestCase):
         # Flush cache
         from checks.libs.wmi.sampler import WMISampler
         WMISampler._wmi_locators = {}
-        WMISampler._wmi_connections = {}
+        WMISampler._wmi_connections = defaultdict(set)
 
-    def assertWMIConnWith(self, wmi_sampler, param):
+    def assertWMIConn(self, wmi_sampler, param=None, count=None):
         """
-        Helper, assert that the WMI connection was established with the right parameter and value.
+        Helper, assertion on the `wmi_sampler`'s WMI connection(s):
+        * `count`: number of active connections
+        * `param`: parameters used to establish the connection
         """
-        wmi_instance = wmi_sampler._get_connection()
-        wmi_conn_args, wmi_conn_kwargs = wmi_instance.get_conn_args()
-        if isinstance(param, tuple):
-            key, value = param
-            self.assertIn(key, wmi_conn_kwargs)
-            self.assertEquals(wmi_conn_kwargs[key], value)
-        else:
-            self.assertIn(param, wmi_conn_args)
+        connections = wmi_sampler._wmi_connections[wmi_sampler.connection_key]
+
+        if count:
+            self.assertEquals(len(connections), count)
+
+        if param:
+            with wmi_sampler.get_connection() as connection:
+                wmi_conn_args, wmi_conn_kwargs = connection.get_conn_args()
+                if isinstance(param, tuple):
+                    key, value = param
+                    self.assertIn(key, wmi_conn_kwargs)
+                    self.assertEquals(wmi_conn_kwargs[key], value)
+                else:
+                    self.assertIn(param, wmi_conn_args)
 
     def assertWMIQuery(self, wmi_sampler, query=None, flags=None):
         """
         Helper, assert that the given WMI query and flags were submitted.
         """
-        wmi_instance = wmi_sampler._get_connection()
+        with wmi_sampler.get_connection() as connection:
+            if query:
+                last_wmi_query = connection.get_last_wmi_query()
+                self.assertEquals(last_wmi_query, query)
 
-        if query:
-            last_wmi_query = wmi_instance.get_last_wmi_query()
-            self.assertEquals(last_wmi_query, query)
-
-        if flags:
-            last_wmi_flags = wmi_instance.get_last_wmi_flags()
-            self.assertEquals(last_wmi_flags, flags)
+            if flags:
+                last_wmi_flags = connection.get_last_wmi_flags()
+                self.assertEquals(last_wmi_flags, flags)
 
     def assertWMIObject(self, wmi_obj, property_names):
         """
@@ -284,14 +292,46 @@ class TestUnitWMISampler(TestCommonWMI):
             username="datadog",
             password="password"
         )
-        wmi_sampler._get_connection()
+
+        # Request a connection but do nothing
+        with wmi_sampler.get_connection():
+            pass
 
         # WMI connection is cached
         self.assertIn('myhost:some/namespace:datadog', wmi_sampler._wmi_connections)
 
         # Connection was established with the right parameters
-        self.assertWMIConnWith(wmi_sampler, "myhost")
-        self.assertWMIConnWith(wmi_sampler, "some/namespace")
+        self.assertWMIConn(wmi_sampler, param="myhost")
+        self.assertWMIConn(wmi_sampler, param="some/namespace")
+
+    def test_one_wmi_connection_at_a_time(self):
+        """
+        Only use one WMI connection at a time.
+        """
+        wmi_sampler = WMISampler(
+            "Win32_PerfRawData_PerfOS_System",
+            ["ProcessorQueueLength"],
+            host="myhost",
+            namespace="some/namespace",
+            username="datadog",
+            password="password"
+        )
+
+        # Create a new connection and release it
+        with wmi_sampler.get_connection():
+            pass
+
+        self.assertWMIConn(wmi_sampler, count=1)
+
+        # Refetch the existing connection
+        with wmi_sampler.get_connection():
+            #  No connection is available, create a new one
+            self.assertWMIConn(wmi_sampler, count=0)
+            with wmi_sampler.get_connection():
+                pass
+
+        # Two connections are now available
+        self.assertWMIConn(wmi_sampler, count=2)
 
     def test_wmi_connection_pooling(self):
         """

--- a/utils/timeout.py
+++ b/utils/timeout.py
@@ -1,0 +1,70 @@
+from threading import Thread
+import functools
+
+_thread_by_func = {}
+
+
+class TimeoutException(Exception):
+    """
+    Raised when a function runtime exceeds the limit set.
+    """
+    pass
+
+
+class ThreadMethod(Thread):
+    """
+    Descendant of `Thread` class.
+
+    Run the specified target method with the specified arguments.
+    Store result and exceptions.
+
+    From: https://code.activestate.com/recipes/440569/
+    """
+    def __init__(self, target, args, kwargs):
+        Thread.__init__(self)
+        self.setDaemon(True)
+        self.target, self.args, self.kwargs = target, args, kwargs
+        self.start()
+
+    def run(self):
+        try:
+            self.result = self.target(*self.args, **self.kwargs)
+        except Exception, e:
+            self.exception = e
+        else:
+            self.exception = None
+
+
+def timeout(timeout):
+    """
+    A decorator to timeout a function. Decorated method calls are executed in a separate new thread
+    with a specified timeout.
+    Also check if a thread for the same function already exists before creating a new one.
+
+    Note: Compatible with Windows (thread based).
+    """
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            key = "{0}:{1}:{2}:{3}".format(id(func), func.__name__, args, kwargs)
+
+            if key in _thread_by_func:
+                # A thread for the same function already exists.
+                worker = _thread_by_func[key]
+            else:
+                worker = ThreadMethod(func, args, kwargs)
+                _thread_by_func[key] = worker
+
+            worker.join(timeout)
+            if worker.is_alive():
+                raise TimeoutException()
+
+            del _thread_by_func[key]
+
+            if worker.exception:
+                raise worker.exception
+            else:
+                return worker.result
+
+        return wrapper
+    return decorator


### PR DESCRIPTION
##### [utils] decorator to timeout a function
A decorator to timeout a function. Decorated method calls are executed in a separate new thread with a specified timeout.
Also check if a thread for the same function already exists before creating a new one.

##### [core][wmi] gracefully timeout WMI queries 
Timeout WMI queries after 10seconds with a warning message and no data.
Recover at next iteration retrieving the existing query.

##### [core][wmi] one active query / connection
Less thread safety error-prone `WMISampler`: have one active query per connection at a time.
* `_get_connection` → `get_connection`, a context manager that
  * returns an existing and available WMI connection, or create one if
    needed
  * release it, i.e. mark it as available when done