### PR TITLE
[dogstatsd][sc] Fix parsing of tag key ending with `m`

### DIFF
--- a/aggregator.py
+++ b/aggregator.py
@@ -558,7 +558,7 @@ class Aggregator(object):
                 'status': int(status)
             }
 
-            message_delimiter = '|m:' if '|m:' in metadata else 'm:'
+            message_delimiter = 'm:' if metadata.startswith('m:') else '|m:'
             if message_delimiter in metadata:
                 meta, message = metadata.rsplit(message_delimiter, 1)
                 service_check['message'] = self._unescape_sc_content(message)


### PR DESCRIPTION
On service checks, tags which keys finished with `m:` were mistaken for
the beginning of a message metadata field.

Fix the behavior, and add a test.

Fixes #2373