### PR TITLE
[mysql] improving accuracy for query exec time. Fixes issue #2406.

### DIFF
--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -1188,7 +1188,7 @@ class MySql(AgentCheck):
         # Fetches the avg query execution time per schema and returns the
         # value in microseconds
 
-        sql_avg_query_run_time = """SELECT schema_name, SUM(count_star) cnt, ROUND(AVG(avg_timer_wait)/1000000) AS avg_us
+        sql_avg_query_run_time = """SELECT schema_name, ROUND((SUM(sum_timer_wait) / SUM(count_star)) / 1000000) AS avg_us
             FROM performance_schema.events_statements_summary_by_digest
             WHERE schema_name IS NOT NULL
             GROUP BY schema_name"""
@@ -1204,7 +1204,7 @@ class MySql(AgentCheck):
                 schema_query_avg_run_time = {}
                 for row in cursor.fetchall():
                     schema_name = str(row[0])
-                    avg_us = long(row[2])
+                    avg_us = long(row[1])
 
                     # set the tag as the dictionary key
                     schema_query_avg_run_time["schema:{0}".format(schema_name)] = avg_us


### PR DESCRIPTION
See #2406.

- `ROUND((SUM(sum_timer_wait) / SUM(count_star)) / 1000000)`: represents the real average `timer_wait` per query for a given schema. Here, `sum_timer_wait` represents the sum of all `timer_wait` times for a certain query, and `count_star` is the number of times a certain query was run. 
- formerly `ROUND(AVG(avg_timer_wait)/1000000)` actually represented the average of averages.

The discrepancy between the two computations may be considerable.
