### PR TITLE
DEVOPS-556 : add pagefault stats to process metrics

### DIFF
--- a/tests/checks/integration/test_process.py
+++ b/tests/checks/integration/test_process.py
@@ -431,6 +431,7 @@ class ProcessCheckTest(AgentCheckTest):
 
     def test_pagefault_stats(self):
         (minflt, cminflt, majflt, cmajflt) = [1, 2, 3, 4]
+
         def mock_get_pagefault_stats(pid):
             return [minflt, cminflt, majflt, cmajflt]
 
@@ -444,8 +445,9 @@ class ProcessCheckTest(AgentCheckTest):
                 }
             }]
         }
+
         def mock_find_pids(_1, _2, _3, **kwargs):
-            return {1}
+            return set([1])
         mocks = {
             'find_pids': mock_find_pids,
             'get_pagefault_stats': mock_get_pagefault_stats,

--- a/tests/checks/integration/test_process.py
+++ b/tests/checks/integration/test_process.py
@@ -428,3 +428,33 @@ class ProcessCheckTest(AgentCheckTest):
         self.assertMetric('system.processes.number', at_least=1, tags=expected_tags)
 
         self.coverage_report()
+
+    def test_pagefault_stats(self):
+        (minflt, cminflt, majflt, cmajflt) = [1, 2, 3, 4]
+        def mock_get_pagefault_stats(pid):
+            return [minflt, cminflt, majflt, cmajflt]
+
+        config = {
+            'instances': [{
+                'name': 'test_0',
+                'search_string': ['test_0'],  # index in the array for our find_pids mock
+                'thresholds': {
+                    'critical': [2, 4],
+                    'warning': [1, 5]
+                }
+            }]
+        }
+        def mock_find_pids(_1, _2, _3, **kwargs):
+            return {1}
+        mocks = {
+            'find_pids': mock_find_pids,
+            'get_pagefault_stats': mock_get_pagefault_stats,
+        }
+        self.run_check(config, mocks=mocks)
+
+        instance_config = config['instances'][0]
+        self.assertMetric('system.processes.mem.minflt', at_least=1, tags=self.generate_expected_tags(instance_config), value=minflt)
+        self.assertMetric('system.processes.mem.cminflt', at_least=1, tags=self.generate_expected_tags(instance_config), value=cminflt)
+        self.assertMetric('system.processes.mem.majflt', at_least=1, tags=self.generate_expected_tags(instance_config), value=majflt)
+        self.assertMetric('system.processes.mem.cmajflt', at_least=1, tags=self.generate_expected_tags(instance_config), value=cmajflt)
+        self.coverage_report()


### PR DESCRIPTION
This pull request obviates https://github.com/DataDog/dd-agent/pull/2238

I'm creating it initially to trigger a travis build to ensure tests are passing.

EDIT: I'm working on fixing the failing tests.