### PR TITLE
When dd_url is empty, continue but log to debug level

### DIFF
--- a/ddagent.py
+++ b/ddagent.py
@@ -213,12 +213,12 @@ class AgentTransaction(Transaction):
         for endpoint in self._endpoints:
             url = self.get_url(endpoint)
             if url[0] == '/':
-              log.debug(
-                  u"For type %s endpoint %s at %s is missing a host specification. Continuing without flush.",
-                  self._type, endpoint, url
-              )
-              response = type('obj', (object,), {'error' : None})
-              self.on_response(response)
+                log.debug(
+                    u"For type %s endpoint %s at %s is missing a host specification. Continuing without flush.",
+                    self._type, endpoint, url
+                )
+                response = type('obj', (object,), {'error' : None})
+                self.on_response(response)
             else:
                 log.debug(
                     u"Sending %s to endpoint %s at %s",


### PR DESCRIPTION
When testing our custom emitter, ddagent/forwarder tries to and complains about connecting to dd_url. 

This change allows dd_url to be empty (nothing new) and if so, logs to loglevel debug and does not attempt to connect to dd_url. Old behaviour was to simply try to connect, even if the url was invalid to begin with.