### PR TITLE
[dev-env] Fix URL of get-pip script

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -61,7 +61,7 @@ task 'setup_env' do
   `python venv/virtualenv.py  --no-site-packages --no-pip --no-setuptools venv/`
   `wget -O venv/ez_setup.py https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py`
   `venv/bin/python venv/ez_setup.py`
-  `wget -O venv/get-pip.py https://raw.github.com/pypa/pip/master/contrib/get-pip.py`
+  `wget -O venv/get-pip.py https://bootstrap.pypa.io/get-pip.py`
   `venv/bin/python venv/get-pip.py`
   `venv/bin/pip install -r requirements.txt`
   `venv/bin/pip install -r requirements-test.txt`


### PR DESCRIPTION
Same as #2220, but for the `rake setup_env` command.