### PR TITLE
[requirements] Add reminder to update omnibus-software too

### DIFF
--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -1,8 +1,16 @@
+######################## WARNING ##########################
+# This file currently determines the python deps installed
+# for the dev env, the source install and the Win build.
+# It is NOT used for the DEB/RPM packages and the OS X
+# build. For these please update:
+# https://github.com/DataDog/omnibus-software
+###########################################################
+
 # core/optional
 # tornado can work without pycurl and use the simple http client
 # but some features won't work, like the abylity to use a proxy
 # Require a compiler and the curl headers+lib
-# On windows - manual install of pycurl might be easier. 
+# On windows - manual install of pycurl might be easier.
 pycurl==7.19.5.1
 
 # core-ish/system -> system check on windows

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,11 @@
+######################## WARNING ##########################
+# This file currently determines the python deps installed
+# for the dev env, the source install and the Win build.
+# It is NOT used for the DEB/RPM packages and the OS X
+# build. For these please update:
+# https://github.com/DataDog/omnibus-software
+###########################################################
+
 ###########################################################
 # These modules are the deps needed by the
 # agent core, meaning every module that is


### PR DESCRIPTION
We get bitten fairly often by differences in the deps/versions of deps
defined in the requirement files and in omnibus. Adding a comment to
make clear that updating only the requirement files is not enough.