### PR TITLE
[integration][vsphere] Add optional vm include parameter

### DIFF
--- a/checks.d/vsphere.py
+++ b/checks.d/vsphere.py
@@ -609,7 +609,7 @@ class VSphereCheck(AgentCheck):
                     return
             # Also, if include_only_marked is true, then check if there exists a
             # custom field with the value DatadogMonitored
-            if _is_affirmative(include_only_marked):
+            if include_only_marked:
                 monitored = False
                 for field in obj.customValue:
                     if field.value == VM_MONITORING_FLAG:
@@ -650,7 +650,7 @@ class VSphereCheck(AgentCheck):
             'host_include': instance.get('host_include_only_regex'),
             'vm_include': instance.get('vm_include_only_regex')
         }
-        include_only_marked = instance.get('include_only_marked', False)
+        include_only_marked = _is_affirmative(instance.get('include_only_marked', False))
         self.pool.apply_async(
             self._cache_morlist_raw_atomic,
             args=(i_key, 'rootFolder', root_folder, [instance_tag], regexes, include_only_marked)

--- a/conf.d/vsphere.yaml.example
+++ b/conf.d/vsphere.yaml.example
@@ -39,6 +39,13 @@ instances:
     # optional
     # vm_include_only_regex: ".*\.sql\.datadoghq\.com"
 
+    # Set to true if you'd like to only collect metrics on vSphere VMs which
+    # are marked by a custom field with the value 'DatadogMonitored'
+    # To set this custom field with PowerCLI, use the follow command: 
+    #   Get-VM <MyVMName> | Set-CustomField -Name "DatadogMonitored" -Value "DatadogMonitored"
+    # optional
+    # include_only_marked: false
+
     # When set to true, this will collect EVERY metric
     # from vCenter, which means a LOT of metrics you probably
     # do not care about. We have selected a set of metrics


### PR DESCRIPTION
This adds the ability to set a custom field from the vSphere PowerCLI which acts as a marker for which VMs you would like to have monitored by the agent. In order to add this custom field, a user can use this command: `Get-VM <MyVMName> | Set-CustomField -Name "DatadogMonitored" -Value "DatadogMonitored"`

The ideal would have been to use the new tagging feature brought in vSphere 6.0 (usable also through the vSphere Web Client), but the vSphere API (at least in vCenter 5.5) does not expose these tags. There is an attribute on the managed object for VirtualMachine, called tag. Unfortunately, this is actually not the same tag set as the ones set in the vSphere Web Client (at least in vCenter 5.5). The tags set in the web client are instead stored in the Inventory Service.

Additionally, Custom Attributes could have been an option, which can be set via PowerCLI or Web Client (I think), but Custom Attributes were deprecated in exchange for Tags in vSphere 6.0.

Alas, this fix gives the ability for all. When vSphere releases another update that makes it easy to access the tags set on VirtualMachine managed objects, then we can add a feature to use tags.