### PR TITLE
[iis] Fix service check on the `_Total` site

### DIFF
--- a/checks.d/iis.py
+++ b/checks.d/iis.py
@@ -151,9 +151,6 @@ class IIS(WinWMICheck):
 
         for wmi_obj in wmi_sampler:
             sitename = wmi_obj['Name']
-            if sitename == "_Total":
-                continue
-
             uptime = wmi_obj["ServiceUptime"]
             status = AgentCheck.CRITICAL if uptime == 0 else AgentCheck.OK
 

--- a/tests/checks/mock/test_iis.py
+++ b/tests/checks/mock/test_iis.py
@@ -9,6 +9,11 @@ from tests.checks.common import AgentCheckTest
 class IISTestCase(AgentCheckTest, TestCommonWMI):
     CHECK_NAME = 'iis'
 
+    WIN_SERVICES_MINIMAL_CONFIG = {
+        'host': ".",
+        'tags': ["mytag1", "mytag2"]
+    }
+
     WIN_SERVICES_CONFIG = {
         'host': ".",
         'tags': ["mytag1", "mytag2"],
@@ -97,4 +102,19 @@ class IISTestCase(AgentCheckTest, TestCommonWMI):
         self.assertServiceCheck('iis.site_up', status=AgentCheck.CRITICAL,
                                 tags=["site:{0}".format(fail_site_name)], count=1)
 
+    def test_check_without_sites_specified(self):
+        """
+        Returns the right metrics and service checks for the `_Total` site
+        """
+        # Run check
+        config = {
+            'instances': [self.WIN_SERVICES_MINIMAL_CONFIG]
+        }
+        self.run_check_twice(config)
+
+        for mname in self.IIS_METRICS:
+            self.assertMetric(mname, tags=["mytag1", "mytag2"], count=1)
+
+        self.assertServiceCheck('iis.site_up', status=AgentCheck.OK,
+                                tags=["site:{0}".format('Total')], count=1)
         self.coverage_report()

--- a/tests/core/test_wmi.py
+++ b/tests/core/test_wmi.py
@@ -175,6 +175,12 @@ class SWbemServices(object):
                      "TotalISAPIExtensionRequests from Win32_PerfFormattedData_W3SVC_WebService WHERE ( Name = 'Failing site' ) OR ( Name = 'Default Web Site' )"):  # noqa
             results += load_fixture("win32_perfformatteddata_w3svc_webservice", ("Name", "Default Web Site"))  # noqa
 
+        if query == ("Select ServiceUptime,TotalBytesSent,TotalBytesReceived,TotalBytesTransferred,CurrentConnections,TotalFilesSent,TotalFilesReceived,"  # noqa
+                     "TotalConnectionAttemptsAllInstances,TotalGetRequests,TotalPostRequests,TotalHeadRequests,TotalPutRequests,TotalDeleteRequests,"  # noqa
+                     "TotalOptionsRequests,TotalTraceRequests,TotalNotFoundErrors,TotalLockedErrors,TotalAnonymousUsers,TotalNonAnonymousUsers,TotalCGIRequests,"  # noqa
+                     "TotalISAPIExtensionRequests from Win32_PerfFormattedData_W3SVC_WebService WHERE ( Name = '_Total' )"):  # noqa
+            results += load_fixture("win32_perfformatteddata_w3svc_webservice", ("Name", "_Total"))  # noqa
+
         if query == ("Select * from Win32_PerfFormattedData_W3SVC_WebService WHERE ( Name = 'Failing site' ) OR ( Name = 'Default Web Site' )"):  # noqa
             results += load_fixture("win32_perfformatteddata_w3svc_webservice_2008", ("Name", "Default Web Site"))  # noqa
 


### PR DESCRIPTION
Before 5.7.0, for `sitename == '_Total'`, we used to send a service check.
5.7.0 to 5.7.2 were always  sending a critical service check for this site name.

Go back to the previous behavior, and add a test case.

Should fix #2354 