### PR TITLE
[tokumx] Handle int64 and replica connections

### DIFF
--- a/conf.d/tokumx.yaml.example
+++ b/conf.d/tokumx.yaml.example
@@ -1,6 +1,8 @@
 init_config:
 
 instances:
+  # Specify the MongoDB URI, with database to use for reporting (defaults to "admin")
+  # E.g. mongodb://datadog:LnCbkX4uhpuLHSUrcayEoAZA@localhost:27017/my-db
   - server: mongodb://localhost:27017
     # tags:
     #   - optional_tag1


### PR DESCRIPTION
Ran into a situation where some data points coming from mongo are of type int64 (ie `0L`, or `2L`). We should take these into account and then coerce them to floats.

Additionally, the integration panel for TokuMX mentions specifying a full MongoDB URI, but the yaml shows no examples.