### PR TITLE
[fluentd] Allow the option to add custom tags

### DIFF
--- a/conf.d/fluentd.yaml.example
+++ b/conf.d/fluentd.yaml.example
@@ -10,4 +10,7 @@ instances:
     # Optional, set 'tag_by' to specify how to tag metrics. By default, metrics are tagged with `plugin_id`
     -  monitor_agent_url: http://example.com:24220/api/plugins.json
        tag_by: type
-
+    # Optional, a list of custom tags which will applied to checks and metrics
+       tags:
+         - tag1
+         - tag2

--- a/tests/checks/integration/test_fluentd.py
+++ b/tests/checks/integration/test_fluentd.py
@@ -79,3 +79,23 @@ class TestFluentd(AgentCheckTest):
         self.assertServiceCheckOK(
             self.check.SERVICE_CHECK_NAME, tags=['fluentd_host:localhost', 'fluentd_port:24220'])
         self.coverage_report()
+
+    def test_fluentd_with_custom_tags(self):
+        config = {
+            "init_config": {
+            },
+            "instances": [
+                {
+                    "monitor_agent_url": "http://localhost:24220/api/plugins.json",
+                    "tag_by": "plugin_id",
+                    "tags": ["tag1", "tag2"]
+                }
+            ]
+        }
+        self.run_check(config)
+        for m in self.CHECK_GAUGES:
+            self.assertMetric('{0}.{1}'.format(self.CHECK_NAME, m), tags=['tag1', 'tag2', 'plugin_id:plg1'])
+            self.assertMetric('{0}.{1}'.format(self.CHECK_NAME, m), tags=['tag1', 'tag2', 'plugin_id:plg2'])
+        self.assertServiceCheckOK(
+            self.check.SERVICE_CHECK_NAME, tags=['tag1', 'tag2', 'fluentd_host:localhost', 'fluentd_port:24220'])
+        self.coverage_report()


### PR DESCRIPTION
This allows us to include an option in `fluentd.yaml` to add custom tags which appears in service checks and metrics:
```
- monitor_agent_url: http://example.com:24220/api/plugins.json
  tags:
    - tag1
    - tag2
```