### PR TITLE
[fluentd] allow custom tags

### DIFF
--- a/checks.d/fluentd.py
+++ b/checks.d/fluentd.py
@@ -23,19 +23,20 @@ class Fluentd(AgentCheck):
     {"plugins":[{"type": "monitor_agent", ...}, {"type": "forward", ...}]}
     """
     def check(self, instance):
-        if 'monitor_agent_url' not in instance:
+        url = instance.get('monitor_agent_url')
+        plugin_ids = instance.get('plugin_ids', [])
+        custom_tags = instance.get('tags', [])
+        tag_by = instance.get('tag_by')
+
+        if not url:
             raise Exception('Fluentd instance missing "monitor_agent_url" value.')
 
+        # Fallback  with `tag_by: plugin_id`
+        if tag_by not in self._AVAILABLE_TAGS:
+            self.log.warning("Invalid `tag_by` paramenter: '{0}' - defaulting to 'plugin_id'".format(tag_by))
+            tag_by = 'plugin_id'
+
         try:
-            url = instance.get('monitor_agent_url')
-            plugin_ids = instance.get('plugin_ids', [])
-
-            custom_tags = instance.get('tags', [])
-
-            # Fallback  with `tag_by: plugin_id`
-            tag_by = instance.get('tag_by')
-            tag_by = tag_by if tag_by in self._AVAILABLE_TAGS else 'plugin_id'
-
             parsed_url = urlparse.urlparse(url)
             monitor_agent_host = parsed_url.hostname
             monitor_agent_port = parsed_url.port or 24220
@@ -47,17 +48,22 @@ class Fluentd(AgentCheck):
             status = r.json()
 
             for p in status['plugins']:
-                custom_tags.append("%s:%s" % (tag_by, p.get(tag_by)))
                 for m in self.GAUGES:
-                    if p.get(m) is None:
+                    value = p.get(m)
+                    if value is None:
                         continue
                     # Filter unspecified plugins to keep backward compatibility.
-                    if len(plugin_ids) == 0 or p.get('plugin_id') in plugin_ids:
-                        self.gauge('fluentd.%s' % (m), p.get(m), custom_tags)
-        except Exception, e:
-            msg = "No stats could be retrieved from %s : %s" % (url, str(e))
+                    if not plugin_ids or p.get('plugin_id') in plugin_ids:
+                        self.gauge('fluentd.{0}'.format(m), value,
+                                   custom_tags + ["{0}:{1}".format(tag_by, p.get(tag_by))])
+
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout, requests.HTTPError, ValueError) as e:
+            msg = "Unable to retrieve stats from {url}".format(url=url)
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
                                tags=service_check_tags, message=msg)
-            raise
+            raise e
+        except Exception as e:
+            self.log.error("Unhandled exception - unable to perform service check, submit metrics: ", e)
+            raise e
         else:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=service_check_tags)

--- a/conf.d/fluentd.yaml.example
+++ b/conf.d/fluentd.yaml.example
@@ -10,4 +10,7 @@ instances:
     # Optional, set 'tag_by' to specify how to tag metrics. By default, metrics are tagged with `plugin_id`
     -  monitor_agent_url: http://example.com:24220/api/plugins.json
        tag_by: type
-
+    # Optional, a list of custom tags which will applied to checks and metrics
+       tags:
+         - tag1
+         - tag2

--- a/tests/checks/integration/test_fluentd.py
+++ b/tests/checks/integration/test_fluentd.py
@@ -79,3 +79,23 @@ class TestFluentd(AgentCheckTest):
         self.assertServiceCheckOK(
             self.check.SERVICE_CHECK_NAME, tags=['fluentd_host:localhost', 'fluentd_port:24220'])
         self.coverage_report()
+
+    def test_fluentd_with_custom_tags(self):
+        config = {
+            "init_config": {
+            },
+            "instances": [
+                {
+                    "monitor_agent_url": "http://localhost:24220/api/plugins.json",
+                    "tag_by": "plugin_id",
+                    "tags": ["tag1", "tag2"]
+                }
+            ]
+        }
+        self.run_check(config)
+        for m in self.CHECK_GAUGES:
+            self.assertMetric('{0}.{1}'.format(self.CHECK_NAME, m), tags=['tag1', 'tag2', 'plugin_id:plg1'])
+            self.assertMetric('{0}.{1}'.format(self.CHECK_NAME, m), tags=['tag1', 'tag2', 'plugin_id:plg2'])
+        self.assertServiceCheckOK(
+            self.check.SERVICE_CHECK_NAME, tags=['tag1', 'tag2', 'fluentd_host:localhost', 'fluentd_port:24220'])
+        self.coverage_report()


### PR DESCRIPTION
Contributed originally by @jgmchan in #2196 - we just cleanup a couple things here and ensure the tests pass. 

This allows us to include an option in `fluentd.yaml` to add custom tags which appears in service checks and metrics:

```
- monitor_agent_url: http://example.com:24220/api/plugins.json
  tags:
    - tag1
    - tag2
```