### PR TITLE
[system] fixed import of missing module

### DIFF
--- a/tests/checks/mock/test_sysstat.py
+++ b/tests/checks/mock/test_sysstat.py
@@ -9,7 +9,7 @@ from checks.system.unix import (
     Load,
     Memory,
 )
-from checks.system.common import System
+from checks.system.unix import System
 from config import get_system_stats
 from tests.checks.common import get_check
 from utils.platform import Platform


### PR DESCRIPTION
In a [recent refactory](https://github.com/DataDog/dd-agent/commit/162c3fab358aa3f02c5beec4bd4189c9a70b40fc) we got rid of  `checks.system.common` module, still `test_sysstat.py` was importing it, causing failures on CI.