### PR TITLE
[system][wmi_check] handle `TimeoutException`

### DIFF
--- a/checks/libs/wmi/sampler.py
+++ b/checks/libs/wmi/sampler.py
@@ -146,11 +146,12 @@ class WMISampler(object):
             self.previous_sample = self.current_sample
             self.current_sample = self._query()
         except TimeoutException:
-            self.logger.warning(
+            self.logger.debug(
                 u"Query timeout after {timeout}s".format(
                     timeout=self._timeout_duration
                 )
             )
+            raise
         else:
             self._sampling = False
             self.logger.debug(u"Sample: {0}".format(self.current_sample))
@@ -161,7 +162,9 @@ class WMISampler(object):
         """
         # No data is returned while sampling
         if self._sampling:
-            return 0
+            raise TypeError(
+                u"Sampling `WMISampler` object has no len()"
+            )
 
         return len(self.current_sample)
 
@@ -171,7 +174,9 @@ class WMISampler(object):
         """
         # No data is returned while sampling
         if self._sampling:
-            return
+            raise TypeError(
+                u"Sampling `WMISampler` object is not iterable"
+            )
 
         if self.is_raw_perf_class:
             # Format required

--- a/checks/libs/wmi/sampler.py
+++ b/checks/libs/wmi/sampler.py
@@ -53,7 +53,7 @@ class WMISampler(object):
     """
     # Shared resources
     _wmi_locators = {}
-    _wmi_connections = defaultdict(set)
+    _wmi_connections = defaultdict(list)
 
     def __init__(self, logger, class_name, property_names, filters="", host="localhost",
                  namespace="root\\cimv2", username="", password="", timeout_duration=10):
@@ -293,7 +293,7 @@ class WMISampler(object):
         yield connection
 
         # Release it
-        self._wmi_connections[self.connection_key].add(connection)
+        self._wmi_connections[self.connection_key].append(connection)
 
     @staticmethod
     def _format_filter(filters):

--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -16,6 +16,9 @@ except Exception:
         """
         return
 
+# datadog
+from utils.timeout import TimeoutException
+
 
 # Device WMI drive types
 class DriveType(object):
@@ -44,7 +47,14 @@ class Processes(Check):
         self.gauge('system.proc.count')
 
     def check(self, agentConfig):
-        self.wmi_sampler.sample()
+        try:
+            self.wmi_sampler.sample()
+        except TimeoutException:
+            self.logger.warning(
+                u"Timeout while querying Win32_PerfRawData_PerfOS_System WMI class."
+                u" Processes metrics will be returned at next iteration."
+            )
+            return
 
         if not (len(self.wmi_sampler)):
             self.logger.info('Missing Win32_PerfRawData_PerfOS_System WMI class.'
@@ -100,7 +110,14 @@ class Memory(Check):
         self.gauge('system.mem.pct_usable')
 
     def check(self, agentConfig):
-        self.os_wmi_sampler.sample()
+        try:
+            self.os_wmi_sampler.sample()
+        except TimeoutException:
+            self.logger.warning(
+                u"Timeout while querying Win32_OperatingSystem WMI class."
+                u" Memory metrics will be returned at next iteration."
+            )
+            return
 
         if not (len(self.os_wmi_sampler)):
             self.logger.info('Missing Win32_OperatingSystem WMI class.'
@@ -123,7 +140,14 @@ class Memory(Check):
             self.save_sample('system.mem.free', free)
             self.save_sample('system.mem.used', total - free)
 
-        self.mem_wmi_sampler.sample()
+        try:
+            self.mem_wmi_sampler.sample()
+        except TimeoutException:
+            self.logger.warning(
+                u"Timeout while querying Win32_PerfRawData_PerfOS_Memory WMI class."
+                u" Memory metrics will be returned at next iteration."
+            )
+            return
 
         if not (len(self.mem_wmi_sampler)):
             self.logger.info('Missing Win32_PerfRawData_PerfOS_Memory WMI class.'
@@ -173,8 +197,14 @@ class Cpu(Check):
         self.counter('system.cpu.system')
 
     def check(self, agentConfig):
-
-        self.wmi_sampler.sample()
+        try:
+            self.wmi_sampler.sample()
+        except TimeoutException:
+            self.logger.warning(
+                u"Timeout while querying Win32_PerfRawData_PerfOS_Processor WMI class."
+                u" CPU metrics will be returned at next iteration."
+            )
+            return
 
         if not (len(self.wmi_sampler)):
             self.logger.info('Missing Win32_PerfRawData_PerfOS_Processor WMI class.'
@@ -230,7 +260,14 @@ class Network(Check):
         self.gauge('system.net.bytes_sent')
 
     def check(self, agentConfig):
-        self.wmi_sampler.sample()
+        try:
+            self.wmi_sampler.sample()
+        except TimeoutException:
+            self.logger.warning(
+                u"Timeout while querying Win32_PerfRawData_Tcpip_NetworkInterface WMI class."
+                u" Network metrics will be returned at next iteration."
+            )
+            return
 
         if not (len(self.wmi_sampler)):
             self.logger.info('Missing Win32_PerfRawData_Tcpip_NetworkInterface WMI class.'
@@ -271,7 +308,14 @@ class IO(Check):
         self.gauge('system.io.avg_q_sz')
 
     def check(self, agentConfig):
-        self.wmi_sampler.sample()
+        try:
+            self.wmi_sampler.sample()
+        except TimeoutException:
+            self.logger.warning(
+                u"Timeout while querying Win32_PerfRawData_PerfDisk_LogicalDiskUnable WMI class."
+                u" I/O metrics will be returned at next iteration."
+            )
+            return
 
         if not (len(self.wmi_sampler)):
             self.logger.info('Missing Win32_PerfRawData_PerfDisk_LogicalDiskUnable WMI class.'

--- a/tests/core/test_wmi.py
+++ b/tests/core/test_wmi.py
@@ -224,7 +224,7 @@ class TestCommonWMI(unittest.TestCase):
         # Flush cache
         from checks.libs.wmi.sampler import WMISampler
         WMISampler._wmi_locators = {}
-        WMISampler._wmi_connections = defaultdict(set)
+        WMISampler._wmi_connections = defaultdict(list)
 
     def assertWMIConn(self, wmi_sampler, param=None, count=None):
         """

--- a/tests/core/test_wmi_calculator.py
+++ b/tests/core/test_wmi_calculator.py
@@ -36,7 +36,7 @@ class TestWMICalculators(unittest.TestCase):
         Asssign a calculator to a counter_type. Raise when the calculator is missing.
         """
         @calculator(123456)
-        def do_something():
+        def do_something(*args, **kwargs):
             """A function that does something."""
             pass
 


### PR DESCRIPTION
#### [core][wmi] `list` to cache connections
Use a `list` to cache WMI connections instead of a `set`.

#### [system][wmi_check] handle `TimeoutException`
WMI queries can potentially raise a `TimeoutException` on query timeouts. Handle it.

