### PR TITLE
Aerospike statistics collection plugin

### DIFF
--- a/checks.d/aerospike.py
+++ b/checks.d/aerospike.py
@@ -1,0 +1,80 @@
+# Aerospike agent check for Datadog Agent.
+# Copyright (C) 2015 Pippio, Inc. All rights reserved.
+
+# stdlib
+import socket
+from contextlib import closing
+
+# project
+from checks import AgentCheck
+
+
+EVENT_TYPE = 'aerospike'
+SERVICE_CHECK_NAME = '%s.server_up' % EVENT_TYPE
+
+
+class Aerospike(AgentCheck):
+    """Collect metrics and events from Aerospike server(s)."""
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config,
+                            agentConfig, instances=instances)
+        self.connection_pool = {}
+
+    def check(self, instance):
+        """Run the Aerospike check for one instance."""
+
+        # Required parameters
+        host = instance['host']
+        port = int(instance['port'])
+
+        # Optional parameters
+        want_metrics = set(instance.get('metrics', []))
+        want_namespace_metrics = set(instance.get('namespace_metrics', []))
+        namespaces = instance.get('namespaces', None)
+
+        key = '%s:%d' % (host, port)
+        conn = self.connection_pool.get(key, None)
+
+        if conn is None:
+            conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            conn.connect((host, port))
+            self.connection_pool[key] = conn
+
+        try:
+            with closing(conn.makefile('r')) as fp:
+                if namespaces is None:
+                    # Probe all namespaces by default.
+                    conn.send('namespaces\r\n')
+                    namespaces = fp.readline().rstrip().split(';')
+
+                conn.send('statistics\r\n')
+                self._send_metrics(fp, want_metrics)
+
+                for n in namespaces:
+                    conn.send('namespace/%s\r\n' % n)
+                    tags = {'namespace': n}
+                    self._send_metrics(fp, want_namespace_metrics, tags)
+
+            self.service_check(SERVICE_CHECK_NAME, AgentCheck.OK)
+        except socket.error:
+            self.log.exception('Error connecting to Aerospike at %s', key)
+            del self.connection_pool[key]
+
+    def _send_metrics(self, fp, only_keys=[], tags={}):
+        vals = dict(x.split('=', 1) for x in fp.readline().rstrip().split(';'))
+        if only_keys:
+            # Cherry pick only desired metrics, if they exist.
+            for skey in only_keys:
+                value = vals.get(skey, None)
+                if value and value.isdigit():
+                    self.gauge(self._make_key(skey), value, tags=tags)
+        else:
+            # Present all metrics.
+            for skey, value in vals.items():
+                if value.isdigit():
+                    self.gauge(self._make_key(skey), value, tags=tags)
+
+    @staticmethod
+    def _make_key(n):
+        return '%s.%s' % (EVENT_TYPE, n.replace('-', '_'))

--- a/conf.d/aerospike.yaml.example
+++ b/conf.d/aerospike.yaml.example
@@ -1,0 +1,23 @@
+init_config:
+
+instances:
+  - host: 127.0.0.1
+    port: 3003
+
+    # All metrics collected by default. You probably don't want to do this,
+    # so list the ones you do want here. Check with asinfo -v statistics -l
+    # and asinfo -v namespace/YOURNAMESPACE -l.
+
+    # metrics:
+    # - migrate_rx_objs
+    # - migrate_tx_objs
+    # namespace_metrics:
+    # - free-pct-disk
+    # - free-pct-memory
+    # - evicted-objects
+    # - expired-objects
+    # - master-objects
+    # - migrate-rx-partitions-initial
+    # - migrate-rx-partitions-remaining
+    # - migrate-tx-partitions-initial
+    # - migrate-tx-partitions-remaining


### PR DESCRIPTION
Add an AgentCheck for collecting statistics from the Aerospike key-value
store. It lets you pick and choose which metrics you want to track since
there are a very large number of metrics and statistics that Aerospike
provides. All get tracked as gauges.

This is a competing plugin to #1775, which I find to be dramatically too heavyweight for my needs.
