### PR TITLE
[core] [windows] Fixes windows agent for windows server 2008 and earlier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ if sys.platform == 'win32':
                 'compressed': True,
                 'bundle_files': 3,
                 'excludes': ['numpy'],
-                'dll_excludes': ["IPHLPAPI.DLL", "NSI.dll",  "WINNSI.DLL",  "WTSAPI32.dll"],
+                'dll_excludes': ['crypt32.dll',"IPHLPAPI.DLL", "NSI.dll",  "WINNSI.DLL",  "WTSAPI32.dll"],
                 'ascii':False,
             },
         },


### PR DESCRIPTION
## Summary
A client contacted us telling us that the agent had stopped working on Windows Server 2008. There were a few things obscuring what was going on, I won't go into detail about how I figured it out. But, after digging through their logs for a while, the root of it was the following error: `WindowsError: [Error -2146893795] Provider DLL failed to initialize correctly`.

This is a known py2exe issue in Windows. [Amazon had the same issue last year](https://github.com/aws/aws-cli/issues/1226) with their AWS cli not working on Windows Server 2008 and earlier, if it had been built on a later system. 

What's happening is that py2exe is bundling all the necessary .dll's into the installer. However, in this case, the .dll is an Operating System .dll. It's not appropriate to bundle the OS specific .dll into the installer. It will cause an error that looks exactly like this.

Our error was propagating from the python random number generators, just like Amazon's. And, like Amazon's, excluding `crypt32.dll` from py2exe was sufficient to fix it.

I have tested this on a Windows 2008 system. And, the client has also confirmed to me that an installer bundled with this specific change fixes their issues.

### Open Questions

1. Are there other dll's that we inadvertently bundle which we should leave out? (Are there ones more specific to this problem?)
1. How do we best prevent this from happening in the future?