### PR TITLE
[core] Remove support of python 2.6 + Cleanup + pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,249 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+init-hook='import sys; sys.path.append(".")'
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS,.git,embedded,venv
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+
+[MESSAGES CONTROL]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+#disable=
+#
+disable=W,C,R,maybe-no-member,no-member,I0011
+# FIXME matt: pylint has a bug that will not let you gradually enable
+# rules in the rcfile, so this is done in our rakefile.
+# http://www.logilab.org/ticket/36584
+enable=
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the massage information. See doc for all details
+msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
+
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,apply,input
+
+# Regular expression which should only match correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression which should only match correct module level names
+const-rgx=(([a-zA-Z_][a-zA-Z0-9_]*)|(__.*__))$
+
+# Regular expression which should only match correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression which should only match correct function names
+function-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match correct method names
+method-rgx=[a-z_][A-Za-z0-9_]*$
+
+# Regular expression which should only match correct instance attribute names
+attr-rgx=[a-z_][a-z0-9_]{1,30}$
+
+# Regular expression which should only match correct argument names
+argument-rgx=[a-z_][A-Za-z0-9_]*$
+
+# Regular expression which should only match correct variable names
+variable-rgx=[a-z_][A-Za-z0-9_]*$
+
+# Regular expression which should only match correct list comprehension /
+# generator expression variable names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Regular expression which should only match functions or classes name which do
+# not require a docstring
+no-docstring-rgx=.*
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=80
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=yes
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject,nose.tools
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent,assert_equal
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the beginning of the name of dummy variables
+# (i.e. not used).
+dummy-variables-rgx=_|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=10
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=50
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branchs=12
+
+# Maximum number of statements in function / method body
+max-statements=80
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,string,TERMIOS,Bastion,rexec,json,Check
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ branches:
 
 language: python
 python:
-  - "2.6"
   - "2.7"
 
 cache:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pull request.
 ## Setup your environment
 
 Required:
-- python 2.6 or 2.7
+- python 2.7
 - bundler
 
 ```

--- a/checks.d/cacti.py
+++ b/checks.d/cacti.py
@@ -231,9 +231,3 @@ class Cacti(AgentCheck):
         if m_name[0:11] in ('system.mem.', 'system.disk'):
             return val / 1024
         return val
-
-
-    '''
-        For backwards compatability with pre-checks.d configuration.
-        Convert old-style config to new-style config.
-    '''

--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -457,9 +457,9 @@ class MongoDb(AgentCheck):
             if isinstance(metrics_to_collect[original_metric_name], tuple) \
             else original_metric_name
 
-        return submit_method, self.normalize(metric_name, submit_method, prefix)
+        return submit_method, self._normalize(metric_name, submit_method, prefix)
 
-    def normalize(self, metric_name, submit_method, prefix):
+    def _normalize(self, metric_name, submit_method, prefix):
         """
         Replace case-sensitive metric name characters, normalize the metric name,
         prefix and suffix according to its type.
@@ -473,7 +473,7 @@ class MongoDb(AgentCheck):
 
         # Normalize, and wrap
         return u"{metric_prefix}{normalized_metric_name}{metric_suffix}".format(
-            normalized_metric_name=super(MongoDb, self).normalize(metric_name.lower()),
+            normalized_metric_name=self.normalize(metric_name.lower()),
             metric_prefix=metric_prefix, metric_suffix=metric_suffix
         )
 

--- a/checks.d/vsphere.py
+++ b/checks.d/vsphere.py
@@ -10,7 +10,7 @@ import traceback
 
 # 3p
 from pyVim import connect
-from pyVmomi import vim
+from pyVmomi import vim # pylint: disable=E0611
 
 # project
 from checks import AgentCheck

--- a/checks.d/zk.py
+++ b/checks.d/zk.py
@@ -67,7 +67,7 @@ zk_max_file_descriptor_count    4096
 '''
 # stdlib
 from collections import defaultdict
-from distutils.version import LooseVersion
+from distutils.version import LooseVersion # pylint: disable=E0611,E0401
 from StringIO import StringIO
 import re
 import socket

--- a/checks/datadog.py
+++ b/checks/datadog.py
@@ -14,16 +14,12 @@ import modules
 from util import windows_friendly_colon_split
 from utils.tailfile import TailFile
 
-if hasattr('some string', 'partition'):
-    def partition(s, sep):
-        return s.partition(sep)
-else:
-    def partition(s, sep):
-        pos = s.find(sep)
-        if pos == -1:
-            return (s, sep, '')
-        else:
-            return s[0:pos], sep, s[pos + len(sep):]
+def partition(s, sep):
+    pos = s.find(sep)
+    if pos == -1:
+        return (s, sep, '')
+    else:
+        return s[0:pos], sep, s[pos + len(sep):]
 
 
 def point_sorter(p):

--- a/checks/libs/wmi/sampler.py
+++ b/checks/libs/wmi/sampler.py
@@ -1,3 +1,4 @@
+# pylint: disable=E0401
 """
 A lightweight Python WMI module wrapper built on top of `pywin32` and `win32com` extensions.
 
@@ -363,7 +364,7 @@ class WMISampler(object):
 
         return " WHERE {clause}".format(clause=build_where_clause(filters))
 
-    def _query(self):
+    def _query(self): # pylint: disable=E0202
         """
         Query WMI using WMI Query Language (WQL) & parse the results.
 

--- a/ci/default.rb
+++ b/ci/default.rb
@@ -42,7 +42,12 @@ namespace :ci do
     task before_script: ['ci:common:before_script']
 
     task lint: ['rubocop'] do
+      sh %(echo "PWD IS")
+      sh %(pwd)
       sh %(flake8)
+      sh %(find . -name '*.py' -not\
+             \\( -path '*.cache*' -or -path '*embedded*' -or -path '*venv*' -or -path '*.git*' \\)\
+             | xargs -n 1 pylint --rcfile=./.pylintrc)
     end
 
     task script: ['ci:common:script', :coverage, :lint] do

--- a/dogstream/cassandra.py
+++ b/dogstream/cassandra.py
@@ -28,7 +28,6 @@ THREADS = [
 ]
 
 DATE_FORMAT = '%Y-%m-%d %H:%M:%S,%f'
-LEGACY_DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 
 # Parse Cassandra default system.log log4j pattern: %5p [%t] %d{ISO8601} %F (line %L) %m%n
 LOG_PATTERN = re.compile(r"".join([
@@ -42,12 +41,7 @@ LOG_PATTERN = re.compile(r"".join([
 
 
 def parse_date(timestamp):
-    try:
-        return common.parse_date(timestamp, DATE_FORMAT)
-    except ValueError:
-        # Only Python >= 2.6 supports %f in the date string
-        timestamp, _ = timestamp.split(',')
-        return common.parse_date(timestamp, LEGACY_DATE_FORMAT)
+    return common.parse_date(timestamp, DATE_FORMAT)
 
 def parse_cassandra(log, line):
     matched = LOG_PATTERN.match(line)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ nose==1.3.4
 flake8==2.5.1
 mock==1.0.1
 pep8==1.5.7
+pylint==1.5.5

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -5,7 +5,6 @@ from itertools import product
 import logging
 import os
 from pprint import pformat
-import signal
 import sys
 import time
 import traceback
@@ -88,23 +87,6 @@ def load_check(name, config, agentConfig):
         raise Exception("Check is using old API, {0}".format(e))
     except Exception:
         raise
-
-
-def kill_subprocess(process_obj):
-    try:
-        process_obj.terminate()
-    except AttributeError:
-        # py < 2.6 doesn't support process.terminate()
-        if get_os() == 'windows':
-            import ctypes
-            PROCESS_TERMINATE = 1
-            handle = ctypes.windll.kernel32.OpenProcess(PROCESS_TERMINATE, False,
-                                                        process_obj.pid)
-            ctypes.windll.kernel32.TerminateProcess(handle, -1)
-            ctypes.windll.kernel32.CloseHandle(handle)
-        else:
-            os.kill(process_obj.pid, signal.SIGKILL)
-
 
 class Fixtures(object):
     @staticmethod
@@ -216,7 +198,7 @@ class AgentCheckTest(unittest.TestCase):
                 self.service_metadata.append(metadata)
 
         if error is not None:
-            raise error
+            raise error # pylint: disable=E0702
 
     def print_current_state(self):
         log.debug("""++++++++ CURRENT STATE ++++++++

--- a/tests/checks/integration/test_redisdb.py
+++ b/tests/checks/integration/test_redisdb.py
@@ -5,7 +5,7 @@ import random
 import time
 
 # 3p
-from distutils.version import StrictVersion
+from distutils.version import StrictVersion # pylint: disable=E0611,E0401
 from nose.plugins.attrib import attr
 from nose.plugins.skip import SkipTest
 import redis

--- a/tests/checks/integration/test_zk.py
+++ b/tests/checks/integration/test_zk.py
@@ -1,6 +1,6 @@
 # stdlib
 import os
-from distutils.version import LooseVersion
+from distutils.version import LooseVersion # pylint: disable=E0611,E0401
 from nose.plugins.attrib import attr
 
 # project

--- a/tests/core/test_timeout.py
+++ b/tests/core/test_timeout.py
@@ -33,7 +33,7 @@ class MyClass(object):
         """
         self.make_sum = timeout(0.2)(self.make_sum)
 
-    def make_sum(self, a, b, sleep=0, raise_exception=False):
+    def make_sum(self, a, b, sleep=0, raise_exception=False): # pylint: disable=E0202
         """Sleep, sum and return `a` with `b`"""
         global count
         count += 1

--- a/tests/core/test_win32_agent.py
+++ b/tests/core/test_win32_agent.py
@@ -41,11 +41,11 @@ class TestWin32Agent(unittest.TestCase):
         WatchDog does not exceed a maximum number of restarts per timeframe.
         """
         # Limit the restart timeframe for test purpose
-        ProcessWatchDog._RESTART_TIMEFRAME = 1  # noqa
+        ProcessWatchDog._RESTART_TIMEFRAME = 1  # noqa pylint: disable=E0602
 
         # Create a WatchDog with a mock process
         process = MockProcess("MyConfig", "MyHostname", foo="bar")
-        process_watchdog = ProcessWatchDog("MyProcess", process, max_restarts=2)  # noqa
+        process_watchdog = ProcessWatchDog("MyProcess", process, max_restarts=2)  # noqa pylint: disable=E0602
 
         # Can restart 2 times
         for x in xrange(0, 2):
@@ -65,7 +65,7 @@ class TestWin32Agent(unittest.TestCase):
         """
         # Create a WatchDog with a mock process
         process = MockProcess("MyConfig", "MyHostname", foo="bar")
-        process_watchdog = ProcessWatchDog("MyProcess", process)  # noqa
+        process_watchdog = ProcessWatchDog("MyProcess", process)  # noqa pylint: disable=E0602
 
         # Restart the process
         process_watchdog.restart()

--- a/tests/core/test_wmi.py
+++ b/tests/core/test_wmi.py
@@ -1,3 +1,4 @@
+# pylint: disable=E0401
 # stdlib
 from functools import partial
 import logging

--- a/util.py
+++ b/util.py
@@ -1,7 +1,6 @@
 # stdlib
 from hashlib import md5
 import logging
-import math
 import os
 import platform
 import re
@@ -101,27 +100,6 @@ def windows_friendly_colon_split(config_string):
         return COLON_NON_WIN_PATH.split(config_string)
     else:
         return config_string.split(':')
-
-def getTopIndex():
-    macV = None
-    if sys.platform == 'darwin':
-        macV = platform.mac_ver()
-
-    # Output from top is slightly modified on OS X 10.6 (case #28239)
-    if macV and macV[0].startswith('10.6.'):
-        return 6
-    else:
-        return 5
-
-
-def isnan(val):
-    if hasattr(math, 'isnan'):
-        return math.isnan(val)
-
-    # for py < 2.6, use a different check
-    # http://stackoverflow.com/questions/944700/how-to-check-for-nan-in-python
-    return str(val) == str(1e400*0)
-
 
 def cast_metric_val(val):
     # ensure that the metric value is a numeric type

--- a/win32/gui.py
+++ b/win32/gui.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=E0401
 #
 # Copyright © 2009-2010 CEA
 # Pierre Raybaut


### PR DESCRIPTION
- Stop testing agent on python 2.6
- Remove code used to handle python < 2.6
- Remove unused code
- Reenable pylint