### PR TITLE
[mysql] Improving replication status check

### DIFF
--- a/conf.d/mysql.yaml.example
+++ b/conf.d/mysql.yaml.example
@@ -32,6 +32,11 @@ instances:
     #                     - mysql.performance.query_run_time.avg (per schema)
     #                     - mysql.performance.digest_95th_percentile.avg_us
     #
+    #           With the addition of new metrics to the MySQL catalog starting with agent >=5.7.0, because
+    #           we query additional schemas to get this full set of metrics. Some of these require the user
+    #           defined for the instance to have PROCESS and SELECT privileges. Please take a look at the
+    #           MySQL integration tile in the Datadog WebUI for further instructions.
+    #
     # ssl:               # Optional
     #   key: /path/to/my/key.file
     #   cert: /path/to/my/cert.file

--- a/tests/checks/integration/test_mysql.py
+++ b/tests/checks/integration/test_mysql.py
@@ -142,6 +142,7 @@ class TestMySql(AgentCheckTest):
     OPTIONAL_REPLICATION_METRICS = [
         'mysql.replication.slave_running',
         'mysql.replication.seconds_behind_master',
+        'mysql.replication.slaves_connected',
     ]
 
     # Additional Vars found in "SHOW STATUS;"


### PR DESCRIPTION
## Why
When we made the MySQL check revamp, this was probably the one point where I had noticed we were lacking a little bit - amongst other things because not all info is available everywhere (ie. the information on a slave node is different to the information available on `master`, and in turn, it'd be different in a system without replication enabled). This attempts to address all use cases.

## Extras
- Also squeezing in a fix to an issue regarding the hostkey that probably came up as a product of a badly resolved conflict.
- Fix to a bad service_check tag issue when the customers connect to their MySQL instance via a port and experience a connection failure. We were updating the tags _after_ the exception - which was naturally not working in the event of a failed check.