### PR TITLE
Add "more unix" plugin with some linux metrics.

### DIFF
--- a/checks.d/linux_proc_extras.py
+++ b/checks.d/linux_proc_extras.py
@@ -1,0 +1,70 @@
+# project
+from checks import AgentCheck
+from utils.subprocess_output import get_subprocess_output
+from collections import defaultdict
+
+PROCESS_STATES = {
+    'D': 'uninterruptible',
+    'R': 'runnable',
+    'S': 'sleeping',
+    'T': 'stopped',
+    'W': 'paging',
+    'X': 'dead',
+    'Z': 'zombie',
+}
+
+PROCESS_PRIOS = {
+    '<': 'high',
+    'N': 'low',
+    'L': 'locked'
+}
+
+class MoreUnixCheck(AgentCheck):
+    def check(self, instance):
+        tags = instance.get('tags', [])
+
+        state_counts = defaultdict(int)
+
+        prio_counts = defaultdict(int)
+
+        with open('/proc/sys/fs/inode-nr', 'r') as inode_info:
+            inode_stats = inode_info.readline().split()
+            self.gauge('system.inodes.total', float(inode_stats[0]), tags=tags)
+            self.gauge('system.inodes.used', float(inode_stats[1]), tags=tags)
+
+        with open('/proc/stat', 'r') as stat_info:
+            lines = [line.strip() for line in stat_info.readlines()]
+
+            for line in lines:
+                if line.startswith('ctxt'):
+                    ctxt_count = float(line.split(' ')[1])
+                    self.monotonic_count('system.linux.context_switches', ctxt_count, tags=tags)
+                elif line.startswith('processes'):
+                    process_count = int(line.split(' ')[1])
+                    self.monotonic_count('system.linux.processes_created', process_count, tags=tags)
+                elif line.startswith('intr'):
+                    interrupts = int(line.split(' ')[1])
+                    self.monotonic_count('system.linux.interrupts', interrupts, tags=tags)
+
+        with open('/proc/sys/kernel/random/entropy_avail') as entropy_info:
+            entropy = entropy_info.readline()
+            self.gauge('system.entropy.available', float(entropy), tags=tags)
+
+        ps = get_subprocess_output(['ps', '--no-header', '-eo', 'stat'], self.log)
+        for state in ps[0]:
+            # Each process state is a flag in a list of characters. See ps(1) for details.
+            for flag in list(state):
+                if state in PROCESS_STATES:
+                    state_counts[PROCESS_STATES[state]] += 1
+                elif state in PROCESS_PRIOS:
+                    prio_counts[PROCESS_PRIOS[state]] += 1
+
+        for state in state_counts:
+            state_tags = list(tags)
+            state_tags.append("state:" + state)
+            self.gauge('system.processes.states', float(state_counts[state]), state_tags)
+
+        for prio in prio_counts:
+            prio_tags = list(tags)
+            prio_tags.append("priority:" + prio)
+            self.gauge('system.processes.priorities', float(prio_counts[prio]), prio_tags)

--- a/conf.d/linux_proc_extras.yaml.example
+++ b/conf.d/linux_proc_extras.yaml.example
@@ -1,0 +1,5 @@
+# There's no configuration necessary for this check.
+init_config:
+
+instances:
+  - tags: []

--- a/tests/checks/integration/test_linux_proc_extras.py
+++ b/tests/checks/integration/test_linux_proc_extras.py
@@ -1,0 +1,40 @@
+# 3p
+from nose.plugins.attrib import attr
+
+# project
+from tests.checks.common import AgentCheckTest
+
+@attr('linux')
+@attr(requires='linux')
+class TestCheckLinuxProcExtras(AgentCheckTest):
+    CHECK_NAME = 'linux_proc_extras'
+
+    INODE_GAUGES = [
+        'system.inodes.total',
+        'system.inodes.used'
+    ]
+
+    PROC_COUNTS = [
+        'system.linux.context_switches',
+        'system.linux.processes_created',
+        'system.linux.interrupts'
+    ]
+
+    ENTROPY_GAUGES = [
+        'system.entropy.available'
+    ]
+
+    PROCESS_STATS_GAUGES = [
+        'system.processes.states',
+        'system.processes.priorities'
+    ]
+
+    # Really a basic check to see if all metrics are there
+    def test_check(self):
+        self.run_check({'instances': []})
+
+        # Assert metrics
+        for metric in self.PROC_COUNTS + self.INODE_GAUGES + self.ENTROPY_GAUGES + self.PROCESS_STATS_GAUGES:
+            self.assertMetric(metric, tags=[])
+
+        self.coverage_report()


### PR DESCRIPTION
I somehow broke #2030 . Oops.

# What's this PR do?

Adds some new system metrics:
* context switch count (for rates!)
* processes created count (for rates!)
* interrupts
* counts of processes by state, with tags
* counts of processes by priority, with tags

# Motivation

These metrics are used in our existing setup and, from what I can tell, are not available today in Datadog agent. We can get them from specific processes via `process.yaml`, but not for the whole system!

# Notes

I originally tried to add this stuff to `unix.py` but I'm unable to determine how those metrics end up as things like `sys.mem.free` and the like. So I settled on making a check that added the metrics I as after. I expect to add more.

Most of these metrics feel very "core" to Linux and therefore seem suitable to be included in something like `unix.py`. But for now I'll opt to take a conservative approach and assume this will just be a plugin. If you are not interested in having it in the agent, we'll just use it locally.

Lemme know and thanks for looking!