### PR TITLE
[win32_event_log] fix `tag_event_id:true` 🐛

### DIFF
--- a/checks.d/win32_event_log.py
+++ b/checks.d/win32_event_log.py
@@ -139,7 +139,7 @@ class LogEvent(object):
     def __init__(self, ev, hostname, tags, notify_list, tag_event_id):
         self.event = ev
         self.hostname = hostname
-        self.tags = self._tags(tags, ev.EventCode) if tag_event_id else tags
+        self.tags = self._tags(tags, self.event['EventCode']) if tag_event_id else tags
         self.notify_list = notify_list
         self.timestamp = self._wmi_to_ts(self.event['TimeGenerated'])
 


### PR DESCRIPTION
Objects returned by the WMISampler have a dictionnary structure.
Fix regression introduced with #2136 when `tag_event_id:true`.