### PR TITLE
[wmi] enable timeout and remove connection caching

### DIFF
--- a/tests/checks/mock/test_wmi_check.py
+++ b/tests/checks/mock/test_wmi_check.py
@@ -3,7 +3,7 @@ from mock import Mock
 
 # project
 from tests.checks.common import AgentCheckTest
-from tests.core.test_wmi import TestCommonWMI
+from tests.core.test_wmi import SWbemServices, TestCommonWMI
 
 
 class WMITestCase(AgentCheckTest, TestCommonWMI):
@@ -217,35 +217,35 @@ class WMITestCase(AgentCheckTest, TestCommonWMI):
         self.run_check(config, mocks={'log': logger})
         self.assertEquals(logger.warning.call_count, 1)
 
-    # def test_query_timeouts(self):
-    #     """
-    #     Gracefully handle WMI query timeouts.
-    #     """
-    #     def __patched_init__(*args, **kwargs):
-    #         """
-    #         Force `timeout_duration` value.
-    #         """
-    #         kwargs['timeout_duration'] = 0.1
-    #         return wmi_constructor(*args, **kwargs)
+    def test_query_timeouts(self):
+        """
+        Gracefully handle WMI query timeouts.
+        """
+        def __patched_init__(*args, **kwargs):
+            """
+            Force `timeout_duration` value.
+            """
+            kwargs['timeout_duration'] = 0.1
+            return wmi_constructor(*args, **kwargs)
 
-    #     # Increase WMI queries' runtime
-    #     SWbemServices._exec_query_run_time = 0.2
+        # Increase WMI queries' runtime
+        SWbemServices._exec_query_run_time = 0.2
 
-    #     # Patch WMISampler to decrease timeout tolerance
-    #     from checks.libs.wmi.sampler import WMISampler
+        # Patch WMISampler to decrease timeout tolerance
+        from checks.libs.wmi.sampler import WMISampler
 
-    #     wmi_constructor = WMISampler.__init__
-    #     WMISampler.__init__ = __patched_init__
+        wmi_constructor = WMISampler.__init__
+        WMISampler.__init__ = __patched_init__
 
-    #     # Set up the check
-    #     config = {
-    #         'instances': [self.WMI_CONFIG]
-    #     }
-    #     logger = Mock()
+        # Set up the check
+        config = {
+            'instances': [self.WMI_CONFIG]
+        }
+        logger = Mock()
 
-    #     # No exception is raised but a WARNING is logged
-    #     self.run_check(config, mocks={'log': logger})
-    #     self.assertTrue(logger.warning.called)
+        # No exception is raised but a WARNING is logged
+        self.run_check(config, mocks={'log': logger})
+        self.assertTrue(logger.warning.called)
 
     def test_mandatory_tag_by(self):
         """

--- a/tests/core/test_win32.py
+++ b/tests/core/test_win32.py
@@ -5,6 +5,7 @@ import unittest
 
 # 3p
 from nose.plugins.attrib import attr
+import psutil
 
 # datadog
 import checks.system.win32 as w32
@@ -28,9 +29,21 @@ class TestWin32(unittest.TestCase):
         finally:
             gc.set_debug(0)
 
-    def testDisk(self):
-        dsk = w32.Disk(log)
-        self._checkMemoryLeak(lambda: dsk.check(AGENT_CONFIG))
+    def _checkHandleLeak(self, func, *args, **kwargs):
+        """
+        Runs the passed func twice and checks that the number of handles held
+        by the process hasn't increased between the first and the second run
+        """
+        # Grab the current process
+        proc = psutil.Process()
+
+        func(*args, **kwargs)
+        middle = proc.num_handles()
+
+        func(*args, **kwargs)
+        end = proc.num_handles()
+
+        self.assertEquals(end - middle, 0)
 
     def testIO(self):
         io = w32.IO(log)
@@ -51,3 +64,16 @@ class TestWin32(unittest.TestCase):
     def testCPU(self):
         cpu = w32.Cpu(log)
         self._checkMemoryLeak(lambda: cpu.check(AGENT_CONFIG))
+
+    def testNoHandleLeak(self):
+        io = w32.IO(log)
+        proc = w32.Processes(log)
+        mem = w32.Memory(log)
+        net = w32.Network(log)
+        cpu = w32.Cpu(log)
+
+        self._checkHandleLeak(io.check, AGENT_CONFIG)
+        self._checkHandleLeak(proc.check, AGENT_CONFIG)
+        self._checkHandleLeak(mem.check, AGENT_CONFIG)
+        self._checkHandleLeak(net.check, AGENT_CONFIG)
+        self._checkHandleLeak(cpu.check, AGENT_CONFIG)


### PR DESCRIPTION
Re-enable the timeout feature (that was reverted in #2366), after some tests.

Sharing COM objects between threads leads to handle/memory
leaks. Because of this, take the safe approach of having one connection
COM object per thread, and never keep reference to the connection once
the thread is terminated.

This could probably be improved on by having a pool of long-lived
threads that would have their own COM objects.

Also, add a test to check that no handle leaks happen on the core check.