### PR TITLE
[rabbitmq] add a way to tag multiple queues in the same "family"

### DIFF
--- a/checks.d/rabbitmq.py
+++ b/checks.d/rabbitmq.py
@@ -9,6 +9,7 @@ import requests
 
 # project
 from checks import AgentCheck
+from config import _is_affirmative
 
 EVENT_TYPE = SOURCE_TYPE_NAME = 'rabbitmq'
 QUEUE_TYPE = 'queues'
@@ -70,6 +71,7 @@ TAGS_MAP = {
                 'name': 'queue',
                 'vhost': 'vhost',
                 'policy': 'policy',
+                'queue_family': 'queue_family',
     },
     NODE_TYPE: {
         'name': 'node',
@@ -198,7 +200,10 @@ class RabbitMQ(AgentCheck):
 
                 match_found = False
                 for p in regex_filters:
-                    if re.search(p, name):
+                    match = re.search(p, name)
+                    if match:
+                        if _is_affirmative(instance.get("tag_families", False)) and match.groups():
+                            data_line["queue_family"] = match.groups()[0]
                         matching_lines.append(data_line)
                         match_found = True
                         break
@@ -216,7 +221,10 @@ class RabbitMQ(AgentCheck):
                     continue
 
                 for p in regex_filters:
-                    if re.search(p, absolute_name):
+                    match = re.search(p, absolute_name)
+                    if match:
+                        if _is_affirmative(instance.get("tag_families", False)) and match.groups():
+                            data_line["queue_family"] = match.groups()[0]
                         matching_lines.append(data_line)
                         match_found = True
                         break

--- a/conf.d/rabbitmq.yaml.example
+++ b/conf.d/rabbitmq.yaml.example
@@ -3,10 +3,13 @@ init_config:
 instances:
   # for every instance a 'rabbitmq_api_url' must be provided, pointing to the api
   # url of the RabbitMQ Managment Plugin (http://www.rabbitmq.com/management.html)
-  # optional: 'rabbitmq_user' (default: guest) and 'rabbitmq_pass' (default: guest)
+  # optional: 'rabbitmq_user' (default: guest), 'rabbitmq_pass' (default: guest),
+  # and 'tag_families' (default: false) to tag queue "families" based off of regex
+  # matching.
   - rabbitmq_api_url: http://localhost:15672/api/
     rabbitmq_user: guest
     rabbitmq_pass: guest
+    # tag_families: true
     # Use the `nodes` or `nodes_regexes` parameters to specify the nodes you'd like to
     # collect metrics on (up to 100 nodes).
     # If you have less than 100 nodes, you don't have to set this parameter,
@@ -23,6 +26,8 @@ instances:
     # If you have less than 200 queues, you don't have to set this parameter,
     # the metrics will be collected on all the queues by default.
     # If you have set up vhosts, set the queue names as `vhost_name/queue_name`.
+    # If you have `tag_families` enabled, the first captured group in the regex
+    # will be used as the queue_family tag
     #
     # queues:
     #   - queue1
@@ -30,6 +35,7 @@ instances:
     # queues_regexes:
     #   - thisqueue-.*
     #   - another_\d+queue
+    #   - (lepidorae)-\d+   # to tag queues in the lepidorae queue_family
 
     # Service checks:
     # By default a list of all vhosts is fetched and each one will be checked

--- a/tests/checks/integration/test_rabbitmq.py
+++ b/tests/checks/integration/test_rabbitmq.py
@@ -28,12 +28,38 @@ CONFIG_REGEX = {
     ]
 }
 
+CONFIG_WITH_FAMILY = {
+    'init_config': {},
+    'instances': [
+        {
+            'rabbitmq_api_url': 'http://localhost:15672/api/',
+            'rabbitmq_user': 'guest',
+            'rabbitmq_pass': 'guest',
+            'tag_families': True,
+            'queues_regexes': ['(test)\d+'],
+        }
+    ]
+}
+
 COMMON_METRICS = [
     'rabbitmq.node.fd_used',
     'rabbitmq.node.mem_used',
     'rabbitmq.node.run_queue',
     'rabbitmq.node.sockets_used',
     'rabbitmq.node.partitions'
+]
+
+Q_METRICS = [
+    'consumers',
+    'memory',
+    'messages',
+    'messages.rate',
+    'messages_ready',
+    'messages_ready.rate',
+    'messages_unacknowledged',
+    'messages_unacknowledged.rate',
+    'messages.publish.count',
+    'messages.publish.rate',
 ]
 
 
@@ -53,18 +79,6 @@ class RabbitMQCheckTest(AgentCheckTest):
         # Queue attributes, should be only one queue fetched
         # TODO: create a 'fake consumer' and get missing metrics
         # active_consumers, acks, delivers, redelivers
-        Q_METRICS = [
-            'consumers',
-            'memory',
-            'messages',
-            'messages.rate',
-            'messages_ready',
-            'messages_ready.rate',
-            'messages_unacknowledged',
-            'messages_unacknowledged.rate',
-            'messages.publish.count',
-            'messages.publish.rate',
-        ]
         for mname in Q_METRICS:
             self.assertMetricTag('rabbitmq.queue.%s' %
                                  mname, 'rabbitmq_queue:test1', count=1)
@@ -80,18 +94,6 @@ class RabbitMQCheckTest(AgentCheckTest):
         for mname in COMMON_METRICS:
             self.assertMetricTagPrefix(mname, 'rabbitmq_node', count=1)
 
-        Q_METRICS = [
-            'consumers',
-            'memory',
-            'messages',
-            'messages.rate',
-            'messages_ready',
-            'messages_ready.rate',
-            'messages_unacknowledged',
-            'messages_unacknowledged.rate',
-            'messages.publish.count',
-            'messages.publish.rate',
-        ]
         for mname in Q_METRICS:
             self.assertMetricTag('rabbitmq.queue.%s' %
                                  mname, 'rabbitmq_queue:test1', count=1)
@@ -102,4 +104,19 @@ class RabbitMQCheckTest(AgentCheckTest):
 
         self.assertServiceCheckOK('rabbitmq.aliveness', tags=['vhost:/'])
 
+        self.coverage_report()
+
+    def test_family_tagging(self):
+        self.run_check(CONFIG_WITH_FAMILY)
+
+        # Node attributes
+        for mname in COMMON_METRICS:
+            self.assertMetricTagPrefix(mname, 'rabbitmq_node', count=1)
+
+        for mname in Q_METRICS:
+            self.assertMetricTag('rabbitmq.queue.%s' %
+                                 mname, 'rabbitmq_queue_family:test', count=2)
+
+        self.assertServiceCheckOK('rabbitmq.aliveness', tags=['vhost:/'])
+        
         self.coverage_report()


### PR DESCRIPTION
# What’s this PR do?

This PR allows tagging rabbitmq queues based on their queue name as a `queue_family`. The behavior is off by default, but if you enable `tag_families` in `rabbitmq.yaml`, the first captured group in a queue regex will be used as the `queue_family`.

# Motivation

Since it’s common practice to run a set of rabbitmq queues as (e.g.) `leporidae-1`, `leporidae-2`, etc., we found it useful to be able to aggregate metrics based off of these sets.

# Testing

I’ve added tests to the rabbitmq integration test to verify that these show up tagged correctly, as well as verifying on a test instance of rabbitmq that the tagging works appropriately.

# Notes

For lack of a better term, I’ve called these queue groupings “families”. I’m not at all attached to this term and am happy to change it if anyone has a better suggestion :smile: