### PR TITLE
[consul] Enforce that get_peers_in_cluster returns a list

### DIFF
--- a/checks.d/consul.py
+++ b/checks.d/consul.py
@@ -137,7 +137,7 @@ class ConsulCheck(AgentCheck):
 
     ### Consul Catalog Accessors
     def get_peers_in_cluster(self, instance):
-        return self.consul_request(instance, '/v1/status/peers')
+        return self.consul_request(instance, '/v1/status/peers') or []
 
     def get_services_in_cluster(self, instance):
         return self.consul_request(instance, '/v1/catalog/services')


### PR DESCRIPTION
The consul API may return `null` instead of `[]` when there are no
peers in the cluster.

Fixes #2336