### PR TITLE
[cassandra] Add read and write latency ColumnFamily metrics

### DIFF
--- a/conf.d/cassandra.yaml.example
+++ b/conf.d/cassandra.yaml.example
@@ -51,7 +51,7 @@ init_config:
         domain: org.apache.cassandra.metrics
         type: ColumnFamily
         bean_regex:
-          - .*keyspace=.*  
+          - .*keyspace=.*
         name:
           - TotalDiskSpaceUsed
           - BloomFilterDiskSpaceUsed
@@ -66,6 +66,14 @@ init_config:
           - MemtableLiveDataSize
           - MemtableSwitchCount
           - MinRowSize
+          - ReadLatency
+          - WriteLatency
+        attribute:
+          - Value
+          - Count
+          - Mean
+          - 99thPercentile
+          - Max
       exclude:
         keyspace:
           - OpsCenter


### PR DESCRIPTION
Read and Write latency are not only a way to figure out how long it takes to run the specified operation against the given columnfamily, the count metric is also the only way to figure out how often we're reading from and writing to a column family.

cc @johnaxel 