### PR TITLE
[pgbouncer] fixed UnboundLocalError for results var

### DIFF
--- a/checks.d/pgbouncer.py
+++ b/checks.d/pgbouncer.py
@@ -76,6 +76,7 @@ class PgBouncer(AgentCheck):
 
         try:
             cursor = db.cursor()
+            results = None
             for scope in metric_scope:
 
                 metrics = scope['metrics']


### PR DESCRIPTION
Fixed an error when there were no results for a query run against a pgbouncer instance. In that case there was a check against a variable `results` that was not yet initialized. I added an initialization before the checks for `results = None`, thus fixing the problem.