### PR TITLE
[haproxy] ` ̶c̶o̶l̶l̶a̶t̶e̶_̶s̶t̶a̶t̶u̶s̶_̶t̶a̶g̶s̶_̶p̶e̶r̶_̶h̶o̶s̶t̶…

### DIFF
--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -23,14 +23,6 @@ class Services(object):
         'up', 'open', 'down', 'maint', 'nolb'
     )
 
-    STATUS_MAP = {
-        'up': 'up',
-        'open': 'up',
-        'down': 'down',
-        'maint': 'down',
-        'nolb': 'down'
-    }
-
     STATUSES_TO_SERVICE_CHECK = {
         'UP': AgentCheck.OK,
         'DOWN': AgentCheck.CRITICAL,
@@ -95,17 +87,6 @@ class HAProxy(AgentCheck):
             instance.get('count_status_by_service', True)
         )
 
-        collate_status_tags_per_host = _is_affirmative(
-            instance.get('collate_status_tags_per_host', False)
-        )
-
-        if collate_status_tags_per_host and not collect_status_metrics_by_host:
-            self.log.warning(
-                u"Status tags collation (`collate_status_tags_per_host`) has no effect when status "
-                u"metrics collection per host (`collect_status_metrics_by_host`) is disabled."
-            )
-            collate_status_tags_per_host = False
-
         tag_service_check_by_host = _is_affirmative(
             instance.get('tag_service_check_by_host', False)
         )
@@ -127,7 +108,6 @@ class HAProxy(AgentCheck):
             services_incl_filter=services_incl_filter,
             services_excl_filter=services_excl_filter,
             count_status_by_service=count_status_by_service,
-            collate_status_tags_per_host=collate_status_tags_per_host
         )
 
     def _fetch_data(self, url, username, password):
@@ -147,8 +127,7 @@ class HAProxy(AgentCheck):
     def _process_data(self, data, collect_aggregates_only, process_events, url=None,
                       collect_status_metrics=False, collect_status_metrics_by_host=False,
                       tag_service_check_by_host=False, services_incl_filter=None,
-                      services_excl_filter=None, count_status_by_service=True,
-                      collate_status_tags_per_host=False):
+                      services_excl_filter=None, count_status_by_service=True):
         ''' Main data-processing loop. For each piece of useful data, we'll
         either save a metric, save an event or both. '''
 
@@ -205,8 +184,7 @@ class HAProxy(AgentCheck):
                 self.hosts_statuses, collect_status_metrics_by_host,
                 services_incl_filter=services_incl_filter,
                 services_excl_filter=services_excl_filter,
-                count_status_by_service=count_status_by_service,
-                collate_status_tags_per_host=collate_status_tags_per_host
+                count_status_by_service=count_status_by_service
             )
 
             self._process_backend_hosts_metric(
@@ -319,7 +297,7 @@ class HAProxy(AgentCheck):
 
     def _process_status_metric(self, hosts_statuses, collect_status_metrics_by_host,
                                services_incl_filter=None, services_excl_filter=None,
-                               count_status_by_service=True, collate_status_tags_per_host=False):
+                               count_status_by_service=True):
         agg_statuses = defaultdict(lambda: {'available': 0, 'unavailable': 0})
 
         # use a counter unless we have a unique tag set to gauge
@@ -345,16 +323,10 @@ class HAProxy(AgentCheck):
             if collect_status_metrics_by_host:
                 tags.append('backend:%s' % hostname)
 
-            if collate_status_tags_per_host:
-                self._gauge_collated_statuses(
-                    "haproxy.count_per_status",
-                    count, status, tags, counter
-                )
-            else:
-                self._gauge_all_statuses(
-                    "haproxy.count_per_status",
-                    count, status, tags, counter
-                )
+            self._gauge_all_statuses(
+                "haproxy.count_per_status",
+                count, status, tags, counter
+            )
 
             if 'up' in status or 'open' in status:
                 agg_statuses[service]['available'] += count
@@ -386,21 +358,6 @@ class HAProxy(AgentCheck):
         for state in Services.ALL_STATUSES:
             if state != status:
                 self.gauge(metric_name, 0, tags + ['status:%s' % state.replace(" ", "_")])
-
-    def _gauge_collated_statuses(self, metric_name, count, status, tags, counter):
-        collated_status = Services.STATUS_MAP.get(status)
-        if not collated_status:
-            # We can't properly collate this guy, because it's a status we don't expect,
-            # let's abandon collation
-            self.log.warning("Unexpected status found %s", status)
-            self._gauge_all_statuses(metric_name, count, status, tags, counter)
-            return
-
-        self.gauge(metric_name, count, tags + ['status:%s' % collated_status])
-
-        for state in ['up', 'down']:
-            if collated_status != state:
-                self.gauge(metric_name, 0, tags + ['status:%s' % state])
 
     def _process_metrics(self, data, url, services_incl_filter=None,
                          services_excl_filter=None):

--- a/conf.d/haproxy.yaml.example
+++ b/conf.d/haproxy.yaml.example
@@ -25,12 +25,6 @@ instances:
     # This only applies if `collect_status_metrics` is True.
     # collect_status_metrics_by_host: False
     #
-    # The (optional) `collate_status_tags_per_host` parameter will collate
-    # `status` tags for `haproxy.count_per_status` up to one of `up, down`
-    # for each discovered backend.
-    # This only applies if `collect_status_metrics_by_host` is True.
-    # collate_status_tags_per_host: False
-    #
     # The (optional) `count_status_by_service` parameter will instruct the check
     # to tag the status counts it collects by service in addition to by host.
     # This only applies if `collect_status_metrics` is True.


### PR DESCRIPTION
…` option

HAProxy newly introduced `collate_status_tags_per_host` option does not
appropriately aggregates metrics when a backend is associated to
multiple service. Remove it, to fix it.