### PR TITLE
[windows] 🔒 permissions on `datadog.conf`

### DIFF
--- a/packaging/datadog-agent/win32/wix/agent.wxs
+++ b/packaging/datadog-agent/win32/wix/agent.wxs
@@ -18,6 +18,10 @@
 
         <Media Id="1" Cabinet="agent.cab" EmbedCab="yes" />
 
+        <PropertyRef Id="WIX_ACCOUNT_ADMINISTRATORS" />
+        <PropertyRef Id="WIX_ACCOUNT_LOCALSYSTEM" />
+        <PropertyRef Id="WIX_ACCOUNT_USERS" />
+
         <Directory Id="TARGETDIR" Name="SourceDir">
             <Directory Id="ProgramFilesFolder">
                 <Directory Id="APPLICATIONROOTDIRECTORY" Name="Datadog"/>
@@ -101,7 +105,11 @@
 
         <DirectoryRef Id="APPLIDATIONDATADIRECTORY">
             <Component Id="datadog.conf" Guid="83461594-01AC-11E2-BE35-37EC6088709B" NeverOverwrite="yes" Permanent="yes">
-                <File Id="datadog.conf" Name="datadog.conf" Source="$(var.InstallFiles)\datadog_win32.conf"></File>
+                <File Id="datadog.conf" Name="datadog.conf" Source="$(var.InstallFiles)\datadog_win32.conf">
+                    <Permission User="[WIX_ACCOUNT_ADMINISTRATORS]" GenericAll="yes" />
+                    <Permission User="[WIX_ACCOUNT_LOCALSYSTEM]" GenericAll="yes" />
+                    <Permission User="[WIX_ACCOUNT_USERS]" GenericAll="no"/>
+                </File>
             </Component>
             <Directory Id="logs" Name="logs">
                         <Component Id="logs" Guid="e194d05a-6dc7-40be-a626-6a15b43c456b"


### PR DESCRIPTION
Datadog Agent configuration file `datadog.conf` contains sensitive data
such as the API key.
Set the file permission, to allow the following access:
* Users. None
* Administrator & System. Full control

Similar to #76.

**Note**: Permissions are set at first install only. It is unchanged on upgrade.