### PR TITLE
better 413 response handling

### DIFF
--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -757,7 +757,7 @@ class ForwarderStatus(AgentStatus):
     NAME = 'Forwarder'
 
     def __init__(self, queue_length=0, queue_size=0, flush_count=0, transactions_received=0,
-                 transactions_flushed=0):
+                 transactions_flushed=0, too_big_count=0):
         AgentStatus.__init__(self)
         self.queue_length = queue_length
         self.queue_size = queue_size
@@ -767,6 +767,7 @@ class ForwarderStatus(AgentStatus):
         self.proxy_data = get_config(parse_args=False).get('proxy_settings')
         self.hidden_username = None
         self.hidden_password = None
+        self.too_big_count = too_big_count
         if self.proxy_data and self.proxy_data.get('user'):
             username = self.proxy_data.get('user')
             hidden = len(username) / 2 if len(username) <= 7 else len(username) - 4
@@ -780,6 +781,7 @@ class ForwarderStatus(AgentStatus):
             "Flush Count: %s" % self.flush_count,
             "Transactions received: %s" % self.transactions_received,
             "Transactions flushed: %s" % self.transactions_flushed,
+            "Transactions rejected: %s" % self.too_big_count,
             ""
         ]
 
@@ -811,6 +813,7 @@ class ForwarderStatus(AgentStatus):
             'proxy_data': self.proxy_data,
             'hidden_username': self.hidden_username,
             'hidden_password': self.hidden_password,
+            'too_big_count': self.too_big_count,
 
         })
         return status_info

--- a/ddagent.py
+++ b/ddagent.py
@@ -266,7 +266,10 @@ class AgentTransaction(Transaction):
     def on_response(self, response):
         if response.error:
             log.error("Response: %s" % response)
-            self._trManager.tr_error(self)
+            if response.code == 413:
+                self._trManager.tr_error_too_big(self)
+            else:
+                self._trManager.tr_error(self)
         else:
             self._trManager.tr_success(self)
 

--- a/transaction.py
+++ b/transaction.py
@@ -79,6 +79,8 @@ class TransactionManager(object):
         self._transactions_received = 0
         self._transactions_flushed = 0
 
+        self._too_big_count = 0
+
         # Global counter to assign a number to each transaction: we may have an issue
         #  if this overlaps
         self._counter = 0
@@ -169,7 +171,8 @@ class TransactionManager(object):
             queue_size=self._total_size,
             flush_count=self._flush_count,
             transactions_received=self._transactions_received,
-            transactions_flushed=self._transactions_flushed).persist()
+            transactions_flushed=self._transactions_flushed,
+            too_big_count=self._too_big_count).persist()
 
     def flush_next(self):
 
@@ -211,6 +214,24 @@ class TransactionManager(object):
         log.warn("Transaction %d in error (%s error%s), it will be replayed after %s" %
           (tr.get_id(), tr.get_error_count(), plural(tr.get_error_count()),
            tr.get_next_flush()))
+
+    def tr_error_too_big(self,tr):
+        tr.inc_error_count()
+        log.warn("Transaction %d is %sKB, it has been rejected as too large. \
+          It will not be replayed." % (tr.get_id(), tr.get_size() / 1024))
+        self._transactions.remove(tr)
+        self._total_count -= 1
+        self._total_size -= tr.get_size()
+        self._transactions_flushed += 1
+        self.print_queue_stats()
+        self._too_big_count += 1
+        ForwarderStatus(
+            queue_length=self._total_count,
+            queue_size=self._total_size,
+            flush_count=self._flush_count,
+            transactions_received=self._transactions_received,
+            transactions_flushed=self._transactions_flushed,
+            too_big_count=self._too_big_count).persist()
 
     def tr_success(self,tr):
         log.debug("Transaction %d completed" % tr.get_id())

--- a/win32/status.html
+++ b/win32/status.html
@@ -242,6 +242,9 @@
             <dt>Flush count</dt>        <dd>{{ forwarder['flush_count'] }}</dd>
             <dt>Queue size</dt>         <dd>{{ forwarder['queue_size'] }} bytes</dd>
             <dt>Queue length</dt>       <dd>{{ forwarder['queue_length'] }}</dd>
+            <dt>Transactions received</dt> <dd>{{ forwarder['transactions_received'] }}</dd>
+            <dt>Transactions flushed</dt> <dd>{{ forwarder['transactions_flushed'] }}</dd>
+            <dt>Transactions rejected</dt>       <dd>{{ forwarder['too_big_count'] }}</dd>
           </dl>
 
           {% if forwarder['proxy_data'] %}


### PR DESCRIPTION
When propjoe responds with a 413 error (payload too big), the agent used to retry the request. It shouldn't. The request shouldn't ever succeed.

This stops it from resubmitting the request. It logs a warning, saying what happened. It also adds a warning to the info page that a request was rejected.