### PR TITLE
Added tag parameter for custom  MySQL queries

### DIFF
--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -200,7 +200,8 @@ class MySql(AgentCheck):
         # Max of 20 queries allowed
         if isinstance(queries, list):
             for index, check in enumerate(queries[:self.MAX_CUSTOM_QUERIES]):
-                self._collect_dict(check['type'], {check['field']: check['metric']}, check['query'], db, tags=tags)
+                total_tags = tags + check.get('tags', [])
+                self._collect_dict(check['type'], {check['field']: check['metric']}, check['query'], db, tags=total_tags)
 
             if len(queries) > self.MAX_CUSTOM_QUERIES:
                 self.warning("Maximum number (%s) of custom queries reached.  Skipping the rest."

--- a/conf.d/mysql.yaml.example
+++ b/conf.d/mysql.yaml.example
@@ -17,10 +17,16 @@ instances:
     #  - # Sample Custom metric
     #    query: SELECT TIMESTAMPDIFF(second,MAX(create_time),NOW()) as last_accessed FROM requests
     #    metric: app.seconds_since_last_request
+    #    tags:               # Optional - only applied to this custom metric query, will not affect default mysql metrics
+    #        - custom_tag1
+    #        - custom_tag2
     #    type: gauge
     #    field: last_accessed
     #  - # Sample Custom metric
     #    query: SELECT TIMESTAMPDIFF(second,MAX(create_time),NOW()) as last_user FROM users
     #    metric: app.seconds_since_new_user
+    #    tags:               # Optional - only applied to this custom metric query, will not affect default mysql metrics
+    #        - custom_tag1
+    #        - custom_tag2
     #    type: gauge
     #    field: last_user


### PR DESCRIPTION
Allow tags for MySQL custom queries, separate from the global tags applied to the default metrics