### PR TITLE
[docker] Ignore mountpoints not accessible by current user

### DIFF
--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -159,7 +159,7 @@ class DockerUtil():
 
             candidate = None
             for _, mountpoint, _, opts, _, _ in cgroup_mounts:
-                if hierarchy in opts:
+                if hierarchy in opts and os.path.exists(mountpoint):
                     if mountpoint.startswith("/host/"):
                         return os.path.join(self._docker_root, mountpoint)
                     candidate = mountpoint


### PR DESCRIPTION
On Ubuntu 16.04, both `/run/lxcfs/controllers`- and `/sys/fs`-style mount points are present. Only the latter are accessible by the **dd-agent** user, but `find_cgroup()` returns the former.

With this PR, `find_cgroup()` checks that the mount point is accessible by the current user.