### PR TITLE
[linux] make /proc configurable.

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -144,7 +144,9 @@ class Agent(Daemon):
 
         self._agentConfig = self._set_agent_config_hostname(config)
         hostname = get_hostname(self._agentConfig)
-        systemStats = get_system_stats()
+        systemStats = get_system_stats(
+            proc_path=self._agentConfig.get('procfs_path', '/proc').rstrip('/')
+        )
         emitters = self._get_emitters()
 
         # Initialize service discovery

--- a/checks.d/agent_metrics.py
+++ b/checks.d/agent_metrics.py
@@ -113,6 +113,7 @@ class AgentMetrics(AgentCheck):
         return self._collector_payload, self._metric_context
 
     def check(self, instance):
+
         if self.in_developer_mode:
             stats, names_to_metric_types = self._psutil_config_to_stats(instance)
             self._register_psutil_metrics(stats, names_to_metric_types)

--- a/checks.d/btrfs.py
+++ b/checks.d/btrfs.py
@@ -15,6 +15,7 @@ import psutil
 
 # project
 from checks import AgentCheck
+from utils.platform import Platform
 
 MIXED = "mixed"
 DATA = "data"
@@ -119,6 +120,11 @@ class BTRFS(AgentCheck):
     def check(self, instance):
         btrfs_devices = {}
         excluded_devices = instance.get('excluded_devices', [])
+
+        if Platform.is_linux():
+            procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
+            psutil.PROCFS_PATH = procfs_path
+
         for p in psutil.disk_partitions():
             if (p.fstype == 'btrfs' and p.device not in btrfs_devices
                     and p.device not in excluded_devices):

--- a/checks.d/disk.py
+++ b/checks.d/disk.py
@@ -39,6 +39,9 @@ class Disk(AgentCheck):
         # Windows and Mac will always have psutil
         # (we have packaged for both of them)
         if self._psutil():
+            if Platform.is_linux():
+                procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
+                psutil.PROCFS_PATH = procfs_path
             self.collect_metrics_psutil()
         else:
             # FIXME: implement all_partitions (df -a)

--- a/checks.d/gunicorn.py
+++ b/checks.d/gunicorn.py
@@ -15,6 +15,7 @@ import psutil
 
 # project
 from checks import AgentCheck
+from util import Platform
 
 
 class GUnicornCheck(AgentCheck):
@@ -36,6 +37,10 @@ class GUnicornCheck(AgentCheck):
     def check(self, instance):
         """ Collect metrics for the given gunicorn instance. """
         self.log.debug("Running instance: %s", instance)
+
+        if Platform.is_linux():
+            procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
+            psutil.PROCFS_PATH = procfs_path
 
         # Validate the config.
         if not instance or self.PROC_NAME not in instance:

--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -20,6 +20,7 @@ except ImportError:
 # project
 from config import _is_affirmative
 from checks import AgentCheck
+from util import Platform
 
 GAUGE = "gauge"
 RATE = "rate"
@@ -288,6 +289,11 @@ class MySql(AgentCheck):
         return {"pymysql": pymysql.__version__}
 
     def check(self, instance):
+
+        if Platform.is_linux() and PSUTIL_AVAILABLE:
+            procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
+            psutil.PROCFS_PATH = procfs_path
+
         host, port, user, password, mysql_sock, defaults_file, tags, options, queries, ssl = \
             self._get_config(instance)
 

--- a/checks.d/process.py
+++ b/checks.d/process.py
@@ -69,8 +69,10 @@ class ProcessCheck(AgentCheck):
 
         if Platform.is_linux():
             procfs_path = init_config.get('procfs_path')
-            if procfs_path:
-                psutil.PROCFS_PATH = procfs_path
+            if not procfs_path:
+                procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
+
+            psutil.PROCFS_PATH = procfs_path
 
         # Process cache, indexed by instance
         self.process_cache = defaultdict(dict)

--- a/checks.d/system_core.py
+++ b/checks.d/system_core.py
@@ -7,11 +7,17 @@ import psutil
 
 # project
 from checks import AgentCheck
+from utils.platform import Platform
 
 
 class SystemCore(AgentCheck):
 
     def check(self, instance):
+
+        if Platform.is_linux():
+            procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
+            psutil.PROCFS_PATH = procfs_path
+
         cpu_times = psutil.cpu_times(percpu=True)
         self.gauge("system.core.count", len(cpu_times))
 

--- a/checks.d/system_swap.py
+++ b/checks.d/system_swap.py
@@ -7,11 +7,17 @@ import psutil
 
 # project
 from checks import AgentCheck
+from utils.platform import Platform
 
 
 class SystemSwap(AgentCheck):
 
     def check(self, instance):
+
+        if Platform.is_linux():
+            procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
+            psutil.PROCFS_PATH = procfs_path
+
         swap_mem = psutil.swap_memory()
         self.rate('system.swap.swapped_in', swap_mem.sin)
         self.rate('system.swap.swapped_out', swap_mem.sout)

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -337,6 +337,10 @@ class AgentCheck(object):
             histogram_percentiles=agentConfig.get('histogram_percentiles')
         )
 
+        if Platform.is_linux() and psutil is not None:
+            procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
+            psutil.PROCFS_PATH = procfs_path
+
         self.events = []
         self.service_checks = []
         self.instances = instances or []

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -655,7 +655,9 @@ class Collector(object):
             if gohai_metadata:
                 payload['gohai'] = gohai_metadata
 
-            payload['systemStats'] = get_system_stats()
+            payload['systemStats'] = get_system_stats(
+                proc_path=self.agentConfig.get('procfs_path', '/proc').rstrip('/')
+            )
             payload['meta'] = self._get_hostname_metadata()
 
             self.hostname_metadata_cache = payload['meta']

--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -225,8 +225,10 @@ class Load(Check):
 
     def check(self, agentConfig):
         if Platform.is_linux():
+            proc_location = agentConfig.get('procfs_path', '/proc').rstrip('/')
             try:
-                with open('/proc/loadavg', 'r') as load_avg:
+                proc_loadavg = "{}/loadavg".format(proc_location)
+                with open(proc_loadavg, 'r') as load_avg:
                     uptime = load_avg.readline().strip()
             except Exception:
                 self.logger.exception('Cannot extract load')
@@ -286,11 +288,13 @@ class Memory(Check):
 
     def check(self, agentConfig):
         if Platform.is_linux():
+            proc_location = agentConfig.get('procfs_path', '/proc').rstrip('/')
             try:
-                with open('/proc/meminfo', 'r') as mem_info:
+                proc_meminfo = "{}/meminfo".format(proc_location)
+                with open(proc_meminfo, 'r') as mem_info:
                     lines = mem_info.readlines()
             except Exception:
-                self.logger.exception('Cannot get memory metrics from /proc/meminfo')
+                self.logger.exception('Cannot get memory metrics from %s', proc_meminfo)
                 return False
 
             # NOTE: not all of the stats below are present on all systems as
@@ -349,7 +353,7 @@ class Memory(Check):
                     if match is not None:
                         meminfo[match.group(1)] = match.group(2)
                 except Exception:
-                    self.logger.exception("Cannot parse /proc/meminfo")
+                    self.logger.exception("Cannot parse %s", proc_meminfo)
 
             memData = {}
 
@@ -374,7 +378,7 @@ class Memory(Check):
                 if memData['physTotal'] > 0:
                     memData['physPctUsable'] = float(memData['physUsable']) / float(memData['physTotal'])
             except Exception:
-                self.logger.exception('Cannot compute stats from /proc/meminfo')
+                self.logger.exception('Cannot compute stats from %s', proc_meminfo)
 
             # Swap
             # FIXME units are in MB, we should use bytes instead
@@ -459,7 +463,7 @@ class Memory(Check):
                 if memData['physTotal'] > 0:
                     memData['physPctUsable'] = float(memData['physUsable']) / float(memData['physTotal'])
             except Exception:
-                self.logger.exception('Cannot compute stats from /proc/meminfo')
+                self.logger.exception('Cannot compute stats from %s', proc_meminfo)
 
             # Swap
             try:

--- a/config.py
+++ b/config.py
@@ -581,7 +581,7 @@ def get_config(parse_args=True, cfg_path=None, options=None):
     return agentConfig
 
 
-def get_system_stats():
+def get_system_stats(proc_path=None):
     systemStats = {
         'machine': platform.machine(),
         'platform': sys.platform,
@@ -593,7 +593,10 @@ def get_system_stats():
 
     try:
         if Platform.is_linux(platf):
-            output, _, _ = get_subprocess_output(['grep', 'model name', '/proc/cpuinfo'], log)
+            if not proc_path:
+                proc_path = "/proc"
+            proc_cpuinfo = os.path.join(proc_path,'cpuinfo')
+            output, _, _ = get_subprocess_output(['grep', 'model name', proc_cpuinfo], log)
             systemStats['cpuCores'] = len(output.splitlines())
 
         if Platform.is_darwin(platf) or Platform.is_freebsd(platf):

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -111,6 +111,15 @@ use_mount: no
 # `/datadog/check_configs` key in the back-end. If you wish otherwise, uncomment this option
 # and modify its value.
 # sd_template_dir: /datadog/check_configs
+#
+# ========================================================================== #
+# Other                                                                      #
+# ========================================================================== #
+#
+# In some environments we may have the procfs file system mounted in a 
+# miscellaneous location. The procfs_path configuration paramenter allows
+# us to override the standard default location '/proc'
+# procfs_path: /proc
 
 # ========================================================================== #
 # DogStatsd configuration                                                    #

--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -87,7 +87,9 @@ class KubeUtil():
     @classmethod
     def _get_default_router(cls):
         try:
-            with open('/proc/net/route') as f:
+            from config import get_config
+            procfs_netroute = os.path.join(get_config(parse_args=True).get('procfs_path','/proc'), 'net', 'route')
+            with open(procfs_netroute) as f:
                 for line in f.readlines():
                     fields = line.strip().split()
                     if fields[1] == '00000000':


### PR DESCRIPTION
Allows overriding of `/proc` by defining `procfs_path` in `datadog.conf` - should be enforcable by using `self.agentConfig.get("procfs_path")` from any of the checks. I believe we enforce that pretty much everywhere relevant with this PR.

Places where we haven't overriden it just yet: 
  - https://github.com/DataDog/dd-agent/blob/jaime/config_proc/daemon.py: because we haven't read the configuration yet.
  - https://github.com/DataDog/dd-agent/blob/jaime/config_proc/utils/process.py: because when those functions are called, we haven't read the configuration either.