### PR TITLE
[directory] Add subdir features.

### DIFF
--- a/checks.d/directory.py
+++ b/checks.d/directory.py
@@ -65,14 +65,13 @@ class DirectoryCheck(AgentCheck):
 
     def _get_stats(self, directory, name, dirtagname, tagsubdirs, subdirtagname, filetagname, filegauges, subdirgauges, histograms, pattern, recursive, countonly):
         orig_dirtags = [dirtagname + ":%s" % name]
-        dirtags = list(orig_dirtags)
         directory_bytes = 0
         directory_files = 0
         recurse_count = 0
         for root, dirs, files in walk(directory):
             subdir_bytes = 0
             if recursive and tagsubdirs and recurse_count > 0:
-                dirtags = [subdirtagname + ":%s" % root] + dirtags
+                dirtags = [subdirtagname + ":%s" % root] + list(orig_dirtags)
 
             for filename in files:
                 filename = join(root, filename)

--- a/checks.d/directory.py
+++ b/checks.d/directory.py
@@ -34,7 +34,6 @@ class DirectoryCheck(AgentCheck):
         "histograms" - boolean, when true histograms for filesizes and times will be generated. default True
         "pattern" - string, the `fnmatch` pattern to use when reading the "directory"'s files. default "*"
         "recursive" - boolean, when true the stats will recurse into directories. default False
-        "recursive_limit" - integer, sets a limit for how deeply to recurse. default 100
     """
 
     SOURCE_TYPE_NAME = 'system'

--- a/checks.d/directory.py
+++ b/checks.d/directory.py
@@ -71,7 +71,9 @@ class DirectoryCheck(AgentCheck):
         for root, dirs, files in walk(directory):
             subdir_bytes = 0
             if recursive and tagsubdirs and recurse_count > 0:
-                dirtags = [subdirtagname + ":%s" % root] + list(orig_dirtags)
+                dirtags = [subdirtagname + ":%s" % root, "is_subdir:true"] + list(orig_dirtags)
+            else:
+                dirtags = ["is_subdir:true"] + list(orig_dirtags)
 
             for filename in files:
                 filename = join(root, filename)
@@ -105,7 +107,7 @@ class DirectoryCheck(AgentCheck):
                         self.histogram("system.disk.directory.file.modified_sec_ago", time.time() - file_stat.st_mtime, tags=dirtags)
                         self.histogram("system.disk.directory.file.created_sec_ago", time.time() - file_stat.st_ctime, tags=dirtags)
 
-            if recurse_count > 0 and subdirgauges:
+            if recurse_count > 0 and subdirgauges and not countonly:
                 # If we've descended in to a subdir then let's emit total for the subdir
                 self.gauge("system.disk.directory.bytes", subdir_bytes, tags=dirtags)
 

--- a/checks.d/directory.py
+++ b/checks.d/directory.py
@@ -90,15 +90,15 @@ class DirectoryCheck(AgentCheck):
                     subdir_bytes += file_stat.st_size
                     directory_bytes += subdir_bytes
                     if filegauges and directory_files <= 20:
-                        filetags = list(dirtags)
+                        filetags = list(subdirtags)
                         filetags.append(filetagname + ":%s" % filename)
                         self.gauge("system.disk.directory.file.bytes", file_stat.st_size, tags=filetags)
                         self.gauge("system.disk.directory.file.modified_sec_ago", time.time() - file_stat.st_mtime, tags=filetags)
                         self.gauge("system.disk.directory.file.created_sec_ago", time.time() - file_stat.st_ctime, tags=filetags)
                     elif not filegauges and histograms:
                         self.histogram("system.disk.directory.file.bytes", file_stat.st_size, tags=subdirtags)
-                        self.histogram("system.disk.directory.file.modified_sec_ago", time.time() - file_stat.st_mtime, tags=dirtags)
-                        self.histogram("system.disk.directory.file.created_sec_ago", time.time() - file_stat.st_ctime, tags=dirtags)
+                        self.histogram("system.disk.directory.file.modified_sec_ago", time.time() - file_stat.st_mtime, tags=subdirtags)
+                        self.histogram("system.disk.directory.file.created_sec_ago", time.time() - file_stat.st_ctime, tags=subdirtags)
 
             if recurse_count > 0 and subdirgauges:
                 # If we've descended in to a subdir then let's emit total for the subdir

--- a/conf.d/directory.yaml.example
+++ b/conf.d/directory.yaml.example
@@ -16,8 +16,12 @@ instances:
   # "directory" - string, the directory to monitor. Required
   # "name" - string, tag metrics with specified name. defaults to the "directory"
   # "dirtagname" - string, the name of the tag used for the directory. defaults to "name"
+  # "tagsubdirs" - string, when true subdirs will be tagged on appropreiate metrics when recursing. default False
+  # "subdirtagname" - string, the name of the tag used for the subdirectory. defaults to "subdir"
   # "filetagname" - string, the name of the tag used for each file. defaults to "filename"
   # "filegauges" - boolean, when true stats will be an individual gauge per file (max. 20 files!) and not a histogram of the whole directory. default False
+  # "subdirgauges" - boolean, when true a total stat will be emitted for each subdirectory. default False
+  # "histograms" - boolean, when true histograms for filesizes and times will be generated. default True
   # "pattern" - string, the `fnmatch` pattern to use when reading the "directory"'s files. The pattern will be matched against the files' absolute paths. default "*"
   # "recursive" - boolean, when true the stats will recurse into directories. default False
   # "countonly" - boolean, when true the stats will only count the number of files matching the pattern. Useful for very large directories.


### PR DESCRIPTION
### What's this PR do?
Adds support for various "subdirectory" options and generally makes the directory check have some fancy new features.

### Motivation
We wanted to evaluate the shape of our Kafka on-disk stuffs. That means we want to look at the Kafka log directory and each subdirectory therein — as that's how topics are stored — and generate metrics for same.

This felt like a job for the directory check, but it turned out we needed a few options to influence it's behavior:

* `subdirtagname` the tag name for each subdir we descend in to
* `subdirgauges` is the boolean for controlling the emission of a per-subdir total-size gauge `system.disk.directory.bytes` with a `subdirtagname` tag. :)
* `histograms` is the boolean for controlling the emission of directory histograms (we don't need em!)

### Notes
* This adds the subdirtagname to each file gauge and histogram, if enabled.
* A updated the listings of options to match in all the places!
* Adds a `is_subdir` tag to things with that tag. The root dir gets a `false` and subdirs get `true`.