### PR TITLE
[core] detect forwarder pathological activity

### DIFF
--- a/ddagent.py
+++ b/ddagent.py
@@ -65,8 +65,14 @@ log.setLevel(get_logging_config()['log_level'] or logging.INFO)
 
 DD_ENDPOINT = "dd_url"
 
+# Transactions
 TRANSACTION_FLUSH_INTERVAL = 5000  # Every 5 seconds
+
+# Watchdog settings
 WATCHDOG_INTERVAL_MULTIPLIER = 10  # 10x flush interval
+WATCHDOG_HIGH_ACTIVITY_THRESHOLD = 1000  # Threshold to detect pathological activity
+
+# Misc
 HEADERS_TO_REMOVE = [
     'Host',
     'Content-Length',
@@ -79,7 +85,7 @@ MAX_WAIT_FOR_REPLAY = timedelta(seconds=90)
 # Maximum queue size in bytes (when this is reached, old messages are dropped)
 MAX_QUEUE_SIZE = 30 * 1024 * 1024  # 30MB
 
-THROTTLING_DELAY = timedelta(microseconds=1000000/2)  # 2 msg/second
+THROTTLING_DELAY = timedelta(microseconds=1000000 / 2)  # 2 msg/second
 
 
 class EmitterThread(threading.Thread):
@@ -404,10 +410,14 @@ class Application(tornado.web.Application):
         if self.skip_ssl_validation:
             log.info("Skipping SSL hostname validation, useful when using a transparent proxy")
 
+        # Monitor activity
         if watchdog:
             watchdog_timeout = TRANSACTION_FLUSH_INTERVAL * WATCHDOG_INTERVAL_MULTIPLIER / 1000
-            self._watchdog = Watchdog(watchdog_timeout,
-                                      max_mem_mb=agentConfig.get('limit_memory_consumption', None))
+            self._watchdog = Watchdog(
+                watchdog_timeout,
+                max_mem_mb=agentConfig.get('limit_memory_consumption', None),
+                max_resets=WATCHDOG_HIGH_ACTIVITY_THRESHOLD
+            )
 
     def log_request(self, handler):
         """ Override the tornado logging method.

--- a/tests/core/test_watchdog.py
+++ b/tests/core/test_watchdog.py
@@ -14,9 +14,9 @@ from nose.plugins.attrib import attr
 
 # project
 # needed because of the subprocess calls
+sys.path.append(os.getcwd())
 from ddagent import Application
 from util import Watchdog
-sys.path.append(os.getcwd())
 
 
 class WatchdogKill(Exception):

--- a/util.py
+++ b/util.py
@@ -479,7 +479,7 @@ class EC2(object):
 
 class Watchdog(object):
     """
-    Simple signal-based watchdog. Restart the process when:
+    Simple signal-based watchdog. Restarts the process when:
     * no reset was made for more than a specified duration
     * (optional) a specified memory threshold is exceeded
     * (optional) a suspicious high activity is detected, i.e. too many resets for a given timeframe.
@@ -523,7 +523,7 @@ class Watchdog(object):
         finally:
             os.kill(os.getpid(), signal.SIGKILL)
 
-    def is_frenetic(self):
+    def _is_frenetic(self):
         """
         Detect suspicious high activity, i.e. the number of resets exceeds the maximum limit set
         on the watchdog timeframe.
@@ -551,7 +551,7 @@ class Watchdog(object):
         # Check activity
         if self._max_resets:
             self._restarts.append(time.time())
-            if self.is_frenetic():
+            if self._is_frenetic():
                 Watchdog.self_destruct(signal.SIGKILL, sys._getframe(0))
 
         # Re arm alarm signal

--- a/util.py
+++ b/util.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 # stdlib
+from collections import deque
 from hashlib import md5
 import logging
 import os
@@ -477,20 +478,27 @@ class EC2(object):
 
 
 class Watchdog(object):
-    """Simple signal-based watchdog that will scuttle the current process
-    if it has not been reset every N seconds, or if the processes exceeds
-    a specified memory threshold.
+    """
+    Simple signal-based watchdog. Restart the process when:
+    * no reset was made for more than a specified duration
+    * (optional) a specified memory threshold is exceeded
+    * (optional) a suspicious high activity is detected, i.e. too many resets for a given timeframe.
+
+    **Warning**: Not thread-safe.
     Can only be invoked once per process, so don't use with multiple threads.
     If you instantiate more than one, you're also asking for trouble.
     """
-    def __init__(self, duration, max_mem_mb = None):
+    # Activity history timeframe
+    _RESTART_TIMEFRAME = 60
+
+    def __init__(self, duration, max_mem_mb=None, max_resets=None):
         import resource
 
-        #Set the duration
+        # Set the duration
         self._duration = int(duration)
         signal.signal(signal.SIGALRM, Watchdog.self_destruct)
 
-        # cap memory usage
+        # Set memory usage threshold
         if max_mem_mb is not None:
             self._max_mem_kb = 1024 * max_mem_mb
             max_mem_bytes = 1024 * self._max_mem_kb
@@ -499,8 +507,15 @@ class Watchdog(object):
         else:
             self.memory_limit_enabled = False
 
+        # Set high activity monitoring
+        self._restarts = deque([])
+        self._max_resets = max_resets
+
     @staticmethod
     def self_destruct(signum, frame):
+        """
+        Kill the process. It will be eventually restarted.
+        """
         try:
             import traceback
             log.error("Self-destructing...")
@@ -508,14 +523,38 @@ class Watchdog(object):
         finally:
             os.kill(os.getpid(), signal.SIGKILL)
 
+    def is_frenetic(self):
+        """
+        Detect suspicious high activity, i.e. the number of resets exceeds the maximum limit set
+        on the watchdog timeframe.
+        Flush old activity history
+        """
+        now = time.time()
+        while(self._restarts and self._restarts[0] < now - self._RESTART_TIMEFRAME):
+            self._restarts.popleft()
+
+        return len(self._restarts) > self._max_resets
 
     def reset(self):
-        # self destruct if using too much memory, as tornado will swallow MemoryErrors
+        """
+        Reset the watchdog state, i.e.
+        * re-arm alarm signal
+        * (optional) check memory consumption
+        * (optional) save reset history, flush old entries and check frequency
+        """
+        # Check memory consumption: restart if too high as tornado will swallow MemoryErrors
         if self.memory_limit_enabled:
             mem_usage_kb = int(os.popen('ps -p %d -o %s | tail -1' % (os.getpid(), 'rss')).read())
             if mem_usage_kb > (0.95 * self._max_mem_kb):
                 Watchdog.self_destruct(signal.SIGKILL, sys._getframe(0))
 
+        # Check activity
+        if self._max_resets:
+            self._restarts.append(time.time())
+            if self.is_frenetic():
+                Watchdog.self_destruct(signal.SIGKILL, sys._getframe(0))
+
+        # Re arm alarm signal
         log.debug("Resetting watchdog for %d" % self._duration)
         signal.alarm(self._duration)
 


### PR DESCRIPTION
**[util] watchdog high activity detection :fire:**

New option to the Watchdog to detect suspiciously high activity:
restarts the process when too many resets were made for a given
timeframe.

**[core] detect forwarder pathological activity**
On some specific system date and scheduled transaction flush time, the
Datadog Agent forwarder's schedule breaks and enters in a frenetic loop.
It gets unreachable, flushes (no transaction) at a very high rate
(several ~100 flushes/second). At this point, only a restart fixes the
situation.

Under the hood, the issue is related to `tornado==3.2.2`. More
information is available here:
https://github.com/tornadoweb/tornado/issues/947

Before considering any upgrade, a simple fix is to use the Watchdog to
detect this pathological high activity.