### PR TITLE
[core] adds swap (pagefile) to windows stats

### DIFF
--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -109,6 +109,11 @@ class Memory(Check):
         # usable = free + cached
         self.gauge('system.mem.usable')
         self.gauge('system.mem.pct_usable')
+        #  details about the usage of the pagefile.
+        self.gauge('system.mem.page_total')
+        self.gauge('system.mem.page_used')
+        self.gauge('system.mem.page_free')
+        self.gauge('system.mem.page_pct_free')
 
     def check(self, agentConfig):
         try:
@@ -177,6 +182,13 @@ class Memory(Check):
         if total > 0:
             pct_usable = float(usable) / total
             self.save_sample('system.mem.pct_usable', pct_usable)
+
+        page = psutil.virtual_memory()
+        if page.total is not None:
+            self.save_sample('system.mem.page_total', page.total / B2MB)
+            self.save_sample('system.mem.page_used', page.used / B2MB)
+            self.save_sample('system.mem.page_free', page.available / B2MB)
+            self.save_sample('system.mem.page_pct_free', (100 - page.percent) / 100)
 
         return self.get_metrics()
 


### PR DESCRIPTION
Our Windows pagefile statistics are not very robust. We've had a few requests to add more, better. This PR adds such metrics.

Now we're capturing the total size of the pagefile, how much is used, how much is available and the percent that's still free.

I've tested it on Windows, it seems to work fine, and the metrics come out looking pretty nice.