### PR TITLE
[gunicorn] use psutil 3 compatible children func

### DIFF
--- a/checks.d/gunicorn.py
+++ b/checks.d/gunicorn.py
@@ -42,7 +42,7 @@ class GUnicornCheck(AgentCheck):
         master_proc = self._get_master_proc_by_name(proc_name)
 
         # Fetch the worker procs and count their states.
-        worker_procs = master_proc.get_children()
+        worker_procs = master_proc.children()
         working, idle = self._count_workers(worker_procs)
 
         # if no workers are running, alert CRITICAL, otherwise OK


### PR DESCRIPTION
This slipped by [when upgrading to psutil 3.3.0](https://github.com/DataDog/dd-agent/pull/2134) . `get_children` is no longer valid.