### PR TITLE
[flake8] Fix F841 in system unix check

### DIFF
--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -749,7 +749,7 @@ def main():
     io = IO(log)
     load = Load(log)
     mem = Memory(log)
-    proc = Processes(log)
+    # proc = Processes(log)
     system = System(log)
 
     config = {"api_key": "666", "device_blacklist_re": re.compile('.*disk0.*')}


### PR DESCRIPTION
Just comment out unused `proc` var.

We should probably remove all this unused `processes` stuff.