### PR TITLE
[memcached] Additional stats metrics

### DIFF
--- a/conf.d/mcache.yaml.example
+++ b/conf.d/mcache.yaml.example
@@ -6,3 +6,8 @@ instances:
   #   port: 11211 # If this line is not present, port will default to 11211
   #   tags:
   #     - optional_tag
+
+  #   options:
+  #     items: false  # set to true if you wish to collect items memcached stats.
+  #     slabs: false  # set to true if you wish to collect slabs memcached stats.
+


### PR DESCRIPTION
## Why
This PR adds support for memcached "items" statistics as reported by `stats items`. It also attempts to simplify the inclusion of additional optional metrics. To do so, it introduces a map of `stats` arguments (ie. items) to a list  of rate metrics, gauge metrics, and if needed a raw stat output handler.

In the particular case of the items statistics, we need an output handler because we need to parse the raw key value (with form "items:<slab_id>:<metric_name>" to extract the `<slab_id>` and actual metric name. The actual value remains untouched - no need to operate over it. We can then use the `slab_id` to tag the relevant metrics. All handlers are expected to return a tuple of metric_name, tags, and actual value. 

Enabling optional metrics requires configuring the `optional_metrics` flag in the memcached yaml. 

### Open Questions
  - should each of the optional metrics get its own feature flag?
  - currently namespacing optional metrics as follows: memcached.`<stats_arg>`.`<metric_name>` - yes? no?

### Reference
https://github.com/memcached/memcached/blob/master/doc/protocol.txt