### PR TITLE
SNMP check as network check (multi-threaded)

### DIFF
--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -167,6 +167,15 @@ class AgentCheckTest(unittest.TestCase):
         time.sleep(1)
         self.run_check(config, agent_config, mocks)
 
+    def run_check_n(self, config, agent_config=None, mocks=None,
+                    force_reload=False, repeat=1):
+        for i in xrange(repeat):
+            if not i:
+                self.run_check(config, agent_config, mocks, force_reload)
+            else:
+                self.run_check(config, agent_config, mocks)
+            time.sleep(1)
+
     def run_check(self, config, agent_config=None, mocks=None, force_reload=False):
         # If not loaded already, do it!
         if self.check is None or force_reload:


### PR DESCRIPTION
# Multi-threaded SNMP Check (as a Network Check)
This PR allows checking for multiple SNMP instances in parallel, each running in it's own thread (within the allocated thread-pool). The actual OID/walk is still done serially for each instance, but this PR should help organizations with multiple instances configured with a performance benefit as a factor of the thread pool size.

NOTE: tests involving rates now require three runs because network checks report the results of the nth run on the n+1 run.