### PR TITLE
[file] New check to test for a file's existence

### DIFF
--- a/checks.d/file.py
+++ b/checks.d/file.py
@@ -1,0 +1,83 @@
+import errno
+import os
+import time
+
+from checks import AgentCheck
+
+class FileCheck(AgentCheck):
+
+    STATUS_ABSENT = 'absent'
+    STATUS_PRESENT = 'present'
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+        self._last_state_by_path = {}
+
+    def has_different_status(self, path, current):
+        last_state = self._last_state_by_path.get(path, None)
+        self._last_state_by_path[path] = current
+        return (last_state is not None and last_state != current)
+
+    def stat_file(self, path):
+        try:
+            statinfo = os.stat(path)
+            return self.STATUS_PRESENT, statinfo
+        except OSError, e:
+            if e.errno == errno.ENOENT:
+                return self.STATUS_ABSENT, []
+            else:
+                raise
+
+    def check(self, instance):
+        """
+        Stats a file and emits service_checks and metrics on file creation/age.
+        """
+        if 'path' not in instance:
+            raise Exception("Missing 'path' in file check config")
+        if 'expect' not in instance:
+            raise Exception("Missing 'expect' in file check config")
+
+        path = instance['path']
+        expect = instance['expect']
+
+        status, statinfo = self.stat_file(path)
+
+        tags = [
+            'expected_status:' + expect,
+            'path:' + path,
+            'actual_status:' + status,
+        ]
+
+        # Emit a service check:
+        msg = "File %s is %s" % (path, expect)
+        check_status = AgentCheck.OK
+        if status != expect:
+            check_status = AgentCheck.CRITICAL
+            msg = "File %s that was expected to be %s is %s instead" % (path, expect, status)
+        self.service_check('file.existence', check_status, message=msg, tags=tags)
+
+        # Emit an event if the previous state is known & it's different:
+        if self.has_different_status(path, status):
+            timestamp = time.time()
+            if status == self.STATUS_PRESENT:
+                timestamp = statinfo.st_ctime
+
+            alert_type = 'success'
+            if check_status != AgentCheck.OK:
+                alert_type = 'error'
+
+            title = 'File %s is now %s' % (path, status)
+            self.event({
+                'timestamp': timestamp,
+                'event_type': 'file.presence_change',
+                'msg_title': title,
+                'alert_type': alert_type,
+                'tags': tags,
+                'aggregation_key': path,
+            })
+
+        # Emit age metrics (of dubious utility):
+        file_age = -1
+        if status == self.STATUS_PRESENT:
+            file_age = time.time() - statinfo.st_ctime
+        self.gauge('file.age_seconds', file_age, tags=tags)

--- a/conf.d/file.yaml.example
+++ b/conf.d/file.yaml.example
@@ -1,0 +1,13 @@
+# init_config:
+# # Not required for this check
+#
+# instances:
+#  - path: '/var/run/reboot-required'
+#    expected: absent
+#  - path: '/etc/passwd'
+#    expected: present
+
+init_config:
+  # Not required for this check
+
+instances:

--- a/tests/checks/integration/test_file.py
+++ b/tests/checks/integration/test_file.py
@@ -1,0 +1,49 @@
+# project
+from checks import AgentCheck
+from tests.checks.common import AgentCheckTest, load_check
+
+class TestFileUnit(AgentCheckTest):
+    CHECK_NAME = 'file'
+
+    def assert_tags(self, expected_tags, present_tags):
+        for tag in expected_tags:
+            self.assertTrue(tag in present_tags)
+
+    def test_present_success(self):
+        conf = {
+            'init_config': {},
+            'instances': [
+                {'path': __file__, 'expect': 'present'}
+            ]
+        }
+        self.check = load_check('file', conf, {})
+        self.check.check(conf['instances'][0])
+        metrics = self.check.get_metrics()
+        self.assertTrue(len(metrics) == 1)
+        metric = metrics[0]
+        self.assertTrue(metric[2] > 0)
+        self.assert_tags(['expected_status:present', 'actual_status:present'], metric[3]['tags'])
+
+        service_checks = self.check.get_service_checks()
+        self.assertTrue(service_checks[0]['status'] == AgentCheck.OK)
+        self.assert_tags(['expected_status:present', 'actual_status:present'], service_checks[0]['tags'])
+
+
+    def test_absent_failure(self):
+        conf = {
+            'init_config': {},
+            'instances': [
+                {'path': __file__, 'expect': 'absent'}
+            ]
+        }
+        self.check = load_check('file', conf, {})
+        self.check.check(conf['instances'][0])
+        metrics = self.check.get_metrics()
+        self.assertTrue(len(metrics) == 1)
+        metric = metrics[0]
+        self.assertTrue(metric[2] > 0)
+        self.assert_tags(['expected_status:absent', 'actual_status:present'], metric[3]['tags'])
+
+        service_checks = self.check.get_service_checks()
+        self.assertTrue(service_checks[0]['status'] == AgentCheck.CRITICAL)
+        self.assert_tags(['expected_status:absent', 'actual_status:present'], service_checks[0]['tags'])


### PR DESCRIPTION
The file.py check allows the agent to test for whether files exist in the local file system, and if they do, emit a metric for how long they have existed. This is particularly useful for files like Debian's "package upgrades require a reboot" marker in /var/run/, or local puppet facts meant to be kept around only for a short time.

I have added almost no documentation to this check (mostly out of ignorance what format / locations are desired!), but would be interested in learning how you all prefer the check docs to be written.
### Testing

I added an integration test for the metric and service_check behavior. We're also running this check on our infra to test for exactly the presence of `/var/run/reboot-required`, and it emits events and service checks as intended.
