### PR TITLE
[packaging][osx] Use osx-specific supervisor.conf

### DIFF
--- a/packaging/osx/supervisor.conf
+++ b/packaging/osx/supervisor.conf
@@ -1,0 +1,56 @@
+[supervisorctl]
+serverurl = unix:///opt/datadog-agent/run/datadog-supervisor.sock
+
+[unix_http_server]
+file=/opt/datadog-agent/run/datadog-supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisord]
+http_port = /opt/datadog-agent/run/datadog-supervisor.sock
+minfds = 1024
+minprocs = 200
+loglevel = info
+logfile = /var/log/datadog/supervisord.log
+logfile_maxbytes = 50MB
+nodaemon = false
+pidfile = /opt/datadog-agent/run/datadog-supervisord.pid
+logfile_backups = 10
+environment=PYTHONPATH=/opt/datadog-agent/agent:/opt/datadog-agent/agent/checks,LANG=POSIX
+
+[program:collector]
+command=/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/agent.py foreground --use-local-forwarder
+stdout_logfile=NONE
+stderr_logfile=NONE
+priority=999
+startsecs=5
+startretries=3
+environment=PYTHONPATH='/opt/datadog-agent/agent:/opt/datadog-agent/agent/checks/libs:$PYTHONPATH'
+
+[program:forwarder]
+command=/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/ddagent.py
+stdout_logfile=NONE
+stderr_logfile=NONE
+startsecs=5
+startretries=3
+priority=998
+
+[program:dogstatsd]
+command=/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/dogstatsd.py --use-local-forwarder
+stdout_logfile=NONE
+stderr_logfile=NONE
+startsecs=5
+startretries=3
+priority=998
+
+[program:jmxfetch]
+command=/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/jmxfetch.py
+stdout_logfile=NONE
+stderr_logfile=NONE
+redirect_stderr=true
+priority=999
+startsecs=3
+
+[group:datadog-agent]
+programs=forwarder,collector,dogstatsd,jmxfetch


### PR DESCRIPTION
Now that go-metro is bundled only on Linux, we use a different
`supervisor.conf` file for OSX.

We could go back to a shared supervisor conf once we have go-metro in the OSX pkg and instructions on how to run it unprivileged.