### PR TITLE
[core] expiration should adjust to longer collection intervals (>300s).

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -299,6 +299,8 @@ class AgentCheck(object):
 
     SOURCE_TYPE_NAME = None
 
+    DEFAULT_EXPIRY_SECONDS = 300
+
     DEFAULT_MIN_COLLECTION_INTERVAL = 0
 
     _enabled_checks = []
@@ -329,8 +331,13 @@ class AgentCheck(object):
 
         self.hostname = agentConfig.get('checksd_hostname') or get_hostname(agentConfig)
         self.log = logging.getLogger('%s.%s' % (__name__, name))
+
+        self.min_collection_interval = self.init_config.get('min_collection_interval',
+                                                            self.DEFAULT_MIN_COLLECTION_INTERVAL)
+
         self.aggregator = MetricsAggregator(
             self.hostname,
+            expiry_seconds = self.min_collection_interval + self.DEFAULT_EXPIRY_SECONDS,
             formatter=agent_formatter,
             recent_point_threshold=agentConfig.get('recent_point_threshold', None),
             histogram_aggregates=agentConfig.get('histogram_aggregates'),
@@ -731,12 +738,8 @@ class AgentCheck(object):
         instance_statuses = []
         for i, instance in enumerate(self.instances):
             try:
-                min_collection_interval = instance.get(
-                    'min_collection_interval', self.init_config.get(
-                        'min_collection_interval',
-                        self.DEFAULT_MIN_COLLECTION_INTERVAL
-                    )
-                )
+                min_collection_interval = instance.get('min_collection_interval', self.min_collection_interval)
+
                 now = time.time()
                 if now - self.last_collection_time[i] < min_collection_interval:
                     self.log.debug("Not running instance #{0} of check {1} as it ran less than {2}s ago".format(i, self.name, min_collection_interval))

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -281,7 +281,8 @@ class TestCore(unittest.TestCase):
 
         # default min collection interval for that check was 20sec
         check = load_check('disk', config, agentConfig)
-        check.DEFAULT_MIN_COLLECTION_INTERVAL = 20
+        check.min_collection_interval = 20
+        check.aggregator.expiry_seconds = 20 + 300
 
         check.run()
         metrics = check.get_metrics()
@@ -301,7 +302,7 @@ class TestCore(unittest.TestCase):
         check.run()
         metrics = check.get_metrics()
         self.assertEquals(len(metrics), 0, metrics)
-        check.DEFAULT_MIN_COLLECTION_INTERVAL = 0
+        check.min_collection_interval = 0
         check.run()
         metrics = check.get_metrics()
         self.assertTrue(len(metrics) > 0, metrics)


### PR DESCRIPTION
## Why
If the `min_collection_interval` > 300 (the default expiration time) then metrics would be expired before running the next interval. This would affect rates, post expiration messages on the log file, and remove metric contexts when it probably shouldn't.

### Proposed fix
Make the expiration time be `X + min_collection_time` where X would typically be the default expiration time.