### PR TITLE
[wmi] Updated metric_type lettercase to account for uppercase Gauge o…

### DIFF
--- a/checks/wmi_check.py
+++ b/checks/wmi_check.py
@@ -214,7 +214,7 @@ class WinWMICheck(AgentCheck):
 
             metric_name, metric_type = metric_name_and_type_by_property[metric.name]
             try:
-                func = getattr(self, metric_type)
+                func = getattr(self, metric_type.lower())
             except AttributeError:
                 raise Exception(u"Invalid metric type: {0}".format(metric_type))
 


### PR DESCRIPTION
…r Counter being entered

This problem originated from ticket 46655.  Trying to grab attribute type of `Gauge` instead of `gauge` results in the following error:

```
Traceback (most recent call last):
  File "checks\__init__.pyc", line 746, in run
  File "C:\Program Files (x86)\Datadog\Datadog Agent\files\..\checks.d\wmi_check.py", line 65, in check
  File "checks\wmi_check.pyc", line 219, in _submit_metrics
Exception: Invalid metric type: Gauge
```

And derives from attributes being set:

https://github.com/DataDog/dd-agent/blob/master/conf.d/wmi_check.yaml.example#L20-L30