### PR TITLE
[disk] add a regex option to exclude disks based on mountpoint

### DIFF
--- a/conf.d/disk.yaml.default
+++ b/conf.d/disk.yaml.default
@@ -17,11 +17,15 @@ instances:
     #
     # The (optional) excluded_disk_re parameter will instruct the check to
     # ignore all disks matching this regex
-    # excluded_disk_re: /dev/sde*
+    # excluded_disk_re: /dev/sde.*
     #
     # The (optional) tag_by_filesystem parameter will instruct the check to
     # tag all disks with their filesystem (for ex: filesystem:nfs)
     # tag_by_filesystem: no
+    #
+    # The (optional) excluded_mountpoint_re parameter will instruct the check to
+    # ignore all mountpoints matching this regex
+    # excluded_mountpoint_re: /mnt/somebody-elses-problem.*
     #
     # The (optional) all_partitions parameter will instruct the check to
     # get metrics for all partitions. use_mount should be set to yes (to avoid

--- a/tests/checks/mock/test_disk.py
+++ b/tests/checks/mock/test_disk.py
@@ -61,6 +61,7 @@ class TestCheckDisk(AgentCheckTest):
     def test_device_exclusion_logic(self):
         self.run_check({'instances': [{'use_mount': 'no',
                                        'excluded_filesystems': ['aaaaaa'],
+                                       'excluded_mountpoint_re': '^/z+$',
                                        'excluded_disks': ['bbbbbb'],
                                        'excluded_disk_re': '^tev+$'}]},
                        mocks={'collect_metrics': lambda: None})
@@ -84,6 +85,10 @@ class TestCheckDisk(AgentCheckTest):
         # excluded devices regex
         self.assertTrue(exclude_disk(MockPart(device='tevvv')))
         self.assertFalse(exclude_disk(MockPart(device='tevvs')))
+
+        # excluded mountpoint regex
+        self.assertTrue(exclude_disk(MockPart(device='sdz', mountpoint='/zz')))
+        self.assertFalse(exclude_disk(MockPart(device='sdz', mountpoint='/zy')))
 
         # and now with all_partitions
         self.check._all_partitions = True


### PR DESCRIPTION
#### summary

This changeset adds an `exclude_mountpoint_re` option the disk integration configuration and corrects a small typo in the disk integration configuration template.

#### motivation

Nagios’s `check_disk` plugin has a `-i` option to ignore paths or partitions based off of regular expressions, and this will add the same functionality to Datadog.

#### testing

I’ve added tests to `mock/test_disk.py` alongside the other disk tests to verify that the regexes exclude what we want and nothing else.