### PR TITLE
[gunicorn] Mention that the `setproctitle` module is required

### DIFF
--- a/conf.d/gunicorn.yaml.example
+++ b/conf.d/gunicorn.yaml.example
@@ -1,3 +1,6 @@
+# NB: This check requires the python environment on which gunicorn runs to
+# have the `setproctitle` module installed (https://pypi.python.org/pypi/setproctitle/)
+
 init_config:
 
 instances:


### PR DESCRIPTION
Without the `setproctitle` module, gunicorn cannot set its own master process name to `unicorn master [appname]` and our check can't find the master process.