### PR TITLE
[go-metro] `apt-get ̶u̶p̶d̶a̶t̶e̶`→`install`

### DIFF
--- a/conf.d/go-metro.yaml.example
+++ b/conf.d/go-metro.yaml.example
@@ -1,5 +1,5 @@
 # NOTE: for go metro to run unprivileged, you will have to set CAP_NET_RAW capabilities on the binary:
-#        (debian based) $ sudo apt-get update libcap
+#        (debian based) $ sudo apt-get install libcap
 #        (redhat based) $ sudo yum install libcap
 #        (redhat based - alternatively) $ sudo yum install compat-libcap1
 #        $ sudo setcap cap_net_raw+ep /opt/datadog-agent/bin/go-metro


### PR DESCRIPTION
Fix `libcap` installation instructions for Debian based distributions on `go-metro` YAML configuration file.