### PR TITLE
[jmxfetch] If statsd is bound to all interfaces, use localhost

### DIFF
--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -233,6 +233,9 @@ class JMXFetch(object):
     def _start(self, path_to_java, java_run_opts, jmx_checks, command, reporter, tools_jar_path, custom_jar_paths, redirect_std_streams):
         if reporter is None:
             statsd_host = self.agentConfig.get('bind_host', 'localhost')
+            if statsd_host == "0.0.0.0":
+                # If statsd is bound to all interfaces, just use localhost for clients
+                statsd_host = "localhost"
             statsd_port = self.agentConfig.get('dogstatsd_port', "8125")
             reporter = "statsd:%s:%s" % (statsd_host, statsd_port)
 


### PR DESCRIPTION
Otherwise jmxfetch won't be able to send metrics