### PR TITLE
[packaging][go-metro] Remove go-metro from the i386 packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The existing `hdfs` check is deprecated and will be removed in a future version 
 ### TCP RTT measurement with `go-metro`
 **This new feature is in beta**
 
-The Datadog Agent on Linux is now bundled with a new component (`go-metro`) that passively calculates TCP RTT metrics between the agent's host and external hosts, and reports them as `system.net.tcp.rtt.avg`, `system.net.tcp.rtt.jitter` and `system.net.tcp.rtt.last` through StatsD.
+The Datadog Agent on 64-bit Linux is now bundled with a new component (`go-metro`) that passively calculates TCP RTT metrics between the agent's host and external hosts, and reports them as `system.net.tcp.rtt.avg`, `system.net.tcp.rtt.jitter` and `system.net.tcp.rtt` through StatsD.
 
 `go-metro` follows TCP streams active within a certain period of time and estimates the RTT between any outgoing packet with data, and its corresponding TCP acknowledgement.
 

--- a/conf.d/go-metro.yaml.example
+++ b/conf.d/go-metro.yaml.example
@@ -13,9 +13,9 @@
 #        Also, please note that go-metro logs to its own file - found in /var/log/datadog/go-metro.log.
 #        Additionally, go-mtro runs standalone so it will *NOT* currently appear on the agent's info page.
 #
-#        Finally, because the go-metro binary is only bundled with the RPM and DEB distributions of the
+#        Finally, because the go-metro binary is only bundled with the 64-bit RPM and DEB distributions of the
 #        datadog-agent, it will only be available in those packaged versions (ie. go-metro is currently
-#        not available with the source install).
+#        unavailable with the source install or the 32-bit packages).
 
 init_config:
     snaplen: 512            # should be >=104 (to accomodate for the largest possible TCP header)

--- a/packaging/supervisor_32.conf
+++ b/packaging/supervisor_32.conf
@@ -1,0 +1,61 @@
+[supervisorctl]
+serverurl = unix:///opt/datadog-agent/run/datadog-supervisor.sock
+
+[unix_http_server]
+file=/opt/datadog-agent/run/datadog-supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisord]
+http_port = /opt/datadog-agent/run/datadog-supervisor.sock
+minfds = 1024
+minprocs = 200
+loglevel = info
+logfile = /var/log/datadog/supervisord.log
+logfile_maxbytes = 50MB
+nodaemon = false
+pidfile = /opt/datadog-agent/run/datadog-supervisord.pid
+logfile_backups = 10
+user=dd-agent
+environment=PYTHONPATH=/opt/datadog-agent/agent:/opt/datadog-agent/agent/checks,LANG=POSIX
+
+[program:collector]
+command=/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/agent.py foreground --use-local-forwarder
+stdout_logfile=NONE
+stderr_logfile=NONE
+priority=999
+startsecs=5
+startretries=3
+user=dd-agent
+environment=PYTHONPATH='/opt/datadog-agent/agent:/opt/datadog-agent/agent/checks/libs:$PYTHONPATH'
+
+[program:forwarder]
+command=/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/ddagent.py
+stdout_logfile=NONE
+stderr_logfile=NONE
+startsecs=5
+startretries=3
+priority=998
+user=dd-agent
+
+[program:dogstatsd]
+command=/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/dogstatsd.py --use-local-forwarder
+stdout_logfile=NONE
+stderr_logfile=NONE
+startsecs=5
+startretries=3
+priority=998
+user=dd-agent
+
+[program:jmxfetch]
+command=/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/jmxfetch.py
+stdout_logfile=NONE
+stderr_logfile=NONE
+redirect_stderr=true
+priority=999
+startsecs=3
+user=dd-agent
+
+[group:datadog-agent]
+programs=forwarder,collector,dogstatsd,jmxfetch


### PR DESCRIPTION
We use 2 different supervisor confs on x64 and i386. The init script
should be able to handle both w/o problems.
