### PR TITLE
[win32_event_log] `event_format` option 🎨

### DIFF
--- a/checks.d/win32_event_log.py
+++ b/checks.d/win32_event_log.py
@@ -17,22 +17,32 @@ from utils.timeout import TimeoutException
 SOURCE_TYPE_NAME = 'event viewer'
 EVENT_TYPE = 'win32_log_event'
 
+
 class Win32EventLogWMI(WinWMICheck):
+    # WMI information
     EVENT_PROPERTIES = [
-        "Message",
+        "EventCode",
         "SourceName",
         "TimeGenerated",
         "Type",
-        "User",
+    ]
+    EXTRA_EVENT_PROPERTIES = [
         "InsertionStrings",
-        "EventCode"
+        "Message",
+        "Logfile",
     ]
     NAMESPACE = "root\\CIMV2"
-    CLASS = "Win32_NTLogEvent"
+    EVENT_CLASS = "Win32_NTLogEvent"
 
     def __init__(self, name, init_config, agentConfig, instances=None):
-        WinWMICheck.__init__(self, name, init_config, agentConfig,
-                            instances=instances)
+        WinWMICheck.__init__(
+            self, name, init_config, agentConfig, instances=instances
+        )
+        # Settings
+        self._tag_event_id = init_config.get('tag_event_id', False)
+        self._verbose = init_config.get('verbose', True)
+
+        # State
         self.last_ts = {}
 
     def check(self, instance):
@@ -49,15 +59,25 @@ class Win32EventLogWMI(WinWMICheck):
         log_files = instance.get('log_file', [])
         event_ids = instance.get('event_id', [])
         message_filters = instance.get('message_filters', [])
+        event_format = instance.get('event_format')
 
         instance_hash = hash_mutable(instance)
-        instance_key = self._get_instance_key(host, self.NAMESPACE, self.CLASS, instance_hash)
+        instance_key = self._get_instance_key(host, self.NAMESPACE, self.EVENT_CLASS, instance_hash)
 
         # Store the last timestamp by instance
         if instance_key not in self.last_ts:
             self.last_ts[instance_key] = datetime.utcnow()
             return
 
+        # Event properties
+        event_properties = list(self.EVENT_PROPERTIES)
+
+        if event_format is not None:
+            event_properties.extend(list(set(self.EXTRA_EVENT_PROPERTIES) & set(event_format)))
+        else:
+            event_properties.extend(self.EXTRA_EVENT_PROPERTIES)
+
+        # Event filters
         query = {}
         filters = []
         last_ts = self.last_ts[instance_key]
@@ -93,7 +113,7 @@ class Win32EventLogWMI(WinWMICheck):
 
         wmi_sampler = self._get_wmi_sampler(
             instance_key,
-            self.CLASS, self.EVENT_PROPERTIES,
+            self.EVENT_CLASS, event_properties,
             filters=filters,
             host=host, namespace=self.NAMESPACE,
             username=username, password=password,
@@ -107,7 +127,7 @@ class Win32EventLogWMI(WinWMICheck):
                 u"[Win32EventLog] WMI query timed out."
                 u" class={wmi_class} - properties={wmi_properties} -"
                 u" filters={filters} - tags={tags}".format(
-                    wmi_class=self.CLASS, wmi_properties=self.EVENT_PROPERTIES,
+                    wmi_class=self.EVENT_CLASS, wmi_properties=event_properties,
                     filters=filters, tags=instance_tags
                 )
             )
@@ -115,8 +135,10 @@ class Win32EventLogWMI(WinWMICheck):
             for ev in wmi_sampler:
                 # for local events we dont need to specify a hostname
                 hostname = None if (host == "localhost" or host == ".") else host
-                log_ev = LogEvent(ev, hostname, instance_tags, notify,
-                                self.init_config.get('tag_event_id', False))
+                log_ev = LogEvent(
+                    ev, self.log, hostname, instance_tags, notify,
+                    self._tag_event_id, event_format
+                )
 
                 # Since WQL only compares on the date and NOT the time, we have to
                 # do a secondary check to make sure events are after the last
@@ -129,7 +151,6 @@ class Win32EventLogWMI(WinWMICheck):
             # Update the last time checked
             self.last_ts[instance_key] = datetime.utcnow()
 
-
     def _dt_to_wmi(self, dt):
         ''' A wrapper around wmi.from_time to get a WMI-formatted time from a
             time struct.
@@ -140,12 +161,14 @@ class Win32EventLogWMI(WinWMICheck):
 
 
 class LogEvent(object):
-    def __init__(self, ev, hostname, tags, notify_list, tag_event_id):
+    def __init__(self, ev, log, hostname, tags, notify_list, tag_event_id, event_format):
         self.event = ev
+        self.log = log
         self.hostname = hostname
         self.tags = self._tags(tags, self.event['EventCode']) if tag_event_id else tags
         self.notify_list = notify_list
         self.timestamp = self._wmi_to_ts(self.event['TimeGenerated'])
+        self._format = event_format
 
     @property
     def _msg_title(self):
@@ -155,12 +178,39 @@ class LogEvent(object):
 
     @property
     def _msg_text(self):
-        msg_text = ""
-        if 'Message' in self.event:
-            msg_text = "{message}\n".format(message=self.event['Message'])
-        elif 'InsertionStrings' in self.event:
-            msg_text = "\n".join([i_str for i_str in self.event['InsertionStrings']
-                                  if i_str.strip()])
+        """
+        Generate the event's body to send to Datadog.
+
+        Consider `event_format` parameter:
+        * Only use the specified list of event properties.
+        * If unspecified, default to the EventLog's `Message` or `InsertionStrings`.
+        """
+        msg_text = u""
+
+        if self._format:
+            msg_text_fields = ["%%%\n```"]
+
+            for event_property in self._format:
+                property_value = self.event.get(event_property)
+                if property_value is None:
+                    self.log.warning(u"Unrecognized `%s` event property.", event_property)
+                    continue
+                msg_text_fields.append(
+                    u"{property_name}: {property_value}".format(
+                        property_name=event_property, property_value=property_value
+                    )
+                )
+
+            msg_text_fields.append("```\n%%%")
+
+            msg_text = "\n".join(msg_text_fields)
+        else:
+            # Override when verbosity
+            if 'Message' in self.event:
+                msg_text = "{message}\n".format(message=self.event['Message'])
+            elif 'InsertionStrings' in self.event:
+                msg_text = "\n".join([i_str for i_str in self.event['InsertionStrings']
+                                      if i_str.strip()])
 
         if self.notify_list:
             msg_text += "\n{notify_list}".format(

--- a/conf.d/win32_event_log.yaml.example
+++ b/conf.d/win32_event_log.yaml.example
@@ -1,5 +1,5 @@
 init_config:
-    # The (optional) tag_event_id setting will add an event id tag to each
+    # The (optional) `tag_event_id` setting will add an event id tag to each
     # event sent from this check. Defaults to false.
     # tag_event_id: false
 
@@ -10,30 +10,30 @@ instances:
   -
     # By default, the local machine's event logs are captured. To capture a remote
     # machine's event logs, specify the machine name (DCOM has to be enabled on
-    # the remote machine). If authentication is needed, specify a username and a
-    # password.
+    # the remote machine). If authentication is needed, specify a `username` and a
+    # `password`.
     # host: remote_machine_name
     # username: user
     # password: pass
 
-    # The (optional) log_file filter will instruct the check to only capture events
+    # The (optional) `log_file` filter will instruct the check to only capture events
     # that belong to one of the specified LogFiles (Application, System, Setup, Security,
     # or application-specific LogFile).
     # log_file:
     #   - Security
 
-    # The (optional) source_name filter will instruct the check to only capture events
+    # The (optional) `source_name` filter will instruct the check to only capture events
     # that come from one of the specified SourceNames.
     # source_name:
     #   - Microsoft-Windows-Security-Auditing
 
-    # The (optional) type filter will instruct the check to only capture events
+    # The (optional) `type` filter will instruct the check to only capture events
     # that have one of the specified Types.
     # Standard values are: Critical, Error, Warning, Information, Audit Success, Audit Failure.
     # type:
     #   - Audit Failure
 
-    # The (optional) event_id filter will instruct the check to only capture events
+    # The (optional) `event_id` filter will instruct the check to only capture events
     # that have one of the specified EventCodes.
     # The event ID can be found through http://www.eventid.net/ and viewed in the
     # Windows Event Viewer.
@@ -41,7 +41,7 @@ instances:
     #   - 4776
     #   - 4672
 
-    # The (optional) message_filters filter will instruct the check to only capture
+    # The (optional) `message_filters` filter will instruct the check to only capture
     # events which Message field matches all of the specified filters.
     # Use % as a wildcard. See http://msdn.microsoft.com/en-us/library/aa392263(v=vs.85).aspx
     # for more on the format for LIKE queries.
@@ -51,11 +51,22 @@ instances:
     #   - "-%success%"
     #   - "%SYSTEM%"
 
-    # The (optional) tags parameter will instruct the check to tag the captured
+    # The (optional) `tags` parameter will instruct the check to tag the captured
     # events with the specified tags.
     # tags:
     #   - security
 
+    # The (optional) `event_format` parameter will instruct the check to generate
+    # Datadog's event bodies with the specified list of event properties.
+    # If unspecified, the EventLog's `Message` or `InsertionStrings` are used by default.
+    # event_format:
+    #   - Logfile
+    #   - SourceName
+    #   - EventCode
+    #   - Message
+    #   - InsertionStrings
+    #   - TimeGenerated
+    #   - Type
 
   # Here are a couple basic examples:
 

--- a/tests/core/test_wmi.py
+++ b/tests/core/test_wmi.py
@@ -195,7 +195,7 @@ class SWbemServices(object):
             results += load_fixture("win32_service_up", ("Name", "WinHttpAutoProxySvc"))
             results += load_fixture("win32_service_down", ("Name", "WSService"))
 
-        if query == ("Select Message,SourceName,TimeGenerated,Type,User,InsertionStrings,EventCode from Win32_NTLogEvent WHERE ( ( SourceName = 'MSSQLSERVER' ) "  # noqa
+        if query == ("Select EventCode,SourceName,TimeGenerated,Type,InsertionStrings,Message,Logfile from Win32_NTLogEvent WHERE ( ( SourceName = 'MSSQLSERVER' ) "  # noqa
                      "AND ( Type = 'Error' OR Type = 'Warning' ) AND TimeGenerated >= '20151224113047.000000-480' )"):  # noqa
             results += load_fixture("win32_ntlogevent")
 


### PR DESCRIPTION
The (optional) `event_format` parameter will instruct the check to
generate
Datadog's event bodies with the specified list of event properties.
If unspecified, the EventLog's `Message` or `InsertionStrings` are used
by default.
Available properties are:
  - Logfile
  - SourceName
  - EventCode
  - Message
  - InsertionStrings
  - TimeGenerated
  - Type