### PR TITLE
[haproxy] add 'active' tag to metrics

### DIFF
--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -373,6 +373,9 @@ class HAProxy(AgentCheck):
         tags = ["type:%s" % back_or_front, "instance_url:%s" % url]
         tags.append("service:%s" % service_name)
 
+        if 'act' in data:
+            tags.append("active:%s" % ('true' if data['act'] else 'false'))
+
         if self._is_service_excl_filtered(service_name, services_incl_filter,
                                           services_excl_filter):
             return

--- a/tests/checks/integration/test_haproxy.py
+++ b/tests/checks/integration/test_haproxy.py
@@ -114,7 +114,7 @@ class HaproxyTest(AgentCheckTest):
                 self.assertMetric(rate, tags=frontend_tags, count=1)
 
     def _test_backend_metrics(self, shared_tag, services=None):
-        backend_tags = shared_tag + ['type:BACKEND']
+        backend_tags = shared_tag + ['type:BACKEND', 'active:true']
         if not services:
             services = self.BACKEND_SERVICES
         for service in services:
@@ -186,7 +186,6 @@ class HaproxyTest(AgentCheckTest):
     def test_wrong_config(self):
         config = self.config
         config['instances'][0]['username'] = 'fake_username'
-
         self.assertRaises(Exception, lambda: self.run_check(config))
 
         # Test that nothing has been emitted


### PR DESCRIPTION
The HAProxy CSV output contains two boolean columns, "act" and "bck" to denote whether a backend belongs to the "active" pool of connections normally used for servicing requests, or the "[backup](http://cbonte.github.io/haproxy-dconv/configuration-1.7.html#5.2-backup)" pool of connections used only when none of the "active" backends are available.

When a primary HAProxy backend fails over and recovers, there still may be connections to the backup backend. Having this tag allows for monitoring how much traffic is flowing to the primary vs backup.

"active" as a term seems ambiguous, but it does follow HAProxy's own language, so I think it's preferential over introducing our own terminology.