### PR TITLE
[mesos_master] Fix key error when a metric is missing.

### DIFF
--- a/checks.d/mesos_master.py
+++ b/checks.d/mesos_master.py
@@ -229,7 +229,8 @@ class MesosMaster(AgentCheck):
                                self.CLUSTER_FRAMEWORK_METRICS, self.STATS_METRICS]
                 for m in metrics:
                     for key_name, (metric_name, metric_func) in m.iteritems():
-                        metric_func(self, metric_name, stats_metrics[key_name], tags=tags)
+                        if key_name in stats_metrics:
+                            metric_func(self, metric_name, stats_metrics[key_name], tags=tags)
 
 
         self.service_check_needed = True


### PR DESCRIPTION
### What's this PR do?
Fixes a case where a missing metric can cause the mesos_master integration to report only a subset of metric values.

### Motivation
Our version of Mesos — 0.21.0 — was missing a key `master/tasks_error` and getting a `KeyError`. This caused it to only report 20 of the possible 60 metrics it should've been collecting!

### Notes
I didn't add any sort of logging for missing keys. Happy to do so if desired.

cc @rhwlo @antifuchs