### PR TITLE
[mongo] Improve messaging&tags on MongoDB replset member state events

### DIFF
--- a/tests/checks/integration/test_mongo.py
+++ b/tests/checks/integration/test_mongo.py
@@ -131,6 +131,20 @@ class TestMongoUnit(AgentCheckTest):
         self.assertEquals((RATE, 'mongodb.foobar.intent_exclusiveps'), resolve_metric('foobar.w', metrics_to_collect))  # noqa
         self.assertEquals((GAUGE, 'mongodb.foobar.exclusive'), resolve_metric('foobar.W', metrics_to_collect))  # noqa
 
+    def test_state_translation(self):
+        """
+        Check that resolving replset member state IDs match to names and descriptions properly.
+        """
+        self.assertEquals('STARTUP2', self.check.get_state_name(5))
+        self.assertEquals('PRIMARY', self.check.get_state_name(1))
+
+        self.assertEquals('Starting Up', self.check.get_state_description(0))
+        self.assertEquals('Recovering', self.check.get_state_description(3))
+
+        # Unknown states:
+        self.assertEquals('UNKNOWN', self.check.get_state_name(500))
+        unknown_desc = self.check.get_state_description(500)
+        self.assertTrue(unknown_desc.find('500') != -1)
 
 @attr(requires='mongo')
 class TestMongo(unittest.TestCase):


### PR DESCRIPTION
This change summarized a lot of changes that improve how leadership election events look in the mongodb service check:

* The event title nowrefers to the explicit hostname if checking localhost
* The title now calls the member state by its official name and gives an the expanded state description in the body.
* Events are only generated if there is a previous, known, state. This elimilates a lot of events being generated whenever the dd-agent is restarted.
* Events now come with a set of tags featuring the previous and current states in a form that can unambiguously be queried, as well as the replSet in question.

This change also eliminates the duplicate replica set state table that got introduced in a previous PR.

## Testing

We're running this updated check in production at the moment. It generates events that we can easily overlay on top of graphs using queries like `tags:member_status:primary,previous_member_status:secondary` (this finds re-elections where the primary is different from before).
