### PR TITLE
Add metrics from Linux's /proc/vmstat

### DIFF
--- a/checks.d/linux_vm_extras.py
+++ b/checks.d/linux_vm_extras.py
@@ -19,4 +19,4 @@ class MoreLinuxVMCheck(AgentCheck):
 
             for line in content:
                 if line[0] in VM_COUNTS:
-                    self.count("system.linux.vm.{0}".format(VM_COUNTS[line[0]]), int(line[1]), tags=tags)
+                    self.monotonic_count("system.linux.vm.{0}".format(VM_COUNTS[line[0]]), int(line[1]), tags=tags)

--- a/checks.d/linux_vm_extras.py
+++ b/checks.d/linux_vm_extras.py
@@ -19,4 +19,4 @@ class MoreLinuxVMCheck(AgentCheck):
 
             for line in content:
                 if line[0] in VM_COUNTS:
-                    self.count("system.linux.{0}".format(VM_COUNTS[line[0]]), int(line[1]), tags=tags)
+                    self.count("system.linux.vm.{0}".format(VM_COUNTS[line[0]]), int(line[1]), tags=tags)

--- a/checks.d/linux_vm_extras.py
+++ b/checks.d/linux_vm_extras.py
@@ -1,0 +1,22 @@
+# project
+from checks import AgentCheck
+
+VM_COUNTS = {
+    'pgpgin': 'pages.in',
+    'pgpgout': 'pages.out',
+    'pswpin': 'pages.swapped_in',
+    'pswpout': 'pages.swapped_out',
+    'pgfault': 'pages.faults',
+    'pgmajfault': 'pages.major_faults'
+}
+
+class MoreLinuxVMCheck(AgentCheck):
+    def check(self, instance):
+        tags = instance.get('tags', [])
+
+        with open('/proc/vmstat', 'r') as vm_info:
+            content = [line.strip().split() for line in vm_info.readlines()]
+
+            for line in content:
+                if line[0] in VM_COUNTS:
+                    self.count("system.linux.{0}".format(VM_COUNTS[line[0]]), int(line[1]), tags=tags)

--- a/conf.d/linux_vm_extras.yaml.example
+++ b/conf.d/linux_vm_extras.yaml.example
@@ -1,0 +1,5 @@
+# There's no configuration necessary for this check.
+init_config:
+
+instances:
+  - tags: []


### PR DESCRIPTION
### What's this PR do?
Adds metrics from Linux' vm subsystem.

* `system.linux.vm` from `/proc/vmstat`
  * `pages.in` for `pgpgin`
  * `pages.out` for `pgpgout`
  * `pages.swapped_in` for `pswpin`
  * `pages.swapped_out` for `pswpout`
  * `pages.faults` for `pgfault`
  * `pages.major_faults` for `pgmajfault`

### Motivation

We have swap totals but we don't have swap _activity_.

### Notes

There are lots of metrics in here and likely some others are useful. I defer to others as to what we might want.

I'd love it if @b0rk, @nelhage and @ebroder looked at this and let me know if there were additions / removals to make from `/proc/vmstat`.

cc @rhwlo 