### PR TITLE
[source] Pin setuptools version

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -358,7 +358,7 @@ VENV_PIP_CMD="$DD_HOME/venv/bin/pip"
 
 print_console "* Setting up setuptools"
 $DOWNLOADER "$DD_HOME/ez_setup.py" https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py
-$VENV_PYTHON_CMD "$DD_HOME/ez_setup.py"
+$VENV_PYTHON_CMD "$DD_HOME/ez_setup.py" --version="20.9.0"
 rm -f "$DD_HOME/ez_setup.py"
 rm -f "$DD_HOME/ez_setup.pyc"
 print_done


### PR DESCRIPTION
Fixes the following error when installing the agent with the source install script:

```
* Setting up setuptools
It looks like you hit an issue when trying to install the Datadog agent.
###
  File "/usr/lib64/python2.7/zipfile.py", line 811, in _RealGetContents
    raise BadZipfile, "File is not a zip file"
zipfile.BadZipfile: File is not a zip file
###
```

Cause: the latest versions of setuptools (`20.10.0` and `20.10.1`) can't be downloaded by
`ez_setup.py`, so make ez_setup download a version that is actually
available.

See also https://github.com/pypa/setuptools/issues/557
