### PR TITLE
[wmi][docs] Document that `%` is the only accepted wildcard in filters

### DIFF
--- a/checks/libs/wmi/sampler.py
+++ b/checks/libs/wmi/sampler.py
@@ -295,8 +295,8 @@ class WMISampler(object):
 
                 NOTE: If we just provide a value we defailt to '=' comparison operator.
                 Otherwise, specify the operator in a tuple as above: (comp_op, value)
-                If we detect a wildcard character such as '*' or '%' we will override
-                the operator to use LIKE
+                If we detect a wildcard character ('%') we will override the operator
+                to use LIKE
         """
         def build_where_clause(fltr):
             f = fltr.pop()

--- a/conf.d/wmi_check.yaml.example
+++ b/conf.d/wmi_check.yaml.example
@@ -33,7 +33,8 @@ instances:
   # `filters` is a list of filters on the WMI query you may want. For example,
   # for a process-based WMI class you may want metrics for only certain
   # processes running on your machine, so you could add a filter for each
-  # process name. See below for an example of this case.
+  # process name. You can also use the '%' character as a wildcard.
+  # See below for examples.
   #
   #
   # `tag_by` optionally lets you tag each metric with a property from the


### PR DESCRIPTION
Fixes #2368