### PR TITLE
Use key:value in example tags

### DIFF
--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -24,7 +24,7 @@ api_key:
 #hostname: mymachine.mydomain
 
 # Set the host's tags
-#tags: mytag0, mytag1
+#tags: mytag, env:prod, role:database
 
 # Add one "dd_check:checkname" tag per running check. It makes it possible to slice
 # and dice per monitored app (= running Agent Check) on Datadog's backend.


### PR DESCRIPTION
The [guide to tagging](http://docs.datadoghq.com/guides/tagging/) recommends that tags are in the key:value syntax. This should be reflected in the example datadog.conf file.