### PR TITLE
[mongodb] set `event_type` & `source_type_name`

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -44,6 +44,7 @@ class MongoDb(AgentCheck):
     * `mongodb.replica_set_member_state`
       Disposition of the member replica set state.
     """
+    # Source
     SOURCE_TYPE_NAME = 'mongodb'
 
     # Service check
@@ -440,7 +441,7 @@ class MongoDb(AgentCheck):
 
         self.event({
             'timestamp': int(time.time()),
-            'event_type': 'Mongo',
+            'source_type_name': self.SOURCE_TYPE_NAME,
             'api_key': agentConfig.get('api_key', ''),
             'msg_title': msg_title,
             'msg_text': msg,


### PR DESCRIPTION
Link MongoDB events to the integration, i.e. set events' `source_type_name`. Ignore `event_type`, as constant (i.e. useless).