### PR TITLE
[utils] Add a default timeout parameter to retrieve_json

### DIFF
--- a/utils/http.py
+++ b/utils/http.py
@@ -1,6 +1,10 @@
 import requests
 
-def retrieve_json(url):
-    r = requests.get(url)
+
+DEFAULT_TIMEOUT = 10
+
+
+def retrieve_json(url, timeout=DEFAULT_TIMEOUT):
+    r = requests.get(url, timeout=timeout)
     r.raise_for_status()
     return r.json()


### PR DESCRIPTION
Add a timeout to avoid hanging requests that get the collector killed.