### PR TITLE
[check] [mysql] Fix buggy tagging in service_checks

### DIFF
--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -353,8 +353,8 @@ class MySql(AgentCheck):
     @contextmanager
     def _connect(self, host, port, mysql_sock, user, password, defaults_file, ssl):
         self.service_check_tags = [
-            'server:{0}'.format(host),
-            'port:{0}'.format(port)
+            'server:%s' % (mysql_sock if mysql_sock != '' else host),
+            'port:%s' % ('unix_socket' if port == 0 else port)
         ]
 
         db = None
@@ -369,10 +369,6 @@ class MySql(AgentCheck):
                     user=user,
                     passwd=password
                 )
-                self.service_check_tags = [
-                    'server:{0}'.format(mysql_sock),
-                    'port:unix_socket'
-                ]
             elif port:
                 db = pymysql.connect(
                     host=host,

--- a/tests/checks/integration/test_mysql.py
+++ b/tests/checks/integration/test_mysql.py
@@ -12,7 +12,7 @@ class TestMySql(AgentCheckTest):
     CHECK_NAME = 'mysql'
 
     METRIC_TAGS = ['tag1', 'tag2']
-    SC_TAGS = ['server:localhost', 'port:0']
+    SC_TAGS = ['server:localhost', 'port:unix_socket']
 
     MYSQL_CONFIG = [{
         'server': 'localhost',
@@ -374,6 +374,7 @@ class TestMySql(AgentCheckTest):
             Exception,
             lambda: self.run_check(config)
         )
+
         self.assertServiceCheck('mysql.can_connect', status=AgentCheck.CRITICAL,
                                 tags=self.SC_TAGS, count=1)
         self.coverage_report()


### PR DESCRIPTION
If the check is configured to use `mysql_sock` but the connection fails for whatever reason, the service check will report a `port:0` tag because the `service_check_tags` update happens after the connection.

This PR fixes that.