### PR TITLE
[core] EC2 tags collection requires an IAM role

### DIFF
--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -30,7 +30,7 @@ api_key:
 # and dice per monitored app (= running Agent Check) on Datadog's backend.
 # create_dd_check_tags: no
 
-# Collect AWS EC2 custom tags as agent tags
+# Collect AWS EC2 custom tags as agent tags (requires an IAM role associated with the instance)
 # collect_ec2_tags: no
 
 # Incorporate security-groups into tags collected from AWS EC2


### PR DESCRIPTION
An IAM role associated with the instance is required to retrieve AWS EC2
custom tags. Log a warning when missing, not an exception.

Fix #1884