### PR TITLE
[consul] Make max number of catalog services configurable

### DIFF
--- a/checks.d/consul.py
+++ b/checks.d/consul.py
@@ -20,7 +20,7 @@ class ConsulCheck(AgentCheck):
     SOURCE_TYPE_NAME = 'consul'
 
     MAX_CONFIG_TTL = 300 # seconds
-    MAX_SERVICES = 50 # cap on distinct Consul ServiceIDs to interrogate
+    DEFAULT_MAX_SERVICES = 50 # cap on distinct Consul ServiceIDs to interrogate
 
     STATUS_SC = {
         'up': AgentCheck.OK,
@@ -147,18 +147,18 @@ class ConsulCheck(AgentCheck):
 
         return self.consul_request(instance, consul_request_url)
 
-    def _cull_services_list(self, services, service_whitelist):
+    def _cull_services_list(self, services, service_whitelist, max_services):
         if service_whitelist:
-            if len(service_whitelist) > self.MAX_SERVICES:
-                self.warning('More than %d services in whitelist. Service list will be truncated.' % self.MAX_SERVICES)
+            if max_services > 0 and len(service_whitelist) > max_services:
+                self.warning('More than %d services in whitelist. Service list will be truncated.' % max_services)
 
-            services = [s for s in services if s in service_whitelist][:self.MAX_SERVICES]
+            services = [s for s in services if s in service_whitelist][:max_services]
         else:
-            if len(services) <= self.MAX_SERVICES:
+            if max_services > 0 and len(services) <= max_services:
                 self.warning('Consul service whitelist not defined. Agent will poll for all %d services found' % len(services))
-            else:
-                self.warning('Consul service whitelist not defined. Agent will poll for at most %d services' % self.MAX_SERVICES)
-                services = list(islice(services.iterkeys(), 0, self.MAX_SERVICES))
+            elif max_services > 0:
+                self.warning('Consul service whitelist not defined. Agent will poll for at most %d services' % max_services)
+                services = list(islice(services.iterkeys(), 0, max_services))
 
         return services
 
@@ -218,8 +218,9 @@ class ConsulCheck(AgentCheck):
             services = self.get_services_in_cluster(instance)
             service_whitelist = instance.get('service_whitelist',
                                              self.init_config.get('service_whitelist', []))
+            max_services = instance.get('max_services', self.init_config.get('max_services', self.DEFAULT_MAX_SERVICES))
 
-            services = self._cull_services_list(services, service_whitelist)
+            services = self._cull_services_list(services, service_whitelist, max_services)
 
             # {node_id: {"up: 0, "passing": 0, "warning": 0, "critical": 0}
             nodes_to_service_status = defaultdict(lambda: defaultdict(int))

--- a/conf.d/consul.yaml.example
+++ b/conf.d/consul.yaml.example
@@ -28,10 +28,18 @@ instances:
       # you will receive one event per leader change per agent
       new_leader_checks: yes
 
+      # Number of services to restrict catalog checks to
+      # By default, the catalog checks allow only 50 services, so if
+      # you have more than this, you'll have to adjust this
+      # number. Use any value less than 1 to query an unlimited number
+      # of services.
+      # max_services: 50
+
       # Services to restrict catalog querying to
-      # The default settings query up to 50 services. So if you have more than
-      # this many in your Consul service catalog, you will want to fill in the
-      # whitelist
+      # The default settings query up to the first 50 services. If you
+      # have more services than max_services above, you can either
+      # pick the specific services to query for (any that exceed
+      # max_services will be removed).
       # service_whitelist:
       #   - zookeeper
       #   - gunicorn


### PR DESCRIPTION
Currently, the consul check cuts off the list of catalogued services that it interrogates at 50, even when using a whitelist to pick out the most important ones. (Which is slightly frustrating if you have more than 50 important services!)

This PR adds a new consul.yaml configuration key which allows setting that limit to be higher, lower, or entirely non-existent (by setting it to be <1). 

The configuration key is documented in consul.yaml.example (and I've taken the liberty of adjusting the config key docs for the whitelist to not imply that the whitelist can be used query for more than 50 services).
## Testing

I have added a test and a new configuration key; tests pass locally, hope that Travis is happy too. We tried this out on a consul cluster running ~160 services, and it picks up the configured number of services there.
