### PR TITLE
Fix bad logging in case a check config file is missing

### DIFF
--- a/utils/checkfiles.py
+++ b/utils/checkfiles.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 
 def get_conf_path(check_name):
-    """Return the yaml config file path for a given check name."""
+    """Return the yaml config file path for a given check name or raise an IOError."""
     from config import get_confd_path, PathNotFound
     confd_path = ''
 
@@ -26,8 +26,7 @@ def get_conf_path(check_name):
     if not os.path.exists(conf_path):
         default_conf_path = os.path.join(confd_path, '%s.yaml.default' % check_name)
         if not os.path.exists(default_conf_path):
-            log.error("Couldn't find any configuration file for the %s check." % check_name)
-            return None
+            raise IOError("Couldn't find any configuration file for the %s check." % check_name)
         else:
             conf_path = default_conf_path
     return conf_path

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -60,7 +60,11 @@ class DockerUtil():
         from util import check_yaml
         from utils.checkfiles import get_conf_path
         init_config, instances = {}, []
-        conf_path = get_conf_path(CHECK_NAME)
+        try:
+            conf_path = get_conf_path(CHECK_NAME)
+        except IOError as ex:
+            log.debug(ex.message)
+            return init_config, {}
 
         if conf_path is not None and os.path.exists(conf_path):
             try:

--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -35,10 +35,14 @@ class KubeUtil():
     DEFAULT_MASTER_PORT = 8080
 
     def __init__(self):
-        config_file_path = get_conf_path(KUBERNETES_CHECK_NAME)
         try:
+            config_file_path = get_conf_path(KUBERNETES_CHECK_NAME)
             check_config = check_yaml(config_file_path)
             instance = check_config['instances'][0]
+        # kubernetes.yaml was not found
+        except IOError as ex:
+            log.error(ex.message)
+            instance = {}
         except Exception:
             log.error('Kubernetes configuration file is invalid. '
                       'Trying connecting to kubelet with default settings anyway...')


### PR DESCRIPTION
get_hostname tries calling DockerUtil in some cases which can lead to irrelevant error logs like
```
2016-05-11 20:23:09,243 | ERROR | dd.collector | utils.checkfiles(checkfiles.py:29) | Couldn't find any configuration file for the docker_daemon check.
2016-05-11 20:23:09,243 | ERROR | dd.collector | utils.dockerutil(dockerutil.py:79) | No instance was found in the docker check configuration. Docker related collection will not work.
```

This PR makes `get_conf_path` raise an IOError instead of logging, and manage this exception more precisely downstream.