### PR TITLE
[core] Allow empty 'instances' section

### DIFF
--- a/config.py
+++ b/config.py
@@ -917,9 +917,9 @@ def load_check_directory(agentConfig, hostname):
         else:
             pass
 
-        # Look for the per-check config, which *must* exist
+        # Look for the per-check config.
         if not check_config.get('instances'):
-            log.error("Config %s is missing 'instances'" % conf_path)
+            log.info('No instances defined for %s' % check_name)
             continue
 
         # Init all of the check's classes with

--- a/util.py
+++ b/util.py
@@ -158,13 +158,14 @@ def check_yaml(conf_path):
         assert 'instances' in check_config, "No 'instances' section found"
 
         valid_instances = True
-        if check_config['instances'] is None or not isinstance(check_config['instances'], list):
-            valid_instances = False
-        else:
+        if isinstance(check_config['instances'], list):
             for i in check_config['instances']:
                 if not isinstance(i, dict):
                     valid_instances = False
                     break
+        elif check_config['instances'] is not None:
+            valid_instances = False
+
         if not valid_instances:
             raise Exception('You need to have at least one instance defined in the YAML file for this check')
         else:


### PR DESCRIPTION
Having a config YAML file with an empty or missing `instances` section is not allowed.

I suggest lifting this restriction so that an empty section is allowed. Having an empty `instances` section should be equivalent to the YAML file not existing.

Under some circumstances it is convenient to always have the file present and dynamically add the individual entries, e.g when auto-generating the file by your configuration management software (Puppet/Salt/etc.).

This PR removes this restriction.