### PR TITLE
[hdfs] Deprecate previous hdfs check

### DIFF
--- a/checks.d/hdfs.py
+++ b/checks.d/hdfs.py
@@ -21,7 +21,11 @@ DEFAULT_PORT = 8020
 
 
 class HDFSCheck(AgentCheck):
-    """Report on free space and space used in HDFS.
+    """
+    Report on free space and space used in HDFS.
+    DEPRECATED:
+    This check is deprecated and will be removed in a future version of the agent
+    Please use the `hdfs_namenode` and `hdfs_datanode` checks instead
     """
 
     def get_client(self, instance):
@@ -65,6 +69,10 @@ class HDFSCheck(AgentCheck):
                 return snakebite.client.HAClient(nodes)
 
     def check(self, instance):
+        self.warning('The "hdfs" check is deprecated and will be removed '
+                     'in a future version of the agent. Please use the "hdfs_namenode" '
+                     'and "hdfs_datanode" checks instead')
+
         if 'namenode' not in instance and 'namenodes' not in instance:
             raise ValueError('Missing key \'namenode\' in HDFSCheck config')
 

--- a/checks.d/hdfs_namenode.py
+++ b/checks.d/hdfs_namenode.py
@@ -129,6 +129,10 @@ class HDFSNameNode(AgentCheck):
                 if metric_value is not None:
                     self._set_metric(metric_name, metric_type, metric_value, tags)
 
+            if 'CapacityUsed' in bean and 'CapacityTotal' in bean:
+                self._set_metric('hdfs_namenode.capacity_in_use', GAUGE,
+                                 float(bean['CapacityUsed']) / float(bean['CapacityTotal']), tags)
+
     def _set_metric(self, metric_name, metric_type, value, tags=None):
         '''
         Set a metric

--- a/conf.d/hdfs.yaml.example
+++ b/conf.d/hdfs.yaml.example
@@ -1,3 +1,7 @@
+# DEPRECATED:
+# This check is deprecated and will be removed in a future version of the agent
+# Please use the `hdfs_namenode` and `hdfs_datanode` checks instead
+
 init_config:
 # HDFS check does not require any init_config
 

--- a/tests/checks/mock/test_hdfs_namenode.py
+++ b/tests/checks/mock/test_hdfs_namenode.py
@@ -53,6 +53,7 @@ class HDFSNameNode(AgentCheckTest):
         'hdfs_namenode.capacity_total': 41167421440,
         'hdfs_namenode.capacity_used': 501932032,
         'hdfs_namenode.capacity_remaining': 27878948864,
+        'hdfs_namenode.capacity_in_use': None,  # Don't test the value as it's a float
         'hdfs_namenode.total_load': 2,
         'hdfs_namenode.fs_lock_queue_length': 0,
         'hdfs_namenode.blocks_total': 27661,


### PR DESCRIPTION
- add a deprecation notice on the old check
- add to the new check a metric (`capacity_in_use`) that was sent by the old check