### PR TITLE
[mongo] Add additional tag on status change to make searching more precise.

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -447,6 +447,7 @@ class MongoDb(AgentCheck):
             'msg_text': msg,
             'host': hostname,
             'tags': [
+                'action:mongo_replset_member_status_change',
                 'member_status:' + short_status,
                 'previous_member_status:' + last_short_status,
                 'replset:' + replset_name,


### PR DESCRIPTION
### What's this PR do?
Adds an additional tag `action:mongo_replset_member_status_change` to events generated for mongo replset status changes.

### Motivation
I don't like relying on full text search for events. I find tag filtering to be a more precise and ergonomic way of asking for a specific type of event. This tag lets us filter *just* for status change events easily.

cc @rhwlo @antifuchs