### PR TITLE
[mongo] more default metrics ↗

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -301,7 +301,6 @@ class MongoDb(AgentCheck):
 
     """
     WiredTiger storage engine.
-
     """
     WIREDTIGER_METRICS = {
         "wiredTiger.cache.bytes currently in the cache": (GAUGE, "wiredTiger.cache.bytes_currently_in_cache"),  # noqa
@@ -309,9 +308,12 @@ class MongoDb(AgentCheck):
         "wiredTiger.cache.in-memory page splits": GAUGE,
         "wiredTiger.cache.maximum bytes configured": GAUGE,
         "wiredTiger.cache.maximum page size at eviction": GAUGE,
+        "wiredTiger.cache.modified pages evicted": GAUGE,
         "wiredTiger.cache.pages currently held in the cache": (GAUGE, "wiredTiger.cache.pages_currently_held_in_cache"),  # noqa
         "wiredTiger.cache.pages evicted because they exceeded the in-memory maximum": (RATE, "wiredTiger.cache.pages_evicted_exceeding_the_in-memory_maximum"),  # noqa
         "wiredTiger.cache.pages evicted by application threads": RATE,
+        "wiredTiger.cache.tracked dirty bytes in the cache": (GAUGE, "wiredTiger.cache.tracked_dirty_bytes_in_cache"),  # noqa
+        "wiredTiger.cache.unmodified pages evicted": GAUGE,
         "wiredTiger.concurrentTransactions.read.available": GAUGE,
         "wiredTiger.concurrentTransactions.read.out": GAUGE,
         "wiredTiger.concurrentTransactions.read.totalTickets": GAUGE,

--- a/conf.d/mongo.yaml.example
+++ b/conf.d/mongo.yaml.example
@@ -24,16 +24,10 @@ instances:
     # The (optional) `additional_metrics` parameter instructs the check to collect additional
     # metrics on specific topics.
     # Available options are:
-    # * `durability` - Journaling-related operations and performance
-    # * `locks` - Locks
     # * `metrics.commands` - Use of database commands
     # * `tcmalloc` -  TCMalloc memory allocator
     # * `top` - Usage statistics for each collection
-    # * `wiredtiger` - WiredTiger storage engine
     # additional_metrics:
-    #   - durability
-    #   - locks
     #   - metrics.commands
     #   - tcmalloc
     #   - top
-    #   - wiredtiger


### PR DESCRIPTION
**[mongo] more default metrics ↗**
The following metric topics are now collected by default:
* `durability` - journaling-related operations and performance report.
* `locks` - serverstatus locks report.
* `wiredtiger` - wiredtiger storage option.

Log a warning to inform the user when any of these metric topics is
listed in the configuration file 🔊 .

**[mongo] additional `wiredtiger` cache metrics**
Collect additional WiredTiger metrics, i.e.
* `wiredTiger.cache.modified_pages_evicted`,
* `wiredTiger.cache.unmodified_pages_evicted`
   Number of pages evicted from the cache
* `wiredTiger.cache.tracked_dirty_bytes_in_cache`
   Amount of space taken by dirty data in the cache (bytes).