### PR TITLE
[hdfs] Bugfix updated bean name in datanode check

### DIFF
--- a/checks.d/hdfs_datanode.py
+++ b/checks.d/hdfs_datanode.py
@@ -35,7 +35,7 @@ JMX_PATH = 'jmx'
 GAUGE = 'gauge'
 
 # HDFS bean name
-HDFS_DATANODE_BEAN_NAME = 'Hadoop:service=DataNode,name=FSDatasetState'
+HDFS_DATANODE_BEAN_NAME = 'Hadoop:service=DataNode,name=FSDatasetState*'
 
 # HDFS metrics
 HDFS_METRICS = {
@@ -76,11 +76,11 @@ class HDFSDataNode(AgentCheck):
 
         if beans:
 
+            # Only get the first bean
             bean = next(iter(beans))
             bean_name = bean.get('name')
 
-            if bean_name != HDFS_DATANODE_BEAN_NAME:
-                raise Exception("Unexpected bean name {0}".format(bean_name))
+            self.log.debug('Bean name retrieved: %s' % (bean_name))
 
             for metric, (metric_name, metric_type) in HDFS_METRICS.iteritems():
                 metric_value = bean.get(metric)

--- a/conf.d/hdfs_datanode.yaml.example
+++ b/conf.d/hdfs_datanode.yaml.example
@@ -1,4 +1,12 @@
 init_config:
 
 instances:
-    -    hdfs_datanode_jmx_uri: http://localhost:50075
+  #
+  # The HDFS DataNode check retrieves metrics from the HDFS DataNode's JMX
+  # interface. This check must be installed on a HDFS DataNode. The HDFS
+  # DataNode JMX URI is composed of the DataNode's hostname and port.
+  #
+  # The hostname and port can be found in the hdfs-site.xml conf file under
+  # the property dfs.datanode.http.address
+  #
+  - hdfs_datanode_jmx_uri: http://localhost:50075

--- a/conf.d/hdfs_namenode.yaml.example
+++ b/conf.d/hdfs_namenode.yaml.example
@@ -1,4 +1,12 @@
 init_config:
 
 instances:
-    -    hdfs_namenode_jmx_uri: http://localhost:50070
+  #
+  # The HDFS NameNode check retrieves metrics from the HDFS NameNode's JMX
+  # interface. This check must be installed on the NameNode. The HDFS
+  # NameNode JMX URI is composed of the NameNode's hostname and port.
+  #
+  # The hostname and port can be found in the hdfs-site.xml conf file under
+  # the property dfs.http.address or dfs.namenode.http-address
+  #
+  -  hdfs_namenode_jmx_uri: http://localhost:50070


### PR DESCRIPTION
This is just a quick bugfix that updates bean name being requested from the DataNode's JMX interface.