### PR TITLE
[mongo] oplog replicationInfo metrics

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -141,6 +141,9 @@ class MongoDb(AgentCheck):
         "opcountersRepl.insert": RATE,
         "opcountersRepl.query": RATE,
         "opcountersRepl.update": RATE,
+        "oplog.totalSizeMB": GAUGE,
+        "oplog.usedSizeMB": GAUGE,
+        "oplog.timeDiffSeconds": GAUGE,
         "replSet.health": GAUGE,
         "replSet.replicationLag": GAUGE,
         "replSet.state": GAUGE,
@@ -482,6 +485,20 @@ class MongoDb(AgentCheck):
         Returns a dictionary that looks a lot like what's sent back by
         db.serverStatus()
         """
+
+        def total_seconds(td):
+            """
+            Returns total seconds of a timedelta in a way that's safe for
+            Python < 2.7
+            """
+            if hasattr(td, 'total_seconds'):
+                return td.total_seconds()
+            else:
+                return (
+                    lag.microseconds +
+                    (lag.seconds + lag.days * 24 * 3600) * 10**6
+                ) / 10.0**6
+
         if 'server' not in instance:
             raise Exception("Missing 'server' in mongo config")
 
@@ -623,14 +640,7 @@ class MongoDb(AgentCheck):
                 # If we have both we can compute a lag time
                 if current is not None and primary is not None:
                     lag = primary['optimeDate'] - current['optimeDate']
-                    # Python 2.7 has this built in, python < 2.7 don't...
-                    if hasattr(lag, 'total_seconds'):
-                        data['replicationLag'] = lag.total_seconds()
-                    else:
-                        data['replicationLag'] = (
-                            lag.microseconds +
-                            (lag.seconds + lag.days * 24 * 3600) * 10**6
-                        ) / 10.0**6
+                    data['replicationLag'] = total_seconds(lag)
 
                 if current is not None:
                     data['health'] = current['health']
@@ -748,3 +758,41 @@ class MongoDb(AgentCheck):
                         submit_method(self, metric_name_alias, value, tags=ns_tags)
             except Exception, e:
                 self.log.warning('Failed to record `top` metrics %s' % str(e))
+
+        # Fetch information analogous to Mongo's db.getReplicationInfo()
+        localdb = cli['local']
+
+        oplog_data = {}
+
+        for ol_collection_name in ("oplog.rs", "oplog.$main"):
+            ol_metadata = localdb.system.namespaces.find_one({"name": "local.%s" % ol_collection_name})
+            if ol_metadata:
+                break
+
+        if ol_metadata:
+            try:
+                oplog_data['totalSizeMB'] = round(ol_metadata['options']['size'] / 2.0 ** 20, 2)
+
+                oplog = localdb[ol_collection_name]
+
+                oplog_data['usedSizeMB'] = round(localdb.command("collstats", ol_collection_name)['size'] / 2.0 ** 20, 2)
+
+                op_asc_cursor = oplog.find().sort("$natural", pymongo.ASCENDING).limit(1)
+                op_dsc_cursor = oplog.find().sort("$natural", pymongo.DESCENDING).limit(1)
+
+                try:
+                    first_timestamp = op_asc_cursor[0]['ts'].as_datetime()
+                    last_timestamp = op_dsc_cursor[0]['ts'].as_datetime()
+                    oplog_data['timeDiffSeconds'] = total_seconds(last_timestamp - first_timestamp)
+                except IndexError: # if the oplog collection doesn't have any entries
+                    pass
+                except KeyError: # if an object in the collection doesn't have a ts value, we ignore it
+                    pass
+
+            except KeyError: # encountered an error trying to access options.size for the oplog collection
+                pass
+
+        for (m, value) in oplog_data.iteritems():
+            submit_method, metric_name_alias = \
+                self._resolve_metric('oplog.%s' % m, metrics_to_collect)
+            submit_method(self, metric_name_alias, value, tags=tags)


### PR DESCRIPTION
# What’s this PR do?

This PR adds a few new metrics to dd-agent's mongo plugin, borrowed from [Mongo's db.getReplicationInfo()][0]:

* [`mongodb.oplog.totalsizemb`][1]
* [`mongodb.oplog.usedsizemb`][2]
* [`mongodb.oplog.timediffseconds`][3]

# Notes

The code for getting the metrics is a more-or-less direct translation from the Javascript `getReplicationInfo()` function from the mongo shell, with a few edits to exclude non-numerical fields. I also updated the metric names to include units where the mongo shell function didn’t.

[0]: https://docs.mongodb.org/v3.2/reference/method/db.getReplicationInfo/
[1]: https://docs.mongodb.org/v3.2/reference/method/db.getReplicationInfo/#db.getReplicationInfo.logSizeMB
[2]: https://docs.mongodb.org/v3.2/reference/method/db.getReplicationInfo/#db.getReplicationInfo.usedMB
[3]: https://docs.mongodb.org/v3.2/reference/method/db.getReplicationInfo/#db.getReplicationInfo.timeDiff