### PR TITLE
[mongo] tag mongo instances by replset state

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -18,6 +18,23 @@ class MongoDb(AgentCheck):
     SERVICE_CHECK_NAME = 'mongodb.can_connect'
     SOURCE_TYPE_NAME = 'mongodb'
 
+    """
+    MongoDB replica set states, as documented at
+    https://docs.mongodb.org/manual/reference/replica-states/
+    """
+    REPLSET_STATES = {
+        0: 'startup',
+        1: 'primary',
+        2: 'secondary',
+        3: 'recovering',
+        5: 'startup2',
+        6: 'unknown',
+        7: 'arbiter',
+        8: 'down',
+        9: 'rollback',
+        10: 'removed'
+    }
+
     # METRIC LIST DEFINITION
     #
     # Format
@@ -619,6 +636,7 @@ class MongoDb(AgentCheck):
                     data['health'] = current['health']
 
                 data['state'] = replSet['myState']
+                tags.append('replset_state:%s' % self.REPLSET_STATES[data['state']])
                 self.check_last_state(
                     data['state'],
                     clean_server_name,


### PR DESCRIPTION
# What’s this PR do?

This PR adds `mongo_replset_state` as a tag to represent [the various replica states](https://docs.mongodb.org/manual/reference/replica-states/) of mongodb instances.

# Motivation

In some cases, we’d like to look at stats only for replica primaries. This gives us that ability!