### PR TITLE
[mapreduce] Switch most metrics to counters

### DIFF
--- a/conf.d/mapreduce.yaml.example
+++ b/conf.d/mapreduce.yaml.example
@@ -2,7 +2,7 @@ instances:
   #
   # The MapReduce check retrieves metrics from YARN's ResourceManager. This
   # check must be run from the Master Node and the ResourceManager URI must
-  # be specified below. The ResourceManager URI is composed of the 
+  # be specified below. The ResourceManager URI is composed of the
   # ResourceManager's hostname and port.
   #
   # The ResourceManager hostname can be found in the yarn-site.xml conf file
@@ -15,6 +15,10 @@ instances:
 
     # A Required friendly name for the cluster.
     # cluster_name: MyMapReduceCluster
+
+    # Set to true to collect histograms on the elapsed time of
+    # map and reduce tasks (default: false)
+    # collect_task_metrics: false
 
     # Optional tags to be applied to every emitted metric.
     # tags:

--- a/tests/checks/mock/test_mapreduce.py
+++ b/tests/checks/mock/test_mapreduce.py
@@ -84,7 +84,8 @@ class MapReduceCheck(AgentCheckTest):
 
     MR_CONFIG = {
         'resourcemanager_uri': 'http://localhost:8088',
-        'cluster_name': CLUSTER_NAME
+        'cluster_name': CLUSTER_NAME,
+        'collect_task_metrics': 'true'
     }
 
     INIT_CONFIG = {
@@ -119,24 +120,24 @@ class MapReduceCheck(AgentCheckTest):
 
     MAPREDUCE_JOB_METRIC_VALUES = {
         'mapreduce.job.elapsed_time.max': 99221829,
-        'mapreduce.job.maps_total.max': 1,
-        'mapreduce.job.maps_completed.max': 0,
-        'mapreduce.job.reduces_total.max': 1,
-        'mapreduce.job.reduces_completed.max': 0,
-        'mapreduce.job.maps_pending.max': 0,
-        'mapreduce.job.maps_running.max': 1,
-        'mapreduce.job.reduces_pending.max': 1,
-        'mapreduce.job.reduces_running.max': 0,
-        'mapreduce.job.new_reduce_attempts.max': 1,
-        'mapreduce.job.running_reduce_attempts.max': 0,
-        'mapreduce.job.failed_reduce_attempts.max': 0,
-        'mapreduce.job.killed_reduce_attempts.max': 0,
-        'mapreduce.job.successful_reduce_attempts.max': 0,
-        'mapreduce.job.new_map_attempts.max': 0,
-        'mapreduce.job.running_map_attempts.max': 1,
-        'mapreduce.job.failed_map_attempts.max': 1,
-        'mapreduce.job.killed_map_attempts.max': 0,
-        'mapreduce.job.successful_map_attempts.max': 0,
+        'mapreduce.job.maps_total': 1,
+        'mapreduce.job.maps_completed': 0,
+        'mapreduce.job.reduces_total': 1,
+        'mapreduce.job.reduces_completed': 0,
+        'mapreduce.job.maps_pending': 0,
+        'mapreduce.job.maps_running': 1,
+        'mapreduce.job.reduces_pending': 1,
+        'mapreduce.job.reduces_running': 0,
+        'mapreduce.job.new_reduce_attempts': 1,
+        'mapreduce.job.running_reduce_attempts': 0,
+        'mapreduce.job.failed_reduce_attempts': 0,
+        'mapreduce.job.killed_reduce_attempts': 0,
+        'mapreduce.job.successful_reduce_attempts': 0,
+        'mapreduce.job.new_map_attempts': 0,
+        'mapreduce.job.running_map_attempts': 1,
+        'mapreduce.job.failed_map_attempts': 1,
+        'mapreduce.job.killed_map_attempts': 0,
+        'mapreduce.job.successful_map_attempts': 0,
     }
 
     MAPREDUCE_JOB_METRIC_TAGS = [
@@ -147,7 +148,6 @@ class MapReduceCheck(AgentCheckTest):
     ]
 
     MAPREDUCE_MAP_TASK_METRIC_VALUES = {
-        'mapreduce.job.map.task.progress.max': 49.11076,
         'mapreduce.job.map.task.elapsed_time.max': 99869037
     }
 
@@ -160,7 +160,6 @@ class MapReduceCheck(AgentCheckTest):
     ]
 
     MAPREDUCE_REDUCE_TASK_METRIC_VALUES = {
-        'mapreduce.job.reduce.task.progress.max': 32.42940,
         'mapreduce.job.reduce.task.elapsed_time.max': 123456
     }
 
@@ -173,15 +172,15 @@ class MapReduceCheck(AgentCheckTest):
     ]
 
     MAPREDUCE_JOB_COUNTER_METRIC_VALUES = {
-        'mapreduce.job.counter.total_counter_value.max': {'value': 0, 'tags': ['counter_name:file_bytes_read']},
-        'mapreduce.job.counter.map_counter_value.max': {'value': 1, 'tags': ['counter_name:file_bytes_read']},
-        'mapreduce.job.counter.reduce_counter_value.max': {'value': 2, 'tags': ['counter_name:file_bytes_read']},
-        'mapreduce.job.counter.total_counter_value.max': {'value': 3, 'tags': ['counter_name:file_bytes_written']},
-        'mapreduce.job.counter.map_counter_value.max': {'value': 4, 'tags': ['counter_name:file_bytes_written']},
-        'mapreduce.job.counter.reduce_counter_value.max': {'value': 5, 'tags': ['counter_name:file_bytes_written']},
-        'mapreduce.job.counter.total_counter_value.max': {'value': 9, 'tags': ['counter_name:map_output_records']},
-        'mapreduce.job.counter.map_counter_value.max': {'value': 10, 'tags': ['counter_name:map_output_records']},
-        'mapreduce.job.counter.reduce_counter_value.max': {'value': 11, 'tags': ['counter_name:map_output_records']},
+        'mapreduce.job.counter.total_counter_value': {'value': 0, 'tags': ['counter_name:file_bytes_read']},
+        'mapreduce.job.counter.map_counter_value': {'value': 1, 'tags': ['counter_name:file_bytes_read']},
+        'mapreduce.job.counter.reduce_counter_value': {'value': 2, 'tags': ['counter_name:file_bytes_read']},
+        'mapreduce.job.counter.total_counter_value': {'value': 3, 'tags': ['counter_name:file_bytes_written']},
+        'mapreduce.job.counter.map_counter_value': {'value': 4, 'tags': ['counter_name:file_bytes_written']},
+        'mapreduce.job.counter.reduce_counter_value': {'value': 5, 'tags': ['counter_name:file_bytes_written']},
+        'mapreduce.job.counter.total_counter_value': {'value': 9, 'tags': ['counter_name:map_output_records']},
+        'mapreduce.job.counter.map_counter_value': {'value': 10, 'tags': ['counter_name:map_output_records']},
+        'mapreduce.job.counter.reduce_counter_value': {'value': 11, 'tags': ['counter_name:map_output_records']},
     }
 
     MAPREDUCE_JOB_COUNTER_METRIC_TAGS = [


### PR DESCRIPTION
With the following exceptions:
- `mapreduce.job.elapsed_time`
- `mapreduce.job.map.task.elapsed_time` (made non-default in config)
- `mapreduce.job.reduce.task.elapsed_time` (made non-default in config)

Also, removed `mapreduce.job.map.task.progress` and
`mapreduce.job.reduce.task.progress`.

We have to ping @kky once this PR is merged and part of a nightly/pre-release package so that he can update the default screenboard accordingly.