### PR TITLE
Use local var for container_name

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -426,7 +426,7 @@ class DockerDaemon(AgentCheck):
             if self._are_tags_filtered(container_tags):
                 container_name = DockerUtil.container_name_extractor(container)[0]
                 self._filtered_containers.add(container_name)
-                self.log.debug("Container {0} is filtered".format(container["Names"][0]))
+                self.log.debug("Container {0} is filtered".format(container_name))
 
 
     def _are_tags_filtered(self, tags):


### PR DESCRIPTION
Fixes
```
2016-05-04 05:24:24 UTC | ERROR | dd.collector | checks.docker_daemon(__init__.py:763) | Check 'docker_daemon' instance #0 failed
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/checks/__init__.py", line 746, in run
    self.check(copy.deepcopy(instance))
  File "/opt/datadog-agent/agent/checks.d/docker_daemon.py", line 222, in check
    containers_by_id = self._get_and_count_containers()
  File "/opt/datadog-agent/agent/checks.d/docker_daemon.py", line 273, in _get_and_count_containers
    self._filter_containers(containers)
  File "/opt/datadog-agent/agent/checks.d/docker_daemon.py", line 412, in _filter_containers
    self.log.debug("Container {0} is filtered".format(container["Names"][0]))
IndexError: list index out of range
```
when trying to exclude containers from monitoring