### PR TITLE
[haproxy] provide options for collapsing `count_per_status` metrics

### DIFF
--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -20,7 +20,7 @@ class Services(object):
     FRONTEND = 'FRONTEND'
     ALL = (BACKEND, FRONTEND)
     ALL_STATUSES = (
-        'up', 'open', 'no check', 'down', 'maint', 'nolb'
+        'up', 'open', 'down', 'maint', 'nolb'
     )
     STATUSES_TO_SERVICE_CHECK = {
         'UP': AgentCheck.OK,
@@ -341,10 +341,8 @@ class HAProxy(AgentCheck):
                 self.gauge("haproxy.count_per_status", count, tags=tags)
 
     def _gauge_all_statuses(self, metric_name, count, status, tags):
-        self.gauge(metric_name, count, tags + ['status:%s' % status])
-        for state in Services.ALL_STATUSES:
-            if state != status:
-                self.gauge(metric_name, 0, tags + ['status:%s' % state.replace(" ", "_")])
+        if status in Services.ALL_STATUSES:
+            self.gauge(metric_name, count, tags + ['status:%s' % status])
 
     def _process_metrics(self, data, url, services_incl_filter=None,
                          services_excl_filter=None):

--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -334,7 +334,10 @@ class HAProxy(AgentCheck):
 
         for service in agg_statuses:
             for status, count in agg_statuses[service].iteritems():
-                tags = ['status:%s' % status, 'service:%s' % service]
+                tags = ['status:%s' % status]
+                if aggregate_status_by_service:
+                    tags.append('service:%s' % service)
+
                 self.gauge("haproxy.count_per_status", count, tags=tags)
 
     def _gauge_all_statuses(self, metric_name, count, status, tags):

--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -371,7 +371,7 @@ class HAProxy(AgentCheck):
             self._gauge_all_statuses(metric_name, count, status, tags)
             return
 
-        self.gauge(metric_name, count, tags + ['status:%s' % status])
+        self.gauge(metric_name, count, tags + ['status:%s' % collated_status])
 
         for state in ['up', 'down']:
             if collated_status != state:

--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -321,6 +321,10 @@ class HAProxy(AgentCheck):
                 service, status = host_status
             status = status.lower()
 
+            if status == 'no check':
+                # Not much useful we can get here, skip this host status
+                continue
+
             tags = []
             if count_status_by_service:
                 tags.append('service:%s' % service)

--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -82,10 +82,6 @@ class HAProxy(AgentCheck):
             instance.get('collect_status_metrics_by_host', False)
         )
 
-        collect_count_per_status = _is_affirmative(
-            instance.get('collect_count_per_status', True)
-        )
-
         count_status_by_service = _is_affirmative(
             instance.get('count_status_by_service', True)
         )
@@ -110,7 +106,6 @@ class HAProxy(AgentCheck):
             tag_service_check_by_host=tag_service_check_by_host,
             services_incl_filter=services_incl_filter,
             services_excl_filter=services_excl_filter,
-            collect_count_per_status=collect_count_per_status,
             count_status_by_service=count_status_by_service
         )
 
@@ -131,8 +126,7 @@ class HAProxy(AgentCheck):
     def _process_data(self, data, collect_aggregates_only, process_events, url=None,
                       collect_status_metrics=False, collect_status_metrics_by_host=False,
                       tag_service_check_by_host=False, services_incl_filter=None,
-                      services_excl_filter=None, collect_count_per_status=True,
-                      count_status_by_service=True):
+                      services_excl_filter=None, count_status_by_service=True):
         ''' Main data-processing loop. For each piece of useful data, we'll
         either save a metric, save an event or both. '''
 
@@ -185,13 +179,12 @@ class HAProxy(AgentCheck):
             )
 
         if collect_status_metrics:
-            if collect_count_per_status:
-                self._process_status_metric(
-                    self.hosts_statuses, collect_status_metrics_by_host,
-                    services_incl_filter=services_incl_filter,
-                    services_excl_filter=services_excl_filter,
-                    count_status_by_service=count_status_by_service
-                )
+            self._process_status_metric(
+                self.hosts_statuses, collect_status_metrics_by_host,
+                services_incl_filter=services_incl_filter,
+                services_excl_filter=services_excl_filter,
+                count_status_by_service=count_status_by_service
+            )
 
             self._process_backend_hosts_metric(
                 self.hosts_statuses,

--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -316,11 +316,11 @@ class HAProxy(AgentCheck):
                                count_status_by_service=True, collate_status_tags_per_host=False):
         agg_statuses = defaultdict(lambda: {'available': 0, 'unavailable': 0})
 
-        # use a counter when we don't have a unique tag set to gauge
-        use_status_counter = not count_status_by_service and not collect_status_metrics_by_host
-        counter = None
-        if use_status_counter:
-            counter = Counter()
+        # use a counter unless we have a unique tag set to gauge
+        counter = Counter()
+        if count_status_by_service and collect_status_metrics_by_host:
+            # `service` and `backend` tags will exist
+            counter = None
 
         for host_status, count in hosts_statuses.iteritems():
             try:

--- a/conf.d/haproxy.yaml.example
+++ b/conf.d/haproxy.yaml.example
@@ -30,6 +30,7 @@ instances:
     # This only applies if collect_status_metrics is True.
     # count_status_by_service: True
     #
+    #
     # The (optional) tag_service_check_by_host parameter will instruct the
     # check to tag the service check status by host on top of other tags.
     # The default case will only tag by backend and service.
@@ -49,3 +50,6 @@ instances:
     # services_include: []
     # services_exclude:
     #   - "thisone"
+    # The (optional) collate_status_per_host parameter will collate `status` tags for `haproxy.count_per_status`
+    # up to one of `up, down` for each discovered backend
+    collate_status_tags_per_host: True

--- a/conf.d/haproxy.yaml.example
+++ b/conf.d/haproxy.yaml.example
@@ -25,6 +25,16 @@ instances:
     # This only applies if collect_status_metrics is True.
     # collect_status_metrics_by_host: False
     #
+    # The (optional) collect_count_per_status parameter will instruct
+    # the check to collect counts for each status by host.
+    # This only applies if collect_status_metrics is True.
+    # collect_count_per_status: True
+    #
+    # The (optional) aggregate_status_by_service parameter will instruct
+    # the check to tag the status counts it collects by service in addition to by host.
+    # This only applies if collect_status_metrics and collect_count_per_status are True.
+    # aggregate_status_by_service: True
+    #
     # The (optional) tag_service_check_by_host parameter will instruct the
     # check to tag the service check status by host on top of other tags.
     # The default case will only tag by backend and service.

--- a/conf.d/haproxy.yaml.example
+++ b/conf.d/haproxy.yaml.example
@@ -25,15 +25,10 @@ instances:
     # This only applies if collect_status_metrics is True.
     # collect_status_metrics_by_host: False
     #
-    # The (optional) collect_count_per_status parameter will instruct
-    # the check to collect counts for each status by host.
-    # This only applies if collect_status_metrics is True.
-    # collect_count_per_status: True
-    #
-    # The (optional) aggregate_status_by_service parameter will instruct
+    # The (optional) count_status_by_service parameter will instruct
     # the check to tag the status counts it collects by service in addition to by host.
     # This only applies if collect_status_metrics and collect_count_per_status are True.
-    # aggregate_status_by_service: True
+    # count_status_by_service: True
     #
     # The (optional) tag_service_check_by_host parameter will instruct the
     # check to tag the service check status by host on top of other tags.

--- a/conf.d/haproxy.yaml.example
+++ b/conf.d/haproxy.yaml.example
@@ -27,7 +27,7 @@ instances:
     #
     # The (optional) count_status_by_service parameter will instruct
     # the check to tag the status counts it collects by service in addition to by host.
-    # This only applies if collect_status_metrics and collect_count_per_status are True.
+    # This only applies if collect_status_metrics is True.
     # count_status_by_service: True
     #
     # The (optional) tag_service_check_by_host parameter will instruct the


### PR DESCRIPTION
Adds two flags to the `haproxy` config:
   - `count_status_by_service` will instruct the check to tag the status counts it collects by service in addition to by host. Defaults `True`
   - `collate_status_tags_per_host` will instruct the check to collate backend-level `status` tags for `haproxy.count_per_status` from `('up', 'open', 'down', 'maint', 'nolb')` to one of `(up, down)` 