### PR TITLE
[vsphere] skip host tags for broken instances

### DIFF
--- a/checks.d/vsphere.py
+++ b/checks.d/vsphere.py
@@ -507,18 +507,25 @@ class VSphereCheck(AgentCheck):
 
         return wanted_metrics
 
-
     def get_external_host_tags(self):
         """ Returns a list of tags for every host that is detected by the vSphere
         integration.
         List of pairs (hostname, list_of_tags)
         """
-        self.log.info("Sending external_host_tags now")
+        self.log.debug(u"Sending external_host_tags now")
         external_host_tags = []
         for instance in self.instances:
             i_key = self._instance_key(instance)
-            mor_list = self.morlist[i_key].items()
-            for mor_name, mor in mor_list:
+            mor_by_mor_name = self.morlist.get(i_key)
+
+            if not mor_by_mor_name:
+                self.log.warning(
+                    u"Unable to extract hosts' tags for `%s` vSphere instance."
+                    u"Is the check failing on this instance?", instance
+                )
+                continue
+
+            for mor in mor_by_mor_name.itervalues():
                 external_host_tags.append((mor['hostname'], {SOURCE_TYPE: mor['tags']}))
 
         return external_host_tags


### PR DESCRIPTION
When the vSphere check fails on an instance, its metadata -stored in the
class- may have not been populated.
Thus, the collector fails and raises a `KeyError` exception when
attempting to collect vSphere external host tags for the given instance,
i.e.
```
2016-05-23 10:10:13 Central Daylight Time | ERROR |
checks.collector(logger.pyc:19) | Uncaught exception while running run
Traceback (most recent call last):
  File "utils\logger.pyc", line 16, in wrapper
  File "checks\collector.pyc", line 486, in run
  File "checks\collector.pyc", line 699, in _populate_payload_metadata
  File "C:\Program Files (x86)\Datadog\Datadog
Agent\files\..\checks.d\vsphere.py", line 511, in get_external_host_tags
KeyError: 'foobar'
```

Do not raise, but log a warning instead.