### PR TITLE
[http_check] Removes deprecated parameters 'threshold' and 'window' from the yaml

### DIFF
--- a/conf.d/http_check.yaml.example
+++ b/conf.d/http_check.yaml.example
@@ -33,13 +33,6 @@ instances:
     # This defaults to 1xx, 2xx and 3xx HTTP status code: (1|2|3)\d\d.
     # http_response_status_code: 401
 
-    # The (optional) window and threshold parameters allow you to trigger
-    # alerts only if the check fails x times within the last y attempts
-    # where x is the threshold and y is the window.
-    #
-    # threshold: 3
-    # window: 5
-
     # The (optional) include_content parameter will instruct the check
     # to include the first 200 characters of the HTTP response body
     # in notifications sent by this plugin. This is best used with


### PR DESCRIPTION
These parameters are not used anymore in the http_check.py code.

Since the introduction of status_check based monitors, users can control from the app UI after how many CRITICAL statuses they want to be alerted etc.

The presence of these 2 parameters is confusing.