### PR TITLE
[go-metro] Adding supervisor entry and sample yaml config.

### DIFF
--- a/conf.d/go-metro.yaml.example
+++ b/conf.d/go-metro.yaml.example
@@ -1,0 +1,40 @@
+# NOTE: for go metro to run unprivileged, you will have to set CAP_NET_RAW capabilities on the binary:
+#        (debian based) $ sudo apt-get update libcap
+#        (redhat based) $ sudo yum install libcap
+#        (redhat based - alternatively) $ sudo yum install compat-libcap1
+#        $ sudo setcap cap_net_raw+ep /opt/datadog-agent/bin/go-metro
+#
+#        Also, please note that go-metro logs to its own file - found in /var/log/datadog/go-metro.log.
+#        Additionally, go-mtro runs standalone so it will *NOT* currently appear on the agent's info page.
+
+init_config:
+    snaplen: 512            # should be >=104 (to accomodate for the largest possible TCP header)
+    idle_ttl: 300           # time after which an idle flow (no traffic received) is flushed.
+    exp_ttl: 60             # time after which a finished flow is flushed.
+    statsd_ip: 127.0.0.1
+    statsd_port: 8125
+    log_to_file: true
+    log_level: info         # available levels: trace, debug, info, warning, error, critical
+
+instances:
+- interface: eth0           # metrics will be also tagged by interface.
+  tags:
+    - foo:bar
+  ips:                        # Whitelist by IP - will perform name lookup and tag with hostname if available.
+    - 192.168.0.1             # <--- SAMPLE IP SET YOUR OWN LIST.
+  hosts:                      # Whitelist by hostname - will perform ip lookup and filter by hosts ip's
+    - somehost.somedomain.to  # <---SAMPLE HOST, SET YOUR OWN LIST.
+
+                              # NOTE: Whitelisting with ips and hosts is *highly* recommended to avoid having
+                              #      go-metro inspect every incoming/outgoing packet through the interface.
+                              #      Under high network load circumstances, the performance impact would not be
+                              #      negligible and could consume valuable CPU/memory resources. Please ensure
+                              #      you define your interesting ips/hosts in the whitelists above.
+
+# - interface: eth2           # multiple interfaces may be sniffed from.
+#   tags:
+#     - bla:zap
+#   hosts:                   # will perform ip lookup and filter by hosts ip's
+#     - datadog.com
+
+

--- a/config.py
+++ b/config.py
@@ -919,6 +919,7 @@ def get_logging_config(cfg_path=None):
         logging_config['forwarder_log_file'] = '/var/log/datadog/forwarder.log'
         logging_config['dogstatsd_log_file'] = '/var/log/datadog/dogstatsd.log'
         logging_config['jmxfetch_log_file'] = '/var/log/datadog/jmxfetch.log'
+        logging_config['go-metro_log_file'] = '/var/log/datadog/go-metro.log'
         logging_config['log_to_syslog'] = True
 
     config_path = get_config_path(cfg_path, os_name=system_os)

--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -50,11 +50,11 @@ check_status() {
 
         s=`$SUPERVISORCTL_PATH -c $SUPERVISOR_CONF status`
 
-        # number of RUNNING supervisord programs (ignoring dogstatsd and jmxfetch)
-	p=`echo "$s" | grep -Ev 'dogstatsd|jmxfetch' | grep -c RUNNING`
+        # number of RUNNING supervisord programs (ignoring dogstatsd, jmxfetch and go-metro)
+	p=`echo "$s" | grep -Ev 'dogstatsd|jmxfetch|go-metro' | grep -c RUNNING`
 
         # number of expected running supervisord programs (ignoring dogstatsd and jmxfetch)
-	c=`grep -Ev 'dogstatsd|jmxfetch' $SUPERVISOR_CONF | grep -c '\[program:'`
+	c=`grep -Ev 'dogstatsd|jmxfetch|go-metro' $SUPERVISOR_CONF | grep -c '\[program:'`
         if [ "$p" -ne "$c" ]; then
             echo "$s"
             echo -n "Datadog Agent (supervisor) is NOT running all child processes"; failure; echo

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -44,14 +44,14 @@ check_status() {
 
         supervisor_processes=$($SUPERVISORCTL_PATH -c $SUPERVISOR_FILE status)
 
-        # Number of RUNNING supervisord programs (ignoring dogstatsd and jmxfetch)
+        # Number of RUNNING supervisord programs (ignoring dogstatsd, jmxfetch and go-metro)
         datadog_supervisor_processes=$(echo "$supervisor_processes" |
-                                       grep -Ev 'dogstatsd|jmxfetch' |
+                                       grep -Ev 'dogstatsd|jmxfetch|go-metro' |
                                        grep $NAME |
                                        grep -c RUNNING)
 
-        # Number of expected running supervisord programs (ignoring dogstatsd and jmxfetch)
-        supervisor_config_programs=$(grep -Ev 'dogstatsd|jmxfetch' $SUPERVISOR_FILE |
+        # Number of expected running supervisord programs (ignoring dogstatsd, jmxfetch and go-metro)
+        supervisor_config_programs=$(grep -Ev 'dogstatsd|jmxfetch|go-metro' $SUPERVISOR_FILE |
                                      grep -c '\[program:')
 
         if [ "$datadog_supervisor_processes" -ne "$supervisor_config_programs" ]; then

--- a/packaging/supervisor.conf
+++ b/packaging/supervisor.conf
@@ -57,5 +57,14 @@ priority=999
 startsecs=3
 user=dd-agent
 
+[program:go-metro]
+command=/opt/datadog-agent/bin/go-metro -cfg="/etc/dd-agent/conf.d/go-metro.yaml"
+stdout_logfile=NONE
+stderr_logfile=NONE
+redirect_stderr=true
+priority=999
+startsecs=2
+user=dd-agent
+
 [group:datadog-agent]
-programs=forwarder,collector,dogstatsd,jmxfetch
+programs=forwarder,collector,dogstatsd,jmxfetch,go-metro

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -208,6 +208,7 @@ class Flare(object):
         self._forwarder_log = config.get('{0}forwarder_log_file'.format(prefix))
         self._dogstatsd_log = config.get('{0}dogstatsd_log_file'.format(prefix))
         self._jmxfetch_log = config.get('jmxfetch_log_file')
+        self._gometro_log = config.get('go-metro_log_file')
 
     # Add logs to the tarfile
     def _add_logs_tar(self):
@@ -215,6 +216,7 @@ class Flare(object):
         self._add_log_file_tar(self._forwarder_log)
         self._add_log_file_tar(self._dogstatsd_log)
         self._add_log_file_tar(self._jmxfetch_log)
+        self._add_log_file_tar(self._gometro_log)
         self._add_log_file_tar(
             "{0}/*supervisord.log".format(os.path.dirname(self._collector_log))
         )


### PR DESCRIPTION
Alternatively, we could add a python launcher that will only launch the binary iff `conf.d/dd-tcp-rtt.yaml` exists.