### PR TITLE
Check if a container is excluded before counting as running

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -306,16 +306,16 @@ class DockerDaemon(AgentCheck):
         for container in containers:
             container_name = DockerUtil.container_name_extractor(container)[0]
 
+            # Check if the container is included/excluded via its tags
+            if self._is_container_excluded(container):
+                self.log.debug("Container {0} is excluded".format(container_name))
+                continue
+
             container_status_tags = self._get_tags(container, CONTAINER)
 
             all_containers_count[tuple(sorted(container_status_tags))] += 1
             if self._is_container_running(container):
                 running_containers_count[tuple(sorted(container_status_tags))] += 1
-
-            # Check if the container is included/excluded via its tags
-            if self._is_container_excluded(container):
-                self.log.debug("Container {0} is excluded".format(container_name))
-                continue
 
             containers_by_id[container['Id']] = container
 


### PR DESCRIPTION
I don't know if the current behavior of including excluded containers in docker.containers.running is expected behavior or if changing this will trigger compatibility issues, but this is how I would expect excluded containers to behave.

Thanks
Brian
