### PR TITLE
[docker_daemon] resolve hierarchy by looking at procfs <pid>/cgroup 

### DIFF
--- a/conf.d/docker.yaml.example
+++ b/conf.d/docker.yaml.example
@@ -12,6 +12,12 @@ init_config:
   # Timeout on Docker socket connection. You may have to increase it if you have many containers.
   # socket_timeout: 5
 
+  # Do you use custom cgroups for your containers? Also relevant if using systemd-docker.
+  # Note: enabling this option modifies the way in which we inspect the containers and causes
+  #       some overhead - if you run a high volume of containers we may timeout. Please only
+  #       enable if absolutely necessary.
+  # custom_cgroups: false
+
 instances:
     # URL of the Docker daemon socket to reach the Docker API. HTTP also works.
   - url: "unix://var/run/docker.sock"
@@ -54,6 +60,13 @@ instances:
     # Create events whenever a container status change.
     #
     # collect_events: true
+    #
+    #
+    # Do you use custom cgroups for this particular instance? Overrides the init_config setting.
+    # Note: enabling this option modifies the way in which we inspect the containers and causes
+    #       some overhead - if you run a high volume of containers we may timeout. Please only
+    #       enable if absolutely necessary.
+    # custom_cgroups: false
 
     # Collect disk usage per container with docker.disk.size metric.
     # Warning: This feature is broken in some version of Docker (such as 1.2).

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -18,6 +18,9 @@ from utils.singleton import Singleton
 class MountException(Exception):
     pass
 
+class CGroupException(Exception):
+    pass
+
 # Default docker client settings
 DEFAULT_TIMEOUT = 5
 DEFAULT_VERSION = 'auto'
@@ -152,7 +155,14 @@ class DockerUtil:
     def get_mountpoints(self, cgroup_metrics):
         mountpoints = {}
         for metric in cgroup_metrics:
-            mountpoints[metric["cgroup"]] = self.find_cgroup(metric["cgroup"])
+            try:
+                mountpoints[metric["cgroup"]] = self.find_cgroup(metric["cgroup"])
+            except CGroupException as e:
+                log.exception("Unable to find cgroup: %s", e)
+
+        if not len(mountpoints):
+            raise CGroupException("No cgroups were found!")
+
         return mountpoints
 
     def find_cgroup(self, hierarchy):
@@ -180,7 +190,40 @@ class DockerUtil:
 
             if candidate is not None:
                 return os.path.join(self._docker_root, candidate)
-            raise Exception("Can't find mounted %s cgroups." % hierarchy)
+            raise CGroupException("Can't find mounted %s cgroups." % hierarchy)
+
+    @classmethod
+    def find_cgroup_from_proc(cls, mountpoints, pid, subsys, docker_root='/'):
+        proc_path = os.path.join(docker_root, 'proc', str(pid), 'cgroup')
+        with open(proc_path, 'r') as fp:
+            lines = map(lambda x: x.split(':'), fp.read().splitlines())
+            subsystems = dict(zip(map(lambda x: x[1], lines), map(lambda x: x[2] if x[2][0] != '/' else x[2][1:], lines)))
+
+        if subsys not in subsystems and subsys == 'cpuacct':
+            for form in "{},cpu", "cpu,{}":
+                _subsys = form.format(subsys)
+                if _subsys in subsystems:
+                    subsys = _subsys
+                    break
+
+        if subsys in subsystems:
+            for mountpoint in mountpoints.itervalues():
+                stat_file_path = os.path.join(mountpoint, subsystems[subsys])
+                if subsys in mountpoint and os.path.exists(stat_file_path):
+                    return os.path.join(stat_file_path, '%(file)s')
+
+                # CentOS7 will report `cpu,cpuacct` and then have the path on
+                # `cpuacct,cpu`
+                if 'cpuacct' in mountpoint and 'cpuacct' in subsys:
+                    flipkey = subsys.split(',')
+                    flipkey = "{},{}".format(flipkey[1], flipkey[0]) if len(flipkey) > 1 else flipkey[0]
+                    mountpoint = os.path.join(os.path.split(mountpoint)[0], flipkey)
+                    stat_file_path = os.path.join(mountpoint, subsystems[subsys])
+                    if os.path.exists(stat_file_path):
+                        return os.path.join(stat_file_path, '%(file)s')
+
+
+        raise MountException("Cannot find Docker cgroup directory. Be sure your system is supported.")
 
     @classmethod
     def find_cgroup_filename_pattern(cls, mountpoints, container_id):


### PR DESCRIPTION
## Why
Containers may be run with custom cgroups, not necessarily falling under the default docker one. Typically I think we should expect these to be subgroups of the docker cgroup, although I'm not sure if that can be guaranteed (maybe we can make that a requirement - amongst other things because the docker group should probably have read privileges to the cgroup files - more testing in order). When customers decide to run the containers like this, we were unable to pick up on the cgroup stats and the check fails.

## How
If we are aware of the container <pids>, which we are (at least when running the agent on the host), we can quickly grab the cgroup file locations by parsing /proc/<pid>/cgroup. We can then iterate over the mountpoints, searching for these files in the particular subsystems of interest.

### Testing
Tested on Xenial - more testing pending across distros (systemd, upstart, etc). Also must test the dockerized agent.

When launching a container you can specify (to some degree) the parent cgroup under which that particular container should be executed. Specify using the docker `--cgroup-parent` option. Also, if you wish to create your own custom cgroups, you can do so with the linux `libcgroup-utils`: 
`cgcreate -a root:docker -g cpu,memory,blkio:docker/<somegroup> -t root:docker`

- [x] systemd - ubuntu (xenial)
- [x] upstart - ubuntu (trusty)
- [x] systemd - centos7
- [x] upstart - centos6(?)
- [x] dockerized
- [x] systemd-docker wrapper