### PR TITLE
[dependencies] Upgrade boto 2.36.0 -> 2.39.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@
 # fails, so they shouldn't have too many deps
 ###########################################################
 
-boto==2.36.0
+boto==2.39.0
 ntplib==0.3.3
 # the libyaml bindings are optional
 pyyaml==3.11


### PR DESCRIPTION
There is a bug in boto 2.36.0 that is fixed in the 2.39.0 release: https://github.com/boto/boto/pull/3399