### PR TITLE
adds scandir to requirements-opt

### DIFF
--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -49,3 +49,6 @@ psycopg2==2.6
 # It's a pure python module, it doesn't require anything to install,
 # but needs the pywin32 extension to work
 wmi==1.4.9
+
+# checks.d/directory.py
+scandir==1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,6 +76,3 @@ dnspython==1.12.0
 # utils/service_discovery/config_stores.py
 python-etcd==0.4.2
 python-consul==0.4.7
-
-# checks.d/directory.py
-scandir==1.2


### PR DESCRIPTION
Scandir requires both the python development headers and GCC in order to be built. So, it should be in requirements-opt rather than the main requirements file. If you want to install it from source, we should allow you to be able to do that without Python.h or gcc.