### PR TITLE
[yarn] Add configurable application tags

### DIFF
--- a/conf.d/yarn.yaml.example
+++ b/conf.d/yarn.yaml.example
@@ -17,6 +17,15 @@ instances:
     # A Required friendly name for the cluster.
     # cluster_name: MyYarnCluster
 
+    # Values from running applications response that will be applied as datadog tags, set as app_key:datadog_tag
+    # You can find the whole list keys on yarn api reference - application response body:
+    # https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API
+    # Example:
+    #   - queue:app_queue
+    #   - user:app_user
+     application_tags:
+       - name:app_name
+
     # Optional tags to be applied to every emitted metric.
     # tags:
     #   - key:value

--- a/tests/checks/mock/test_yarn.py
+++ b/tests/checks/mock/test_yarn.py
@@ -53,7 +53,14 @@ class YARNCheck(AgentCheckTest):
 
     YARN_CONFIG = {
         'resourcemanager_uri': 'http://localhost:8088',
-        'cluster_name': CLUSTER_NAME
+        'cluster_name': CLUSTER_NAME,
+        'tags': [
+            'opt_key:opt_value'
+        ],
+        'application_tags': [
+            'id:app_id',
+            'name:app_name'
+        ]
     }
 
     YARN_CLUSTER_METRICS_VALUES = {
@@ -82,7 +89,10 @@ class YARNCheck(AgentCheckTest):
         'yarn.metrics.rebooted_nodes': 0,
     }
 
-    YARN_CLUSTER_METRICS_TAGS = ['cluster_name:%s' % CLUSTER_NAME]
+    YARN_CLUSTER_METRICS_TAGS = [
+        'cluster_name:%s' % CLUSTER_NAME,
+        'opt_key:opt_value'
+    ]
 
     YARN_APP_METRICS_VALUES = {
         'yarn.apps.progress': 100,
@@ -98,7 +108,9 @@ class YARNCheck(AgentCheckTest):
 
     YARN_APP_METRICS_TAGS = [
         'cluster_name:%s' % CLUSTER_NAME,
-        'app_name:word count'
+        'app_name:word count',
+        'app_id:application_1326815542473_0001',
+        'opt_key:opt_value'
     ]
 
     YARN_NODE_METRICS_VALUES = {
@@ -112,7 +124,8 @@ class YARNCheck(AgentCheckTest):
 
     YARN_NODE_METRICS_TAGS = [
         'cluster_name:%s' % CLUSTER_NAME,
-        'node_id:h2:1235'
+        'node_id:h2:1235',
+        'opt_key:opt_value'
     ]
 
     @mock.patch('requests.get', side_effect=requests_get_mock)


### PR DESCRIPTION
Added application tags in the configuration file,
allowing set extra tags for app metrics like queue,
user, etc.

Also, added the tags functionality merged in
https://github.com/DataDog/dd-agent/pull/2473
on tests
