### PR TITLE
[dogstatsd] improve logging of incorrect packet

### DIFF
--- a/aggregator.py
+++ b/aggregator.py
@@ -496,8 +496,7 @@ class Aggregator(object):
             except (IndexError, AssertionError):
                 log.warning(u'Incorrect metric metadata: metric_name:%s, metadata:%s',
                             name, u' '.join(value_and_metadata[2:]))
-                sample_rate = 1
-                tags = None
+                sample_rate = 1  # In case it's in a bad state
             parsed_packets.append((name, value, metric_type, tags, sample_rate))
 
         return parsed_packets
@@ -600,21 +599,20 @@ class Aggregator(object):
                 continue
 
             if packet.startswith('_e'):
-                self.event_count += 1
                 event = self.parse_event_packet(packet)
                 self.event(**event)
+                self.event_count += 1
             elif packet.startswith('_sc'):
-                self.service_check_count += 1
                 service_check = self.parse_sc_packet(packet)
                 self.service_check(**service_check)
+                self.service_check_count += 1
             else:
-                self.count += 1
                 parsed_packets = self.parse_metric_packet(packet)
+                self.count += 1
                 for name, value, mtype, tags, sample_rate in parsed_packets:
                     hostname, device_name, tags = self._extract_magic_tags(tags)
                     self.submit_metric(name, value, mtype, tags=tags, hostname=hostname,
-                        device_name=device_name, sample_rate=sample_rate)
-
+                                       device_name=device_name, sample_rate=sample_rate)
 
     def _extract_magic_tags(self, tags):
         """Magic tags (host, device) override metric hostname and device_name attributes"""

--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -346,6 +346,7 @@ class Server(object):
 
         # Run our select loop.
         self.running = True
+        message = None
         while self.running:
             try:
                 ready = select_select(sock, [], [], timeout)
@@ -363,7 +364,7 @@ class Server(object):
             except (KeyboardInterrupt, SystemExit):
                 break
             except Exception:
-                log.exception('Error receiving datagram')
+                log.exception('Error receiving datagram `%s`', message)
 
     def stop(self):
         self.running = False


### PR DESCRIPTION
Copy/paste from the two commits:

## log metadata error instead of failing
Previously, if `dogstatsd` received a packet with an incorrect metadata (empty
for example), it would fail and raise an exception without explanation.

This commits changes this behaviour: if something is wrong with the metadata,
it is logged at warning level but does not fail.

## log useful parse errors
Previously dogstasd was only logging
```
            except Exception:
                log.exception('Error receiving datagram')
```
whereas the `parse_*` functions were trying to raise useful errors.

This shouldn't happen anymore, as the parse exception are now handled and
logged in the aggregator.

It has another benefit: if there are incorrect packets in the "datagram",
the correct ones will be processed correctly (it was not the case before,
`dogstatsd` was failing at the first incorrect packet).