### PR TITLE
DataDog agent check for apt package updates.

### DIFF
--- a/checks.d/apt.py
+++ b/checks.d/apt.py
@@ -1,5 +1,4 @@
 # stdlib
-import requests
 import re
 
 # project
@@ -33,7 +32,7 @@ class APT(AgentCheck):
             self.service_check(SECURITY_CHECK, AgentCheck.OK)
 
     def updates(self, instance):
-        updates = { 'packages': 0, 'security': 0 }
+        updates = {'packages': 0, 'security': 0}
 
         with open(instance['updates_file'], 'r') as fd:
             content = fd.read()

--- a/checks.d/apt.py
+++ b/checks.d/apt.py
@@ -1,0 +1,44 @@
+# stdlib
+import requests
+import re
+
+# project
+from checks import AgentCheck
+
+# The name of the service check we'll use to report when there are package
+# updates available. Normal non-security related packages will generate a
+# warning, security related package updates will generate a critical alert.
+SECURITY_CHECK = 'apt.updates'
+
+# Regular expressions to match the /var/lib/update-notifier/updates-available format.
+PACKAGES_REGEX = re.compile(r"^(\d+) packages can be updated.*", re.MULTILINE)
+SECURITY_REGEX = re.compile(r"^(\d+) updates are security updates.*$", re.MULTILINE)
+
+
+class APT(AgentCheck):
+    """Generates metrics and service alerts when package updates are available
+    """
+
+    def check(self, instance):
+        updates = self.updates(instance)
+
+        self.gauge('apt.updates.packages', updates['packages'])
+        self.gauge('apt.updates.security', updates['security'])
+
+        if updates['security'] > 0:
+            self.service_check(SECURITY_CHECK, AgentCheck.CRITICAL)
+        elif updates['packages'] > 0:
+            self.service_check(SECURITY_CHECK, AgentCheck.WARNING)
+        else:
+            self.service_check(SECURITY_CHECK, AgentCheck.OK)
+
+    def updates(self, instance):
+        updates = {}
+        content = open(instance['updates_file'], 'r').read()
+
+        for m in PACKAGES_REGEX.finditer(content):
+            updates['packages'] = int(m.groups()[0])
+        for m in SECURITY_REGEX.finditer(content):
+            updates['security'] = int(m.groups()[0])
+
+        return updates

--- a/checks.d/apt.py
+++ b/checks.d/apt.py
@@ -11,8 +11,8 @@ from checks import AgentCheck
 SECURITY_CHECK = 'apt.updates'
 
 # Regular expressions to match the /var/lib/update-notifier/updates-available format.
-PACKAGES_REGEX = re.compile(r"^(\d+) packages can be updated.*", re.MULTILINE)
-SECURITY_REGEX = re.compile(r"^(\d+) updates are security updates.*$", re.MULTILINE)
+PACKAGES_REGEX = re.compile(r"^(\d+) packages? can be updated.*", re.MULTILINE)
+SECURITY_REGEX = re.compile(r"^(\d+) updates? (is a|are) security updates?.*$", re.MULTILINE)
 
 
 class APT(AgentCheck):
@@ -33,7 +33,8 @@ class APT(AgentCheck):
             self.service_check(SECURITY_CHECK, AgentCheck.OK)
 
     def updates(self, instance):
-        updates = {}
+        updates = { 'packages': 0, 'security': 0 }
+
         with open(instance['updates_file'], 'r') as fd:
             content = fd.read()
 

--- a/checks.d/apt.py
+++ b/checks.d/apt.py
@@ -34,11 +34,12 @@ class APT(AgentCheck):
 
     def updates(self, instance):
         updates = {}
-        content = open(instance['updates_file'], 'r').read()
+        with open(instance['updates_file'], 'r') as fd:
+            content = fd.read()
 
-        for m in PACKAGES_REGEX.finditer(content):
-            updates['packages'] = int(m.groups()[0])
-        for m in SECURITY_REGEX.finditer(content):
-            updates['security'] = int(m.groups()[0])
+            for m in PACKAGES_REGEX.finditer(content):
+                updates['packages'] = int(m.groups()[0])
+            for m in SECURITY_REGEX.finditer(content):
+                updates['security'] = int(m.groups()[0])
 
         return updates

--- a/conf.d/apt.yaml.example
+++ b/conf.d/apt.yaml.example
@@ -1,0 +1,8 @@
+init_config:
+
+instances:
+  -
+    # The file where apt stores available updates.
+    #
+    # See also http://askubuntu.com/questions/49958/how-to-find-the-number-of-packages-needing-update-from-the-command-line
+    updates_file: /var/lib/update-notifier/updates-available

--- a/tests/checks/fixtures/apt/updates-available.no-updates
+++ b/tests/checks/fixtures/apt/updates-available.no-updates
@@ -1,0 +1,4 @@
+
+0 packages can be updated.
+0 updates are security updates.
+

--- a/tests/checks/fixtures/apt/updates-available.package-updates
+++ b/tests/checks/fixtures/apt/updates-available.package-updates
@@ -1,0 +1,4 @@
+
+15 packages can be updated.
+0 updates are security updates.
+

--- a/tests/checks/fixtures/apt/updates-available.security-updates
+++ b/tests/checks/fixtures/apt/updates-available.security-updates
@@ -1,0 +1,4 @@
+
+10 packages can be updated.
+2 updates are security updates.
+

--- a/tests/checks/fixtures/apt/updates-available.single
+++ b/tests/checks/fixtures/apt/updates-available.single
@@ -1,0 +1,4 @@
+
+1 package can be updated.
+1 update is a security update.
+

--- a/tests/checks/mock/test_apt.py
+++ b/tests/checks/mock/test_apt.py
@@ -1,16 +1,7 @@
-# 3rd party
-import mock
-import json
-
-from tests.checks.common import AgentCheckTest, load_check, Fixtures
+from tests.checks.common import AgentCheckTest, Fixtures
 
 def mock_config(fixture):
-    return {
-            'init_config': {},
-            'instances' : [{
-                'updates_file': Fixtures.file(fixture)
-                }]
-            }
+    return {'init_config': {}, 'instances' : [{'updates_file': Fixtures.file(fixture)}]}
 
 class TestCheckAPT(AgentCheckTest):
     CHECK_NAME = 'apt'

--- a/tests/checks/mock/test_apt.py
+++ b/tests/checks/mock/test_apt.py
@@ -32,3 +32,9 @@ class TestCheckAPT(AgentCheckTest):
         self.assertServiceCheckCritical('apt.updates')
         self.assertMetric('apt.updates.packages', value=10)
         self.assertMetric('apt.updates.security', value=2)
+
+    def test_single_update(self):
+        self.run_check(mock_config('updates-available.single'))
+        self.assertServiceCheckCritical('apt.updates')
+        self.assertMetric('apt.updates.packages', value=1)
+        self.assertMetric('apt.updates.security', value=1)

--- a/tests/checks/mock/test_apt.py
+++ b/tests/checks/mock/test_apt.py
@@ -1,0 +1,34 @@
+# 3rd party
+import mock
+import json
+
+from tests.checks.common import AgentCheckTest, load_check, Fixtures
+
+def mock_config(fixture):
+    return {
+            'init_config': {},
+            'instances' : [{
+                'updates_file': Fixtures.file(fixture)
+                }]
+            }
+
+class TestCheckAPT(AgentCheckTest):
+    CHECK_NAME = 'apt'
+
+    def test_no_updates(self):
+        self.run_check(mock_config('updates-available.no-updates'))
+        self.assertServiceCheckOK('apt.updates')
+        self.assertMetric('apt.updates.packages', value=0)
+        self.assertMetric('apt.updates.security', value=0)
+
+    def test_package_updates(self):
+        self.run_check(mock_config('updates-available.package-updates'))
+        self.assertServiceCheckWarning('apt.updates')
+        self.assertMetric('apt.updates.packages', value=15)
+        self.assertMetric('apt.updates.security', value=0)
+
+    def test_package_security_updates(self):
+        self.run_check(mock_config('updates-available.security-updates'))
+        self.assertServiceCheckCritical('apt.updates')
+        self.assertMetric('apt.updates.packages', value=10)
+        self.assertMetric('apt.updates.security', value=2)


### PR DESCRIPTION
This is a custom agent check that will generate metrics and service alerts for apt package updates. It uses the `/var/lib/update-notifier/updates-available` file to determine what package updates are available (see http://askubuntu.com/questions/49958/how-to-find-the-number-of-packages-needing-update-from-the-command-line).

If there are security related updates available, the `apt.updates` service check goes critical. If there are non-security related package updates, the `apt.updates` check warns.
