### PR TITLE
[cassandra] exclude new system_schema keyspace

### DIFF
--- a/conf.d/cassandra.yaml.example
+++ b/conf.d/cassandra.yaml.example
@@ -72,6 +72,7 @@ init_config:
           - system
           - system_auth
           - system_distributed
+          - system_schema
           - system_traces
     - include:
         domain: org.apache.cassandra.metrics


### PR DESCRIPTION
Cassandra added a new `system_schema` keyspace in version 3.0. If not excluded from the JMX check, this keyspace reports ~130 additional JMX metrics to Datadog. Tested on Cassandra 3.0.4.