### PR TITLE
[kafka] changed default Kafka broker port

### DIFF
--- a/conf.d/kafka_consumer.yaml.example
+++ b/conf.d/kafka_consumer.yaml.example
@@ -5,7 +5,7 @@ init_config:
 #  kafka_timeout: 5
 
 instances:
-  # - kafka_connect_str: localhost:19092
+  # - kafka_connect_str: localhost:9092
   #   zk_connect_str: localhost:2181
   #   zk_prefix: /0.8
   #   consumer_groups:


### PR DESCRIPTION
changed the default Kafka broker port listed in the configuration to the _actual_ default port

[skip ci]