### PR TITLE
[source] Revamp our source install script (part 2)

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -8,7 +8,7 @@ set -u
 # SCRIPT KNOBS
 #######################################################################
 # Update for new releases, will pull this tag in the repo
-AGENT_VERSION="5.6.3"
+DEFAULT_AGENT_VERSION="5.6.3"
 # Pin pip version, in the past there was some buggy releases and get-pip.py
 # always pulls the latest version
 PIP_VERSION="6.0.8"
@@ -17,7 +17,9 @@ SUPERVISOR_VERSION="3.0b2"
 
 #######################################################################
 # OVERRIDABLE VARIABLES:
-#
+# $AGENT_VERSION
+#   The tag or branch from which the source install performs.
+#   Defaults to $DEFAULT_AGENT_VERSION
 # $DD_API_KEY
 #   Sets your API key in the config when installing.
 #   If not specified, the script will not install a default config.
@@ -39,6 +41,8 @@ SUPERVISOR_VERSION="3.0b2"
 #   your cartridge if you're using it.
 #######################################################################
 set +u # accept temporarily unbound vars, because we set defaults
+AGENT_VERSION=${AGENT_VERSION:-$DEFAULT_AGENT_VERSION}
+
 # If DD_HOME is unset
 if [ -z "$DD_HOME" ]; then
     # Compatibilty: dd_home used in lieu of DD_HOME

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -434,7 +434,7 @@ if [ "$DD_START_AGENT" = "0" ]; then
 fi
 
 # on solaris, skip the test, svcadm the Agent
-if [ "$(uname)" = "SunOs" ]; then
+if [ "$(uname)" = "SunOS" ]; then
     # Install pyexpat for our version of python, a dependency for xml parsing (varnish et al.)
     # Tested with /bin/sh
     $PYTHON_CMD -V 2>&1 | awk '{split($2, arr, "."); printf("py%d%d-expat", arr[1], arr[2]);}' | xargs pkgin -y in

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -512,14 +512,4 @@ up again in the foreground, run:
     $DD_HOME/bin/agent
 "
 
-if [ "$(uname)" = "Darwin" ]; then
-    print_console "To set it up as a daemon that always runs in the background
-while you're logged in, run:
-
-    mkdir -p ~/Library/LaunchAgents
-    cp $DD_HOME/launchd/com.datadoghq.Agent.plist ~/Library/LaunchAgents/
-    launchctl load -w ~/Library/LaunchAgents/com.datadoghq.Agent.plist
-"
-fi
-
 wait $AGENT_PID

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -11,9 +11,9 @@ set -u
 DEFAULT_AGENT_VERSION="5.6.3"
 # Pin pip version, in the past there was some buggy releases and get-pip.py
 # always pulls the latest version
-PIP_VERSION="6.0.8"
+PIP_VERSION="6.1.1"
 VIRTUALENV_VERSION="1.11.6"
-SUPERVISOR_VERSION="3.0b2"
+SUPERVISOR_VERSION="3.1.3"
 
 #######################################################################
 # OVERRIDABLE VARIABLES:

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -135,19 +135,19 @@ BASE_GITHUB_URL="https://raw.githubusercontent.com/DataDog/dd-agent/$AGENT_VERSI
 # Error reporting helpers
 #######################################################################
 print_console() {
-    printf "%s\n" "$*" | tee /dev/fd/3
+    printf "%s\n" "$*" | tee -a "$LOGFILE" >&3
 }
 
 print_console_wo_nl() {
-    printf "%s" "$*" | tee /dev/fd/3
+    printf "%s" "$*" | tee -a "$LOGFILE" >&3
 }
 
 print_red() {
-    printf "\033[31m%s\033[0m\n" "$*" | tee /dev/fd/3
+    printf "\033[31m%s\033[0m\n" "$*" | tee -a "$LOGFILE" >&3
 }
 
 print_green() {
-    printf "\033[32m%s\033[0m\n" "$*" | tee /dev/fd/3
+    printf "\033[32m%s\033[0m\n" "$*" | tee -a "$LOGFILE" >&3
 }
 
 print_done() {
@@ -218,7 +218,7 @@ error_trap() {
     if [ -n "$ERROR_MESSAGE" ]; then
         print_red "$ERROR_MESSAGE"
     else
-        tail -n 5 "$LOGFILE" | tee /dev/fd/3
+        tail -n 5 "$LOGFILE" | tee -a "$LOGFILE" >&3
     fi
     print_console "###"
 

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -248,7 +248,8 @@ print_console "Checking that logfile is writable"
 print_green "OK"
 
 # Catch errors and handle them
-trap error_trap INT TERM EXIT
+trap error_trap INT TERM
+trap '[ "$?" -eq 0 ] || error_trap' EXIT
 
 if [ "$DD_DOG" != "0" ]; then
     echo "$DOG" 1>&3
@@ -446,7 +447,6 @@ if [ "$(uname)" = "SunOS" ]; then
         print_console "*** The Agent is running. My work here is done... (^_^) ***"
         exit 0
     else
-        # KTHXBYE
         exit $?
     fi
 fi

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -367,23 +367,6 @@ $VENV_PIP_CMD install -r "$DD_HOME/requirements.txt"
 rm -f "$DD_HOME/requirements.txt"
 print_done
 
-print_console "* Trying to install optional requirements"
-$DOWNLOADER "$DD_HOME/requirements-opt.txt" "$BASE_GITHUB_URL/requirements-opt.txt"
-OPTIONAL_FAILED="0"
-while read DEPENDENCY; do
-    if $VENV_PIP_CMD install "$DEPENDENCY"; then
-        print_console "   - $DEPENDENCY installed"
-    else
-        print_console "   - Couldn't install $DEPENDENCY"
-        OPTIONAL_FAILED="1"
-    fi
-done < "$DD_HOME/requirements-opt.txt"
-if [ "$OPTIONAL_FAILED" = "1" ]; then
-    print_console "Some optional requirements couldn't be installed (but you may not need them).
-Usually this can be fixed easily by installing the python-dev package and/or compiling tools"
-fi
-print_done
-
 print_console "* Downloading agent version $AGENT_VERSION from GitHub (~5 MB)"
 mkdir -p "$DD_HOME/agent"
 $DOWNLOADER "$DD_HOME/agent.tar.gz" "https://github.com/DataDog/dd-agent/tarball/$AGENT_VERSION"
@@ -392,6 +375,11 @@ print_done
 print_console "* Uncompressing tarball"
 tar -xz -C "$DD_HOME/agent" --strip-components 1 -f "$DD_HOME/agent.tar.gz"
 rm -f "$DD_HOME/agent.tar.gz"
+print_done
+
+print_console "* Trying to install optional requirements"
+$DOWNLOADER "$DD_HOME/requirements-opt.txt" "$BASE_GITHUB_URL/requirements-opt.txt"
+"$DD_HOME/agent/utils/pip-allow-failures.sh" "$DD_HOME/requirements-opt.txt"
 print_done
 
 print_console "* Setting up a datadog.conf generic configuration file"

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -8,7 +8,7 @@ set -u
 # SCRIPT KNOBS
 #######################################################################
 # Update for new releases, will pull this tag in the repo
-DEFAULT_AGENT_VERSION="5.6.3"
+DEFAULT_AGENT_VERSION="5.7.0"
 # Pin pip version, in the past there was some buggy releases and get-pip.py
 # always pulls the latest version
 PIP_VERSION="6.1.1"

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -507,9 +507,9 @@ fi
 # Yay IT WORKED!
 print_green "Success! Your Agent is functioning properly, and will continue to run
 in the foreground. To stop it, simply press CTRL-C. To start it back
-up again in the foreground, run:
+up again in the foreground, run the following command from the $DD_HOME directory:
 
-    $DD_HOME/bin/agent
+    bin/agent
 "
 
 wait $AGENT_PID


### PR DESCRIPTION
Applies the changes of #1504 to the `setup_agent.sh` file, and sets the default agent version to `5.7.0`.

Should be merged right after 5.7.0 is released (i.e. once the the repo has the `5.7.0` tag)

Supersedes #1504 when combined with #2198.