### PR TITLE
[SDK] Minor changes to allow testing of the SDK check modules

### DIFF
--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -61,12 +61,15 @@ def load_class(check_name, class_name):
     raise Exception(u"Unable to import class {0} from the check module.".format(class_name))
 
 
-def load_check(name, config, agentConfig):
-    checksd_path = get_checksd_path(get_os())
+def load_check(name, config, agentConfig, is_sdk=False):
+    if not is_sdk:
+        checksd_path = get_checksd_path(get_os())
 
-    # find (in checksd_path) and load the check module
-    fd, filename, desc = imp.find_module(name, [checksd_path])
-    check_module = imp.load_module(name, fd, filename, desc)
+        # find (in checksd_path) and load the check module
+        fd, filename, desc = imp.find_module(name, [checksd_path])
+        check_module = imp.load_module(name, fd, filename, desc)
+    else:
+        check_module = __import__("check")
 
     check_class = None
     classes = inspect.getmembers(check_module, inspect.isclass)
@@ -139,12 +142,15 @@ class AgentCheckTest(unittest.TestCase):
 
         self.check = None
 
+    def is_sdk(self):
+        return "SDK_TESTING" in os.environ
+
     def is_travis(self):
         return "TRAVIS" in os.environ
 
     def load_check(self, config, agent_config=None):
         agent_config = agent_config or self.DEFAULT_AGENT_CONFIG
-        self.check = load_check(self.CHECK_NAME, config, agent_config)
+        self.check = load_check(self.CHECK_NAME, config, agent_config, is_sdk=self.is_sdk())
 
     def load_class(self, name):
         """


### PR DESCRIPTION
Modules will normally live in `integrations-core/foo` or `integrations-extra/bar` and a file typically called (by convention) `check.py`...

These changes would allow us to use the AgentCheckTest facilities with CircleCI and the SDK. We might have to fine-grain a little bit how we load the checks if `is_sdk=True`.

Should be backward compatible.