### PR TITLE
[elasticsearch] Restricts 1.x specific stats to v1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ env:
     - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.5.2
     - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.6.2
     - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=1.7.4
+    - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=2.0.2
+    - TRAVIS_FLAVOR=elasticsearch FLAVOR_VERSION=2.1.1
     - TRAVIS_FLAVOR=etcd
     - TRAVIS_FLAVOR=fluentd
     - TRAVIS_FLAVOR=go_expvar

--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -135,9 +135,6 @@ class ESCheck(AgentCheck):
         "elasticsearch.thread_pool.management.active": ("gauge", "thread_pool.management.active"),
         "elasticsearch.thread_pool.management.threads": ("gauge", "thread_pool.management.threads"),
         "elasticsearch.thread_pool.management.queue": ("gauge", "thread_pool.management.queue"),
-        "elasticsearch.thread_pool.merge.active": ("gauge", "thread_pool.merge.active"),
-        "elasticsearch.thread_pool.merge.threads": ("gauge", "thread_pool.merge.threads"),
-        "elasticsearch.thread_pool.merge.queue": ("gauge", "thread_pool.merge.queue"),
         "elasticsearch.thread_pool.percolate.active": ("gauge", "thread_pool.percolate.active"),
         "elasticsearch.thread_pool.percolate.threads": ("gauge", "thread_pool.percolate.threads"),
         "elasticsearch.thread_pool.percolate.queue": ("gauge", "thread_pool.percolate.queue"),
@@ -183,11 +180,14 @@ class ESCheck(AgentCheck):
 
     ADDITIONAL_METRICS_POST_0_90_5 = {
         "elasticsearch.search.fetch.open_contexts": ("gauge", "indices.search.open_contexts"),
+        "elasticsearch.fielddata.size": ("gauge", "indices.fielddata.memory_size_in_bytes"),
+        "elasticsearch.fielddata.evictions": ("gauge", "indices.fielddata.evictions"),
+    }
+
+    ADDITIONAL_METRICS_POST_0_90_5_PRE_2_0 = {
         "elasticsearch.cache.filter.evictions": ("gauge", "indices.filter_cache.evictions"),
         "elasticsearch.cache.filter.size": ("gauge", "indices.filter_cache.memory_size_in_bytes"),
         "elasticsearch.id_cache.size": ("gauge", "indices.id_cache.memory_size_in_bytes"),
-        "elasticsearch.fielddata.size": ("gauge", "indices.fielddata.memory_size_in_bytes"),
-        "elasticsearch.fielddata.evictions": ("gauge", "indices.fielddata.evictions"),
     }
 
     ADDITIONAL_METRICS_PRE_0_90_5 = {
@@ -220,6 +220,12 @@ class ESCheck(AgentCheck):
     ADDITIONAL_METRICS_POST_1_4_0 = {
         "elasticsearch.indices.segments.index_writer_max_memory_in_bytes": ("gauge", "indices.segments.index_writer_max_memory_in_bytes"),
         "elasticsearch.indices.segments.fixed_bit_set_memory_in_bytes": ("gauge", "indices.segments.fixed_bit_set_memory_in_bytes"),
+    }
+
+    ADDITIONAL_METRICS_PRE_2_0 = {
+        "elasticsearch.thread_pool.merge.active": ("gauge", "thread_pool.merge.active"),
+        "elasticsearch.thread_pool.merge.threads": ("gauge", "thread_pool.merge.threads"),
+        "elasticsearch.thread_pool.merge.queue": ("gauge", "thread_pool.merge.queue"),
     }
 
     CLUSTER_HEALTH_METRICS = {
@@ -396,8 +402,12 @@ class ESCheck(AgentCheck):
         if version >= [1, 0, 0]:
             stats_metrics.update(self.ADDITIONAL_METRICS_POST_1_0_0)
 
-        if version >= [1, 0, 0] and version < [2, 0, 0]:
-            stats_metrics.update(self.ADDITIONAL_METRICS_1_x)
+        if version < [2, 0, 0]:
+            stats_metrics.update(self.ADDITIONAL_METRICS_PRE_2_0)
+            if version >= [0, 90, 5]:
+                stats_metrics.update(self.ADDITIONAL_METRICS_POST_0_90_5_PRE_2_0)
+            if version >= [1, 0, 0]:
+                stats_metrics.update(self.ADDITIONAL_METRICS_1_x)
 
         if version >= [1, 3, 0]:
             stats_metrics.update(self.ADDITIONAL_METRICS_POST_1_3_0)

--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -201,6 +201,9 @@ class ESCheck(AgentCheck):
     ADDITIONAL_METRICS_POST_1_0_0 = {
         "elasticsearch.indices.translog.size_in_bytes": ("gauge", "indices.translog.size_in_bytes"),
         "elasticsearch.indices.translog.operations": ("gauge", "indices.translog.operations"),
+    }
+
+    ADDITIONAL_METRICS_1_x = {  # Stats are only valid for v1.x
         "elasticsearch.fs.total.disk_reads": ("rate", "fs.total.disk_reads"),
         "elasticsearch.fs.total.disk_writes": ("rate", "fs.total.disk_writes"),
         "elasticsearch.fs.total.disk_io_op": ("rate", "fs.total.disk_io_op"),
@@ -392,6 +395,9 @@ class ESCheck(AgentCheck):
 
         if version >= [1, 0, 0]:
             stats_metrics.update(self.ADDITIONAL_METRICS_POST_1_0_0)
+
+        if version >= [1, 0, 0] and version < [2, 0, 0]:
+            stats_metrics.update(self.ADDITIONAL_METRICS_1_x)
 
         if version >= [1, 3, 0]:
             stats_metrics.update(self.ADDITIONAL_METRICS_POST_1_3_0)

--- a/tests/checks/integration/test_elastic.py
+++ b/tests/checks/integration/test_elastic.py
@@ -111,9 +111,6 @@ STATS_METRICS = {  # Metrics that are common to all Elasticsearch versions
     "elasticsearch.thread_pool.management.active": ("gauge", "thread_pool.management.active"),
     "elasticsearch.thread_pool.management.threads": ("gauge", "thread_pool.management.threads"),
     "elasticsearch.thread_pool.management.queue": ("gauge", "thread_pool.management.queue"),
-    "elasticsearch.thread_pool.merge.active": ("gauge", "thread_pool.merge.active"),
-    "elasticsearch.thread_pool.merge.threads": ("gauge", "thread_pool.merge.threads"),
-    "elasticsearch.thread_pool.merge.queue": ("gauge", "thread_pool.merge.queue"),
     "elasticsearch.thread_pool.percolate.active": ("gauge", "thread_pool.percolate.active"),
     "elasticsearch.thread_pool.percolate.threads": ("gauge", "thread_pool.percolate.threads"),
     "elasticsearch.thread_pool.percolate.queue": ("gauge", "thread_pool.percolate.queue"),
@@ -159,11 +156,14 @@ JVM_METRICS_PRE_0_90_10 = {
 
 ADDITIONAL_METRICS_POST_0_90_5 = {
     "elasticsearch.search.fetch.open_contexts": ("gauge", "indices.search.open_contexts"),
+    "elasticsearch.fielddata.size": ("gauge", "indices.fielddata.memory_size_in_bytes"),
+    "elasticsearch.fielddata.evictions": ("gauge", "indices.fielddata.evictions"),
+}
+
+ADDITIONAL_METRICS_POST_0_90_5_PRE_2_0 = {
     "elasticsearch.cache.filter.evictions": ("gauge", "indices.filter_cache.evictions"),
     "elasticsearch.cache.filter.size": ("gauge", "indices.filter_cache.memory_size_in_bytes"),
     "elasticsearch.id_cache.size": ("gauge", "indices.id_cache.memory_size_in_bytes"),
-    "elasticsearch.fielddata.size": ("gauge", "indices.fielddata.memory_size_in_bytes"),
-    "elasticsearch.fielddata.evictions": ("gauge", "indices.fielddata.evictions"),
 }
 
 ADDITIONAL_METRICS_PRE_0_90_5 = {
@@ -197,6 +197,12 @@ ADDITIONAL_METRICS_POST_1_3_0 = {
 ADDITIONAL_METRICS_POST_1_4_0 = {
     "elasticsearch.indices.segments.index_writer_max_memory_in_bytes": ("gauge", "indices.segments.index_writer_max_memory_in_bytes"),
     "elasticsearch.indices.segments.fixed_bit_set_memory_in_bytes": ("gauge", "indices.segments.fixed_bit_set_memory_in_bytes"),
+}
+
+ADDITIONAL_METRICS_PRE_2_0 = {
+    "elasticsearch.thread_pool.merge.active": ("gauge", "thread_pool.merge.active"),
+    "elasticsearch.thread_pool.merge.threads": ("gauge", "thread_pool.merge.threads"),
+    "elasticsearch.thread_pool.merge.queue": ("gauge", "thread_pool.merge.queue"),
 }
 
 CLUSTER_HEALTH_METRICS = {
@@ -277,8 +283,12 @@ class TestElastic(AgentCheckTest):
         if es_version >= [1, 0, 0]:
             expected_metrics.update(ADDITIONAL_METRICS_POST_1_0_0)
 
-        if es_version >= [1, 0, 0] and es_version < [2, 0, 0]:
-            expected_metrics.update(ADDITIONAL_METRICS_1_x)
+        if es_version < [2, 0, 0]:
+            expected_metrics.update(ADDITIONAL_METRICS_PRE_2_0)
+            if es_version >= [0, 90, 5]:
+                expected_metrics.update(ADDITIONAL_METRICS_POST_0_90_5_PRE_2_0)
+            if es_version >= [1, 0, 0]:
+                expected_metrics.update(ADDITIONAL_METRICS_1_x)
 
         if es_version >= [1, 3, 0]:
             expected_metrics.update(ADDITIONAL_METRICS_POST_1_3_0)

--- a/tests/checks/integration/test_elastic.py
+++ b/tests/checks/integration/test_elastic.py
@@ -177,6 +177,9 @@ ADDITIONAL_METRICS_PRE_0_90_5 = {
 ADDITIONAL_METRICS_POST_1_0_0 = {
     "elasticsearch.indices.translog.size_in_bytes": ("gauge", "indices.translog.size_in_bytes"),
     "elasticsearch.indices.translog.operations": ("gauge", "indices.translog.operations"),
+}
+
+ADDITIONAL_METRICS_1_x = {
     # Currently has issues in test framework:
     # "elasticsearch.fs.total.disk_reads": ("rate", "fs.total.disk_reads"),
     # "elasticsearch.fs.total.disk_writes": ("rate", "fs.total.disk_writes"),
@@ -273,6 +276,9 @@ class TestElastic(AgentCheckTest):
 
         if es_version >= [1, 0, 0]:
             expected_metrics.update(ADDITIONAL_METRICS_POST_1_0_0)
+
+        if es_version >= [1, 0, 0] and es_version < [2, 0, 0]:
+            expected_metrics.update(ADDITIONAL_METRICS_1_x)
 
         if es_version >= [1, 3, 0]:
             expected_metrics.update(ADDITIONAL_METRICS_POST_1_3_0)

--- a/tests/checks/integration/test_elastic.py
+++ b/tests/checks/integration/test_elastic.py
@@ -296,15 +296,16 @@ class TestElastic(AgentCheckTest):
         if es_version >= [1, 4, 0]:
             expected_metrics.update(ADDITIONAL_METRICS_POST_1_4_0)
 
+        local_hostname = socket.gethostname() if es_version < [2, 0, 0] else '127.0.0.1'
         contexts = [
             (conf_hostname, default_tags + tags),
-            (socket.gethostname(), default_tags)
+            (local_hostname, default_tags)
         ]
 
         for m_name, desc in expected_metrics.iteritems():
             for hostname, m_tags in contexts:
                 if (m_name in CLUSTER_HEALTH_METRICS
-                        and hostname == socket.gethostname()):
+                        and hostname == local_hostname):
                     hostname = conf_hostname
 
                 if desc[0] == "gauge":


### PR DESCRIPTION
Some of the stats I introduced for 1.x are removed in 2.x. :cry: 
Resolves #2186 