### PR TITLE
Adds Python Interpreter Arch to Info Cmd

### DIFF
--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -182,7 +182,9 @@ class AgentStatus(object):
         fields += [
             ("Pid", self.created_by_pid),
             ("Platform", platform.platform()),
-            ("Python Version", platform.python_version()),
+            ("Python Version", "%s, %s" % (
+                platform.python_version(),
+                Platform.python_architecture())),
             ("Logs", logger_info()),
         ]
 

--- a/utils/platform.py
+++ b/utils/platform.py
@@ -60,6 +60,13 @@ class Platform(object):
         return Platform.is_win32(name)
 
     @staticmethod
+    def python_architecture():
+        if sys.maxsize > 2**32:
+            return "64bit"
+        else:
+            return "32bit"
+
+    @staticmethod
     def is_ecs_instance():
         """Return True if the agent is running in an ECS instance, False otherwise."""
         global _is_ecs

--- a/win32/gui.py
+++ b/win32/gui.py
@@ -401,6 +401,7 @@ class HTMLWindow(QTextEdit):
                 platform=platform.platform(),
                 agent_version=get_version(),
                 python_version=platform.python_version(),
+                python_architecture=Platform.python_architecture(),
                 logger_info=logger_info(),
                 dogstatsd=dogstatsd_status.to_dict(),
                 forwarder=forwarder_status.to_dict(),

--- a/win32/status.html
+++ b/win32/status.html
@@ -138,7 +138,7 @@
           <dl>
             <dt>Agent version</dt>    <dd>{{ agent_version }}</dd>
             <dt>Platform</dt>         <dd>{{ platform }}</dd>
-            <dt>Python version</dt>   <dd>{{ python_version }}</dd>
+            <dt>Python version</dt>   <dd>{{ python_version }}, {{ python_architecture }}</dd>
             <dt>Logger</dt>           <dd>{{ logger_info }}</dd>
           </dl>
 


### PR DESCRIPTION
The header on the Python interpreter will now include the Python Interpreter Architecture as well as the version. It will look like this:

```
Status date: 2016-04-12 15:49:45 (2s ago)
Pid: 31865
Platform: Linux-3.13.0-32-generic-x86_64-with-debian-wheezy-sid
Python Version: 2.7.11, 64bit
Logs: <stderr>, /tmp/collector.log
```