### PR TITLE
[docker] fix container ID extraction for RancherOS

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -762,9 +762,9 @@ class DockerDaemon(AgentCheck):
                 else:
                     continue
 
-                match = CONTAINER_ID_RE.search(cpuacct)
-                if match:
-                    container_id = match.group(0)
+                matches = re.findall(CONTAINER_ID_RE, cpuacct)
+                if matches:
+                    container_id = matches[-1]
                     if container_id not in container_dict:
                         self.log.debug("Container %s not in container_dict, it's likely excluded", container_id)
                         continue


### PR DESCRIPTION
fixes https://github.com/DataDog/dd-agent/issues/2454

Lines in `/proc/$PID/cgroup` don't have the same format for all system.
- In CoreOS they look like: `3:cpu,cpuacct:/system.slice/docker-$CONTAINER_ID.scope`
- In RancherOS: `5:cpu,cpuacct:/docker/$USER_DOCKER_CID/docker/$CONTAINER_ID`
- In Ubuntu: `4:cpuacct:/docker/$CONTAINER_ID`

To avoid picking the first (wrong) container ID, let's switch from `search` to `re.findall`.