### PR TITLE
Update ceph.py

### DIFF
--- a/checks.d/ceph.py
+++ b/checks.d/ceph.py
@@ -23,16 +23,16 @@ class Ceph(AgentCheck):
     DEFAULT_CEPH_CMD = '/usr/bin/ceph'
     NAMESPACE = "ceph"
 
-    def _collect_raw(self, ceph_cmd, instance):
+    def _collect_raw(self, ceph_cmd, instance, name):
         use_sudo = _is_affirmative(instance.get('use_sudo', False))
         ceph_args = []
         if use_sudo:
             test_sudo = os.system('setsid sudo -l < /dev/null')
             if test_sudo != 0:
                 raise Exception('The dd-agent user does not have sudo access')
-            ceph_args = ['sudo', ceph_cmd]
+            ceph_args = ['sudo', ceph_cmd, '--cluster', name]
         else:
-            ceph_args = [ceph_cmd]
+            ceph_args = [ceph_cmd, '--cluster', name]
 
         args = ceph_args + ['version']
         try:
@@ -148,9 +148,9 @@ class Ceph(AgentCheck):
                 status = AgentCheck.CRITICAL
             self.service_check(self.NAMESPACE + '.overall_status', status)
 
-    def check(self, instance):
+    def check(self, instance, name):
         ceph_cmd = instance.get('ceph_cmd') or self.DEFAULT_CEPH_CMD
-        raw = self._collect_raw(ceph_cmd, instance)
+        raw = self._collect_raw(ceph_cmd, instance, name)
         tags = self._extract_tags(raw, instance)
         self._extract_metrics(raw, tags)
         self._perform_service_checks(raw, tags)


### PR DESCRIPTION
Add to ceph_args two parameters in order to take the name of the Ceph cluster, since If you set the cluster name at install time, then the ceph_args is not going to take the valid name and failed. It needs to change _collect_raw and check functions in order to pass the name parameter. Also it would be great to pass the name of the cluster on the yaml file.
