### PR TITLE
[haproxy] options to collapse status count metrics

### DIFF
--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -7,7 +7,6 @@ import time
 import requests
 
 # project
-from collections import Counter
 from checks import AgentCheck
 from config import _is_affirmative
 from util import headers
@@ -324,7 +323,7 @@ class HAProxy(AgentCheck):
         agg_statuses = defaultdict(lambda: {'available': 0, 'unavailable': 0})
 
         # use a counter unless we have a unique tag set to gauge
-        counter = Counter()
+        counter = defaultdict(int)
         if count_status_by_service and collect_status_metrics_by_host:
             # `service` and `backend` tags will exist
             counter = None

--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -62,13 +62,13 @@ class HAProxy(AgentCheck):
         "eresp": ("rate", "errors.resp_rate"),
         "wretr": ("rate", "warnings.retr_rate"),
         "wredis": ("rate", "warnings.redis_rate"),
-        "req_rate": ("gauge", "requests.rate"), # HA Proxy 1.4 and higher
+        "req_rate": ("gauge", "requests.rate"),  # HA Proxy 1.4 and higher
         "hrsp_1xx": ("rate", "response.1xx"),  # HA Proxy 1.4 and higher
-        "hrsp_2xx": ("rate", "response.2xx"), # HA Proxy 1.4 and higher
-        "hrsp_3xx": ("rate", "response.3xx"), # HA Proxy 1.4 and higher
-        "hrsp_4xx": ("rate", "response.4xx"), # HA Proxy 1.4 and higher
-        "hrsp_5xx": ("rate", "response.5xx"), # HA Proxy 1.4 and higher
-        "hrsp_other": ("rate", "response.other"), # HA Proxy 1.4 and higher
+        "hrsp_2xx": ("rate", "response.2xx"),  # HA Proxy 1.4 and higher
+        "hrsp_3xx": ("rate", "response.3xx"),  # HA Proxy 1.4 and higher
+        "hrsp_4xx": ("rate", "response.4xx"),  # HA Proxy 1.4 and higher
+        "hrsp_5xx": ("rate", "response.5xx"),  # HA Proxy 1.4 and higher
+        "hrsp_other": ("rate", "response.other"),  # HA Proxy 1.4 and higher
         "qtime": ("gauge", "queue.time"),  # HA Proxy 1.5 and higher
         "ctime": ("gauge", "connect.time"),  # HA Proxy 1.5 and higher
         "rtime": ("gauge", "response.time"),  # HA Proxy 1.5 and higher
@@ -99,6 +99,13 @@ class HAProxy(AgentCheck):
         collate_status_tags_per_host = _is_affirmative(
             instance.get('collate_status_tags_per_host', False)
         )
+
+        if collate_status_tags_per_host and not collect_status_metrics_by_host:
+            self.log.warning(
+                u"Status tags collation (`collate_status_tags_per_host`) has no effect when status "
+                u"metrics collection per host (`collect_status_metrics_by_host`) is disabled."
+            )
+            collate_status_tags_per_host = False
 
         tag_service_check_by_host = _is_affirmative(
             instance.get('tag_service_check_by_host', False)

--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -7,6 +7,7 @@ import time
 import requests
 
 # project
+from collections import Counter
 from checks import AgentCheck
 from config import _is_affirmative
 from util import headers
@@ -20,8 +21,17 @@ class Services(object):
     FRONTEND = 'FRONTEND'
     ALL = (BACKEND, FRONTEND)
     ALL_STATUSES = (
-        'up', 'open', 'no check', 'down', 'maint', 'nolb'
+        'up', 'open', 'down', 'maint', 'nolb'
     )
+
+    STATUS_MAP = {
+        'up': 'up',
+        'open': 'up',
+        'down': 'down',
+        'maint': 'down',
+        'nolb': 'down'
+    }
+
     STATUSES_TO_SERVICE_CHECK = {
         'UP': AgentCheck.OK,
         'DOWN': AgentCheck.CRITICAL,
@@ -77,12 +87,23 @@ class HAProxy(AgentCheck):
         collect_status_metrics = _is_affirmative(
             instance.get('collect_status_metrics', False)
         )
+
         collect_status_metrics_by_host = _is_affirmative(
             instance.get('collect_status_metrics_by_host', False)
         )
+
+        count_status_by_service = _is_affirmative(
+            instance.get('count_status_by_service', True)
+        )
+
+        collate_status_tags_per_host = _is_affirmative(
+            instance.get('collate_status_tags_per_host', False)
+        )
+
         tag_service_check_by_host = _is_affirmative(
             instance.get('tag_service_check_by_host', False)
         )
+
         services_incl_filter = instance.get('services_include', [])
         services_excl_filter = instance.get('services_exclude', [])
 
@@ -98,7 +119,9 @@ class HAProxy(AgentCheck):
             collect_status_metrics_by_host=collect_status_metrics_by_host,
             tag_service_check_by_host=tag_service_check_by_host,
             services_incl_filter=services_incl_filter,
-            services_excl_filter=services_excl_filter
+            services_excl_filter=services_excl_filter,
+            count_status_by_service=count_status_by_service,
+            collate_status_tags_per_host=collate_status_tags_per_host
         )
 
     def _fetch_data(self, url, username, password):
@@ -118,7 +141,8 @@ class HAProxy(AgentCheck):
     def _process_data(self, data, collect_aggregates_only, process_events, url=None,
                       collect_status_metrics=False, collect_status_metrics_by_host=False,
                       tag_service_check_by_host=False, services_incl_filter=None,
-                      services_excl_filter=None):
+                      services_excl_filter=None, count_status_by_service=True,
+                      collate_status_tags_per_host=False):
         ''' Main data-processing loop. For each piece of useful data, we'll
         either save a metric, save an event or both. '''
 
@@ -174,8 +198,11 @@ class HAProxy(AgentCheck):
             self._process_status_metric(
                 self.hosts_statuses, collect_status_metrics_by_host,
                 services_incl_filter=services_incl_filter,
-                services_excl_filter=services_excl_filter
+                services_excl_filter=services_excl_filter,
+                count_status_by_service=count_status_by_service,
+                collate_status_tags_per_host=collate_status_tags_per_host
             )
+
             self._process_backend_hosts_metric(
                 self.hosts_statuses,
                 services_incl_filter=services_incl_filter,
@@ -285,8 +312,16 @@ class HAProxy(AgentCheck):
         return agg_statuses
 
     def _process_status_metric(self, hosts_statuses, collect_status_metrics_by_host,
-                               services_incl_filter=None, services_excl_filter=None):
+                               services_incl_filter=None, services_excl_filter=None,
+                               count_status_by_service=True, collate_status_tags_per_host=False):
         agg_statuses = defaultdict(lambda: {'available': 0, 'unavailable': 0})
+
+        # use a counter unless we have a unique tag set to gauge
+        counter = Counter()
+        if count_status_by_service and collect_status_metrics_by_host:
+            # `service` and `backend` tags will exist
+            counter = None
+
         for host_status, count in hosts_statuses.iteritems():
             try:
                 service, hostname, status = host_status
@@ -294,29 +329,72 @@ class HAProxy(AgentCheck):
                 service, status = host_status
             status = status.lower()
 
-            tags = ['service:%s' % service]
+            tags = []
+            if count_status_by_service:
+                tags.append('service:%s' % service)
+
             if self._is_service_excl_filtered(service, services_incl_filter, services_excl_filter):
                 continue
 
             if collect_status_metrics_by_host:
                 tags.append('backend:%s' % hostname)
-            self._gauge_all_statuses("haproxy.count_per_status", count, status, tags=tags)
+
+            if collate_status_tags_per_host:
+                self._gauge_collated_statuses(
+                    "haproxy.count_per_status",
+                    count, status, tags, counter
+                )
+            else:
+                self._gauge_all_statuses(
+                    "haproxy.count_per_status",
+                    count, status, tags, counter
+                )
 
             if 'up' in status or 'open' in status:
                 agg_statuses[service]['available'] += count
             if 'down' in status or 'maint' in status or 'nolb' in status:
                 agg_statuses[service]['unavailable'] += count
 
+        if counter is not None:
+            # send aggregated counts as gauges
+            for key, count in counter.iteritems():
+                metric_name, tags = key[0], key[1]
+                self.gauge(metric_name, count, tags=tags)
+
         for service in agg_statuses:
             for status, count in agg_statuses[service].iteritems():
-                tags = ['status:%s' % status, 'service:%s' % service]
+                tags = ['status:%s' % status]
+                if count_status_by_service:
+                    tags.append('service:%s' % service)
+
                 self.gauge("haproxy.count_per_status", count, tags=tags)
 
-    def _gauge_all_statuses(self, metric_name, count, status, tags):
-        self.gauge(metric_name, count, tags + ['status:%s' % status])
+    def _gauge_all_statuses(self, metric_name, count, status, tags, counter):
+        if counter is not None:
+            counter_key = tuple([metric_name, tuple(tags + ['status:%s' % status])])
+            counter[counter_key] += count
+        else:
+            # assume we have enough context, just send a gauge
+            self.gauge(metric_name, count, tags + ['status:%s' % status])
+
         for state in Services.ALL_STATUSES:
             if state != status:
                 self.gauge(metric_name, 0, tags + ['status:%s' % state.replace(" ", "_")])
+
+    def _gauge_collated_statuses(self, metric_name, count, status, tags, counter):
+        collated_status = Services.STATUS_MAP.get(status)
+        if not collated_status:
+            # We can't properly collate this guy, because it's a status we don't expect,
+            # let's abandon collation
+            self.log.warning("Unexpected status found %s", status)
+            self._gauge_all_statuses(metric_name, count, status, tags, counter)
+            return
+
+        self.gauge(metric_name, count, tags + ['status:%s' % collated_status])
+
+        for state in ['up', 'down']:
+            if collated_status != state:
+                self.gauge(metric_name, 0, tags + ['status:%s' % state])
 
     def _process_metrics(self, data, url, services_incl_filter=None,
                          services_excl_filter=None):

--- a/conf.d/haproxy.yaml.example
+++ b/conf.d/haproxy.yaml.example
@@ -5,38 +5,43 @@ instances:
     # username: username
     # password: password
     #
-    # The (optional) status_check paramater will instruct the check to
+    # The (optional) `status_check` paramater will instruct the check to
     # send events on status changes in the backend. This is DEPRECATED in
     # favor creation a monitor on the service check status and will be
     # removed in a future version.
     # status_check: False
     #
-    # The (optional) collect_aggregates_only parameter will instruct the
+    # The (optional) `collect_aggregates_only` parameter will instruct the
     # check to collect metrics only from the aggregate frontend/backend
     # status lines from the stats output instead of for each backend.
     # collect_aggregates_only: True
     #
-    # The (optional) collect_status_metrics parameter will instruct the
+    # The (optional) `collect_status_metrics` parameter will instruct the
     # check to collect metrics on status counts (e.g. haproxy.count_per_status)
     # collect_status_metrics: False
     #
-    # The (optional) collect_status_metrics_by_host parameter will instruct
+    # The (optional) `collect_status_metrics_by_host` parameter will instruct
     # the check to collect status metrics per host instead of per service.
-    # This only applies if collect_status_metrics is True.
+    # This only applies if `collect_status_metrics` is True.
     # collect_status_metrics_by_host: False
     #
-    # The (optional) count_status_by_service parameter will instruct
-    # the check to tag the status counts it collects by service in addition to by host.
-    # This only applies if collect_status_metrics is True.
+    # The (optional) `collate_status_tags_per_host` parameter will collate
+    # `status` tags for `haproxy.count_per_status` up to one of `up, down`
+    # for each discovered backend.
+    # This only applies if `collect_status_metrics_by_host` is True.
+    # collate_status_tags_per_host: False
+    #
+    # The (optional) `count_status_by_service` parameter will instruct the check
+    # to tag the status counts it collects by service in addition to by host.
+    # This only applies if `collect_status_metrics` is True.
     # count_status_by_service: True
     #
-    #
-    # The (optional) tag_service_check_by_host parameter will instruct the
+    # The (optional) `tag_service_check_by_host` parameter will instruct the
     # check to tag the service check status by host on top of other tags.
     # The default case will only tag by backend and service.
     # tag_service_check_by_host: False
     #
-    # optional, filter metrics by services
+    # (Optional) Filter metrics by services.
     # How it works: if a tag matches an exclude rule, it won't be included
     # unless it also matches an include rule.
     # e.g. include ONLY these two services
@@ -50,6 +55,4 @@ instances:
     # services_include: []
     # services_exclude:
     #   - "thisone"
-    # The (optional) collate_status_per_host parameter will collate `status` tags for `haproxy.count_per_status`
-    # up to one of `up, down` for each discovered backend
-    collate_status_tags_per_host: True
+

--- a/conf.d/haproxy.yaml.example
+++ b/conf.d/haproxy.yaml.example
@@ -25,6 +25,12 @@ instances:
     # This only applies if collect_status_metrics is True.
     # collect_status_metrics_by_host: False
     #
+    # The (optional) count_status_by_service parameter will instruct
+    # the check to tag the status counts it collects by service in addition to by host.
+    # This only applies if collect_status_metrics is True.
+    # count_status_by_service: True
+    #
+    #
     # The (optional) tag_service_check_by_host parameter will instruct the
     # check to tag the service check status by host on top of other tags.
     # The default case will only tag by backend and service.
@@ -44,3 +50,6 @@ instances:
     # services_include: []
     # services_exclude:
     #   - "thisone"
+    # The (optional) collate_status_per_host parameter will collate `status` tags for `haproxy.count_per_status`
+    # up to one of `up, down` for each discovered backend
+    collate_status_tags_per_host: True


### PR DESCRIPTION
### Options to collapse status count metrics
*Rebase of @talwai's original work #2256.*

Adds two flags to the HAProxy config:
* `count_status_by_service` instructs the check to tag the status
counts it collects by service in addition to by host. Defaults True
* `collate_status_tags_per_host` instructs the check to collate
   backend-level status tags for `haproxy.count_per_status` from (`up`,
  `open`, `down`, `maint', `nolb`) to one of (`up`, `down`)


### `collate_status_tags_per_host` requirements
`collate_status_tags_per_host` only applies when `collect_status_metrics_by_host` is `True`.