### PR TITLE
[core] Make sure to flush service metadata

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -515,6 +515,8 @@ class Collector(object):
                 log.debug("\n Agent developer mode stats: \n {0}".format(
                     Collector._stats_for_display(agent_stats))
                 )
+            # Flush metadata for the Agent Metrics check. Otherwise they'll just accumulate and leak.
+            self._agent_metrics.get_service_metadata()
 
         # Let's send our payload
         emitter_statuses = payload.emit(log, self.agentConfig, self.emitters,


### PR DESCRIPTION
Otherwise they will just leak. No need to store them or send them in the agent payload though (they are empty).