### PR TITLE
[Config] Update config logic to look for checks in 3rd-party directory (rebased)

### DIFF
--- a/tests/core/fixtures/checks/invalid_check_1.py
+++ b/tests/core/fixtures/checks/invalid_check_1.py
@@ -1,0 +1,2 @@
+class InvalidCheck(object):
+    pass

--- a/tests/core/fixtures/checks/invalid_check_2.py
+++ b/tests/core/fixtures/checks/invalid_check_2.py
@@ -1,0 +1,4 @@
+import nothing  # noqa
+
+class InvalidCheck(object):
+    pass

--- a/tests/core/fixtures/checks/invalid_conf.yaml
+++ b/tests/core/fixtures/checks/invalid_conf.yaml
@@ -1,0 +1,1 @@
+init_config:

--- a/tests/core/fixtures/checks/valid_check_1.py
+++ b/tests/core/fixtures/checks/valid_check_1.py
@@ -1,0 +1,8 @@
+from checks import AgentCheck
+
+OUTPUT = 'valid_check_1'
+
+class ValidCheck(AgentCheck):
+
+    def check(self, instance):
+        return OUTPUT

--- a/tests/core/fixtures/checks/valid_check_2.py
+++ b/tests/core/fixtures/checks/valid_check_2.py
@@ -1,0 +1,8 @@
+from checks import AgentCheck
+
+OUTPUT = 'valid_check_2'
+
+class ValidCheck(AgentCheck):
+
+    def check(self, instance):
+        return OUTPUT

--- a/tests/core/fixtures/checks/valid_conf.yaml
+++ b/tests/core/fixtures/checks/valid_conf.yaml
@@ -1,0 +1,4 @@
+init_config:
+
+instances:
+  - host: localhost

--- a/tests/core/fixtures/checks/valid_conf_2.yaml
+++ b/tests/core/fixtures/checks/valid_conf_2.yaml
@@ -1,0 +1,5 @@
+init_config:
+
+instances:
+  - host: localhost
+  - host: localh0st

--- a/tests/core/fixtures/checks/valid_sub_check.py
+++ b/tests/core/fixtures/checks/valid_sub_check.py
@@ -1,0 +1,8 @@
+from tests.core.fixtures.checks.valid_check_2 import ValidCheck
+
+OUTPUT = 'valid_check_1'
+
+class InheritedCheck(ValidCheck):
+
+    def check(self, instance):
+        return OUTPUT

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -3,7 +3,9 @@
 import os
 import os.path
 import tempfile
+import mock
 import unittest
+from shutil import copyfile, rmtree
 
 # project
 from config import get_config, load_check_directory
@@ -13,6 +15,7 @@ from utils.platform import Platform
 
 # No more hardcoded default checks
 DEFAULT_CHECKS = []
+
 
 class TestConfig(unittest.TestCase):
     def testWhiteSpaceConfig(self):
@@ -67,10 +70,10 @@ class TestConfig(unittest.TestCase):
             u'i-123445',
             u'5dfsdfsdrrfsv',
             u'432498234234A'
-            u'234234235235235235', # Couldn't find anything in the RFC saying it's not valid
+            u'234234235235235235',  # Couldn't find anything in the RFC saying it's not valid
             u'A45fsdff045-dsflk4dfsdc.ret43tjssfd',
             u'4354sfsdkfj4TEfdlv56gdgdfRET.dsf-dg',
-            u'r'*255,
+            u'r' * 255,
         ]
 
         not_valid_hostnames = [
@@ -91,11 +94,11 @@ class TestConfig(unittest.TestCase):
         # Make the function run as if it was on windows
         func = Platform.is_win32
         try:
-            Platform.is_win32 = staticmethod(lambda : True)
+            Platform.is_win32 = staticmethod(lambda: True)
 
             test_cases = [
-                ("C:\\Documents\\Users\\script.py:C:\\Documents\\otherscript.py", ["C:\\Documents\\Users\\script.py","C:\\Documents\\otherscript.py"]),
-                ("C:\\Documents\\Users\\script.py:parser.py", ["C:\\Documents\\Users\\script.py","parser.py"])
+                ("C:\\Documents\\Users\\script.py:C:\\Documents\\otherscript.py", ["C:\\Documents\\Users\\script.py", "C:\\Documents\\otherscript.py"]),
+                ("C:\\Documents\\Users\\script.py:parser.py", ["C:\\Documents\\Users\\script.py", "parser.py"])
             ]
 
             for test_case, expected_result in test_cases:
@@ -110,3 +113,150 @@ class TestConfig(unittest.TestCase):
 
         for c in DEFAULT_CHECKS:
             self.assertTrue(c in init_checks_names)
+
+
+TMP_DIR = tempfile.gettempdir()
+DD_AGENT_TEST_DIR = 'dd-agent-tests'
+TEMP_3RD_PARTY_CHECKS_DIR = os.path.join(TMP_DIR, DD_AGENT_TEST_DIR, '3rd-party')
+TEMP_ETC_CHECKS_DIR = os.path.join(TMP_DIR, DD_AGENT_TEST_DIR, 'etc', 'checks.d')
+TEMP_ETC_CONF_DIR = os.path.join(TMP_DIR, DD_AGENT_TEST_DIR, 'etc', 'conf.d')
+TEMP_AGENT_CHECK_DIR = os.path.join(TMP_DIR, DD_AGENT_TEST_DIR)
+FIXTURE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtures', 'checks')
+
+
+@mock.patch('config.get_checksd_path', return_value=TEMP_AGENT_CHECK_DIR)
+@mock.patch('config.get_confd_path', return_value=TEMP_ETC_CONF_DIR)
+@mock.patch('config.get_3rd_party_path', return_value=TEMP_3RD_PARTY_CHECKS_DIR)
+class TestConfigLoadCheckDirectory(unittest.TestCase):
+
+    TEMP_DIRS = [
+        '%s/test_check' % TEMP_3RD_PARTY_CHECKS_DIR,
+        TEMP_ETC_CHECKS_DIR, TEMP_ETC_CONF_DIR, TEMP_AGENT_CHECK_DIR
+    ]
+
+    def setUp(self):
+        for _dir in self.TEMP_DIRS:
+            if not os.path.exists(_dir):
+                os.makedirs(_dir)
+
+    def testConfigInvalid(self, *args):
+        copyfile('%s/invalid_conf.yaml' % FIXTURE_PATH,
+            '%s/test_check.yaml' % TEMP_ETC_CONF_DIR)
+        copyfile('%s/valid_check_1.py' % FIXTURE_PATH,
+            '%s/test_check.py' % TEMP_AGENT_CHECK_DIR)
+        checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
+        self.assertEquals(1, len(checks['init_failed_checks']))
+
+    def testConfigNotFound(self, *args):
+        copyfile('%s/valid_conf.yaml' % FIXTURE_PATH,
+            '%s/test_check.yaml' % TEMP_ETC_CONF_DIR)
+        checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
+        self.assertEquals(0, len(checks['init_failed_checks']))
+        self.assertEquals(0, len(checks['initialized_checks']))
+
+    def testConfigAgentOnly(self, *args):
+        copyfile('%s/valid_conf.yaml' % FIXTURE_PATH,
+            '%s/test_check.yaml' % TEMP_ETC_CONF_DIR)
+        copyfile('%s/valid_check_1.py' % FIXTURE_PATH,
+            '%s/test_check.py' % TEMP_AGENT_CHECK_DIR)
+        checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
+        self.assertEquals(1, len(checks['initialized_checks']))
+
+    def testConfigETCOnly(self, *args):
+        copyfile('%s/valid_conf.yaml' % FIXTURE_PATH,
+            '%s/test_check.yaml' % TEMP_ETC_CONF_DIR)
+        copyfile('%s/valid_check_1.py' % FIXTURE_PATH,
+            '%s/test_check.py' % TEMP_ETC_CHECKS_DIR)
+        checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
+        self.assertEquals(1, len(checks['initialized_checks']))
+
+    def testConfigAgentETC(self, *args):
+        copyfile('%s/valid_conf.yaml' % FIXTURE_PATH,
+            '%s/test_check.yaml' % TEMP_ETC_CONF_DIR)
+        copyfile('%s/valid_check_2.py' % FIXTURE_PATH,
+            '%s/test_check.py' % TEMP_AGENT_CHECK_DIR)
+        copyfile('%s/valid_check_1.py' % FIXTURE_PATH,
+            '%s/test_check.py' % TEMP_ETC_CHECKS_DIR)
+        checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
+        self.assertEquals(1, len(checks['initialized_checks']))
+        self.assertEquals('valid_check_1', checks['initialized_checks'][0].check(None))
+
+    def testConfigCheckNotAgentCheck(self, *args):
+        copyfile('%s/valid_conf.yaml' % FIXTURE_PATH,
+            '%s/test_check.yaml' % TEMP_ETC_CONF_DIR)
+        copyfile('%s/invalid_check_1.py' % FIXTURE_PATH,
+            '%s/test_check.py' % TEMP_AGENT_CHECK_DIR)
+        checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
+        self.assertEquals(0, len(checks['init_failed_checks']))
+        self.assertEquals(0, len(checks['initialized_checks']))
+
+    def testConfigCheckImportError(self, *args):
+        copyfile('%s/valid_conf.yaml' % FIXTURE_PATH,
+            '%s/test_check.yaml' % TEMP_ETC_CONF_DIR)
+        copyfile('%s/invalid_check_2.py' % FIXTURE_PATH,
+            '%s/test_check.py' % TEMP_AGENT_CHECK_DIR)
+        checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
+        self.assertEquals(1, len(checks['init_failed_checks']))
+
+    def testConfig3rdPartyAgent(self, *args):
+        copyfile('%s/valid_conf.yaml' % FIXTURE_PATH,
+            '%s/test_check.yaml' % TEMP_ETC_CONF_DIR)
+        copyfile('%s/valid_check_2.py' % FIXTURE_PATH,
+            '%s/test_check.py' % TEMP_AGENT_CHECK_DIR)
+        copyfile('%s/valid_check_1.py' % FIXTURE_PATH,
+            '%s/test_check/check.py' % TEMP_3RD_PARTY_CHECKS_DIR)
+        checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
+        self.assertEquals(1, len(checks['initialized_checks']))
+        self.assertEquals('valid_check_1', checks['initialized_checks'][0].check(None))
+
+    def testConfigETC3rdParty(self, *args):
+        copyfile('%s/valid_conf.yaml' % FIXTURE_PATH,
+            '%s/test_check.yaml' % TEMP_ETC_CONF_DIR)
+        copyfile('%s/valid_check_2.py' % FIXTURE_PATH,
+            '%s/test_check/check.py' % TEMP_3RD_PARTY_CHECKS_DIR)
+        copyfile('%s/valid_check_1.py' % FIXTURE_PATH,
+            '%s/test_check.py' % TEMP_ETC_CHECKS_DIR)
+        checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
+        self.assertEquals(1, len(checks['initialized_checks']))
+        self.assertEquals('valid_check_1', checks['initialized_checks'][0].check(None))
+
+    def testConfigInheritedCheck(self, *args):
+        copyfile('%s/valid_conf.yaml' % FIXTURE_PATH,
+            '%s/test_check.yaml' % TEMP_ETC_CONF_DIR)
+        copyfile('%s/valid_sub_check.py' % FIXTURE_PATH,
+            '%s/test_check.py' % TEMP_ETC_CHECKS_DIR)
+        checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
+        self.assertEquals(1, len(checks['initialized_checks']))
+        self.assertEquals('valid_check_1', checks['initialized_checks'][0].check(None))
+
+    def testConfigDeprecatedNagiosConfig(self, *args):
+        copyfile('%s/valid_check_1.py' % FIXTURE_PATH,
+            '%s/nagios.py' % TEMP_ETC_CHECKS_DIR)
+        checks = load_check_directory({"nagios_perf_cfg": None, "additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
+        self.assertEquals(1, len(checks['initialized_checks']))
+        self.assertEquals('valid_check_1', checks['initialized_checks'][0].check(None))
+
+    def testConfigDefault(self, *args):
+        copyfile('%s/valid_conf.yaml' % FIXTURE_PATH,
+            '%s/test_check.yaml.default' % TEMP_ETC_CONF_DIR)
+        copyfile('%s/valid_check_1.py' % FIXTURE_PATH,
+            '%s/test_check.py' % TEMP_ETC_CHECKS_DIR)
+        checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
+        self.assertEquals(1, len(checks['initialized_checks']))
+
+    def testConfigCustomOverDefault(self, *args):
+        copyfile('%s/valid_conf.yaml' % FIXTURE_PATH,
+            '%s/test_check.yaml.default' % TEMP_ETC_CONF_DIR)
+        # a 2nd valid conf file, slightly different so that we can test which one has been picked up
+        # (with 2 instances for instance)
+        copyfile('%s/valid_conf_2.yaml' % FIXTURE_PATH,
+            '%s/test_check.yaml' % TEMP_ETC_CONF_DIR)
+        copyfile('%s/valid_check_1.py' % FIXTURE_PATH,
+            '%s/test_check.py' % TEMP_ETC_CHECKS_DIR)
+        checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
+        self.assertEquals(1, len(checks['initialized_checks']))
+        self.assertEquals(2, checks['initialized_checks'][0].instance_count())  # check that we picked the right conf
+
+    def tearDown(self):
+        for _dir in self.TEMP_DIRS:
+            rmtree(_dir)


### PR DESCRIPTION
Based on @tmichelet's work in #2273, rebased on top of master (i.e. it now handles configs from the service discovery).

When we load the checks, we take into account the configs from files (`.yaml` and `.default.yaml`) first, and then the configs from service discovery for the checks that haven't been loaded yet.

Also, this changes the logic of `get_check_class` in `utils.checkfiles` to take into account checks from 3rd-party dirs.

cc @hkaj 

Original PR message:
```
- Add tests on config's logic
- Refactor logic
- Update logic to look for checks in 3rd-party directory
```