### PR TITLE
[cassandra] Exclude aggregated metrics not associated with a specific keyspace

### DIFF
--- a/conf.d/cassandra.yaml.example
+++ b/conf.d/cassandra.yaml.example
@@ -50,6 +50,8 @@ init_config:
     - include:
         domain: org.apache.cassandra.metrics
         type: ColumnFamily
+        bean_regex:
+          - .*keyspace=.*  
         name:
           - TotalDiskSpaceUsed
           - BloomFilterDiskSpaceUsed


### PR DESCRIPTION
`ColumnFamily` metrics are available two ways: as global aggregates and per keyspace/column family. This regex from @olivielpeau limits metric collection to those metrics associated with a specific keyspace to omit the global aggregates. This eliminates confusingly similar metric names (e.g. `cassandra.total_disk_space_used` and `cassandra.total_disk_space_used.count`) and prevents the double-counting of certain metrics.