### PR TITLE
[source_install] updating setuptools ez_setup.py to new recommended location.

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -357,7 +357,7 @@ VENV_PYTHON_CMD="$DD_HOME/venv/bin/python"
 VENV_PIP_CMD="$DD_HOME/venv/bin/pip"
 
 print_console "* Setting up setuptools"
-$DOWNLOADER "$DD_HOME/ez_setup.py" https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py
+$DOWNLOADER "$DD_HOME/ez_setup.py" https://bootstrap.pypa.io/ez_setup.py
 $VENV_PYTHON_CMD "$DD_HOME/ez_setup.py" --version="20.9.0"
 rm -f "$DD_HOME/ez_setup.py"
 rm -f "$DD_HOME/ez_setup.pyc"


### PR DESCRIPTION
### Why?

Setuptools has moved to github from bitbucket. As per the github readme the new preferred location is:
https://bootstrap.pypa.io/ez_setup.py
