### PR TITLE
[kubernetes] Ingest k8s events + limits and requests metrics

### DIFF
--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -30,6 +30,7 @@ DEFAULT_ENABLED_RATES = [
     'diskio.io_service_bytes.stats.total',
     'network.??_bytes',
     'cpu.*.total']
+DEFAULT_COLLECT_EVENTS = False
 
 NET_ERRORS = ['rx_errors', 'tx_errors', 'rx_dropped', 'tx_dropped']
 
@@ -118,7 +119,8 @@ class Kubernetes(AgentCheck):
         self._update_metrics(instance, pods_list)
 
         # kubelet events
-        self._process_events(instance, pods_list)
+        if _is_affirmative(instance.get('collect_events', DEFAULT_COLLECT_EVENTS)):
+            self._process_events(instance, pods_list)
 
     def _publish_raw_metrics(self, metric, dat, tags, depth=0):
         if depth >= self.max_depth:

--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -306,7 +306,7 @@ class Kubernetes(AgentCheck):
                             continue
                         self.publish_gauge(self, '{}.{}.requests'.format(NAMESPACE, request), values[0], _tags)
                 except (KeyError, AttributeError) as e:
-                    self.log.error("Unable to retrieve container requests for %s: %s", c_id, e)
+                    self.log.error("Unable to retrieve container requests for %s: %s", c_name, e)
                     self.log.debug(container)
 
         self._update_pods_metrics(instance, pods_list)

--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -58,10 +58,13 @@ class Kubernetes(AgentCheck):
     def __init__(self, name, init_config, agentConfig, instances=None):
         if instances is not None and len(instances) > 1:
             raise Exception('Kubernetes check only supports one configured instance.')
+
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
-        self.kubeutil = KubeUtil()
+
+        inst = instances[0] if instances is not None else None
+        self.kubeutil = KubeUtil(instance=inst)
         if not self.kubeutil.host:
-            raise Exception('Unable to get default router and host parameter is not set')
+            raise Exception('Unable to retrieve Docker hostname and host parameter is not set')
 
     def _perform_kubelet_checks(self, url):
         service_check_base = NAMESPACE + '.kubelet.check'

--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -288,10 +288,12 @@ class Kubernetes(AgentCheck):
                 c_name = container.get('name')
                 _tags = container_tags.get(name2id.get(c_name), [])
 
+                prog = re.compile(r'[-+]?\d+[\.]?\d*')
+
                 # limits
                 try:
                     for limit, value_str in container['resources']['limits'].iteritems():
-                        values = [float(s) for s in re.findall(r'[-+]?\d+[\.]?\d*', value_str)]
+                        values = [float(s) for s in prog.findall(value_str)]
                         if len(values) != 1:
                             self.log.warning("Error parsing limits value string: %s", value_str)
                             continue
@@ -303,7 +305,7 @@ class Kubernetes(AgentCheck):
                 # requests
                 try:
                     for request, value_str in container['resources']['requests'].iteritems():
-                        values = [float(s) for s in re.findall(r'[-+]?\d+[\.]?\d*', value_str)]
+                        values = [float(s) for s in prog.findall(value_str)]
                         if len(values) != 1:
                             self.log.warning("Error parsing requests value string: %s", value_str)
                             continue

--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -396,7 +396,6 @@ class Kubernetes(AgentCheck):
                 'source_type_name': EVENT_TYPE,
                 'event_object': 'kubernetes:{}'.format(involved_obj.get('name')),
             }
-            self.log.debug('Posting event: {}'.format(dd_event))
             self.event(dd_event)
 
         if most_recent_read > 0:

--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -300,7 +300,7 @@ class Kubernetes(AgentCheck):
                         self.publish_gauge(self, '{}.{}.limits'.format(NAMESPACE, limit), values[0], _tags)
                 except (KeyError, AttributeError) as e:
                     self.log.error("Unable to retrieve container limits for %s: %s", c_name, e)
-                    self.log.debug(container)
+                    self.log.debug("Container object for {}: {}".format(c_name, container))
 
                 # requests
                 try:
@@ -312,7 +312,7 @@ class Kubernetes(AgentCheck):
                         self.publish_gauge(self, '{}.{}.requests'.format(NAMESPACE, request), values[0], _tags)
                 except (KeyError, AttributeError) as e:
                     self.log.error("Unable to retrieve container requests for %s: %s", c_name, e)
-                    self.log.debug(container)
+                    self.log.debug("Container object for {}: {}".format(c_name, container))
 
         self._update_pods_metrics(instance, pods_list)
 
@@ -346,12 +346,12 @@ class Kubernetes(AgentCheck):
         """
         Retrieve a list of events from the kubernetes API.
 
-        At the moment there is no support to select events based on a timestamp query, so we
+        At the moment (k8s v1.3) there is no support to select events based on a timestamp query, so we
         go through the whole list every time. This should be fine for now as events
         have a TTL of one hour[1] but logic needs to improve as soon as they provide
         query capabilities or at least pagination, see [2][3].
 
-        [1] https://github.com/kubernetes/kubernetes/blob/master/cmd/kube-apiserver/app/options/options.go#L50
+        [1] https://github.com/kubernetes/kubernetes/blob/release-1.3.0/cmd/kube-apiserver/app/options/options.go#L51
         [2] https://github.com/kubernetes/kubernetes/issues/4432
         [3] https://github.com/kubernetes/kubernetes/issues/1362
         """

--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -370,12 +370,12 @@ class Kubernetes(AgentCheck):
         self.log.debug('Found {} events, filtering out using timestamp: {}'.format(len(event_items), last_read))
 
         for event in event_items:
-            involved_obj = event.get('involvedObject', {})
-
             # skip if the event is too old
             event_ts = int(time.mktime(time.strptime(event.get('lastTimestamp'), '%Y-%m-%dT%H:%M:%SZ')))
             if event_ts <= last_read:
                 continue
+
+            involved_obj = event.get('involvedObject', {})
 
             # compute the most recently seen event, without relying on items order
             if event_ts > most_recent_read:

--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -299,7 +299,7 @@ class Kubernetes(AgentCheck):
                             continue
                         self.publish_gauge(self, '{}.{}.limits'.format(NAMESPACE, limit), values[0], _tags)
                 except (KeyError, AttributeError) as e:
-                    self.log.error("Unable to retrieve container limits for %s: %s", c_name, e)
+                    self.log.debug("Unable to retrieve container limits for %s: %s", c_name, e)
                     self.log.debug("Container object for {}: {}".format(c_name, container))
 
                 # requests

--- a/conf.d/kubernetes.yaml.example
+++ b/conf.d/kubernetes.yaml.example
@@ -15,13 +15,18 @@ instances:
   # method: http
  - port: 4194
 
-  # use_histogram controls whether we send detailed metrics, i.e. one per container.
+  # collect_events controls whether the agent should fetch events from the kubernetes API and
+  # ingest them in Datadog. To avoid duplicates, only one agent at a time across the entire
+  # cluster should have this feature enabled.
+   collect_events: False
+
+  # use_histogram controls whether we send detailed metrics, i.e. one per container. 
   # When false, we send detailed metrics corresponding to individual containers, tagging by container id
   # to keep them unique.
   # When true, we aggregate data based on container image.
   #
-  # use_histogram: True
-  #
+   use_histogram: True
+
   # kubelet_port: 10255
   #
   # We can define a whitelist of patterns that permit publishing raw metrics.

--- a/conf.d/kubernetes.yaml.example
+++ b/conf.d/kubernetes.yaml.example
@@ -17,8 +17,8 @@ instances:
 
   # collect_events controls whether the agent should fetch events from the kubernetes API and
   # ingest them in Datadog. To avoid duplicates, only one agent at a time across the entire
-  # cluster should have this feature enabled.
-   collect_events: False
+  # cluster should have this feature enabled. To enable the feature, set the parameter to True.
+  # collect_events: False
 
   # use_histogram controls whether we send detailed metrics, i.e. one per container. 
   # When false, we send detailed metrics corresponding to individual containers, tagging by container id

--- a/conf.d/kubernetes.yaml.example
+++ b/conf.d/kubernetes.yaml.example
@@ -25,7 +25,7 @@ instances:
   # to keep them unique.
   # When true, we aggregate data based on container image.
   #
-   use_histogram: True
+  # use_histogram: False
 
   # kubelet_port: 10255
   #

--- a/conf.d/kubernetes.yaml.example
+++ b/conf.d/kubernetes.yaml.example
@@ -17,15 +17,15 @@ instances:
 
   # collect_events controls whether the agent should fetch events from the kubernetes API and
   # ingest them in Datadog. To avoid duplicates, only one agent at a time across the entire
-  # cluster should have this feature enabled. To enable the feature, set the parameter to True.
-  # collect_events: False
+  # cluster should have this feature enabled. To enable the feature, set the parameter to `true`.
+  # collect_events: false
 
   # use_histogram controls whether we send detailed metrics, i.e. one per container. 
   # When false, we send detailed metrics corresponding to individual containers, tagging by container id
   # to keep them unique.
   # When true, we aggregate data based on container image.
   #
-  # use_histogram: False
+  # use_histogram: false
 
   # kubelet_port: 10255
   #

--- a/tests/checks/fixtures/kubernetes/events.json
+++ b/tests/checks/fixtures/kubernetes/events.json
@@ -1,0 +1,532 @@
+{
+  "kind": "EventList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/namespaces/default/events",
+    "resourceVersion": "4002"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "hello-node-47289321-91tfd.14527a0ef5236be9",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321-91tfd.14527a0ef5236be9",
+        "uid": "440bdb23-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3991",
+        "creationTimestamp": "2016-05-27T16:37:13Z",
+        "deletionTimestamp": "2016-05-27T17:37:13Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "hello-node-47289321-91tfd",
+        "uid": "5754714c-0054-11e6-9a89-42010af00098",
+        "apiVersion": "v1",
+        "resourceVersion": "265433"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned hello-node-47289321-91tfd to gke-test-agent58-massi-default-pool-a5024221-klj2",
+      "source": {
+        "component": "default-scheduler"
+      },
+      "firstTimestamp": "2016-05-27T16:37:13Z",
+      "lastTimestamp": "2016-05-27T16:37:13Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321-91tfd.14527a0f08a86f99",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321-91tfd.14527a0f08a86f99",
+        "uid": "443ba407-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3994",
+        "creationTimestamp": "2016-05-27T16:37:13Z",
+        "deletionTimestamp": "2016-05-27T17:37:13Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "hello-node-47289321-91tfd",
+        "uid": "43fed8e2-2429-11e6-b9c2-42010af00026",
+        "apiVersion": "v1",
+        "resourceVersion": "265438",
+        "fieldPath": "spec.containers{hello-node}"
+      },
+      "reason": "Pulled",
+      "message": "Container image \"gcr.io/datadoghq.com/api-project-590215963173/hello-node:v1\" already present on machine",
+      "source": {
+        "component": "kubelet",
+        "host": "gke-test-agent58-massi-default-pool-a5024221-klj2"
+      },
+      "firstTimestamp": "2016-05-27T16:37:13Z",
+      "lastTimestamp": "2016-05-27T16:37:13Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321-91tfd.14527a0f0eae341d",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321-91tfd.14527a0f0eae341d",
+        "uid": "444aed88-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3996",
+        "creationTimestamp": "2016-05-27T16:37:13Z",
+        "deletionTimestamp": "2016-05-27T17:37:13Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "hello-node-47289321-91tfd",
+        "uid": "43fed8e2-2429-11e6-b9c2-42010af00026",
+        "apiVersion": "v1",
+        "resourceVersion": "265438",
+        "fieldPath": "spec.containers{hello-node}"
+      },
+      "reason": "Created",
+      "message": "Created container with docker id f8fd21f7256b",
+      "source": {
+        "component": "kubelet",
+        "host": "gke-test-agent58-massi-default-pool-a5024221-klj2"
+      },
+      "firstTimestamp": "2016-05-27T16:37:13Z",
+      "lastTimestamp": "2016-05-27T16:37:13Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321-91tfd.14527a0f12e90221",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321-91tfd.14527a0f12e90221",
+        "uid": "4455ee11-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3998",
+        "creationTimestamp": "2016-05-27T16:37:14Z",
+        "deletionTimestamp": "2016-05-27T17:37:14Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "hello-node-47289321-91tfd",
+        "uid": "43fed8e2-2429-11e6-b9c2-42010af00026",
+        "apiVersion": "v1",
+        "resourceVersion": "265438",
+        "fieldPath": "spec.containers{hello-node}"
+      },
+      "reason": "Started",
+      "message": "Started container with docker id f8fd21f7256b",
+      "source": {
+        "component": "kubelet",
+        "host": "gke-test-agent58-massi-default-pool-a5024221-klj2"
+      },
+      "firstTimestamp": "2016-05-27T16:37:14Z",
+      "lastTimestamp": "2016-05-27T16:37:14Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321-a3x8n.14527a0efb469137",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321-a3x8n.14527a0efb469137",
+        "uid": "441b3674-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3993",
+        "creationTimestamp": "2016-05-27T16:37:13Z",
+        "deletionTimestamp": "2016-05-27T17:37:13Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "hello-node-47289321-a3x8n",
+        "uid": "43ffaae0-2429-11e6-b9c2-42010af00026",
+        "apiVersion": "v1",
+        "resourceVersion": "265435"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned hello-node-47289321-a3x8n to gke-test-agent58-massi-default-pool-a5024221-ieeh",
+      "source": {
+        "component": "default-scheduler"
+      },
+      "firstTimestamp": "2016-05-27T16:37:13Z",
+      "lastTimestamp": "2016-05-27T16:37:13Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321-a3x8n.14527a0f1427b775",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321-a3x8n.14527a0f1427b775",
+        "uid": "44590d45-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3999",
+        "creationTimestamp": "2016-05-27T16:37:14Z",
+        "deletionTimestamp": "2016-05-27T17:37:14Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "hello-node-47289321-a3x8n",
+        "uid": "43ffaae0-2429-11e6-b9c2-42010af00026",
+        "apiVersion": "v1",
+        "resourceVersion": "265442",
+        "fieldPath": "spec.containers{hello-node}"
+      },
+      "reason": "Pulled",
+      "message": "Container image \"gcr.io/datadoghq.com/api-project-590215963173/hello-node:v1\" already present on machine",
+      "source": {
+        "component": "kubelet",
+        "host": "gke-test-agent58-massi-default-pool-a5024221-ieeh"
+      },
+      "firstTimestamp": "2016-05-27T16:37:14Z",
+      "lastTimestamp": "2016-05-27T16:37:14Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321-a3x8n.14527a0f19c5ef70",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321-a3x8n.14527a0f19c5ef70",
+        "uid": "44675282-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "4001",
+        "creationTimestamp": "2016-05-27T16:37:14Z",
+        "deletionTimestamp": "2016-05-27T17:37:14Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "hello-node-47289321-a3x8n",
+        "uid": "43ffaae0-2429-11e6-b9c2-42010af00026",
+        "apiVersion": "v1",
+        "resourceVersion": "265442",
+        "fieldPath": "spec.containers{hello-node}"
+      },
+      "reason": "Created",
+      "message": "Created container with docker id 330e8cfdd201",
+      "source": {
+        "component": "kubelet",
+        "host": "gke-test-agent58-massi-default-pool-a5024221-ieeh"
+      },
+      "firstTimestamp": "2016-05-27T16:37:14Z",
+      "lastTimestamp": "2016-05-27T16:37:14Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321-a3x8n.14527a0f1e0f7145",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321-a3x8n.14527a0f1e0f7145",
+        "uid": "44726204-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "4002",
+        "creationTimestamp": "2016-05-27T16:37:14Z",
+        "deletionTimestamp": "2016-05-27T17:37:14Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "hello-node-47289321-a3x8n",
+        "uid": "43ffaae0-2429-11e6-b9c2-42010af00026",
+        "apiVersion": "v1",
+        "resourceVersion": "265442",
+        "fieldPath": "spec.containers{hello-node}"
+      },
+      "reason": "Started",
+      "message": "Started container with docker id 330e8cfdd201",
+      "source": {
+        "component": "kubelet",
+        "host": "gke-test-agent58-massi-default-pool-a5024221-ieeh"
+      },
+      "firstTimestamp": "2016-05-27T16:37:14Z",
+      "lastTimestamp": "2016-05-27T16:37:14Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321-lr676.14527a0ef883841a",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321-lr676.14527a0ef883841a",
+        "uid": "4414c0f7-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3992",
+        "creationTimestamp": "2016-05-27T16:37:13Z",
+        "deletionTimestamp": "2016-05-27T17:37:13Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "hello-node-47289321-lr676",
+        "uid": "43ff4e32-2429-11e6-b9c2-42010af00026",
+        "apiVersion": "v1",
+        "resourceVersion": "265434"
+      },
+      "reason": "Scheduled",
+      "message": "Successfully assigned hello-node-47289321-lr676 to gke-test-agent58-massi-default-pool-a5024221-leul",
+      "source": {
+        "component": "default-scheduler"
+      },
+      "firstTimestamp": "2016-05-27T16:37:13Z",
+      "lastTimestamp": "2016-05-27T16:37:13Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321-lr676.14527a0f0bb85494",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321-lr676.14527a0f0bb85494",
+        "uid": "44437f7a-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3995",
+        "creationTimestamp": "2016-05-27T16:37:13Z",
+        "deletionTimestamp": "2016-05-27T17:37:13Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "hello-node-47289321-lr676",
+        "uid": "43ff4e32-2429-11e6-b9c2-42010af00026",
+        "apiVersion": "v1",
+        "resourceVersion": "265440",
+        "fieldPath": "spec.containers{hello-node}"
+      },
+      "reason": "Pulled",
+      "message": "Container image \"gcr.io/datadoghq.com/api-project-590215963173/hello-node:v1\" already present on machine",
+      "source": {
+        "component": "kubelet",
+        "host": "gke-test-agent58-massi-default-pool-a5024221-leul"
+      },
+      "firstTimestamp": "2016-05-27T16:37:13Z",
+      "lastTimestamp": "2016-05-27T16:37:13Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321-lr676.14527a0f10cf3d9a",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321-lr676.14527a0f10cf3d9a",
+        "uid": "44505e4f-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3997",
+        "creationTimestamp": "2016-05-27T16:37:13Z",
+        "deletionTimestamp": "2016-05-27T17:37:13Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "hello-node-47289321-lr676",
+        "uid": "43ff4e32-2429-11e6-b9c2-42010af00026",
+        "apiVersion": "v1",
+        "resourceVersion": "265440",
+        "fieldPath": "spec.containers{hello-node}"
+      },
+      "reason": "Created",
+      "message": "Created container with docker id 9bef4c78b302",
+      "source": {
+        "component": "kubelet",
+        "host": "gke-test-agent58-massi-default-pool-a5024221-leul"
+      },
+      "firstTimestamp": "2016-05-27T16:37:13Z",
+      "lastTimestamp": "2016-05-27T16:37:13Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321-lr676.14527a0f14f8d749",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321-lr676.14527a0f14f8d749",
+        "uid": "445b621c-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "4000",
+        "creationTimestamp": "2016-05-27T16:37:14Z",
+        "deletionTimestamp": "2016-05-27T17:37:14Z"
+      },
+      "involvedObject": {
+        "kind": "Pod",
+        "namespace": "default",
+        "name": "hello-node-47289321-lr676",
+        "uid": "43ff4e32-2429-11e6-b9c2-42010af00026",
+        "apiVersion": "v1",
+        "resourceVersion": "265440",
+        "fieldPath": "spec.containers{hello-node}"
+      },
+      "reason": "Started",
+      "message": "Started container with docker id 9bef4c78b302",
+      "source": {
+        "component": "kubelet",
+        "host": "gke-test-agent58-massi-default-pool-a5024221-leul"
+      },
+      "firstTimestamp": "2016-05-27T16:37:14Z",
+      "lastTimestamp": "2016-05-27T16:37:14Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321.14527a0d1e4cd257",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321.14527a0d1e4cd257",
+        "uid": "3f544bdb-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3985",
+        "creationTimestamp": "2016-05-27T16:37:05Z",
+        "deletionTimestamp": "2016-05-27T17:37:05Z"
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "default",
+        "name": "hello-node-47289321",
+        "uid": "e6161e98-1c0f-11e6-b9c2-42010af00026",
+        "apiVersion": "extensions",
+        "resourceVersion": "265418"
+      },
+      "reason": "SuccessfulDelete",
+      "message": "Deleted pod: hello-node-47289321-iw34d",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2016-05-27T16:37:05Z",
+      "lastTimestamp": "2016-05-27T16:37:05Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321.14527a0d1edd64a3",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321.14527a0d1edd64a3",
+        "uid": "3f58f33f-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3986",
+        "creationTimestamp": "2016-05-27T16:37:05Z",
+        "deletionTimestamp": "2016-05-27T17:37:05Z"
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "default",
+        "name": "hello-node-47289321",
+        "uid": "e6161e98-1c0f-11e6-b9c2-42010af00026",
+        "apiVersion": "extensions",
+        "resourceVersion": "265418"
+      },
+      "reason": "SuccessfulDelete",
+      "message": "Deleted pod: hello-node-47289321-z4ap9",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2016-05-27T16:37:05Z",
+      "lastTimestamp": "2016-05-27T16:37:05Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321.14527a0d1ee371ea",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321.14527a0d1ee371ea",
+        "uid": "3f5ada17-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3987",
+        "creationTimestamp": "2016-05-27T16:37:05Z",
+        "deletionTimestamp": "2016-05-27T17:37:05Z"
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "default",
+        "name": "hello-node-47289321",
+        "uid": "e6161e98-1c0f-11e6-b9c2-42010af00026",
+        "apiVersion": "extensions",
+        "resourceVersion": "265418"
+      },
+      "reason": "SuccessfulDelete",
+      "message": "Deleted pod: hello-node-47289321-pib40",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2016-05-27T16:37:05Z",
+      "lastTimestamp": "2016-05-27T16:37:05Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321.14527a0ef18f9373",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321.14527a0ef18f9373",
+        "uid": "44019fcc-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3988",
+        "creationTimestamp": "2016-05-27T16:37:13Z",
+        "deletionTimestamp": "2016-05-27T17:37:13Z"
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "default",
+        "name": "hello-node-47289321",
+        "uid": "e6161e98-1c0f-11e6-b9c2-42010af00026",
+        "apiVersion": "extensions",
+        "resourceVersion": "265432"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: hello-node-47289321-lr676",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2016-05-27T16:37:13Z",
+      "lastTimestamp": "2016-05-27T16:37:13Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321.14527a0ef2424590",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321.14527a0ef2424590",
+        "uid": "44043ba8-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3989",
+        "creationTimestamp": "2016-05-27T16:37:13Z",
+        "deletionTimestamp": "2016-05-27T17:37:13Z"
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "default",
+        "name": "hello-node-47289321",
+        "uid": "e6161e98-1c0f-11e6-b9c2-42010af00026",
+        "apiVersion": "extensions",
+        "resourceVersion": "265432"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: hello-node-47289321-91tfd",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2016-05-27T16:37:13Z",
+      "lastTimestamp": "2016-05-27T16:37:13Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "hello-node-47289321.14527a0ef2e10858",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/hello-node-47289321.14527a0ef2e10858",
+        "uid": "4405edc4-2429-11e6-b9c2-42010af00026",
+        "resourceVersion": "3990",
+        "creationTimestamp": "2016-05-27T16:37:13Z",
+        "deletionTimestamp": "2016-05-27T17:37:13Z"
+      },
+      "involvedObject": {
+        "kind": "ReplicaSet",
+        "namespace": "default",
+        "name": "hello-node-47289321",
+        "uid": "e6161e98-1c0f-11e6-b9c2-42010af00026",
+        "apiVersion": "extensions",
+        "resourceVersion": "265432"
+      },
+      "reason": "SuccessfulCreate",
+      "message": "Created pod: hello-node-47289321-a3x8n",
+      "source": {
+        "component": "replicaset-controller"
+      },
+      "firstTimestamp": "2016-05-27T16:37:13Z",
+      "lastTimestamp": "2016-05-27T16:37:13Z",
+      "count": 1,
+      "type": "Normal"
+    }
+  ]
+}

--- a/tests/checks/fixtures/kubernetes/metrics_1.2.json
+++ b/tests/checks/fixtures/kubernetes/metrics_1.2.json
@@ -1,1 +1,7545 @@
-[{"id":"e3e04eb19919e30da3b187cb901b49678a030e705b936473db1385cb2403f066","name":"/e3e04eb19919e30da3b187cb901b49678a030e705b936473db1385cb2403f066","aliases":["k8s_healthz.4039147e_kube-dns-v11-63tae_kube-system_5754714c-0054-11e6-9a89-42010af00098_d8e1d132","e3e04eb19919e30da3b187cb901b49678a030e705b936473db1385cb2403f066"],"namespace":"docker","labels":{"io.kubernetes.container.hash":"4039147e","io.kubernetes.container.name":"healthz","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"/dev/termination-log","io.kubernetes.pod.name":"kube-dns-v11-63tae","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"5754714c-0054-11e6-9a89-42010af00098"},"spec":{"creation_time":"2016-04-12T02:27:29.476900993Z","labels":{"io.kubernetes.container.hash":"4039147e","io.kubernetes.container.name":"healthz","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"/dev/termination-log","io.kubernetes.pod.name":"kube-dns-v11-63tae","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"5754714c-0054-11e6-9a89-42010af00098"},"has_cpu":true,"cpu":{"limit":10,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":20971520,"swap_limit":18446744073709551615},"has_network":false,"has_filesystem":true,"has_diskio":true,"has_custom_metrics":false,"image":"gcr.io/google_containers/exechealthz:1.0"},"stats":[{"timestamp":"2016-04-19T22:24:23.192386293Z","cpu":{"usage":{"total":472595413252,"per_cpu_usage":[472595413252],"user":109010000000,"system":182170000000},"load_average":0},"diskio":{},"memory":{"usage":1884160,"cache":4096,"rss":1880064,"working_set":1884160,"failcnt":0,"container_data":{"pgfault":45233251,"pgmajfault":0},"hierarchical_data":{"pgfault":45233251,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":11735040,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:41.457434861Z","cpu":{"usage":{"total":472609550665,"per_cpu_usage":[472609550665],"user":109020000000,"system":182170000000},"load_average":0},"diskio":{},"memory":{"usage":1884160,"cache":4096,"rss":1880064,"working_set":1884160,"failcnt":0,"container_data":{"pgfault":45234553,"pgmajfault":0},"hierarchical_data":{"pgfault":45234553,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":11743232,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:57.65491213Z","cpu":{"usage":{"total":472621824523,"per_cpu_usage":[472621824523],"user":109020000000,"system":182180000000},"load_average":0},"diskio":{},"memory":{"usage":1961984,"cache":4096,"rss":1880064,"working_set":1961984,"failcnt":0,"container_data":{"pgfault":45235729,"pgmajfault":0},"hierarchical_data":{"pgfault":45235729,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":11743232,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:15.525154809Z","cpu":{"usage":{"total":472632202384,"per_cpu_usage":[472632202384],"user":109020000000,"system":182190000000},"load_average":0},"diskio":{},"memory":{"usage":1884160,"cache":4096,"rss":1880064,"working_set":1884160,"failcnt":0,"container_data":{"pgfault":45236767,"pgmajfault":0},"hierarchical_data":{"pgfault":45236767,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":11743232,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:29.399021551Z","cpu":{"usage":{"total":472642037243,"per_cpu_usage":[472642037243],"user":109020000000,"system":182200000000},"load_average":0},"diskio":{},"memory":{"usage":1884160,"cache":4096,"rss":1880064,"working_set":1884160,"failcnt":0,"container_data":{"pgfault":45237697,"pgmajfault":0},"hierarchical_data":{"pgfault":45237697,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":11743232,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:45.155802956Z","cpu":{"usage":{"total":472652701998,"per_cpu_usage":[472652701998],"user":109020000000,"system":182210000000},"load_average":0},"diskio":{},"memory":{"usage":1884160,"cache":4096,"rss":1880064,"working_set":1884160,"failcnt":0,"container_data":{"pgfault":45238747,"pgmajfault":0},"hierarchical_data":{"pgfault":45238747,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":11747328,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:01.52084141Z","cpu":{"usage":{"total":472663867717,"per_cpu_usage":[472663867717],"user":109030000000,"system":182210000000},"load_average":0},"diskio":{},"memory":{"usage":1884160,"cache":4096,"rss":1880064,"working_set":1884160,"failcnt":0,"container_data":{"pgfault":45239819,"pgmajfault":0},"hierarchical_data":{"pgfault":45239819,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":11747328,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:21.258042814Z","cpu":{"usage":{"total":472677008358,"per_cpu_usage":[472677008358],"user":109030000000,"system":182220000000},"load_average":0},"diskio":{},"memory":{"usage":1884160,"cache":4096,"rss":1880064,"working_set":1884160,"failcnt":0,"container_data":{"pgfault":45241143,"pgmajfault":0},"hierarchical_data":{"pgfault":45241143,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":11747328,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]},{"id":"281c01bcfd243f11a876f9929d64d856615035aa2cd3af558be74aa12a494f38","name":"/281c01bcfd243f11a876f9929d64d856615035aa2cd3af558be74aa12a494f38","aliases":["k8s_fluentd-cloud-logging.fe59dd68_fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node-29lx_kube-system_da7e41ef0372c29c65a24b417b5dd69f_3cacfb32","281c01bcfd243f11a876f9929d64d856615035aa2cd3af558be74aa12a494f38"],"namespace":"docker","labels":{"io.kubernetes.container.hash":"fe59dd68","io.kubernetes.container.name":"fluentd-cloud-logging","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"/dev/termination-log","io.kubernetes.pod.name":"fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node-29lx","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"da7e41ef0372c29c65a24b417b5dd69f"},"spec":{"creation_time":"2016-03-22T20:26:44.448814119Z","labels":{"io.kubernetes.container.hash":"fe59dd68","io.kubernetes.container.name":"fluentd-cloud-logging","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"/dev/termination-log","io.kubernetes.pod.name":"fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node-29lx","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"da7e41ef0372c29c65a24b417b5dd69f"},"has_cpu":true,"cpu":{"limit":102,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":209715200,"swap_limit":18446744073709551615},"has_network":false,"has_filesystem":true,"has_diskio":true,"has_custom_metrics":false,"image":"gcr.io/google_containers/fluentd-gcp:1.18"},"stats":[{"timestamp":"2016-04-19T22:24:38.851757083Z","cpu":{"usage":{"total":15615186457041,"per_cpu_usage":[15615186457041],"user":12969670000000,"system":1647260000000},"load_average":0},"diskio":{},"memory":{"usage":111247360,"cache":294912,"rss":110952448,"working_set":111198208,"failcnt":0,"container_data":{"pgfault":1678826,"pgmajfault":0},"hierarchical_data":{"pgfault":1678826,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:52.189240795Z","cpu":{"usage":{"total":15615328963531,"per_cpu_usage":[15615328963531],"user":12969780000000,"system":1647280000000},"load_average":0},"diskio":{},"memory":{"usage":111247360,"cache":294912,"rss":110952448,"working_set":111198208,"failcnt":0,"container_data":{"pgfault":1678844,"pgmajfault":0},"hierarchical_data":{"pgfault":1678844,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:03.959395274Z","cpu":{"usage":{"total":15615428914836,"per_cpu_usage":[15615428914836],"user":12969850000000,"system":1647300000000},"load_average":0},"diskio":{},"memory":{"usage":111247360,"cache":294912,"rss":110952448,"working_set":111198208,"failcnt":0,"container_data":{"pgfault":1678856,"pgmajfault":0},"hierarchical_data":{"pgfault":1678856,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:17.813389614Z","cpu":{"usage":{"total":15615570807646,"per_cpu_usage":[15615570807646],"user":12969970000000,"system":1647300000000},"load_average":0},"diskio":{},"memory":{"usage":111247360,"cache":294912,"rss":110952448,"working_set":111198208,"failcnt":0,"container_data":{"pgfault":1678874,"pgmajfault":0},"hierarchical_data":{"pgfault":1678874,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:28.861398007Z","cpu":{"usage":{"total":15615681494524,"per_cpu_usage":[15615681494524],"user":12970050000000,"system":1647300000000},"load_average":0},"diskio":{},"memory":{"usage":111247360,"cache":294912,"rss":110952448,"working_set":111198208,"failcnt":0,"container_data":{"pgfault":1678886,"pgmajfault":0},"hierarchical_data":{"pgfault":1678886,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:48.175183701Z","cpu":{"usage":{"total":15615860901022,"per_cpu_usage":[15615860901022],"user":12970220000000,"system":1647310000000},"load_average":0},"diskio":{},"memory":{"usage":111247360,"cache":294912,"rss":110952448,"working_set":111198208,"failcnt":0,"container_data":{"pgfault":1678907,"pgmajfault":0},"hierarchical_data":{"pgfault":1678907,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:03.982827303Z","cpu":{"usage":{"total":15616041836614,"per_cpu_usage":[15616041836614],"user":12970380000000,"system":1647310000000},"load_average":0},"diskio":{},"memory":{"usage":111247360,"cache":294912,"rss":110952448,"working_set":111198208,"failcnt":0,"container_data":{"pgfault":1678925,"pgmajfault":0},"hierarchical_data":{"pgfault":1678925,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:20.746231916Z","cpu":{"usage":{"total":15616237580132,"per_cpu_usage":[15616237580132],"user":12970540000000,"system":1647320000000},"load_average":0},"diskio":{},"memory":{"usage":111247360,"cache":294912,"rss":110952448,"working_set":111198208,"failcnt":0,"container_data":{"pgfault":1678949,"pgmajfault":0},"hierarchical_data":{"pgfault":1678949,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]},{"id":"f5d58fe04da979421530b1e2125d9f2078d608798bea694a24d1dc9043774f3f","name":"/f5d58fe04da979421530b1e2125d9f2078d608798bea694a24d1dc9043774f3f","aliases":["k8s_skydns.7ad23ad1_kube-dns-v11-63tae_kube-system_5754714c-0054-11e6-9a89-42010af00098_b082387b","f5d58fe04da979421530b1e2125d9f2078d608798bea694a24d1dc9043774f3f"],"namespace":"docker","labels":{"io.kubernetes.container.hash":"7ad23ad1","io.kubernetes.container.name":"skydns","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"/dev/termination-log","io.kubernetes.pod.name":"kube-dns-v11-63tae","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"5754714c-0054-11e6-9a89-42010af00098"},"spec":{"creation_time":"2016-04-12T02:27:40.200758269Z","labels":{"io.kubernetes.container.hash":"7ad23ad1","io.kubernetes.container.name":"skydns","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"/dev/termination-log","io.kubernetes.pod.name":"kube-dns-v11-63tae","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"5754714c-0054-11e6-9a89-42010af00098"},"has_cpu":true,"cpu":{"limit":102,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":209715200,"swap_limit":18446744073709551615},"has_network":false,"has_filesystem":true,"has_diskio":true,"has_custom_metrics":false,"image":"gcr.io/google_containers/skydns:2015-10-13-8c72f8c"},"stats":[{"timestamp":"2016-04-19T22:24:36.722007724Z","cpu":{"usage":{"total":1325079866768,"per_cpu_usage":[1325079866768],"user":1082810000000,"system":375760000000},"load_average":0},"diskio":{},"memory":{"usage":4050944,"cache":24576,"rss":4026368,"working_set":4050944,"failcnt":0,"container_data":{"pgfault":4038,"pgmajfault":0},"hierarchical_data":{"pgfault":4038,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":65536,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:49.16797703Z","cpu":{"usage":{"total":1325100019556,"per_cpu_usage":[1325100019556],"user":1082820000000,"system":375780000000},"load_average":0},"diskio":{},"memory":{"usage":4050944,"cache":24576,"rss":4026368,"working_set":4050944,"failcnt":0,"container_data":{"pgfault":4038,"pgmajfault":0},"hierarchical_data":{"pgfault":4038,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":65536,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:03.866872948Z","cpu":{"usage":{"total":1325132074258,"per_cpu_usage":[1325132074258],"user":1082830000000,"system":375790000000},"load_average":0},"diskio":{},"memory":{"usage":4050944,"cache":24576,"rss":4026368,"working_set":4050944,"failcnt":0,"container_data":{"pgfault":4038,"pgmajfault":0},"hierarchical_data":{"pgfault":4038,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":65536,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:20.437240717Z","cpu":{"usage":{"total":1325161705351,"per_cpu_usage":[1325161705351],"user":1082840000000,"system":375800000000},"load_average":0},"diskio":{},"memory":{"usage":4050944,"cache":24576,"rss":4026368,"working_set":4050944,"failcnt":0,"container_data":{"pgfault":4038,"pgmajfault":0},"hierarchical_data":{"pgfault":4038,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":65536,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:31.63465611Z","cpu":{"usage":{"total":1325189770399,"per_cpu_usage":[1325189770399],"user":1082860000000,"system":375810000000},"load_average":0},"diskio":{},"memory":{"usage":4050944,"cache":24576,"rss":4026368,"working_set":4050944,"failcnt":0,"container_data":{"pgfault":4038,"pgmajfault":0},"hierarchical_data":{"pgfault":4038,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":65536,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:46.031414634Z","cpu":{"usage":{"total":1325217701988,"per_cpu_usage":[1325217701988],"user":1082880000000,"system":375820000000},"load_average":0},"diskio":{},"memory":{"usage":4050944,"cache":24576,"rss":4026368,"working_set":4050944,"failcnt":0,"container_data":{"pgfault":4038,"pgmajfault":0},"hierarchical_data":{"pgfault":4038,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":65536,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:04.173577569Z","cpu":{"usage":{"total":1325253409611,"per_cpu_usage":[1325253409611],"user":1082900000000,"system":375820000000},"load_average":0},"diskio":{},"memory":{"usage":4050944,"cache":24576,"rss":4026368,"working_set":4050944,"failcnt":0,"container_data":{"pgfault":4038,"pgmajfault":0},"hierarchical_data":{"pgfault":4038,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":65536,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:19.080638511Z","cpu":{"usage":{"total":1325277843742,"per_cpu_usage":[1325277843742],"user":1082920000000,"system":375830000000},"load_average":0},"diskio":{},"memory":{"usage":4050944,"cache":24576,"rss":4026368,"working_set":4050944,"failcnt":0,"container_data":{"pgfault":4038,"pgmajfault":0},"hierarchical_data":{"pgfault":4038,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":65536,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:29.411836219Z","cpu":{"usage":{"total":1325297009332,"per_cpu_usage":[1325297009332],"user":1082940000000,"system":375840000000},"load_average":0},"diskio":{},"memory":{"usage":4050944,"cache":24576,"rss":4026368,"working_set":4050944,"failcnt":0,"container_data":{"pgfault":4038,"pgmajfault":0},"hierarchical_data":{"pgfault":4038,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":65536,"base_usage":28672,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]},{"id":"ef20f4bb10087c626aae1fb32db18c3f8cee0d57f9acc63c85126d3294f1c659","name":"/ef20f4bb10087c626aae1fb32db18c3f8cee0d57f9acc63c85126d3294f1c659","aliases":["k8s_dd-agent.67c1e3c5_dd-agent-idydc_default_adecdd57-f5c3-11e5-8f7c-42010af00098_5154bb06","ef20f4bb10087c626aae1fb32db18c3f8cee0d57f9acc63c85126d3294f1c659"],"namespace":"docker","labels":{"io.kubernetes.container.hash":"67c1e3c5","io.kubernetes.container.name":"dd-agent","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"/dev/termination-log","io.kubernetes.pod.name":"dd-agent-idydc","io.kubernetes.pod.namespace":"default","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"adecdd57-f5c3-11e5-8f7c-42010af00098"},"spec":{"creation_time":"2016-03-29T15:34:10.152872215Z","labels":{"io.kubernetes.container.hash":"67c1e3c5","io.kubernetes.container.name":"dd-agent","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"/dev/termination-log","io.kubernetes.pod.name":"dd-agent-idydc","io.kubernetes.pod.namespace":"default","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"adecdd57-f5c3-11e5-8f7c-42010af00098"},"has_cpu":true,"cpu":{"limit":102,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":18446744073709551615,"swap_limit":18446744073709551615},"has_network":false,"has_filesystem":true,"has_diskio":true,"has_custom_metrics":false,"image":"datadog/docker-dd-agent:kubernetes"},"stats":[{"timestamp":"2016-04-19T22:24:33.701634147Z","cpu":{"usage":{"total":31751146170637,"per_cpu_usage":[31751146170637],"user":17469810000000,"system":14007700000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":1187840,"Read":1187840,"Sync":0,"Total":1187840,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":78,"Read":78,"Sync":0,"Total":78,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2320}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":971449825,"Read":971449825,"Sync":0,"Total":971449825,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":14433152,"Read":14433152,"Sync":0,"Total":14433152,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":83}}]},"memory":{"usage":115019776,"cache":12681216,"rss":102219776,"working_set":110747648,"failcnt":0,"container_data":{"pgfault":441872371,"pgmajfault":30},"hierarchical_data":{"pgfault":441872371,"pgmajfault":30}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":13627392,"base_usage":13606912,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:47.357826911Z","cpu":{"usage":{"total":31751300507098,"per_cpu_usage":[31751300507098],"user":17469920000000,"system":14007740000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":1187840,"Read":1187840,"Sync":0,"Total":1187840,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":78,"Read":78,"Sync":0,"Total":78,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2320}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":971449825,"Read":971449825,"Sync":0,"Total":971449825,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":14433152,"Read":14433152,"Sync":0,"Total":14433152,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":83}}]},"memory":{"usage":114782208,"cache":12677120,"rss":102105088,"working_set":110510080,"failcnt":0,"container_data":{"pgfault":441875361,"pgmajfault":30},"hierarchical_data":{"pgfault":441875361,"pgmajfault":30}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":13627392,"base_usage":13606912,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:05.748859093Z","cpu":{"usage":{"total":31751638326747,"per_cpu_usage":[31751638326747],"user":17470090000000,"system":14007890000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":1187840,"Read":1187840,"Sync":0,"Total":1187840,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":78,"Read":78,"Sync":0,"Total":78,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2320}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":971449825,"Read":971449825,"Sync":0,"Total":971449825,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":14433152,"Read":14433152,"Sync":0,"Total":14433152,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":83}}]},"memory":{"usage":114782208,"cache":12677120,"rss":102105088,"working_set":110510080,"failcnt":0,"container_data":{"pgfault":441880165,"pgmajfault":30},"hierarchical_data":{"pgfault":441880165,"pgmajfault":30}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":13627392,"base_usage":13606912,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:24.359661732Z","cpu":{"usage":{"total":31751988577006,"per_cpu_usage":[31751988577006],"user":17470310000000,"system":14008050000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":1187840,"Read":1187840,"Sync":0,"Total":1187840,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":78,"Read":78,"Sync":0,"Total":78,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2320}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":971449825,"Read":971449825,"Sync":0,"Total":971449825,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":14433152,"Read":14433152,"Sync":0,"Total":14433152,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":83}}]},"memory":{"usage":114782208,"cache":12677120,"rss":102105088,"working_set":110510080,"failcnt":0,"container_data":{"pgfault":441884964,"pgmajfault":30},"hierarchical_data":{"pgfault":441884964,"pgmajfault":30}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":13627392,"base_usage":13606912,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:42.177188154Z","cpu":{"usage":{"total":31752324151237,"per_cpu_usage":[31752324151237],"user":17470490000000,"system":14008200000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":1187840,"Read":1187840,"Sync":0,"Total":1187840,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":78,"Read":78,"Sync":0,"Total":78,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2320}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":971449825,"Read":971449825,"Sync":0,"Total":971449825,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":14433152,"Read":14433152,"Sync":0,"Total":14433152,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":83}}]},"memory":{"usage":114888704,"cache":12677120,"rss":102105088,"working_set":110616576,"failcnt":0,"container_data":{"pgfault":441889759,"pgmajfault":30},"hierarchical_data":{"pgfault":441889759,"pgmajfault":30}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":13627392,"base_usage":13606912,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:58.678584924Z","cpu":{"usage":{"total":31752657199605,"per_cpu_usage":[31752657199605],"user":17470680000000,"system":14008340000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":1187840,"Read":1187840,"Sync":0,"Total":1187840,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":78,"Read":78,"Sync":0,"Total":78,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2320}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":971449825,"Read":971449825,"Sync":0,"Total":971449825,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":14433152,"Read":14433152,"Sync":0,"Total":14433152,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":83}}]},"memory":{"usage":114900992,"cache":12677120,"rss":102105088,"working_set":110628864,"failcnt":0,"container_data":{"pgfault":441894566,"pgmajfault":30},"hierarchical_data":{"pgfault":441894566,"pgmajfault":30}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":13627392,"base_usage":13606912,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:12.318020382Z","cpu":{"usage":{"total":31752995309202,"per_cpu_usage":[31752995309202],"user":17470900000000,"system":14008480000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":1187840,"Read":1187840,"Sync":0,"Total":1187840,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":78,"Read":78,"Sync":0,"Total":78,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2320}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":971449825,"Read":971449825,"Sync":0,"Total":971449825,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":14433152,"Read":14433152,"Sync":0,"Total":14433152,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":83}}]},"memory":{"usage":114884608,"cache":12677120,"rss":102105088,"working_set":110612480,"failcnt":0,"container_data":{"pgfault":441899359,"pgmajfault":30},"hierarchical_data":{"pgfault":441899359,"pgmajfault":30}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":13627392,"base_usage":13606912,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:26.083049243Z","cpu":{"usage":{"total":31753029705892,"per_cpu_usage":[31753029705892],"user":17470930000000,"system":14008490000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":1187840,"Read":1187840,"Sync":0,"Total":1187840,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":78,"Read":78,"Sync":0,"Total":78,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2320}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":971449825,"Read":971449825,"Sync":0,"Total":971449825,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":14433152,"Read":14433152,"Sync":0,"Total":14433152,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":83}}]},"memory":{"usage":114782208,"cache":12677120,"rss":102105088,"working_set":110510080,"failcnt":0,"container_data":{"pgfault":441899371,"pgmajfault":30},"hierarchical_data":{"pgfault":441899371,"pgmajfault":30}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":13627392,"base_usage":13606912,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]},{"id":"512523fbe722384328ef5a44e475077e76758fc9935af4639c8874cadae70a3d","name":"/512523fbe722384328ef5a44e475077e76758fc9935af4639c8874cadae70a3d","aliases":["k8s_kube2sky.8cbc016c_kube-dns-v11-63tae_kube-system_5754714c-0054-11e6-9a89-42010af00098_d6df3862","512523fbe722384328ef5a44e475077e76758fc9935af4639c8874cadae70a3d"],"namespace":"docker","labels":{"io.kubernetes.container.hash":"8cbc016c","io.kubernetes.container.name":"kube2sky","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"/dev/termination-log","io.kubernetes.pod.name":"kube-dns-v11-63tae","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"5754714c-0054-11e6-9a89-42010af00098"},"spec":{"creation_time":"2016-04-12T02:27:33.492623318Z","labels":{"io.kubernetes.container.hash":"8cbc016c","io.kubernetes.container.name":"kube2sky","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"/dev/termination-log","io.kubernetes.pod.name":"kube-dns-v11-63tae","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"5754714c-0054-11e6-9a89-42010af00098"},"has_cpu":true,"cpu":{"limit":102,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":209715200,"swap_limit":18446744073709551615},"has_network":false,"has_filesystem":true,"has_diskio":true,"has_custom_metrics":false,"image":"gcr.io/google_containers/kube2sky:1.14"},"stats":[{"timestamp":"2016-04-19T22:24:31.492646282Z","cpu":{"usage":{"total":46131588951,"per_cpu_usage":[46131588951],"user":41730000000,"system":29760000000},"load_average":0},"diskio":{},"memory":{"usage":5259264,"cache":28672,"rss":5230592,"working_set":5259264,"failcnt":0,"container_data":{"pgfault":46861,"pgmajfault":0},"hierarchical_data":{"pgfault":46861,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:50.467479644Z","cpu":{"usage":{"total":46132300485,"per_cpu_usage":[46132300485],"user":41730000000,"system":29760000000},"load_average":0},"diskio":{},"memory":{"usage":5259264,"cache":28672,"rss":5230592,"working_set":5259264,"failcnt":0,"container_data":{"pgfault":46861,"pgmajfault":0},"hierarchical_data":{"pgfault":46861,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:08.378808783Z","cpu":{"usage":{"total":46132890865,"per_cpu_usage":[46132890865],"user":41730000000,"system":29760000000},"load_average":0},"diskio":{},"memory":{"usage":5259264,"cache":28672,"rss":5230592,"working_set":5259264,"failcnt":0,"container_data":{"pgfault":46861,"pgmajfault":0},"hierarchical_data":{"pgfault":46861,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:19.503403236Z","cpu":{"usage":{"total":46133149351,"per_cpu_usage":[46133149351],"user":41730000000,"system":29760000000},"load_average":0},"diskio":{},"memory":{"usage":5259264,"cache":28672,"rss":5230592,"working_set":5259264,"failcnt":0,"container_data":{"pgfault":46861,"pgmajfault":0},"hierarchical_data":{"pgfault":46861,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:33.716171954Z","cpu":{"usage":{"total":46133497171,"per_cpu_usage":[46133497171],"user":41730000000,"system":29760000000},"load_average":0},"diskio":{},"memory":{"usage":5259264,"cache":28672,"rss":5230592,"working_set":5259264,"failcnt":0,"container_data":{"pgfault":46861,"pgmajfault":0},"hierarchical_data":{"pgfault":46861,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:48.272890128Z","cpu":{"usage":{"total":46134066279,"per_cpu_usage":[46134066279],"user":41730000000,"system":29760000000},"load_average":0},"diskio":{},"memory":{"usage":5259264,"cache":28672,"rss":5230592,"working_set":5259264,"failcnt":0,"container_data":{"pgfault":46861,"pgmajfault":0},"hierarchical_data":{"pgfault":46861,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:02.478017499Z","cpu":{"usage":{"total":46134313237,"per_cpu_usage":[46134313237],"user":41730000000,"system":29760000000},"load_average":0},"diskio":{},"memory":{"usage":5259264,"cache":28672,"rss":5230592,"working_set":5259264,"failcnt":0,"container_data":{"pgfault":46861,"pgmajfault":0},"hierarchical_data":{"pgfault":46861,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:18.662931577Z","cpu":{"usage":{"total":46137709295,"per_cpu_usage":[46137709295],"user":41730000000,"system":29760000000},"load_average":0},"diskio":{},"memory":{"usage":5259264,"cache":28672,"rss":5230592,"working_set":5259264,"failcnt":0,"container_data":{"pgfault":46861,"pgmajfault":0},"hierarchical_data":{"pgfault":46861,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":53248,"base_usage":32768,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]},{"id":"bb6f7f98ad7b9d7a666db8d3b14c0801dc282326adbe3463b77bf05babfd0f4f","name":"/bb6f7f98ad7b9d7a666db8d3b14c0801dc282326adbe3463b77bf05babfd0f4f","aliases":["k8s_POD.6059dfa2_fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node-29lx_kube-system_da7e41ef0372c29c65a24b417b5dd69f_b4d7ed62","bb6f7f98ad7b9d7a666db8d3b14c0801dc282326adbe3463b77bf05babfd0f4f"],"namespace":"docker","labels":{"io.kubernetes.container.hash":"6059dfa2","io.kubernetes.container.name":"POD","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"","io.kubernetes.pod.name":"fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node-29lx","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"da7e41ef0372c29c65a24b417b5dd69f"},"spec":{"creation_time":"2016-03-22T20:26:23.792683438Z","labels":{"io.kubernetes.container.hash":"6059dfa2","io.kubernetes.container.name":"POD","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"","io.kubernetes.pod.name":"fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node-29lx","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"da7e41ef0372c29c65a24b417b5dd69f"},"has_cpu":true,"cpu":{"limit":2,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":18446744073709551615,"swap_limit":18446744073709551615},"has_network":true,"has_filesystem":true,"has_diskio":true,"has_custom_metrics":false,"image":"gcr.io/google_containers/pause:2.0"},"stats":[{"timestamp":"2016-04-19T22:24:20.465356587Z","cpu":{"usage":{"total":1733587119,"per_cpu_usage":[1733587119],"user":370000000,"system":640000000},"load_average":0},"diskio":{},"memory":{"usage":1523712,"cache":8192,"rss":1515520,"working_set":1523712,"failcnt":0,"container_data":{"pgfault":2455,"pgmajfault":0},"hierarchical_data":{"pgfault":2455,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":3472585798,"rx_packets":10642998,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975148450,"tx_packets":10938483,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":3472585798,"rx_packets":10642998,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975148450,"tx_packets":10938483,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:33.83529506Z","cpu":{"usage":{"total":1733587119,"per_cpu_usage":[1733587119],"user":370000000,"system":640000000},"load_average":0},"diskio":{},"memory":{"usage":1523712,"cache":8192,"rss":1515520,"working_set":1523712,"failcnt":0,"container_data":{"pgfault":2455,"pgmajfault":0},"hierarchical_data":{"pgfault":2455,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":3472604620,"rx_packets":10643053,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975160136,"tx_packets":10938544,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":3472604620,"rx_packets":10643053,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975160136,"tx_packets":10938544,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:53.641484554Z","cpu":{"usage":{"total":1733629458,"per_cpu_usage":[1733629458],"user":370000000,"system":640000000},"load_average":0},"diskio":{},"memory":{"usage":1523712,"cache":8192,"rss":1515520,"working_set":1523712,"failcnt":0,"container_data":{"pgfault":2455,"pgmajfault":0},"hierarchical_data":{"pgfault":2455,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":3472655094,"rx_packets":10643197,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975190727,"tx_packets":10938704,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":3472655094,"rx_packets":10643197,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975190727,"tx_packets":10938704,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:05.184837451Z","cpu":{"usage":{"total":1733629458,"per_cpu_usage":[1733629458],"user":370000000,"system":640000000},"load_average":0},"diskio":{},"memory":{"usage":1523712,"cache":8192,"rss":1515520,"working_set":1523712,"failcnt":0,"container_data":{"pgfault":2455,"pgmajfault":0},"hierarchical_data":{"pgfault":2455,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":3472692238,"rx_packets":10643303,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975213443,"tx_packets":10938823,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":3472692238,"rx_packets":10643303,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975213443,"tx_packets":10938823,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:21.157095239Z","cpu":{"usage":{"total":1733629458,"per_cpu_usage":[1733629458],"user":370000000,"system":640000000},"load_average":0},"diskio":{},"memory":{"usage":1523712,"cache":8192,"rss":1515520,"working_set":1523712,"failcnt":0,"container_data":{"pgfault":2455,"pgmajfault":0},"hierarchical_data":{"pgfault":2455,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":3472731135,"rx_packets":10643414,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975236510,"tx_packets":10938945,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":3472731135,"rx_packets":10643414,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975236510,"tx_packets":10938945,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:38.75391894Z","cpu":{"usage":{"total":1733629458,"per_cpu_usage":[1733629458],"user":370000000,"system":640000000},"load_average":0},"diskio":{},"memory":{"usage":1523712,"cache":8192,"rss":1515520,"working_set":1523712,"failcnt":0,"container_data":{"pgfault":2455,"pgmajfault":0},"hierarchical_data":{"pgfault":2455,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":3472762841,"rx_packets":10643504,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975256461,"tx_packets":10939045,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":3472762841,"rx_packets":10643504,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975256461,"tx_packets":10939045,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:49.994170465Z","cpu":{"usage":{"total":1733663990,"per_cpu_usage":[1733663990],"user":370000000,"system":640000000},"load_average":0},"diskio":{},"memory":{"usage":1523712,"cache":8192,"rss":1515520,"working_set":1523712,"failcnt":0,"container_data":{"pgfault":2455,"pgmajfault":0},"hierarchical_data":{"pgfault":2455,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":3472794584,"rx_packets":10643595,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975274529,"tx_packets":10939146,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":3472794584,"rx_packets":10643595,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975274529,"tx_packets":10939146,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:03.357136852Z","cpu":{"usage":{"total":1733663990,"per_cpu_usage":[1733663990],"user":370000000,"system":640000000},"load_average":0},"diskio":{},"memory":{"usage":1523712,"cache":8192,"rss":1515520,"working_set":1523712,"failcnt":0,"container_data":{"pgfault":2455,"pgmajfault":0},"hierarchical_data":{"pgfault":2455,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":3472826075,"rx_packets":10643685,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975294235,"tx_packets":10939246,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":3472826075,"rx_packets":10643685,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975294235,"tx_packets":10939246,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:18.040808802Z","cpu":{"usage":{"total":1733663990,"per_cpu_usage":[1733663990],"user":370000000,"system":640000000},"load_average":0},"diskio":{},"memory":{"usage":1523712,"cache":8192,"rss":1515520,"working_set":1523712,"failcnt":0,"container_data":{"pgfault":2455,"pgmajfault":0},"hierarchical_data":{"pgfault":2455,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":3472864051,"rx_packets":10643793,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975317224,"tx_packets":10939368,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":3472864051,"rx_packets":10643793,"rx_errors":0,"rx_dropped":0,"tx_bytes":1975317224,"tx_packets":10939368,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]},{"name":"/docker-daemon","spec":{"creation_time":"2016-04-15T18:57:33.087465933Z","has_cpu":true,"cpu":{"limit":1024,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":2724577280},"has_network":false,"has_filesystem":false,"has_diskio":true,"has_custom_metrics":false},"stats":[{"timestamp":"2016-04-19T22:24:33.07562288Z","cpu":{"usage":{"total":8198965333301,"per_cpu_usage":[8198965333301],"user":9264150000000,"system":1518460000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":282624,"Read":282624,"Sync":987136,"Total":1269760,"Write":987136}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":16,"Read":16,"Sync":188,"Total":204,"Write":188}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2480}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":258198694,"Read":258198694,"Sync":252219513,"Total":510418207,"Write":252219513}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":5837450,"Read":5837450,"Sync":208631685,"Total":214469135,"Write":208631685}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":182}}]},"memory":{"usage":253153280,"cache":243462144,"rss":9691136,"working_set":98148352,"failcnt":0,"container_data":{"pgfault":316894,"pgmajfault":6},"hierarchical_data":{"pgfault":316894,"pgmajfault":6}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:45.030418861Z","cpu":{"usage":{"total":8199017042420,"per_cpu_usage":[8199017042420],"user":9264210000000,"system":1518470000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":282624,"Read":282624,"Sync":987136,"Total":1269760,"Write":987136}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":16,"Read":16,"Sync":188,"Total":204,"Write":188}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2480}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":258198694,"Read":258198694,"Sync":252219513,"Total":510418207,"Write":252219513}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":5837450,"Read":5837450,"Sync":208631685,"Total":214469135,"Write":208631685}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":182}}]},"memory":{"usage":253153280,"cache":243462144,"rss":9691136,"working_set":98148352,"failcnt":0,"container_data":{"pgfault":316894,"pgmajfault":6},"hierarchical_data":{"pgfault":316894,"pgmajfault":6}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:03.885326531Z","cpu":{"usage":{"total":8199091851026,"per_cpu_usage":[8199091851026],"user":9264280000000,"system":1518490000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":282624,"Read":282624,"Sync":987136,"Total":1269760,"Write":987136}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":16,"Read":16,"Sync":188,"Total":204,"Write":188}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2480}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":258198694,"Read":258198694,"Sync":252219513,"Total":510418207,"Write":252219513}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":5837450,"Read":5837450,"Sync":208631685,"Total":214469135,"Write":208631685}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":182}}]},"memory":{"usage":253153280,"cache":243462144,"rss":9691136,"working_set":98148352,"failcnt":0,"container_data":{"pgfault":316894,"pgmajfault":6},"hierarchical_data":{"pgfault":316894,"pgmajfault":6}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:20.560387375Z","cpu":{"usage":{"total":8199179382983,"per_cpu_usage":[8199179382983],"user":9264380000000,"system":1518500000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":282624,"Read":282624,"Sync":987136,"Total":1269760,"Write":987136}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":16,"Read":16,"Sync":188,"Total":204,"Write":188}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2480}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":258198694,"Read":258198694,"Sync":252219513,"Total":510418207,"Write":252219513}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":5837450,"Read":5837450,"Sync":208631685,"Total":214469135,"Write":208631685}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":182}}]},"memory":{"usage":253157376,"cache":243466240,"rss":9691136,"working_set":98152448,"failcnt":0,"container_data":{"pgfault":316894,"pgmajfault":6},"hierarchical_data":{"pgfault":316894,"pgmajfault":6}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:37.082669593Z","cpu":{"usage":{"total":8199255237333,"per_cpu_usage":[8199255237333],"user":9264450000000,"system":1518510000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":282624,"Read":282624,"Sync":987136,"Total":1269760,"Write":987136}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":16,"Read":16,"Sync":188,"Total":204,"Write":188}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2480}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":258198694,"Read":258198694,"Sync":252219513,"Total":510418207,"Write":252219513}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":5837450,"Read":5837450,"Sync":208631685,"Total":214469135,"Write":208631685}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":182}}]},"memory":{"usage":253157376,"cache":243466240,"rss":9691136,"working_set":98152448,"failcnt":0,"container_data":{"pgfault":316894,"pgmajfault":6},"hierarchical_data":{"pgfault":316894,"pgmajfault":6}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:54.049165653Z","cpu":{"usage":{"total":8199324068612,"per_cpu_usage":[8199324068612],"user":9264520000000,"system":1518530000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":282624,"Read":282624,"Sync":987136,"Total":1269760,"Write":987136}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":16,"Read":16,"Sync":188,"Total":204,"Write":188}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2480}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":258198694,"Read":258198694,"Sync":252219513,"Total":510418207,"Write":252219513}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":5837450,"Read":5837450,"Sync":208631685,"Total":214469135,"Write":208631685}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":182}}]},"memory":{"usage":253161472,"cache":243470336,"rss":9691136,"working_set":98156544,"failcnt":0,"container_data":{"pgfault":316894,"pgmajfault":6},"hierarchical_data":{"pgfault":316894,"pgmajfault":6}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:09.289026183Z","cpu":{"usage":{"total":8199387989472,"per_cpu_usage":[8199387989472],"user":9264580000000,"system":1518540000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":282624,"Read":282624,"Sync":987136,"Total":1269760,"Write":987136}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":16,"Read":16,"Sync":188,"Total":204,"Write":188}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2480}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":258198694,"Read":258198694,"Sync":252219513,"Total":510418207,"Write":252219513}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":5837450,"Read":5837450,"Sync":208631685,"Total":214469135,"Write":208631685}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":182}}]},"memory":{"usage":253161472,"cache":243470336,"rss":9691136,"working_set":98156544,"failcnt":0,"container_data":{"pgfault":316894,"pgmajfault":6},"hierarchical_data":{"pgfault":316894,"pgmajfault":6}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:28.043124944Z","cpu":{"usage":{"total":8199448054146,"per_cpu_usage":[8199448054146],"user":9264650000000,"system":1518560000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":282624,"Read":282624,"Sync":987136,"Total":1269760,"Write":987136}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":16,"Read":16,"Sync":188,"Total":204,"Write":188}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2480}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":258198694,"Read":258198694,"Sync":252219513,"Total":510418207,"Write":252219513}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":5837450,"Read":5837450,"Sync":208631685,"Total":214469135,"Write":208631685}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":182}}]},"memory":{"usage":253165568,"cache":243474432,"rss":9691136,"working_set":98160640,"failcnt":0,"container_data":{"pgfault":316894,"pgmajfault":6},"hierarchical_data":{"pgfault":316894,"pgmajfault":6}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]},{"name":"/kubelet","spec":{"creation_time":"2016-03-22T20:24:19.894791Z","has_cpu":true,"cpu":{"limit":1024,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":18446744073709551615},"has_network":false,"has_filesystem":false,"has_diskio":true,"has_custom_metrics":false},"stats":[{"timestamp":"2016-04-19T22:24:25.299216204Z","cpu":{"usage":{"total":26988848203216,"per_cpu_usage":[26988848203216],"user":13405660000000,"system":12225840000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":692224,"Read":692224,"Sync":0,"Total":692224,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":52,"Read":52,"Sync":0,"Total":52,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":1352}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":569919003,"Read":569919003,"Sync":0,"Total":569919003,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":404492225,"Read":404492225,"Sync":0,"Total":404492225,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":111}}]},"memory":{"usage":70631424,"cache":3588096,"rss":67006464,"working_set":70270976,"failcnt":0,"container_data":{"pgfault":1586035874,"pgmajfault":19},"hierarchical_data":{"pgfault":1586035874,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:35.773667438Z","cpu":{"usage":{"total":26988971405539,"per_cpu_usage":[26988971405539],"user":13405700000000,"system":12225910000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":692224,"Read":692224,"Sync":0,"Total":692224,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":52,"Read":52,"Sync":0,"Total":52,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":1352}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":569919003,"Read":569919003,"Sync":0,"Total":569919003,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":404492225,"Read":404492225,"Sync":0,"Total":404492225,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":111}}]},"memory":{"usage":70594560,"cache":3588096,"rss":67006464,"working_set":70234112,"failcnt":0,"container_data":{"pgfault":1586043187,"pgmajfault":19},"hierarchical_data":{"pgfault":1586043187,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:53.424146615Z","cpu":{"usage":{"total":26989157860819,"per_cpu_usage":[26989157860819],"user":13405790000000,"system":12226000000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":692224,"Read":692224,"Sync":0,"Total":692224,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":52,"Read":52,"Sync":0,"Total":52,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":1352}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":569919003,"Read":569919003,"Sync":0,"Total":569919003,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":404492225,"Read":404492225,"Sync":0,"Total":404492225,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":111}}]},"memory":{"usage":70598656,"cache":3588096,"rss":67006464,"working_set":70238208,"failcnt":0,"container_data":{"pgfault":1586053190,"pgmajfault":19},"hierarchical_data":{"pgfault":1586053190,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:10.26076653Z","cpu":{"usage":{"total":26989583730171,"per_cpu_usage":[26989583730171],"user":13405950000000,"system":12226270000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":692224,"Read":692224,"Sync":0,"Total":692224,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":52,"Read":52,"Sync":0,"Total":52,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":1352}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":569919003,"Read":569919003,"Sync":0,"Total":569919003,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":404492225,"Read":404492225,"Sync":0,"Total":404492225,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":111}}]},"memory":{"usage":70438912,"cache":3588096,"rss":66850816,"working_set":70078464,"failcnt":0,"container_data":{"pgfault":1586072030,"pgmajfault":19},"hierarchical_data":{"pgfault":1586072030,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:26.389549914Z","cpu":{"usage":{"total":26989743332879,"per_cpu_usage":[26989743332879],"user":13406050000000,"system":12226350000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":692224,"Read":692224,"Sync":0,"Total":692224,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":52,"Read":52,"Sync":0,"Total":52,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":1352}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":569919003,"Read":569919003,"Sync":0,"Total":569919003,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":404492225,"Read":404492225,"Sync":0,"Total":404492225,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":111}}]},"memory":{"usage":70635520,"cache":3592192,"rss":66957312,"working_set":70275072,"failcnt":0,"container_data":{"pgfault":1586081184,"pgmajfault":19},"hierarchical_data":{"pgfault":1586081184,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:45.516345774Z","cpu":{"usage":{"total":26990005260245,"per_cpu_usage":[26990005260245],"user":13406200000000,"system":12226460000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":692224,"Read":692224,"Sync":0,"Total":692224,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":52,"Read":52,"Sync":0,"Total":52,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":1352}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":569919003,"Read":569919003,"Sync":0,"Total":569919003,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":404492225,"Read":404492225,"Sync":0,"Total":404492225,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":111}}]},"memory":{"usage":70549504,"cache":3592192,"rss":66957312,"working_set":70189056,"failcnt":0,"container_data":{"pgfault":1586100712,"pgmajfault":19},"hierarchical_data":{"pgfault":1586100712,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:02.08019262Z","cpu":{"usage":{"total":26990180343574,"per_cpu_usage":[26990180343574],"user":13406280000000,"system":12226540000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":692224,"Read":692224,"Sync":0,"Total":692224,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":52,"Read":52,"Sync":0,"Total":52,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":1352}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":569919003,"Read":569919003,"Sync":0,"Total":569919003,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":404492225,"Read":404492225,"Sync":0,"Total":404492225,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":111}}]},"memory":{"usage":70549504,"cache":3592192,"rss":66957312,"working_set":70189056,"failcnt":0,"container_data":{"pgfault":1586110262,"pgmajfault":19},"hierarchical_data":{"pgfault":1586110262,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:15.404584381Z","cpu":{"usage":{"total":26990296574019,"per_cpu_usage":[26990296574019],"user":13406350000000,"system":12226580000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":692224,"Read":692224,"Sync":0,"Total":692224,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":52,"Read":52,"Sync":0,"Total":52,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":1352}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":569919003,"Read":569919003,"Sync":0,"Total":569919003,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":404492225,"Read":404492225,"Sync":0,"Total":404492225,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":111}}]},"memory":{"usage":70549504,"cache":3592192,"rss":66957312,"working_set":70189056,"failcnt":0,"container_data":{"pgfault":1586115885,"pgmajfault":19},"hierarchical_data":{"pgfault":1586115885,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]},{"id":"eb896866194dd2393153ac8f91e1150986a9a1b26c9105163375372bcd1e5961","name":"/eb896866194dd2393153ac8f91e1150986a9a1b26c9105163375372bcd1e5961","aliases":["k8s_POD.35220667_dd-agent-idydc_default_adecdd57-f5c3-11e5-8f7c-42010af00098_e2c005a0","eb896866194dd2393153ac8f91e1150986a9a1b26c9105163375372bcd1e5961"],"namespace":"docker","labels":{"io.kubernetes.container.hash":"35220667","io.kubernetes.container.name":"POD","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"","io.kubernetes.pod.name":"dd-agent-idydc","io.kubernetes.pod.namespace":"default","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"adecdd57-f5c3-11e5-8f7c-42010af00098"},"spec":{"creation_time":"2016-03-29T15:34:09.336402981Z","labels":{"io.kubernetes.container.hash":"35220667","io.kubernetes.container.name":"POD","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"","io.kubernetes.pod.name":"dd-agent-idydc","io.kubernetes.pod.namespace":"default","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"adecdd57-f5c3-11e5-8f7c-42010af00098"},"has_cpu":true,"cpu":{"limit":2,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":18446744073709551615,"swap_limit":18446744073709551615},"has_network":true,"has_filesystem":true,"has_diskio":true,"has_custom_metrics":false,"image":"gcr.io/google_containers/pause:2.0"},"stats":[{"timestamp":"2016-04-19T22:24:22.386654984Z","cpu":{"usage":{"total":1332041607,"per_cpu_usage":[1332041607],"user":380000000,"system":330000000},"load_average":0},"diskio":{},"memory":{"usage":1495040,"cache":4096,"rss":1490944,"working_set":1495040,"failcnt":0,"container_data":{"pgfault":2318,"pgmajfault":0},"hierarchical_data":{"pgfault":2318,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":21649764586,"rx_packets":7881809,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460900988,"tx_packets":8540036,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":21649764586,"rx_packets":7881809,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460900988,"tx_packets":8540036,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":40960,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:39.643761831Z","cpu":{"usage":{"total":1332077670,"per_cpu_usage":[1332077670],"user":380000000,"system":330000000},"load_average":0},"diskio":{},"memory":{"usage":1495040,"cache":4096,"rss":1490944,"working_set":1495040,"failcnt":0,"container_data":{"pgfault":2318,"pgmajfault":0},"hierarchical_data":{"pgfault":2318,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":21650039558,"rx_packets":7881887,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460914762,"tx_packets":8540113,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":21650039558,"rx_packets":7881887,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460914762,"tx_packets":8540113,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":40960,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:56.341983523Z","cpu":{"usage":{"total":1332077670,"per_cpu_usage":[1332077670],"user":380000000,"system":330000000},"load_average":0},"diskio":{},"memory":{"usage":1495040,"cache":4096,"rss":1490944,"working_set":1495040,"failcnt":0,"container_data":{"pgfault":2318,"pgmajfault":0},"hierarchical_data":{"pgfault":2318,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":21650319165,"rx_packets":7881983,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460931301,"tx_packets":8540205,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":21650319165,"rx_packets":7881983,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460931301,"tx_packets":8540205,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":40960,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:07.361668925Z","cpu":{"usage":{"total":1332077670,"per_cpu_usage":[1332077670],"user":380000000,"system":330000000},"load_average":0},"diskio":{},"memory":{"usage":1495040,"cache":4096,"rss":1490944,"working_set":1495040,"failcnt":0,"container_data":{"pgfault":2318,"pgmajfault":0},"hierarchical_data":{"pgfault":2318,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":21650327379,"rx_packets":7882003,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460934051,"tx_packets":8540221,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":21650327379,"rx_packets":7882003,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460934051,"tx_packets":8540221,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":40960,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:19.007066231Z","cpu":{"usage":{"total":1332077670,"per_cpu_usage":[1332077670],"user":380000000,"system":330000000},"load_average":0},"diskio":{},"memory":{"usage":1495040,"cache":4096,"rss":1490944,"working_set":1495040,"failcnt":0,"container_data":{"pgfault":2318,"pgmajfault":0},"hierarchical_data":{"pgfault":2318,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":21650597723,"rx_packets":7882081,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460947891,"tx_packets":8540298,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":21650597723,"rx_packets":7882081,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460947891,"tx_packets":8540298,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":40960,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:37.05508977Z","cpu":{"usage":{"total":1332111710,"per_cpu_usage":[1332111710],"user":380000000,"system":330000000},"load_average":0},"diskio":{},"memory":{"usage":1495040,"cache":4096,"rss":1490944,"working_set":1495040,"failcnt":0,"container_data":{"pgfault":2318,"pgmajfault":0},"hierarchical_data":{"pgfault":2318,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":21650875070,"rx_packets":7882180,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460964703,"tx_packets":8540393,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":21650875070,"rx_packets":7882180,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460964703,"tx_packets":8540393,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":40960,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:48.397362847Z","cpu":{"usage":{"total":1332111710,"per_cpu_usage":[1332111710],"user":380000000,"system":330000000},"load_average":0},"diskio":{},"memory":{"usage":1495040,"cache":4096,"rss":1490944,"working_set":1495040,"failcnt":0,"container_data":{"pgfault":2318,"pgmajfault":0},"hierarchical_data":{"pgfault":2318,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":21650883284,"rx_packets":7882200,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460967453,"tx_packets":8540409,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":21650883284,"rx_packets":7882200,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460967453,"tx_packets":8540409,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":40960,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:02.281524128Z","cpu":{"usage":{"total":1332111710,"per_cpu_usage":[1332111710],"user":380000000,"system":330000000},"load_average":0},"diskio":{},"memory":{"usage":1495040,"cache":4096,"rss":1490944,"working_set":1495040,"failcnt":0,"container_data":{"pgfault":2318,"pgmajfault":0},"hierarchical_data":{"pgfault":2318,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":21651160691,"rx_packets":7882299,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460984011,"tx_packets":8540503,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":21651160691,"rx_packets":7882299,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460984011,"tx_packets":8540503,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":40960,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:19.38149238Z","cpu":{"usage":{"total":1332111710,"per_cpu_usage":[1332111710],"user":380000000,"system":330000000},"load_average":0},"diskio":{},"memory":{"usage":1495040,"cache":4096,"rss":1490944,"working_set":1495040,"failcnt":0,"container_data":{"pgfault":2318,"pgmajfault":0},"hierarchical_data":{"pgfault":2318,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":21651435597,"rx_packets":7882376,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460997779,"tx_packets":8540580,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":21651435597,"rx_packets":7882376,"rx_errors":0,"rx_dropped":0,"tx_bytes":1460997779,"tx_packets":8540580,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":40960,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]},{"id":"89ee50ff6005d47354ba8a252248623ebca0297d36de16387826373be9e52a17","name":"/89ee50ff6005d47354ba8a252248623ebca0297d36de16387826373be9e52a17","aliases":["k8s_etcd.81a33530_kube-dns-v11-63tae_kube-system_5754714c-0054-11e6-9a89-42010af00098_e811864e","89ee50ff6005d47354ba8a252248623ebca0297d36de16387826373be9e52a17"],"namespace":"docker","labels":{"io.kubernetes.container.hash":"81a33530","io.kubernetes.container.name":"etcd","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"/dev/termination-log","io.kubernetes.pod.name":"kube-dns-v11-63tae","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"5754714c-0054-11e6-9a89-42010af00098"},"spec":{"creation_time":"2016-04-12T02:27:31.656726267Z","labels":{"io.kubernetes.container.hash":"81a33530","io.kubernetes.container.name":"etcd","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"/dev/termination-log","io.kubernetes.pod.name":"kube-dns-v11-63tae","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"5754714c-0054-11e6-9a89-42010af00098"},"has_cpu":true,"cpu":{"limit":102,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":524288000,"swap_limit":18446744073709551615},"has_network":false,"has_filesystem":true,"has_diskio":true,"has_custom_metrics":false,"image":"gcr.io/google_containers/etcd-amd64:2.2.1"},"stats":[{"timestamp":"2016-04-19T22:24:25.595517305Z","cpu":{"usage":{"total":1506421277916,"per_cpu_usage":[1506421277916],"user":513770000000,"system":455670000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":5716905984,"Total":5716905984,"Write":5716905984}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1358541,"Total":1358541,"Write":1358541}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":11165832}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1304637301146,"Total":1304637301146,"Write":1304637301146}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":59111587434,"Total":59111587434,"Write":59111587434}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":2716570}}]},"memory":{"usage":160059392,"cache":150278144,"rss":9781248,"working_set":128487424,"failcnt":0,"container_data":{"pgfault":188546,"pgmajfault":0},"hierarchical_data":{"pgfault":188546,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":90112,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:43.198080667Z","cpu":{"usage":{"total":1506459595177,"per_cpu_usage":[1506459595177],"user":513780000000,"system":455690000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":5717053440,"Total":5717053440,"Write":5717053440}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1358576,"Total":1358576,"Write":1358576}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":11166120}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1304670111224,"Total":1304670111224,"Write":1304670111224}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":59112279428,"Total":59112279428,"Write":59112279428}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":2716640}}]},"memory":{"usage":160063488,"cache":150282240,"rss":9781248,"working_set":128487424,"failcnt":0,"container_data":{"pgfault":188546,"pgmajfault":0},"hierarchical_data":{"pgfault":188546,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":90112,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:00.427596966Z","cpu":{"usage":{"total":1506501870832,"per_cpu_usage":[1506501870832],"user":513800000000,"system":455700000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":5717196800,"Total":5717196800,"Write":5717196800}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1358611,"Total":1358611,"Write":1358611}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":11166400}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1304704088763,"Total":1304704088763,"Write":1304704088763}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":59112979245,"Total":59112979245,"Write":59112979245}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":2716710}}]},"memory":{"usage":160063488,"cache":150282240,"rss":9781248,"working_set":128491520,"failcnt":0,"container_data":{"pgfault":188546,"pgmajfault":0},"hierarchical_data":{"pgfault":188546,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":90112,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:14.838846498Z","cpu":{"usage":{"total":1506534508690,"per_cpu_usage":[1506534508690],"user":513810000000,"system":455710000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":5717319680,"Total":5717319680,"Write":5717319680}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1358640,"Total":1358640,"Write":1358640}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":11166640}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1304731704254,"Total":1304731704254,"Write":1304731704254}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":59113562927,"Total":59113562927,"Write":59113562927}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":2716768}}]},"memory":{"usage":160067584,"cache":150286336,"rss":9781248,"working_set":128495616,"failcnt":0,"container_data":{"pgfault":188546,"pgmajfault":0},"hierarchical_data":{"pgfault":188546,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":90112,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:28.74048666Z","cpu":{"usage":{"total":1506563869858,"per_cpu_usage":[1506563869858],"user":513820000000,"system":455720000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":5717434368,"Total":5717434368,"Write":5717434368}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1358667,"Total":1358667,"Write":1358667}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":11166864}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1304756878224,"Total":1304756878224,"Write":1304756878224}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":59114061927,"Total":59114061927,"Write":59114061927}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":2716822}}]},"memory":{"usage":160071680,"cache":150290432,"rss":9781248,"working_set":128499712,"failcnt":0,"container_data":{"pgfault":188546,"pgmajfault":0},"hierarchical_data":{"pgfault":188546,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":90112,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:44.027938171Z","cpu":{"usage":{"total":1506597049513,"per_cpu_usage":[1506597049513],"user":513830000000,"system":455730000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":5717565440,"Total":5717565440,"Write":5717565440}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1358698,"Total":1358698,"Write":1358698}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":11167120}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1304785433530,"Total":1304785433530,"Write":1304785433530}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":59114649566,"Total":59114649566,"Write":59114649566}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":2716884}}]},"memory":{"usage":160075776,"cache":150294528,"rss":9781248,"working_set":128503808,"failcnt":0,"container_data":{"pgfault":188546,"pgmajfault":0},"hierarchical_data":{"pgfault":188546,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":90112,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:02.503428172Z","cpu":{"usage":{"total":1506638137277,"per_cpu_usage":[1506638137277],"user":513850000000,"system":455740000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":5717721088,"Total":5717721088,"Write":5717721088}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1358735,"Total":1358735,"Write":1358735}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":11167424}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1304818313386,"Total":1304818313386,"Write":1304818313386}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":59115363381,"Total":59115363381,"Write":59115363381}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":2716958}}]},"memory":{"usage":160079872,"cache":150298624,"rss":9781248,"working_set":128507904,"failcnt":0,"container_data":{"pgfault":188546,"pgmajfault":0},"hierarchical_data":{"pgfault":188546,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":90112,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:18.455584603Z","cpu":{"usage":{"total":1506673435219,"per_cpu_usage":[1506673435219],"user":513880000000,"system":455740000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":5717856256,"Total":5717856256,"Write":5717856256}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1358767,"Total":1358767,"Write":1358767}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":11167688}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":1304847459264,"Total":1304847459264,"Write":1304847459264}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":59116258553,"Total":59116258553,"Write":59116258553}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":2717022}}]},"memory":{"usage":160083968,"cache":150302720,"rss":9781248,"working_set":128512000,"failcnt":0,"container_data":{"pgfault":188546,"pgmajfault":0},"hierarchical_data":{"pgfault":188546,"pgmajfault":0}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":90112,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]},{"id":"b74f106dfe26a20b64849d587f3d273bc417cbe52af2456d2c4142b44f85cf45","name":"/b74f106dfe26a20b64849d587f3d273bc417cbe52af2456d2c4142b44f85cf45","aliases":["k8s_POD.6059dfa2_kube-proxy-gke-cluster-remi-62c0dd29-node-29lx_kube-system_f70c43857a22d5495bf204918d5ab984_e17ace7a","b74f106dfe26a20b64849d587f3d273bc417cbe52af2456d2c4142b44f85cf45"],"namespace":"docker","labels":{"io.kubernetes.container.hash":"6059dfa2","io.kubernetes.container.name":"POD","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"","io.kubernetes.pod.name":"kube-proxy-gke-cluster-remi-62c0dd29-node-29lx","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"f70c43857a22d5495bf204918d5ab984"},"spec":{"creation_time":"2016-03-22T20:26:23.392516936Z","labels":{"io.kubernetes.container.hash":"6059dfa2","io.kubernetes.container.name":"POD","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"","io.kubernetes.pod.name":"kube-proxy-gke-cluster-remi-62c0dd29-node-29lx","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"f70c43857a22d5495bf204918d5ab984"},"has_cpu":true,"cpu":{"limit":2,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":18446744073709551615,"swap_limit":18446744073709551615},"has_network":true,"has_filesystem":true,"has_diskio":true,"has_custom_metrics":false,"image":"gcr.io/google_containers/pause:2.0"},"stats":[{"timestamp":"2016-04-19T22:24:30.465171144Z","cpu":{"usage":{"total":1751377293,"per_cpu_usage":[1751377293],"user":410000000,"system":650000000},"load_average":0},"diskio":{},"memory":{"usage":1527808,"cache":8192,"rss":1519616,"working_set":1527808,"failcnt":0,"container_data":{"pgfault":2462,"pgmajfault":0},"hierarchical_data":{"pgfault":2462,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":11127468140,"rx_packets":26683533,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732526615,"tx_packets":27140209,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11127468140,"rx_packets":26683533,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732526615,"tx_packets":27140209,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110569787,"rx_packets":26286542,"rx_errors":0,"rx_dropped":0,"tx_bytes":31135252045,"tx_packets":23325218,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:42.402651322Z","cpu":{"usage":{"total":1751377293,"per_cpu_usage":[1751377293],"user":410000000,"system":650000000},"load_average":0},"diskio":{},"memory":{"usage":1527808,"cache":8192,"rss":1519616,"working_set":1527808,"failcnt":0,"container_data":{"pgfault":2462,"pgmajfault":0},"hierarchical_data":{"pgfault":2462,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":11127527891,"rx_packets":26683689,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732563771,"tx_packets":27140381,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11127527891,"rx_packets":26683689,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732563771,"tx_packets":27140381,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110611996,"rx_packets":26286806,"rx_errors":0,"rx_dropped":0,"tx_bytes":31135563918,"tx_packets":23325429,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:00.807472889Z","cpu":{"usage":{"total":1751410895,"per_cpu_usage":[1751410895],"user":410000000,"system":650000000},"load_average":0},"diskio":{},"memory":{"usage":1527808,"cache":8192,"rss":1519616,"working_set":1527808,"failcnt":0,"container_data":{"pgfault":2462,"pgmajfault":0},"hierarchical_data":{"pgfault":2462,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":11127658358,"rx_packets":26683992,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732624184,"tx_packets":27140708,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11127658358,"rx_packets":26683992,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732624184,"tx_packets":27140708,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110664228,"rx_packets":26287138,"rx_errors":0,"rx_dropped":0,"tx_bytes":31135892998,"tx_packets":23325718,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:19.351986298Z","cpu":{"usage":{"total":1751410895,"per_cpu_usage":[1751410895],"user":410000000,"system":650000000},"load_average":0},"diskio":{},"memory":{"usage":1527808,"cache":8192,"rss":1519616,"working_set":1527808,"failcnt":0,"container_data":{"pgfault":2462,"pgmajfault":0},"hierarchical_data":{"pgfault":2462,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":11127772981,"rx_packets":26684443,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732718269,"tx_packets":27141230,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11127772981,"rx_packets":26684443,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732718269,"tx_packets":27141230,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110715870,"rx_packets":26287469,"rx_errors":0,"rx_dropped":0,"tx_bytes":31136216577,"tx_packets":23325996,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:35.543948538Z","cpu":{"usage":{"total":1751410895,"per_cpu_usage":[1751410895],"user":410000000,"system":650000000},"load_average":0},"diskio":{},"memory":{"usage":1527808,"cache":8192,"rss":1519616,"working_set":1527808,"failcnt":0,"container_data":{"pgfault":2462,"pgmajfault":0},"hierarchical_data":{"pgfault":2462,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":11127853982,"rx_packets":26684668,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732768774,"tx_packets":27141477,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11127853982,"rx_packets":26684668,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732768774,"tx_packets":27141477,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110770901,"rx_packets":26287808,"rx_errors":0,"rx_dropped":0,"tx_bytes":31136544258,"tx_packets":23326276,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:47.720061497Z","cpu":{"usage":{"total":1751442157,"per_cpu_usage":[1751442157],"user":410000000,"system":650000000},"load_average":0},"diskio":{},"memory":{"usage":1527808,"cache":8192,"rss":1519616,"working_set":1527808,"failcnt":0,"container_data":{"pgfault":2462,"pgmajfault":0},"hierarchical_data":{"pgfault":2462,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":11127952931,"rx_packets":26684889,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732807615,"tx_packets":27141713,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11127952931,"rx_packets":26684889,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732807615,"tx_packets":27141713,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110797756,"rx_packets":26287996,"rx_errors":0,"rx_dropped":0,"tx_bytes":31136586865,"tx_packets":23326450,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:06.900786912Z","cpu":{"usage":{"total":1751442157,"per_cpu_usage":[1751442157],"user":410000000,"system":650000000},"load_average":0},"diskio":{},"memory":{"usage":1527808,"cache":8192,"rss":1519616,"working_set":1527808,"failcnt":0,"container_data":{"pgfault":2462,"pgmajfault":0},"hierarchical_data":{"pgfault":2462,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":11128046224,"rx_packets":26685188,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732880408,"tx_packets":27142017,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11128046224,"rx_packets":26685188,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732880408,"tx_packets":27142017,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110856076,"rx_packets":26288365,"rx_errors":0,"rx_dropped":0,"tx_bytes":31136921971,"tx_packets":23326762,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:19.429215233Z","cpu":{"usage":{"total":1751442157,"per_cpu_usage":[1751442157],"user":410000000,"system":650000000},"load_average":0},"diskio":{},"memory":{"usage":1527808,"cache":8192,"rss":1519616,"working_set":1527808,"failcnt":0,"container_data":{"pgfault":2462,"pgmajfault":0},"hierarchical_data":{"pgfault":2462,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":11128109197,"rx_packets":26685358,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732919242,"tx_packets":27142194,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11128109197,"rx_packets":26685358,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732919242,"tx_packets":27142194,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110892268,"rx_packets":26288597,"rx_errors":0,"rx_dropped":0,"tx_bytes":31137225818,"tx_packets":23326951,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]},{"id":"63463444e6e0d369d8f0ba91f30c4570ead01808a36b3f2ee32138e293a0e115","name":"/63463444e6e0d369d8f0ba91f30c4570ead01808a36b3f2ee32138e293a0e115","aliases":["k8s_POD.e2764897_kube-dns-v11-63tae_kube-system_5754714c-0054-11e6-9a89-42010af00098_c33e4b64","63463444e6e0d369d8f0ba91f30c4570ead01808a36b3f2ee32138e293a0e115"],"namespace":"docker","labels":{"io.kubernetes.container.hash":"e2764897","io.kubernetes.container.name":"POD","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"","io.kubernetes.pod.name":"kube-dns-v11-63tae","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"5754714c-0054-11e6-9a89-42010af00098"},"spec":{"creation_time":"2016-04-12T02:27:25.74857904Z","labels":{"io.kubernetes.container.hash":"e2764897","io.kubernetes.container.name":"POD","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"","io.kubernetes.pod.name":"kube-dns-v11-63tae","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"5754714c-0054-11e6-9a89-42010af00098"},"has_cpu":true,"cpu":{"limit":2,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":18446744073709551615,"swap_limit":18446744073709551615},"has_network":true,"has_filesystem":true,"has_diskio":true,"has_custom_metrics":false,"image":"gcr.io/google_containers/pause:2.0"},"stats":[{"timestamp":"2016-04-19T22:24:40.948724411Z","cpu":{"usage":{"total":479397672,"per_cpu_usage":[479397672],"user":140000000,"system":170000000},"load_average":0},"diskio":{},"memory":{"usage":1519616,"cache":4096,"rss":1515520,"working_set":1519616,"failcnt":0,"container_data":{"pgfault":2471,"pgmajfault":0},"hierarchical_data":{"pgfault":2471,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":590849697,"rx_packets":4431148,"rx_errors":0,"rx_dropped":0,"tx_bytes":595405020,"tx_packets":4146580,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":590849697,"rx_packets":4431148,"rx_errors":0,"rx_dropped":0,"tx_bytes":595405020,"tx_packets":4146580,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:00.182790229Z","cpu":{"usage":{"total":479397672,"per_cpu_usage":[479397672],"user":140000000,"system":170000000},"load_average":0},"diskio":{},"memory":{"usage":1519616,"cache":4096,"rss":1515520,"working_set":1519616,"failcnt":0,"container_data":{"pgfault":2471,"pgmajfault":0},"hierarchical_data":{"pgfault":2471,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":590866726,"rx_packets":4431280,"rx_errors":0,"rx_dropped":0,"tx_bytes":595422222,"tx_packets":4146702,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":590866726,"rx_packets":4431280,"rx_errors":0,"rx_dropped":0,"tx_bytes":595422222,"tx_packets":4146702,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:11.391126796Z","cpu":{"usage":{"total":479397672,"per_cpu_usage":[479397672],"user":140000000,"system":170000000},"load_average":0},"diskio":{},"memory":{"usage":1519616,"cache":4096,"rss":1515520,"working_set":1519616,"failcnt":0,"container_data":{"pgfault":2471,"pgmajfault":0},"hierarchical_data":{"pgfault":2471,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":590875962,"rx_packets":4431350,"rx_errors":0,"rx_dropped":0,"tx_bytes":595431654,"tx_packets":4146768,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":590875962,"rx_packets":4431350,"rx_errors":0,"rx_dropped":0,"tx_bytes":595431654,"tx_packets":4146768,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:29.255274262Z","cpu":{"usage":{"total":479397672,"per_cpu_usage":[479397672],"user":140000000,"system":170000000},"load_average":0},"diskio":{},"memory":{"usage":1519616,"cache":4096,"rss":1515520,"working_set":1519616,"failcnt":0,"container_data":{"pgfault":2471,"pgmajfault":0},"hierarchical_data":{"pgfault":2471,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":590891329,"rx_packets":4431468,"rx_errors":0,"rx_dropped":0,"tx_bytes":595446945,"tx_packets":4146876,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":590891329,"rx_packets":4431468,"rx_errors":0,"rx_dropped":0,"tx_bytes":595446945,"tx_packets":4146876,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:49.028658Z","cpu":{"usage":{"total":479422377,"per_cpu_usage":[479422377],"user":140000000,"system":170000000},"load_average":0},"diskio":{},"memory":{"usage":1519616,"cache":4096,"rss":1515520,"working_set":1519616,"failcnt":0,"container_data":{"pgfault":2471,"pgmajfault":0},"hierarchical_data":{"pgfault":2471,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":590909943,"rx_packets":4431615,"rx_errors":0,"rx_dropped":0,"tx_bytes":595466490,"tx_packets":4147015,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":590909943,"rx_packets":4431615,"rx_errors":0,"rx_dropped":0,"tx_bytes":595466490,"tx_packets":4147015,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:02.041653156Z","cpu":{"usage":{"total":479422377,"per_cpu_usage":[479422377],"user":140000000,"system":170000000},"load_average":0},"diskio":{},"memory":{"usage":1519616,"cache":4096,"rss":1515520,"working_set":1519616,"failcnt":0,"container_data":{"pgfault":2471,"pgmajfault":0},"hierarchical_data":{"pgfault":2471,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":590922610,"rx_packets":4431711,"rx_errors":0,"rx_dropped":0,"tx_bytes":595480278,"tx_packets":4147107,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":590922610,"rx_packets":4431711,"rx_errors":0,"rx_dropped":0,"tx_bytes":595480278,"tx_packets":4147107,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:15.975250944Z","cpu":{"usage":{"total":479422377,"per_cpu_usage":[479422377],"user":140000000,"system":170000000},"load_average":0},"diskio":{},"memory":{"usage":1519616,"cache":4096,"rss":1515520,"working_set":1519616,"failcnt":0,"container_data":{"pgfault":2471,"pgmajfault":0},"hierarchical_data":{"pgfault":2471,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":590934489,"rx_packets":4431806,"rx_errors":0,"rx_dropped":0,"tx_bytes":595492321,"tx_packets":4147194,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":590934489,"rx_packets":4431806,"rx_errors":0,"rx_dropped":0,"tx_bytes":595492321,"tx_packets":4147194,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:29.116978585Z","cpu":{"usage":{"total":479422377,"per_cpu_usage":[479422377],"user":140000000,"system":170000000},"load_average":0},"diskio":{},"memory":{"usage":1519616,"cache":4096,"rss":1515520,"working_set":1519616,"failcnt":0,"container_data":{"pgfault":2471,"pgmajfault":0},"hierarchical_data":{"pgfault":2471,"pgmajfault":0}},"network":{"name":"eth0","rx_bytes":590942887,"rx_packets":4431870,"rx_errors":0,"rx_dropped":0,"tx_bytes":595500564,"tx_packets":4147254,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":590942887,"rx_packets":4431870,"rx_errors":0,"rx_dropped":0,"tx_bytes":595500564,"tx_packets":4147254,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":45056,"base_usage":12288,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]},{"name":"/system","spec":{"creation_time":"2016-03-22T20:26:17.648053Z","has_cpu":true,"cpu":{"limit":1024,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":18446744073709551615},"has_network":false,"has_filesystem":false,"has_diskio":true,"has_custom_metrics":false},"stats":[{"timestamp":"2016-04-19T22:24:34.567031663Z","cpu":{"usage":{"total":15367294009978,"per_cpu_usage":[15367294009978],"user":10793960000000,"system":4958250000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":32911360,"Read":32911360,"Sync":1430667264,"Total":1463578624,"Write":1430667264}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":2226,"Read":2226,"Sync":13256,"Total":15482,"Write":13256}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2858552}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":15792788686,"Read":15792788686,"Sync":1154221095345,"Total":1170013884031,"Write":1154221095345}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":1048604887,"Read":1048604887,"Sync":8556391795,"Total":9604996682,"Write":8556391795}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":12,"Read":12,"Sync":51,"Total":63,"Write":51}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":4022}}]},"memory":{"usage":685936640,"cache":619560960,"rss":66375680,"working_set":379011072,"failcnt":0,"container_data":{"pgfault":1039459755,"pgmajfault":484},"hierarchical_data":{"pgfault":1039459755,"pgmajfault":484}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:50.36233341Z","cpu":{"usage":{"total":15367379249460,"per_cpu_usage":[15367379249460],"user":10794010000000,"system":4958280000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":32911360,"Read":32911360,"Sync":1430667264,"Total":1463578624,"Write":1430667264}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":2226,"Read":2226,"Sync":13256,"Total":15482,"Write":13256}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2858552}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":15792788686,"Read":15792788686,"Sync":1154221095345,"Total":1170013884031,"Write":1154221095345}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":1048604887,"Read":1048604887,"Sync":8556391795,"Total":9604996682,"Write":8556391795}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":12,"Read":12,"Sync":51,"Total":63,"Write":51}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":4022}}]},"memory":{"usage":685948928,"cache":619560960,"rss":66387968,"working_set":379023360,"failcnt":0,"container_data":{"pgfault":1039466863,"pgmajfault":484},"hierarchical_data":{"pgfault":1039466863,"pgmajfault":484}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:03.264835932Z","cpu":{"usage":{"total":15367694477206,"per_cpu_usage":[15367694477206],"user":10794260000000,"system":4958390000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":32911360,"Read":32911360,"Sync":1430667264,"Total":1463578624,"Write":1430667264}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":2226,"Read":2226,"Sync":13256,"Total":15482,"Write":13256}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2858552}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":15792788686,"Read":15792788686,"Sync":1154221095345,"Total":1170013884031,"Write":1154221095345}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":1048604887,"Read":1048604887,"Sync":8556391795,"Total":9604996682,"Write":8556391795}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":12,"Read":12,"Sync":51,"Total":63,"Write":51}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":4022}}]},"memory":{"usage":685953024,"cache":619565056,"rss":66387968,"working_set":379027456,"failcnt":0,"container_data":{"pgfault":1039483402,"pgmajfault":484},"hierarchical_data":{"pgfault":1039483402,"pgmajfault":484}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:15.427491475Z","cpu":{"usage":{"total":15367746151911,"per_cpu_usage":[15367746151911],"user":10794290000000,"system":4958400000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":32911360,"Read":32911360,"Sync":1430667264,"Total":1463578624,"Write":1430667264}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":2226,"Read":2226,"Sync":13256,"Total":15482,"Write":13256}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2858552}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":15792788686,"Read":15792788686,"Sync":1154221095345,"Total":1170013884031,"Write":1154221095345}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":1048604887,"Read":1048604887,"Sync":8556391795,"Total":9604996682,"Write":8556391795}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":12,"Read":12,"Sync":51,"Total":63,"Write":51}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":4022}}]},"memory":{"usage":685957120,"cache":619565056,"rss":66392064,"working_set":379035648,"failcnt":0,"container_data":{"pgfault":1039486570,"pgmajfault":484},"hierarchical_data":{"pgfault":1039486570,"pgmajfault":484}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:29.155617931Z","cpu":{"usage":{"total":15367802928664,"per_cpu_usage":[15367802928664],"user":10794320000000,"system":4958420000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":32911360,"Read":32911360,"Sync":1430667264,"Total":1463578624,"Write":1430667264}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":2226,"Read":2226,"Sync":13256,"Total":15482,"Write":13256}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2858552}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":15792788686,"Read":15792788686,"Sync":1154221095345,"Total":1170013884031,"Write":1154221095345}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":1048604887,"Read":1048604887,"Sync":8556391795,"Total":9604996682,"Write":8556391795}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":12,"Read":12,"Sync":51,"Total":63,"Write":51}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":4022}}]},"memory":{"usage":685957120,"cache":619565056,"rss":66392064,"working_set":379035648,"failcnt":0,"container_data":{"pgfault":1039490294,"pgmajfault":484},"hierarchical_data":{"pgfault":1039490294,"pgmajfault":484}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:46.175922312Z","cpu":{"usage":{"total":15367911533835,"per_cpu_usage":[15367911533835],"user":10794390000000,"system":4958470000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":32911360,"Read":32911360,"Sync":1430667264,"Total":1463578624,"Write":1430667264}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":2226,"Read":2226,"Sync":13256,"Total":15482,"Write":13256}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2858552}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":15792788686,"Read":15792788686,"Sync":1154221095345,"Total":1170013884031,"Write":1154221095345}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":1048604887,"Read":1048604887,"Sync":8556391795,"Total":9604996682,"Write":8556391795}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":12,"Read":12,"Sync":51,"Total":63,"Write":51}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":4022}}]},"memory":{"usage":685973504,"cache":619569152,"rss":66404352,"working_set":379052032,"failcnt":0,"container_data":{"pgfault":1039498859,"pgmajfault":484},"hierarchical_data":{"pgfault":1039498859,"pgmajfault":484}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:57.224441284Z","cpu":{"usage":{"total":15367961722261,"per_cpu_usage":[15367961722261],"user":10794420000000,"system":4958490000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":32911360,"Read":32911360,"Sync":1430667264,"Total":1463578624,"Write":1430667264}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":2226,"Read":2226,"Sync":13256,"Total":15482,"Write":13256}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2858552}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":15792788686,"Read":15792788686,"Sync":1154221095345,"Total":1170013884031,"Write":1154221095345}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":1048604887,"Read":1048604887,"Sync":8556391795,"Total":9604996682,"Write":8556391795}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":12,"Read":12,"Sync":51,"Total":63,"Write":51}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":4022}}]},"memory":{"usage":685969408,"cache":619569152,"rss":66400256,"working_set":379047936,"failcnt":0,"container_data":{"pgfault":1039502416,"pgmajfault":484},"hierarchical_data":{"pgfault":1039502416,"pgmajfault":484}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:12.142012961Z","cpu":{"usage":{"total":15368081897341,"per_cpu_usage":[15368081897341],"user":10794480000000,"system":4958530000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":32911360,"Read":32911360,"Sync":1430667264,"Total":1463578624,"Write":1430667264}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":2226,"Read":2226,"Sync":13256,"Total":15482,"Write":13256}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2858552}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":15792788686,"Read":15792788686,"Sync":1154221095345,"Total":1170013884031,"Write":1154221095345}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":1048604887,"Read":1048604887,"Sync":8556391795,"Total":9604996682,"Write":8556391795}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":12,"Read":12,"Sync":51,"Total":63,"Write":51}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":4022}}]},"memory":{"usage":676384768,"cache":619569152,"rss":56815616,"working_set":369659904,"failcnt":0,"container_data":{"pgfault":1039510414,"pgmajfault":484},"hierarchical_data":{"pgfault":1039510414,"pgmajfault":484}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:31.538388924Z","cpu":{"usage":{"total":15368145981156,"per_cpu_usage":[15368145981156],"user":10794520000000,"system":4958540000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":32911360,"Read":32911360,"Sync":1430667264,"Total":1463578624,"Write":1430667264}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":2226,"Read":2226,"Sync":13256,"Total":15482,"Write":13256}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":2858552}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":15792788686,"Read":15792788686,"Sync":1154221095345,"Total":1170013884031,"Write":1154221095345}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":1048604887,"Read":1048604887,"Sync":8556391795,"Total":9604996682,"Write":8556391795}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":12,"Read":12,"Sync":51,"Total":63,"Write":51}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":4022}}]},"memory":{"usage":676384768,"cache":619569152,"rss":56815616,"working_set":369659904,"failcnt":0,"container_data":{"pgfault":1039513985,"pgmajfault":484},"hierarchical_data":{"pgfault":1039513985,"pgmajfault":484}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]},{"id":"181cf004f75c0634443a3e77ab6f310b9fbb02f8df386405322eadb30bc29f34","name":"/181cf004f75c0634443a3e77ab6f310b9fbb02f8df386405322eadb30bc29f34","aliases":["k8s_kube-proxy.cf23f4be_kube-proxy-gke-cluster-remi-62c0dd29-node-29lx_kube-system_f70c43857a22d5495bf204918d5ab984_4e315ef3","181cf004f75c0634443a3e77ab6f310b9fbb02f8df386405322eadb30bc29f34"],"namespace":"docker","labels":{"io.kubernetes.container.hash":"cf23f4be","io.kubernetes.container.name":"kube-proxy","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"/dev/termination-log","io.kubernetes.pod.name":"kube-proxy-gke-cluster-remi-62c0dd29-node-29lx","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"f70c43857a22d5495bf204918d5ab984"},"spec":{"creation_time":"2016-03-22T20:26:23.672160349Z","labels":{"io.kubernetes.container.hash":"cf23f4be","io.kubernetes.container.name":"kube-proxy","io.kubernetes.container.restartCount":"0","io.kubernetes.container.terminationMessagePath":"/dev/termination-log","io.kubernetes.pod.name":"kube-proxy-gke-cluster-remi-62c0dd29-node-29lx","io.kubernetes.pod.namespace":"kube-system","io.kubernetes.pod.terminationGracePeriod":"30","io.kubernetes.pod.uid":"f70c43857a22d5495bf204918d5ab984"},"has_cpu":true,"cpu":{"limit":204,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":18446744073709551615,"swap_limit":18446744073709551615},"has_network":false,"has_filesystem":true,"has_diskio":true,"has_custom_metrics":false,"image":"gcr.io/google_containers/kube-proxy:6a3c7bde4710fbeb04cee371779c437b"},"stats":[{"timestamp":"2016-04-19T22:24:25.482530368Z","cpu":{"usage":{"total":1529417592442,"per_cpu_usage":[1529417592442],"user":640210000000,"system":1170460000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":253952,"Read":253952,"Sync":0,"Total":253952,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":22,"Read":22,"Sync":0,"Total":22,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":496}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":295192145,"Read":295192145,"Sync":0,"Total":295192145,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":400786,"Read":400786,"Sync":0,"Total":400786,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":48}}]},"memory":{"usage":5615616,"cache":323584,"rss":5292032,"working_set":5603328,"failcnt":0,"container_data":{"pgfault":197542132,"pgmajfault":19},"hierarchical_data":{"pgfault":197542132,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":57344,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:44.207741158Z","cpu":{"usage":{"total":1529418566199,"per_cpu_usage":[1529418566199],"user":640210000000,"system":1170460000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":253952,"Read":253952,"Sync":0,"Total":253952,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":22,"Read":22,"Sync":0,"Total":22,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":496}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":295192145,"Read":295192145,"Sync":0,"Total":295192145,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":400786,"Read":400786,"Sync":0,"Total":400786,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":48}}]},"memory":{"usage":5615616,"cache":323584,"rss":5292032,"working_set":5603328,"failcnt":0,"container_data":{"pgfault":197542232,"pgmajfault":19},"hierarchical_data":{"pgfault":197542232,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":57344,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:57.474926404Z","cpu":{"usage":{"total":1529433560070,"per_cpu_usage":[1529433560070],"user":640220000000,"system":1170480000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":253952,"Read":253952,"Sync":0,"Total":253952,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":22,"Read":22,"Sync":0,"Total":22,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":496}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":295192145,"Read":295192145,"Sync":0,"Total":295192145,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":400786,"Read":400786,"Sync":0,"Total":400786,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":48}}]},"memory":{"usage":5615616,"cache":323584,"rss":5292032,"working_set":5603328,"failcnt":0,"container_data":{"pgfault":197544144,"pgmajfault":19},"hierarchical_data":{"pgfault":197544144,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":57344,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:13.555351083Z","cpu":{"usage":{"total":1529433800356,"per_cpu_usage":[1529433800356],"user":640220000000,"system":1170480000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":253952,"Read":253952,"Sync":0,"Total":253952,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":22,"Read":22,"Sync":0,"Total":22,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":496}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":295192145,"Read":295192145,"Sync":0,"Total":295192145,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":400786,"Read":400786,"Sync":0,"Total":400786,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":48}}]},"memory":{"usage":5615616,"cache":323584,"rss":5292032,"working_set":5603328,"failcnt":0,"container_data":{"pgfault":197544144,"pgmajfault":19},"hierarchical_data":{"pgfault":197544144,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":57344,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:23.680211962Z","cpu":{"usage":{"total":1529450124740,"per_cpu_usage":[1529450124740],"user":640220000000,"system":1170490000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":253952,"Read":253952,"Sync":0,"Total":253952,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":22,"Read":22,"Sync":0,"Total":22,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":496}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":295192145,"Read":295192145,"Sync":0,"Total":295192145,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":400786,"Read":400786,"Sync":0,"Total":400786,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":48}}]},"memory":{"usage":5697536,"cache":323584,"rss":5373952,"working_set":5685248,"failcnt":0,"container_data":{"pgfault":197546203,"pgmajfault":19},"hierarchical_data":{"pgfault":197546203,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":57344,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:37.779891481Z","cpu":{"usage":{"total":1529467750092,"per_cpu_usage":[1529467750092],"user":640230000000,"system":1170500000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":253952,"Read":253952,"Sync":0,"Total":253952,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":22,"Read":22,"Sync":0,"Total":22,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":496}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":295192145,"Read":295192145,"Sync":0,"Total":295192145,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":400786,"Read":400786,"Sync":0,"Total":400786,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":48}}]},"memory":{"usage":5804032,"cache":323584,"rss":5480448,"working_set":5791744,"failcnt":0,"container_data":{"pgfault":197548640,"pgmajfault":19},"hierarchical_data":{"pgfault":197548640,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":57344,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:56.306965937Z","cpu":{"usage":{"total":1529483017186,"per_cpu_usage":[1529483017186],"user":640230000000,"system":1170510000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":253952,"Read":253952,"Sync":0,"Total":253952,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":22,"Read":22,"Sync":0,"Total":22,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":496}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":295192145,"Read":295192145,"Sync":0,"Total":295192145,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":400786,"Read":400786,"Sync":0,"Total":400786,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":48}}]},"memory":{"usage":5820416,"cache":323584,"rss":5496832,"working_set":5808128,"failcnt":0,"container_data":{"pgfault":197550554,"pgmajfault":19},"hierarchical_data":{"pgfault":197550554,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":57344,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:06.819976073Z","cpu":{"usage":{"total":1529483209518,"per_cpu_usage":[1529483209518],"user":640230000000,"system":1170510000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":253952,"Read":253952,"Sync":0,"Total":253952,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":22,"Read":22,"Sync":0,"Total":22,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":496}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":295192145,"Read":295192145,"Sync":0,"Total":295192145,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":400786,"Read":400786,"Sync":0,"Total":400786,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":48}}]},"memory":{"usage":5820416,"cache":323584,"rss":5496832,"working_set":5808128,"failcnt":0,"container_data":{"pgfault":197550555,"pgmajfault":19},"hierarchical_data":{"pgfault":197550555,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":57344,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:24.011987742Z","cpu":{"usage":{"total":1529483534249,"per_cpu_usage":[1529483534249],"user":640240000000,"system":1170510000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":253952,"Read":253952,"Sync":0,"Total":253952,"Write":0}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":22,"Read":22,"Sync":0,"Total":22,"Write":0}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":496}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":295192145,"Read":295192145,"Sync":0,"Total":295192145,"Write":0}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":400786,"Read":400786,"Sync":0,"Total":400786,"Write":0}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":48}}]},"memory":{"usage":5820416,"cache":323584,"rss":5496832,"working_set":5808128,"failcnt":0,"container_data":{"pgfault":197550557,"pgmajfault":19},"hierarchical_data":{"pgfault":197550557,"pgmajfault":19}},"network":{"name":"","rx_bytes":0,"rx_packets":0,"rx_errors":0,"rx_dropped":0,"tx_bytes":0,"tx_packets":0,"tx_errors":0,"tx_dropped":0,"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":57344,"base_usage":40960,"available":0,"inodes_free":0,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]},{"name":"/","subcontainers":[{"name":"/181cf004f75c0634443a3e77ab6f310b9fbb02f8df386405322eadb30bc29f34"},{"name":"/281c01bcfd243f11a876f9929d64d856615035aa2cd3af558be74aa12a494f38"},{"name":"/512523fbe722384328ef5a44e475077e76758fc9935af4639c8874cadae70a3d"},{"name":"/63463444e6e0d369d8f0ba91f30c4570ead01808a36b3f2ee32138e293a0e115"},{"name":"/89ee50ff6005d47354ba8a252248623ebca0297d36de16387826373be9e52a17"},{"name":"/b74f106dfe26a20b64849d587f3d273bc417cbe52af2456d2c4142b44f85cf45"},{"name":"/bb6f7f98ad7b9d7a666db8d3b14c0801dc282326adbe3463b77bf05babfd0f4f"},{"name":"/docker-daemon"},{"name":"/e3e04eb19919e30da3b187cb901b49678a030e705b936473db1385cb2403f066"},{"name":"/eb896866194dd2393153ac8f91e1150986a9a1b26c9105163375372bcd1e5961"},{"name":"/ef20f4bb10087c626aae1fb32db18c3f8cee0d57f9acc63c85126d3294f1c659"},{"name":"/f5d58fe04da979421530b1e2125d9f2078d608798bea694a24d1dc9043774f3f"},{"name":"/kubelet"},{"name":"/system"}],"spec":{"creation_time":"2016-03-22T20:24:19.894791Z","has_cpu":true,"cpu":{"limit":1024,"max_limit":0,"mask":"0"},"has_memory":true,"memory":{"limit":3892248576},"has_network":true,"has_filesystem":true,"has_diskio":true,"has_custom_metrics":false},"stats":[{"timestamp":"2016-04-19T22:24:29.230846662Z","cpu":{"usage":{"total":115388926583335,"per_cpu_usage":[115388926583335],"user":71743910000000,"system":41489840000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":20865337344,"Read":170973184,"Sync":50198843392,"Total":71064180736,"Write":70893207552}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":3850943,"Read":8402,"Sync":3039131,"Total":6890074,"Write":6881672}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":138797228}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":16388943711622,"Read":40460310305,"Sync":4150034434732,"Total":20538978146354,"Write":20498517836049}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":4051061965790,"Read":8900380499,"Sync":10492959814788,"Total":14544021780578,"Write":14535121400079}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":14002,"Read":439,"Sync":51,"Total":14053,"Write":13614}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":16230016}}]},"memory":{"usage":2388340736,"cache":949469184,"rss":20217856,"working_set":1417732096,"failcnt":0,"container_data":{"pgfault":598240,"pgmajfault":827},"hierarchical_data":{"pgfault":598240,"pgmajfault":827}},"network":{"name":"eth0","rx_bytes":11127461423,"rx_packets":26683512,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732522098,"tx_packets":27140186,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11127461423,"rx_packets":26683512,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732522098,"tx_packets":27140186,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110565530,"rx_packets":26286518,"rx_errors":0,"rx_dropped":0,"tx_bytes":31135245286,"tx_packets":23325196,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":3829534720,"base_usage":0,"available":97304731648,"inodes_free":6447558,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:24:48.130535989Z","cpu":{"usage":{"total":115389967142180,"per_cpu_usage":[115389967142180],"user":71744490000000,"system":41490230000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":20865525760,"Read":170973184,"Sync":50199748608,"Total":71065274368,"Write":70894301184}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":3850985,"Read":8402,"Sync":3039207,"Total":6890192,"Write":6881790}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":138799364}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":16389064666122,"Read":40460310305,"Sync":4150103034402,"Total":20539167700524,"Write":20498707390219}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":4051063554554,"Read":8900380499,"Sync":10493249576224,"Total":14544313130778,"Write":14535412750279}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":14002,"Read":439,"Sync":51,"Total":14053,"Write":13614}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":16230247}}]},"memory":{"usage":2388357120,"cache":949469184,"rss":20217856,"working_set":1417748480,"failcnt":0,"container_data":{"pgfault":598240,"pgmajfault":827},"hierarchical_data":{"pgfault":598240,"pgmajfault":827}},"network":{"name":"eth0","rx_bytes":11127594166,"rx_packets":26683822,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732584085,"tx_packets":27140521,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11127594166,"rx_packets":26683822,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732584085,"tx_packets":27140521,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110621818,"rx_packets":26286876,"rx_errors":0,"rx_dropped":0,"tx_bytes":31135580444,"tx_packets":23325499,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":3829518336,"base_usage":0,"available":97304748032,"inodes_free":6447558,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:00.396812352Z","cpu":{"usage":{"total":115390802304676,"per_cpu_usage":[115390802304676],"user":71745010000000,"system":41490530000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":20865554432,"Read":170973184,"Sync":50200330240,"Total":71065884672,"Write":70894911488}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":3850992,"Read":8402,"Sync":3039257,"Total":6890249,"Write":6881847}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":138800556}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":16389070630932,"Read":40460310305,"Sync":4150148052165,"Total":20539218683097,"Write":20498758372792}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":4051063647419,"Read":8900380499,"Sync":10493443177507,"Total":14544506824926,"Write":14535606444427}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":14002,"Read":439,"Sync":51,"Total":14053,"Write":13614}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":16230397}}]},"memory":{"usage":2388357120,"cache":949469184,"rss":20217856,"working_set":1417748480,"failcnt":0,"container_data":{"pgfault":598240,"pgmajfault":827},"hierarchical_data":{"pgfault":598240,"pgmajfault":827}},"network":{"name":"eth0","rx_bytes":11127658358,"rx_packets":26683992,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732624184,"tx_packets":27140708,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11127658358,"rx_packets":26683992,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732624184,"tx_packets":27140708,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110664228,"rx_packets":26287138,"rx_errors":0,"rx_dropped":0,"tx_bytes":31135892998,"tx_packets":23325718,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":3829518336,"base_usage":0,"available":97304748032,"inodes_free":6447558,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:16.19499718Z","cpu":{"usage":{"total":115392157012396,"per_cpu_usage":[115392157012396],"user":71745780000000,"system":41491100000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":20865615872,"Read":170973184,"Sync":50201141248,"Total":71066757120,"Write":70895783936}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":3851006,"Read":8402,"Sync":3039319,"Total":6890325,"Write":6881923}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":138802260}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":16389083897019,"Read":40460310305,"Sync":4150205127636,"Total":20539289024655,"Write":20498828714350}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":4051063803297,"Read":8900380499,"Sync":10493679828207,"Total":14544743631504,"Write":14535843251005}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":14002,"Read":439,"Sync":51,"Total":14053,"Write":13614}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":16230601}}]},"memory":{"usage":2388324352,"cache":949469184,"rss":20217856,"working_set":1417719808,"failcnt":0,"container_data":{"pgfault":598240,"pgmajfault":827},"hierarchical_data":{"pgfault":598240,"pgmajfault":827}},"network":{"name":"eth0","rx_bytes":11127762494,"rx_packets":26684428,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732713471,"tx_packets":27141214,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11127762494,"rx_packets":26684428,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732713471,"tx_packets":27141214,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110715565,"rx_packets":26287465,"rx_errors":0,"rx_dropped":0,"tx_bytes":31136216048,"tx_packets":23325992,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":3829538816,"base_usage":0,"available":97304727552,"inodes_free":6447557,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:32.993998441Z","cpu":{"usage":{"total":115393123178173,"per_cpu_usage":[115393123178173],"user":71746340000000,"system":41491460000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":20865873920,"Read":170973184,"Sync":50201915392,"Total":71067789312,"Write":70896816128}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":3851064,"Read":8402,"Sync":3039387,"Total":6890451,"Write":6882049}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":138804276}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":16389492402732,"Read":40460310305,"Sync":4150269509680,"Total":20539761912412,"Write":20499301602107}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":4051065966079,"Read":8900380499,"Sync":10493943264336,"Total":14545009230415,"Write":14536108849916}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":14002,"Read":439,"Sync":51,"Total":14053,"Write":13614}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":16230817}}]},"memory":{"usage":2388516864,"cache":949469184,"rss":20217856,"working_set":1417912320,"failcnt":0,"container_data":{"pgfault":598240,"pgmajfault":827},"hierarchical_data":{"pgfault":598240,"pgmajfault":827}},"network":{"name":"eth0","rx_bytes":11127840920,"rx_packets":26684627,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732759997,"tx_packets":27141431,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11127840920,"rx_packets":26684627,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732759997,"tx_packets":27141431,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110762900,"rx_packets":26287765,"rx_errors":0,"rx_dropped":0,"tx_bytes":31136531328,"tx_packets":23326237,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":3829551104,"base_usage":0,"available":97304715264,"inodes_free":6447557,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:43.469816344Z","cpu":{"usage":{"total":115393563575692,"per_cpu_usage":[115393563575692],"user":71746660000000,"system":41491570000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":20865902592,"Read":170973184,"Sync":50202324992,"Total":71068227584,"Write":70897254400}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":3851071,"Read":8402,"Sync":3039429,"Total":6890500,"Write":6882098}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":138805132}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":16389499330183,"Read":40460310305,"Sync":4150306168329,"Total":20539805498512,"Write":20499345188207}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":4051066050545,"Read":8900380499,"Sync":10494102961638,"Total":14545169012183,"Write":14536268631684}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":14002,"Read":439,"Sync":51,"Total":14053,"Write":13614}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":16230941}}]},"memory":{"usage":2388541440,"cache":949469184,"rss":20217856,"working_set":1417936896,"failcnt":0,"container_data":{"pgfault":598240,"pgmajfault":827},"hierarchical_data":{"pgfault":598240,"pgmajfault":827}},"network":{"name":"eth0","rx_bytes":11127887078,"rx_packets":26684759,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732788084,"tx_packets":27141575,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11127887078,"rx_packets":26684759,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732788084,"tx_packets":27141575,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110785853,"rx_packets":26287909,"rx_errors":0,"rx_dropped":0,"tx_bytes":31136568200,"tx_packets":23326363,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":3829555200,"base_usage":0,"available":97304711168,"inodes_free":6447557,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:25:59.401026002Z","cpu":{"usage":{"total":115394526889089,"per_cpu_usage":[115394526889089],"user":71747250000000,"system":41491890000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":20866168832,"Read":170973184,"Sync":50203144192,"Total":71069313024,"Write":70898339840}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":3851128,"Read":8402,"Sync":3039493,"Total":6890621,"Write":6882219}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":138807252}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":16389859208870,"Read":40460310305,"Sync":4150362415825,"Total":20540221624695,"Write":20499761314390}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":4051070576169,"Read":8900380499,"Sync":10494352801513,"Total":14545423377682,"Write":14536522997183}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":14002,"Read":439,"Sync":51,"Total":14053,"Write":13614}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":16231161}}]},"memory":{"usage":2388557824,"cache":949469184,"rss":20217856,"working_set":1417953280,"failcnt":0,"container_data":{"pgfault":598240,"pgmajfault":827},"hierarchical_data":{"pgfault":598240,"pgmajfault":827}},"network":{"name":"eth0","rx_bytes":11128004961,"rx_packets":26685030,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732840637,"tx_packets":27141866,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11128004961,"rx_packets":26685030,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732840637,"tx_packets":27141866,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110832991,"rx_packets":26288216,"rx_errors":0,"rx_dropped":0,"tx_bytes":31136883894,"tx_packets":23326631,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":3829538816,"base_usage":0,"available":97304727552,"inodes_free":6447557,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:12.762311269Z","cpu":{"usage":{"total":115395396371422,"per_cpu_usage":[115395396371422],"user":71747830000000,"system":41492140000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":20866205696,"Read":170973184,"Sync":50203750400,"Total":71069956096,"Write":70898982912}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":3851137,"Read":8402,"Sync":3039545,"Total":6890682,"Write":6882280}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":138808508}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":16389866629749,"Read":40460310305,"Sync":4150408038800,"Total":20540274668549,"Write":20499814358244}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":4051070701010,"Read":8900380499,"Sync":10494553397246,"Total":14545624098256,"Write":14536723717757}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":14002,"Read":439,"Sync":51,"Total":14053,"Write":13614}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":16231325}}]},"memory":{"usage":2378973184,"cache":949469184,"rss":20217856,"working_set":1408565248,"failcnt":0,"container_data":{"pgfault":598240,"pgmajfault":827},"hierarchical_data":{"pgfault":598240,"pgmajfault":827}},"network":{"name":"eth0","rx_bytes":11128085638,"rx_packets":26685298,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732905800,"tx_packets":27142124,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11128085638,"rx_packets":26685298,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732905800,"tx_packets":27142124,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110883071,"rx_packets":26288531,"rx_errors":0,"rx_dropped":0,"tx_bytes":31137210114,"tx_packets":23326888,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":3829538816,"base_usage":0,"available":97304727552,"inodes_free":6447557,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}},{"timestamp":"2016-04-19T22:26:22.934068474Z","cpu":{"usage":{"total":115396052079869,"per_cpu_usage":[115396052079869],"user":71748140000000,"system":41492460000000},"load_average":0},"diskio":{"io_service_bytes":[{"major":8,"minor":0,"stats":{"Async":20866234368,"Read":170973184,"Sync":50204131328,"Total":71070365696,"Write":70899392512}}],"io_serviced":[{"major":8,"minor":0,"stats":{"Async":3851144,"Read":8402,"Sync":3039587,"Total":6890731,"Write":6882329}}],"io_queued":[{"major":8,"minor":0,"stats":{"Async":0,"Read":0,"Sync":0,"Total":0,"Write":0}}],"sectors":[{"major":8,"minor":0,"stats":{"Count":138809308}}],"io_service_time":[{"major":8,"minor":0,"stats":{"Async":16389874003355,"Read":40460310305,"Sync":4150443853629,"Total":20540317856984,"Write":20499857546679}}],"io_wait_time":[{"major":8,"minor":0,"stats":{"Async":4051070781392,"Read":8900380499,"Sync":10494712800868,"Total":14545783582260,"Write":14536883201761}}],"io_merged":[{"major":8,"minor":0,"stats":{"Async":14002,"Read":439,"Sync":51,"Total":14053,"Write":13614}}],"io_time":[{"major":8,"minor":0,"stats":{"Count":16231445}}]},"memory":{"usage":2378981376,"cache":949469184,"rss":20217856,"working_set":1408573440,"failcnt":0,"container_data":{"pgfault":598240,"pgmajfault":827},"hierarchical_data":{"pgfault":598240,"pgmajfault":827}},"network":{"name":"eth0","rx_bytes":11128129965,"rx_packets":26685416,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732930957,"tx_packets":27142256,"tx_errors":0,"tx_dropped":0,"interfaces":[{"name":"eth0","rx_bytes":11128129965,"rx_packets":26685416,"rx_errors":0,"rx_dropped":0,"tx_bytes":5732930957,"tx_packets":27142256,"tx_errors":0,"tx_dropped":0},{"name":"cbr0","rx_bytes":4110905886,"rx_packets":26288678,"rx_errors":0,"rx_dropped":0,"tx_bytes":31137247221,"tx_packets":23327015,"tx_errors":0,"tx_dropped":0}],"tcp":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0},"tcp6":{"Established":0,"SynSent":0,"SynRecv":0,"FinWait1":0,"FinWait2":0,"TimeWait":0,"Close":0,"CloseWait":0,"LastAck":0,"Listen":0,"Closing":0}},"filesystem":[{"device":"/dev/disk/by-uuid/0f4155c3-2c08-43f0-9949-b25bb21e3561","type":"vfs","capacity":105553100800,"usage":3829542912,"base_usage":0,"available":97304723456,"inodes_free":6447557,"reads_completed":0,"reads_merged":0,"sectors_read":0,"read_time":0,"writes_completed":0,"writes_merged":0,"sectors_written":0,"write_time":0,"io_in_progress":0,"io_time":0,"weighted_io_time":0}],"task_stats":{"nr_sleeping":0,"nr_running":0,"nr_stopped":0,"nr_uninterruptible":0,"nr_io_wait":0}}]}]
+[
+  {
+    "name": "/system",
+    "spec": {
+      "creation_time": "2016-06-03T18:09:19.215272Z",
+      "has_cpu": true,
+      "cpu": {
+        "limit": 1024,
+        "max_limit": 0,
+        "mask": "0-1"
+      },
+      "has_memory": true,
+      "memory": {
+        "limit": 18446744073709551615
+      },
+      "has_network": false,
+      "has_filesystem": false,
+      "has_diskio": true,
+      "has_custom_metrics": false
+    },
+    "stats": [
+      {
+        "timestamp": "2016-06-17T16:06:04.78767617Z",
+        "cpu": {
+          "usage": {
+            "total": 9191944896812,
+            "per_cpu_usage": [
+              4562797469082,
+              4629147427730
+            ],
+            "user": 6063910000000,
+            "system": 2910120000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068859392,
+          "cache": 1025363968,
+          "rss": 43405312,
+          "working_set": 382758912,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488857191,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488857191,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:24.750670773Z",
+        "cpu": {
+          "usage": {
+            "total": 9192107007848,
+            "per_cpu_usage": [
+              4562899766191,
+              4629207241657
+            ],
+            "user": 6064000000000,
+            "system": 2910180000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068822528,
+          "cache": 1025363968,
+          "rss": 43409408,
+          "working_set": 382722048,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488866687,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488866687,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:36.90598914Z",
+        "cpu": {
+          "usage": {
+            "total": 9192175569640,
+            "per_cpu_usage": [
+              4562942156940,
+              4629233412700
+            ],
+            "user": 6064050000000,
+            "system": 2910200000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068773376,
+          "cache": 1025363968,
+          "rss": 43409408,
+          "working_set": 382672896,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488870176,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488870176,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:53.940285874Z",
+        "cpu": {
+          "usage": {
+            "total": 9192237889901,
+            "per_cpu_usage": [
+              4562982412364,
+              4629255477537
+            ],
+            "user": 6064090000000,
+            "system": 2910230000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068765184,
+          "cache": 1025363968,
+          "rss": 43401216,
+          "working_set": 382664704,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488873655,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488873655,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:12.072940622Z",
+        "cpu": {
+          "usage": {
+            "total": 9192364942229,
+            "per_cpu_usage": [
+              4563078620548,
+              4629286321681
+            ],
+            "user": 6064160000000,
+            "system": 2910280000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068773376,
+          "cache": 1025363968,
+          "rss": 43409408,
+          "working_set": 382672896,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488880873,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488880873,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:26.834587365Z",
+        "cpu": {
+          "usage": {
+            "total": 9192503656920,
+            "per_cpu_usage": [
+              4563133565996,
+              4629370090924
+            ],
+            "user": 6064260000000,
+            "system": 2910320000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068769280,
+          "cache": 1025363968,
+          "rss": 43405312,
+          "working_set": 382668800,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488889777,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488889777,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:37.710788065Z",
+        "cpu": {
+          "usage": {
+            "total": 9192560639497,
+            "per_cpu_usage": [
+              4563158820732,
+              4629401818765
+            ],
+            "user": 6064290000000,
+            "system": 2910340000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068761088,
+          "cache": 1025363968,
+          "rss": 43397120,
+          "working_set": 382660608,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488892687,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488892687,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:48.63605798Z",
+        "cpu": {
+          "usage": {
+            "total": 9192616604693,
+            "per_cpu_usage": [
+              4563197945547,
+              4629418659146
+            ],
+            "user": 6064330000000,
+            "system": 2910350000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18264064,
+                "Read": 18264064,
+                "Sync": 1231773696,
+                "Total": 1250037760,
+                "Write": 1231773696
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1153,
+                "Read": 1153,
+                "Sync": 8949,
+                "Total": 10102,
+                "Write": 8949
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2441480
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1262509386,
+                "Read": 1262509386,
+                "Sync": 612091543602,
+                "Total": 613354052988,
+                "Write": 612091543602
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 361179477,
+                "Read": 361179477,
+                "Sync": 28191821920,
+                "Total": 28553001397,
+                "Write": 28191821920
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 30,
+                "Read": 30,
+                "Sync": 72,
+                "Total": 102,
+                "Write": 72
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 2367
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 1068773376,
+          "cache": 1025363968,
+          "rss": 43409408,
+          "working_set": 382672896,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 488895886,
+            "pgmajfault": 536
+          },
+          "hierarchical_data": {
+            "pgfault": 488895886,
+            "pgmajfault": 536
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      }
+    ]
+  },
+  {
+    "id": "1d6e5db3abbfbb69718899748a882e2519da5b5d798b4b6bf1ec7dd6b5f26a60",
+    "name": "/1d6e5db3abbfbb69718899748a882e2519da5b5d798b4b6bf1ec7dd6b5f26a60",
+    "aliases": [
+      "k8s_dd-agent.7b520f3f_dd-agent-1rxlh_default_12c7be82-33ca-11e6-ac8f-42010af00003_321fecb4",
+      "1d6e5db3abbfbb69718899748a882e2519da5b5d798b4b6bf1ec7dd6b5f26a60"
+    ],
+    "namespace": "docker",
+    "labels": {
+      "io.kubernetes.container.hash": "7b520f3f",
+      "io.kubernetes.container.name": "dd-agent",
+      "io.kubernetes.container.restartCount": "0",
+      "io.kubernetes.container.terminationMessagePath": "/dev/termination-log",
+      "io.kubernetes.pod.name": "dd-agent-1rxlh",
+      "io.kubernetes.pod.namespace": "default",
+      "io.kubernetes.pod.terminationGracePeriod": "30",
+      "io.kubernetes.pod.uid": "12c7be82-33ca-11e6-ac8f-42010af00003"
+    },
+    "spec": {
+      "creation_time": "2016-06-16T13:56:08.429573036Z",
+      "labels": {
+        "io.kubernetes.container.hash": "7b520f3f",
+        "io.kubernetes.container.name": "dd-agent",
+        "io.kubernetes.container.restartCount": "0",
+        "io.kubernetes.container.terminationMessagePath": "/dev/termination-log",
+        "io.kubernetes.pod.name": "dd-agent-1rxlh",
+        "io.kubernetes.pod.namespace": "default",
+        "io.kubernetes.pod.terminationGracePeriod": "30",
+        "io.kubernetes.pod.uid": "12c7be82-33ca-11e6-ac8f-42010af00003"
+      },
+      "has_cpu": true,
+      "cpu": {
+        "limit": 256,
+        "max_limit": 0,
+        "mask": "0-1"
+      },
+      "has_memory": true,
+      "memory": {
+        "limit": 134217728,
+        "swap_limit": 18446744073709551615
+      },
+      "has_network": false,
+      "has_filesystem": true,
+      "has_diskio": true,
+      "has_custom_metrics": false,
+      "image": "datadog/docker-dd-agent:massi_ingest_k8s_events"
+    },
+    "stats": [
+      {
+        "timestamp": "2016-06-17T16:05:57.64670846Z",
+        "cpu": {
+          "usage": {
+            "total": 1634848700452,
+            "per_cpu_usage": [
+              814746181291,
+              820102519161
+            ],
+            "user": 937600000000,
+            "system": 656690000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 14802944,
+                "Read": 14802944,
+                "Sync": 3379200,
+                "Total": 18182144,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 439,
+                "Read": 439,
+                "Sync": 335,
+                "Total": 774,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 35512
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 1907661653,
+                "Read": 1907661653,
+                "Sync": 277170727,
+                "Total": 2184832380,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 298588569,
+                "Read": 298588569,
+                "Sync": 1436416786,
+                "Total": 1735005355,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 974
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 97558528,
+          "cache": 19447808,
+          "rss": 78110720,
+          "working_set": 90456064,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17726582,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17726582,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57810944,
+            "base_usage": 57790464,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:17.420933191Z",
+        "cpu": {
+          "usage": {
+            "total": 1635254620441,
+            "per_cpu_usage": [
+              814953401532,
+              820301218909
+            ],
+            "user": 937780000000,
+            "system": 656900000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 15151104,
+                "Read": 15151104,
+                "Sync": 3379200,
+                "Total": 18530304,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 470,
+                "Read": 470,
+                "Sync": 335,
+                "Total": 805,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 36192
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2046335181,
+                "Read": 2046335181,
+                "Sync": 277170727,
+                "Total": 2323505908,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 298831824,
+                "Read": 298831824,
+                "Sync": 1436416786,
+                "Total": 1735248610,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1005
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 100651008,
+          "cache": 19836928,
+          "rss": 80814080,
+          "working_set": 93540352,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17731898,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17731898,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57810944,
+            "base_usage": 57790464,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:34.752028641Z",
+        "cpu": {
+          "usage": {
+            "total": 1635377578105,
+            "per_cpu_usage": [
+              815016183684,
+              820361394421
+            ],
+            "user": 937880000000,
+            "system": 656930000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 15392768,
+                "Read": 15392768,
+                "Sync": 3379200,
+                "Total": 18771968,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 488,
+                "Read": 488,
+                "Sync": 335,
+                "Total": 823,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 36664
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2150066629,
+                "Read": 2150066629,
+                "Sync": 277170727,
+                "Total": 2427237356,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 298985452,
+                "Read": 298985452,
+                "Sync": 1436416786,
+                "Total": 1735402238,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1026
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 102555648,
+          "cache": 20086784,
+          "rss": 82468864,
+          "working_set": 95449088,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17732545,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17732545,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57892864,
+            "base_usage": 57872384,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:52.101541457Z",
+        "cpu": {
+          "usage": {
+            "total": 1635742144956,
+            "per_cpu_usage": [
+              815130325898,
+              820611819058
+            ],
+            "user": 938070000000,
+            "system": 657090000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 15392768,
+                "Read": 15392768,
+                "Sync": 3379200,
+                "Total": 18771968,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 488,
+                "Read": 488,
+                "Sync": 335,
+                "Total": 823,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 36664
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2150066629,
+                "Read": 2150066629,
+                "Sync": 277170727,
+                "Total": 2427237356,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 298985452,
+                "Read": 298985452,
+                "Sync": 1436416786,
+                "Total": 1735402238,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1026
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 100925440,
+          "cache": 20119552,
+          "rss": 80805888,
+          "working_set": 93818880,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17737838,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17737838,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57892864,
+            "base_usage": 57872384,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:05.989800285Z",
+        "cpu": {
+          "usage": {
+            "total": 1636003536413,
+            "per_cpu_usage": [
+              815224331260,
+              820779205153
+            ],
+            "user": 938240000000,
+            "system": 657170000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18366464,
+                "Read": 18366464,
+                "Sync": 3379200,
+                "Total": 21745664,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 751,
+                "Read": 751,
+                "Sync": 335,
+                "Total": 1086,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 42472
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2720237570,
+                "Read": 2720237570,
+                "Sync": 277170727,
+                "Total": 2997408297,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 307131077,
+                "Read": 307131077,
+                "Sync": 1436416786,
+                "Total": 1743547863,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1184
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 117256192,
+          "cache": 23101440,
+          "rss": 94154752,
+          "working_set": 110149632,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17743275,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17743275,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57892864,
+            "base_usage": 57872384,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:17.564225474Z",
+        "cpu": {
+          "usage": {
+            "total": 1636429715422,
+            "per_cpu_usage": [
+              815388768290,
+              821040947132
+            ],
+            "user": 938490000000,
+            "system": 657350000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18366464,
+                "Read": 18366464,
+                "Sync": 3379200,
+                "Total": 21745664,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 751,
+                "Read": 751,
+                "Sync": 335,
+                "Total": 1086,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 42472
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2720237570,
+                "Read": 2720237570,
+                "Sync": 277170727,
+                "Total": 2997408297,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 307131077,
+                "Read": 307131077,
+                "Sync": 1436416786,
+                "Total": 1743547863,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1184
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 101531648,
+          "cache": 23130112,
+          "rss": 78155776,
+          "working_set": 94425088,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17749444,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17749444,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57892864,
+            "base_usage": 57872384,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:35.59670058Z",
+        "cpu": {
+          "usage": {
+            "total": 1636539574210,
+            "per_cpu_usage": [
+              815443742737,
+              821095831473
+            ],
+            "user": 938600000000,
+            "system": 657380000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18366464,
+                "Read": 18366464,
+                "Sync": 3379200,
+                "Total": 21745664,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 751,
+                "Read": 751,
+                "Sync": 335,
+                "Total": 1086,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 42472
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2720237570,
+                "Read": 2720237570,
+                "Sync": 277170727,
+                "Total": 2997408297,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 307131077,
+                "Read": 307131077,
+                "Sync": 1436416786,
+                "Total": 1743547863,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1184
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 101298176,
+          "cache": 23142400,
+          "rss": 78155776,
+          "working_set": 94191616,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17750130,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17750130,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57970688,
+            "base_usage": 57950208,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:53.544235192Z",
+        "cpu": {
+          "usage": {
+            "total": 1636943556502,
+            "per_cpu_usage": [
+              815669021273,
+              821274535229
+            ],
+            "user": 938860000000,
+            "system": 657510000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18366464,
+                "Read": 18366464,
+                "Sync": 3379200,
+                "Total": 21745664,
+                "Write": 3379200
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 751,
+                "Read": 751,
+                "Sync": 335,
+                "Total": 1086,
+                "Write": 335
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 42472
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2720237570,
+                "Read": 2720237570,
+                "Sync": 277170727,
+                "Total": 2997408297,
+                "Write": 277170727
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 307131077,
+                "Read": 307131077,
+                "Sync": 1436416786,
+                "Total": 1743547863,
+                "Write": 1436416786
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 10,
+                "Read": 10,
+                "Sync": 0,
+                "Total": 10,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1184
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 101560320,
+          "cache": 23179264,
+          "rss": 78155776,
+          "working_set": 94449664,
+          "failcnt": 10636,
+          "container_data": {
+            "pgfault": 17755275,
+            "pgmajfault": 55
+          },
+          "hierarchical_data": {
+            "pgfault": 17755275,
+            "pgmajfault": 55
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 57970688,
+            "base_usage": 57950208,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      }
+    ]
+  },
+  {
+    "name": "/",
+    "subcontainers": [
+      {
+        "name": "/04a2cbd416c0fc4b33a64d70ff97aa6c91714da8011065241cbef7cd30f26f03"
+      },
+      {
+        "name": "/1d6e5db3abbfbb69718899748a882e2519da5b5d798b4b6bf1ec7dd6b5f26a60"
+      },
+      {
+        "name": "/22ce1054bb0ddb446b910b41f0f5812d103fe3695e8cb63ae4aff96c58dbfb1a"
+      },
+      {
+        "name": "/4110c0dfdccfc11115b1aa653af4483e286d03179439ac17369d554c999c45ee"
+      },
+      {
+        "name": "/4f269da73287845650fce62e0b4ab40a76489e646a79d30a39ce961912f0833e"
+      },
+      {
+        "name": "/59fb6c47177e23255821a3b13561b756b764057d009f017670fc784df9a27a54"
+      },
+      {
+        "name": "/84105ff06547050d06d1e660cbfbf6047a9320f272f492293d0445bd9b97d366"
+      },
+      {
+        "name": "/91a2c7cdd3d92b484bad9841dbf7c26c8ff162fb644e844f474679a1f5a8dc7a"
+      },
+      {
+        "name": "/93af471dce34e270324e5ff6bd60864987c21a1583896d6c3be28fa04596702d"
+      },
+      {
+        "name": "/95d825d9028d9d2cec80026bce445d51252b74ae3883e104f79533c4b503e95d"
+      },
+      {
+        "name": "/a5154bd791e0772090b639a8258cb66844435b1fc21d093e8ca9c69560925a0f"
+      },
+      {
+        "name": "/b32dbc427781a0518bd93d604a2192117eba2cf95f7b005e2aa68949f4c1ca21"
+      },
+      {
+        "name": "/c527db6142bf0d1c59144e7ca560d87cd61898522543ae3c97a6c3c13deec61e"
+      },
+      {
+        "name": "/cff492f36458780b0a8d2087a15f01508ea8f2047e32d91de7713caadcee2925"
+      },
+      {
+        "name": "/d77f3323403c90613e2af712c054e6322ceeb1eccb85c54eacfa61b7f7ed1e49"
+      },
+      {
+        "name": "/docker-daemon"
+      },
+      {
+        "name": "/e417974bac19012b5e529150d5143a587d359fe95669651461be6ecbf70b4d48"
+      },
+      {
+        "name": "/kubelet"
+      },
+      {
+        "name": "/system"
+      }
+    ],
+    "spec": {
+      "creation_time": "2016-06-03T18:08:06.908607Z",
+      "has_cpu": true,
+      "cpu": {
+        "limit": 1024,
+        "max_limit": 0,
+        "mask": "0-1"
+      },
+      "has_memory": true,
+      "memory": {
+        "limit": 7864135680
+      },
+      "has_network": true,
+      "has_filesystem": true,
+      "has_diskio": true,
+      "has_custom_metrics": false
+    },
+    "stats": [
+      {
+        "timestamp": "2016-06-17T16:05:56.340368492Z",
+        "cpu": {
+          "usage": {
+            "total": 179042041063101,
+            "per_cpu_usage": [
+              93200485881604,
+              85841555181497
+            ],
+            "user": 54180060000000,
+            "system": 24269760000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18377934848,
+                "Read": 192600064,
+                "Sync": 60708503552,
+                "Total": 79086438400,
+                "Write": 78893838336
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2671941,
+                "Read": 7783,
+                "Sync": 4867950,
+                "Total": 7539891,
+                "Write": 7532108
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154465700
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12745689693976,
+                "Read": 11861990478,
+                "Sync": 5277324407048,
+                "Total": 18023014101024,
+                "Write": 18011152110546
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866609812853,
+                "Read": 8519871772,
+                "Sync": 18427163373106,
+                "Total": 21293773185959,
+                "Write": 21285253314187
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15242069
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3849244672,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1948114944,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15010981908,
+          "rx_packets": 23100180,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487196318,
+          "tx_packets": 25882767,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15010981908,
+              "rx_packets": 23100180,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487196318,
+              "tx_packets": 25882767,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295416867,
+              "rx_packets": 29315400,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26578448003,
+              "tx_packets": 24711003,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037447680,
+            "base_usage": 0,
+            "available": 97096818688,
+            "inodes_free": 6452350,
+            "reads_completed": 7298,
+            "reads_merged": 665,
+            "sectors_read": 371906,
+            "read_time": 19932,
+            "writes_completed": 9953743,
+            "writes_merged": 10022113,
+            "sectors_written": 173462608,
+            "write_time": 42514100,
+            "io_in_progress": 0,
+            "io_time": 30343812,
+            "weighted_io_time": 42533336
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:07.395683905Z",
+        "cpu": {
+          "usage": {
+            "total": 179043530512776,
+            "per_cpu_usage": [
+              93201252697084,
+              85842277815692
+            ],
+            "user": 54180450000000,
+            "system": 24269920000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18377967616,
+                "Read": 192600064,
+                "Sync": 60709015552,
+                "Total": 79086983168,
+                "Write": 78894383104
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2671949,
+                "Read": 7783,
+                "Sync": 4867994,
+                "Total": 7539943,
+                "Write": 7532160
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154466764
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12745696647304,
+                "Read": 11861990478,
+                "Sync": 5277361175313,
+                "Total": 18023057822617,
+                "Write": 18011195832139
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866609909691,
+                "Read": 8519871772,
+                "Sync": 18427331809977,
+                "Total": 21293941719668,
+                "Write": 21285421847896
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15242207
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3850002432,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1948868608,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15011182316,
+          "rx_packets": 23100566,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487258895,
+          "tx_packets": 25883139,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15011182316,
+              "rx_packets": 23100566,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487258895,
+              "tx_packets": 25883139,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295468713,
+              "rx_packets": 29315686,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26578642729,
+              "tx_packets": 24711247,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037480448,
+            "base_usage": 0,
+            "available": 97096785920,
+            "inodes_free": 6452350,
+            "reads_completed": 7298,
+            "reads_merged": 665,
+            "sectors_read": 371906,
+            "read_time": 19932,
+            "writes_completed": 9953817,
+            "writes_merged": 10022193,
+            "sectors_written": 173463848,
+            "write_time": 42514368,
+            "io_in_progress": 0,
+            "io_time": 30344080,
+            "weighted_io_time": 42533604
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:27.391689204Z",
+        "cpu": {
+          "usage": {
+            "total": 179046568018248,
+            "per_cpu_usage": [
+              93202840116878,
+              85843727901370
+            ],
+            "user": 54181340000000,
+            "system": 24270480000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18378987520,
+                "Read": 193189888,
+                "Sync": 60710166528,
+                "Total": 79089154048,
+                "Write": 78895964160
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2672077,
+                "Read": 7832,
+                "Sync": 4868075,
+                "Total": 7540152,
+                "Write": 7532320
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154471004
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12746543126199,
+                "Read": 12104395454,
+                "Sync": 5277434916980,
+                "Total": 18023978043179,
+                "Write": 18011873647725
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866612975632,
+                "Read": 8520268655,
+                "Sync": 18427657144392,
+                "Total": 21294270120024,
+                "Write": 21285749851369
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15242502
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3855687680,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1954549760,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15011464513,
+          "rx_packets": 23101224,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487376574,
+          "tx_packets": 25883836,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15011464513,
+              "rx_packets": 23101224,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487376574,
+              "tx_packets": 25883836,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295559318,
+              "rx_packets": 29316192,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26579154760,
+              "tx_packets": 24711667,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037533696,
+            "base_usage": 0,
+            "available": 97096732672,
+            "inodes_free": 6452350,
+            "reads_completed": 7347,
+            "reads_merged": 665,
+            "sectors_read": 373058,
+            "read_time": 20168,
+            "writes_completed": 9954017,
+            "writes_merged": 10022406,
+            "sectors_written": 173467256,
+            "write_time": 42515376,
+            "io_in_progress": 0,
+            "io_time": 30344840,
+            "weighted_io_time": 42534848
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:42.169306136Z",
+        "cpu": {
+          "usage": {
+            "total": 179048706533910,
+            "per_cpu_usage": [
+              93204025336324,
+              85844681197586
+            ],
+            "user": 54181920000000,
+            "system": 24270750000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18379065344,
+                "Read": 193189888,
+                "Sync": 60710838272,
+                "Total": 79089903616,
+                "Write": 78896713728
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2672092,
+                "Read": 7832,
+                "Sync": 4868133,
+                "Total": 7540225,
+                "Write": 7532393
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154472468
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12746561033226,
+                "Read": 12104395454,
+                "Sync": 5277488165199,
+                "Total": 18024049198425,
+                "Write": 18011944802971
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866613139955,
+                "Read": 8520268655,
+                "Sync": 18427875822195,
+                "Total": 21294488962150,
+                "Write": 21285968693495
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15242678
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3851542528,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1950404608,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15011544108,
+          "rx_packets": 23101532,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487436320,
+          "tx_packets": 25884153,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15011544108,
+              "rx_packets": 23101532,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487436320,
+              "tx_packets": 25884153,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295608099,
+              "rx_packets": 29316451,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26579217854,
+              "tx_packets": 24711874,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037500928,
+            "base_usage": 0,
+            "available": 97096765440,
+            "inodes_free": 6452348,
+            "reads_completed": 7347,
+            "reads_merged": 665,
+            "sectors_read": 373058,
+            "read_time": 20168,
+            "writes_completed": 9954119,
+            "writes_merged": 10022511,
+            "sectors_written": 173468952,
+            "write_time": 42515732,
+            "io_in_progress": 0,
+            "io_time": 30345196,
+            "weighted_io_time": 42535204
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:59.618565812Z",
+        "cpu": {
+          "usage": {
+            "total": 179051236542906,
+            "per_cpu_usage": [
+              93205314439243,
+              85845922103663
+            ],
+            "user": 54182770000000,
+            "system": 24271090000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18382309376,
+                "Read": 196163584,
+                "Sync": 60711763968,
+                "Total": 79094073344,
+                "Write": 78897909760
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2672402,
+                "Read": 8095,
+                "Sync": 4868203,
+                "Total": 7540605,
+                "Write": 7532510
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154480612
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12747384571506,
+                "Read": 12674566395,
+                "Sync": 5277546702522,
+                "Total": 18024931274028,
+                "Write": 18012256707633
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866623224311,
+                "Read": 8528414280,
+                "Sync": 18428240734510,
+                "Total": 21294863958821,
+                "Write": 21286335544541
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15243055
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3870437376,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1969303552,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15011706862,
+          "rx_packets": 23102117,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487523080,
+          "tx_packets": 25884707,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15011706862,
+              "rx_packets": 23102117,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487523080,
+              "tx_packets": 25884707,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295671774,
+              "rx_packets": 29316833,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26579663262,
+              "tx_packets": 24712182,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037550080,
+            "base_usage": 0,
+            "available": 97096716288,
+            "inodes_free": 6452350,
+            "reads_completed": 7610,
+            "reads_merged": 665,
+            "sectors_read": 378866,
+            "read_time": 20740,
+            "writes_completed": 9954272,
+            "writes_merged": 10022677,
+            "sectors_written": 173471576,
+            "write_time": 42516464,
+            "io_in_progress": 0,
+            "io_time": 30346220,
+            "weighted_io_time": 42536508
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:10.211012449Z",
+        "cpu": {
+          "usage": {
+            "total": 179052786041383,
+            "per_cpu_usage": [
+              93206161600436,
+              85846624440947
+            ],
+            "user": 54183210000000,
+            "system": 24271310000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18382325760,
+                "Read": 196163584,
+                "Sync": 60712280064,
+                "Total": 79094605824,
+                "Write": 78898442240
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2672406,
+                "Read": 8095,
+                "Sync": 4868245,
+                "Total": 7540651,
+                "Write": 7532556
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154481652
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12747387670643,
+                "Read": 12674566395,
+                "Sync": 5277582536121,
+                "Total": 18024970206764,
+                "Write": 18012295640369
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866623304691,
+                "Read": 8528414280,
+                "Sync": 18428401571755,
+                "Total": 21295024876446,
+                "Write": 21286496462166
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15243168
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3870306304,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1969172480,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15011873809,
+          "rx_packets": 23102557,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487589710,
+          "tx_packets": 25885119,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15011873809,
+              "rx_packets": 23102557,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487589710,
+              "tx_packets": 25885119,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295725082,
+              "rx_packets": 29317139,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26579820478,
+              "tx_packets": 24712437,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037574656,
+            "base_usage": 0,
+            "available": 97096691712,
+            "inodes_free": 6452348,
+            "reads_completed": 7610,
+            "reads_merged": 665,
+            "sectors_read": 378866,
+            "read_time": 20740,
+            "writes_completed": 9954339,
+            "writes_merged": 10022761,
+            "sectors_written": 173472784,
+            "write_time": 42516720,
+            "io_in_progress": 0,
+            "io_time": 30346476,
+            "weighted_io_time": 42536764
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:21.214787552Z",
+        "cpu": {
+          "usage": {
+            "total": 179054329110335,
+            "per_cpu_usage": [
+              93206896270740,
+              85847432839595
+            ],
+            "user": 54183850000000,
+            "system": 24271560000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18382723072,
+                "Read": 196163584,
+                "Sync": 60712935424,
+                "Total": 79095658496,
+                "Write": 78899494912
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2672465,
+                "Read": 8095,
+                "Sync": 4868290,
+                "Total": 7540755,
+                "Write": 7532660
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154483708
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12747806674999,
+                "Read": 12674566395,
+                "Sync": 5277621162064,
+                "Total": 18025427837063,
+                "Write": 18012753270668
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866626274496,
+                "Read": 8528414280,
+                "Sync": 18428578071212,
+                "Total": 21295204345708,
+                "Write": 21286675931428
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15243286
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3854356480,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1953222656,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15012051337,
+          "rx_packets": 23102848,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487638692,
+          "tx_packets": 25885414,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15012051337,
+              "rx_packets": 23102848,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487638692,
+              "tx_packets": 25885414,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295767620,
+              "rx_packets": 29317409,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26580250840,
+              "tx_packets": 24712660,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037599232,
+            "base_usage": 0,
+            "available": 97096667136,
+            "inodes_free": 6452350,
+            "reads_completed": 7610,
+            "reads_merged": 665,
+            "sectors_read": 378866,
+            "read_time": 20740,
+            "writes_completed": 9954465,
+            "writes_merged": 10022913,
+            "sectors_written": 173475016,
+            "write_time": 42517336,
+            "io_in_progress": 0,
+            "io_time": 30346760,
+            "weighted_io_time": 42537380
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:34.68462852Z",
+        "cpu": {
+          "usage": {
+            "total": 179055886272683,
+            "per_cpu_usage": [
+              93207725236369,
+              85848161036314
+            ],
+            "user": 54184390000000,
+            "system": 24271740000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18382854144,
+                "Read": 196163584,
+                "Sync": 60713603072,
+                "Total": 79096457216,
+                "Write": 78900293632
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2672486,
+                "Read": 8095,
+                "Sync": 4868344,
+                "Total": 7540830,
+                "Write": 7532735
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154485268
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12747830692415,
+                "Read": 12674566395,
+                "Sync": 5277667632724,
+                "Total": 18025498325139,
+                "Write": 18012823758744
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866626460503,
+                "Read": 8528414280,
+                "Sync": 18428787988281,
+                "Total": 21295414448784,
+                "Write": 21286886034504
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15243470
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3854516224,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1953378304,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15012206451,
+          "rx_packets": 23103347,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10487982441,
+          "tx_packets": 25885949,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15012206451,
+              "rx_packets": 23103347,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10487982441,
+              "tx_packets": 25885949,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295839126,
+              "rx_packets": 29317789,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26580662832,
+              "tx_packets": 24712962,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037619712,
+            "base_usage": 0,
+            "available": 97096646656,
+            "inodes_free": 6452350,
+            "reads_completed": 7610,
+            "reads_merged": 665,
+            "sectors_read": 378866,
+            "read_time": 20740,
+            "writes_completed": 9954567,
+            "writes_merged": 10023021,
+            "sectors_written": 173476792,
+            "write_time": 42517664,
+            "io_in_progress": 0,
+            "io_time": 30347088,
+            "weighted_io_time": 42537708
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:50.026851815Z",
+        "cpu": {
+          "usage": {
+            "total": 179058059341746,
+            "per_cpu_usage": [
+              93208756590673,
+              85849302751073
+            ],
+            "user": 54185060000000,
+            "system": 24272070000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 18382895104,
+                "Read": 196163584,
+                "Sync": 60714319872,
+                "Total": 79097214976,
+                "Write": 78901051392
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2672495,
+                "Read": 8095,
+                "Sync": 4868406,
+                "Total": 7540901,
+                "Write": 7532806
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 154486748
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12747838785738,
+                "Read": 12674566395,
+                "Sync": 5277718029508,
+                "Total": 18025556815246,
+                "Write": 18012882248851
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 2866626590137,
+                "Read": 8528414280,
+                "Sync": 18429027490183,
+                "Total": 21295654080320,
+                "Write": 21287125666040
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 36393,
+                "Read": 712,
+                "Sync": 72,
+                "Total": 36465,
+                "Write": 35753
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 15243643
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 3854888960,
+          "cache": 1538514944,
+          "rss": 26042368,
+          "working_set": 1953751040,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          },
+          "hierarchical_data": {
+            "pgfault": 606358,
+            "pgmajfault": 888
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 15012305689,
+          "rx_packets": 23103617,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 10488381037,
+          "tx_packets": 25886314,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 15012305689,
+              "rx_packets": 23103617,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 10488381037,
+              "tx_packets": 25886314,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            },
+            {
+              "name": "cbr0",
+              "rx_bytes": 10295887677,
+              "rx_packets": 29318104,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 26581366889,
+              "tx_packets": 24713218,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 4037660672,
+            "base_usage": 0,
+            "available": 97096605696,
+            "inodes_free": 6452350,
+            "reads_completed": 7610,
+            "reads_merged": 665,
+            "sectors_read": 378866,
+            "read_time": 20740,
+            "writes_completed": 9954669,
+            "writes_merged": 10023134,
+            "sectors_written": 173478520,
+            "write_time": 42518036,
+            "io_in_progress": 0,
+            "io_time": 30347460,
+            "weighted_io_time": 42538080
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      }
+    ]
+  },
+  {
+    "id": "4f269da73287845650fce62e0b4ab40a76489e646a79d30a39ce961912f0833e",
+    "name": "/4f269da73287845650fce62e0b4ab40a76489e646a79d30a39ce961912f0833e",
+    "aliases": [
+      "k8s_POD.35220667_dd-agent-1rxlh_default_12c7be82-33ca-11e6-ac8f-42010af00003_f5cf585f",
+      "4f269da73287845650fce62e0b4ab40a76489e646a79d30a39ce961912f0833e"
+    ],
+    "namespace": "docker",
+    "labels": {
+      "io.kubernetes.container.hash": "35220667",
+      "io.kubernetes.container.name": "POD",
+      "io.kubernetes.container.restartCount": "0",
+      "io.kubernetes.container.terminationMessagePath": "",
+      "io.kubernetes.pod.name": "dd-agent-1rxlh",
+      "io.kubernetes.pod.namespace": "default",
+      "io.kubernetes.pod.terminationGracePeriod": "30",
+      "io.kubernetes.pod.uid": "12c7be82-33ca-11e6-ac8f-42010af00003"
+    },
+    "spec": {
+      "creation_time": "2016-06-16T13:56:07.429624077Z",
+      "labels": {
+        "io.kubernetes.container.hash": "35220667",
+        "io.kubernetes.container.name": "POD",
+        "io.kubernetes.container.restartCount": "0",
+        "io.kubernetes.container.terminationMessagePath": "",
+        "io.kubernetes.pod.name": "dd-agent-1rxlh",
+        "io.kubernetes.pod.namespace": "default",
+        "io.kubernetes.pod.terminationGracePeriod": "30",
+        "io.kubernetes.pod.uid": "12c7be82-33ca-11e6-ac8f-42010af00003"
+      },
+      "has_cpu": true,
+      "cpu": {
+        "limit": 2,
+        "max_limit": 0,
+        "mask": "0-1"
+      },
+      "has_memory": true,
+      "memory": {
+        "limit": 18446744073709551615,
+        "swap_limit": 18446744073709551615
+      },
+      "has_network": true,
+      "has_filesystem": true,
+      "has_diskio": true,
+      "has_custom_metrics": false,
+      "image": "gcr.io/google_containers/pause:2.0"
+    },
+    "stats": [
+      {
+        "timestamp": "2016-06-17T16:06:07.215780953Z",
+        "cpu": {
+          "usage": {
+            "total": 144151891,
+            "per_cpu_usage": [
+              82147059,
+              62004832
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1215086584,
+          "rx_packets": 433288,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 85937915,
+          "tx_packets": 474878,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1215086584,
+              "rx_packets": 433288,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 85937915,
+              "tx_packets": 474878,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:23.346328555Z",
+        "cpu": {
+          "usage": {
+            "total": 144195836,
+            "per_cpu_usage": [
+              82147059,
+              62048777
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1215421096,
+          "rx_packets": 433353,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 85946733,
+          "tx_packets": 474957,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1215421096,
+              "rx_packets": 433353,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 85946733,
+              "tx_packets": 474957,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:34.379448136Z",
+        "cpu": {
+          "usage": {
+            "total": 144195836,
+            "per_cpu_usage": [
+              82147059,
+              62048777
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1215445040,
+          "rx_packets": 433415,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 85963763,
+          "tx_packets": 475020,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1215445040,
+              "rx_packets": 433415,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 85963763,
+              "tx_packets": 475020,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:45.228077482Z",
+        "cpu": {
+          "usage": {
+            "total": 144195836,
+            "per_cpu_usage": [
+              82147059,
+              62048777
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1215778374,
+          "rx_packets": 433480,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 85972174,
+          "tx_packets": 475095,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1215778374,
+              "rx_packets": 433480,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 85972174,
+              "tx_packets": 475095,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:58.687312616Z",
+        "cpu": {
+          "usage": {
+            "total": 144195836,
+            "per_cpu_usage": [
+              82147059,
+              62048777
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1215794444,
+          "rx_packets": 433523,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 85985319,
+          "tx_packets": 475139,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1215794444,
+              "rx_packets": 433523,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 85985319,
+              "tx_packets": 475139,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:16.871361033Z",
+        "cpu": {
+          "usage": {
+            "total": 144237834,
+            "per_cpu_usage": [
+              82147059,
+              62090775
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1216135061,
+          "rx_packets": 433608,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 85997868,
+          "tx_packets": 475237,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1216135061,
+              "rx_packets": 433608,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 85997868,
+              "tx_packets": 475237,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:35.339682222Z",
+        "cpu": {
+          "usage": {
+            "total": 144237834,
+            "per_cpu_usage": [
+              82147059,
+              62090775
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1216449517,
+          "rx_packets": 433697,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 86017114,
+          "tx_packets": 475330,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1216449517,
+              "rx_packets": 433697,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 86017114,
+              "tx_packets": 475330,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:55.23647675Z",
+        "cpu": {
+          "usage": {
+            "total": 144237834,
+            "per_cpu_usage": [
+              82147059,
+              62090775
+            ],
+            "user": 50000000,
+            "system": 20000000
+          },
+          "load_average": 0
+        },
+        "diskio": {},
+        "memory": {
+          "usage": 1482752,
+          "cache": 12288,
+          "rss": 1470464,
+          "working_set": 1482752,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          },
+          "hierarchical_data": {
+            "pgfault": 2158,
+            "pgmajfault": 0
+          }
+        },
+        "network": {
+          "name": "eth0",
+          "rx_bytes": 1217092163,
+          "rx_packets": 433830,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 86040599,
+          "tx_packets": 475476,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "interfaces": [
+            {
+              "name": "eth0",
+              "rx_bytes": 1217092163,
+              "rx_packets": 433830,
+              "rx_errors": 0,
+              "rx_dropped": 0,
+              "tx_bytes": 86040599,
+              "tx_packets": 475476,
+              "tx_errors": 0,
+              "tx_dropped": 0
+            }
+          ],
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "filesystem": [
+          {
+            "device": "/dev/sda1",
+            "type": "vfs",
+            "capacity": 105553100800,
+            "usage": 40960,
+            "base_usage": 12288,
+            "available": 0,
+            "inodes_free": 0,
+            "reads_completed": 0,
+            "reads_merged": 0,
+            "sectors_read": 0,
+            "read_time": 0,
+            "writes_completed": 0,
+            "writes_merged": 0,
+            "sectors_written": 0,
+            "write_time": 0,
+            "io_in_progress": 0,
+            "io_time": 0,
+            "weighted_io_time": 0
+          }
+        ],
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      }
+    ]
+  },
+  {
+    "name": "/kubelet",
+    "spec": {
+      "creation_time": "2016-06-03T18:09:19.215272Z",
+      "has_cpu": true,
+      "cpu": {
+        "limit": 1024,
+        "max_limit": 0,
+        "mask": "0-1"
+      },
+      "has_memory": true,
+      "memory": {
+        "limit": 18446744073709551615
+      },
+      "has_network": false,
+      "has_filesystem": false,
+      "has_diskio": true,
+      "has_custom_metrics": false
+    },
+    "stats": [
+      {
+        "timestamp": "2016-06-17T16:06:00.948755171Z",
+        "cpu": {
+          "usage": {
+            "total": 16123089672810,
+            "per_cpu_usage": [
+              8035337123629,
+              8087752549181
+            ],
+            "user": 9728340000000,
+            "system": 6800630000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28196864,
+          "cache": 2928640,
+          "rss": 25137152,
+          "working_set": 28028928,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958270167,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958270167,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:12.173521573Z",
+        "cpu": {
+          "usage": {
+            "total": 16123237019970,
+            "per_cpu_usage": [
+              8035399671598,
+              8087837348372
+            ],
+            "user": 9728410000000,
+            "system": 6800710000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28065792,
+          "cache": 2928640,
+          "rss": 25137152,
+          "working_set": 27897856,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958277439,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958277439,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:26.767741807Z",
+        "cpu": {
+          "usage": {
+            "total": 16123487061408,
+            "per_cpu_usage": [
+              8035498502302,
+              8087988559106
+            ],
+            "user": 9728520000000,
+            "system": 6800840000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28188672,
+          "cache": 2928640,
+          "rss": 25137152,
+          "working_set": 28020736,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958294283,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958294283,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:42.532779778Z",
+        "cpu": {
+          "usage": {
+            "total": 16123637588626,
+            "per_cpu_usage": [
+              8035570853507,
+              8088066735119
+            ],
+            "user": 9728600000000,
+            "system": 6800900000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28151808,
+          "cache": 2928640,
+          "rss": 25137152,
+          "working_set": 27983872,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958300819,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958300819,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:06:58.57437104Z",
+        "cpu": {
+          "usage": {
+            "total": 16123912176618,
+            "per_cpu_usage": [
+              8035724584592,
+              8088187592026
+            ],
+            "user": 9728820000000,
+            "system": 6801000000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28188672,
+          "cache": 2928640,
+          "rss": 25137152,
+          "working_set": 28020736,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958316092,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958316092,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:11.831640168Z",
+        "cpu": {
+          "usage": {
+            "total": 16124089954108,
+            "per_cpu_usage": [
+              8035827605670,
+              8088262348438
+            ],
+            "user": 9728920000000,
+            "system": 6801080000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28065792,
+          "cache": 2928640,
+          "rss": 25137152,
+          "working_set": 27897856,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958327494,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958327494,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:26.52679237Z",
+        "cpu": {
+          "usage": {
+            "total": 16124335383034,
+            "per_cpu_usage": [
+              8035944558049,
+              8088390824985
+            ],
+            "user": 9729060000000,
+            "system": 6801170000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28192768,
+          "cache": 2932736,
+          "rss": 25137152,
+          "working_set": 28020736,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958342702,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958342702,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:37.023709829Z",
+        "cpu": {
+          "usage": {
+            "total": 16124475873350,
+            "per_cpu_usage": [
+              8036016777741,
+              8088459095609
+            ],
+            "user": 9729150000000,
+            "system": 6801230000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28164096,
+          "cache": 2932736,
+          "rss": 25137152,
+          "working_set": 27992064,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958350016,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958350016,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      },
+      {
+        "timestamp": "2016-06-17T16:07:51.445118458Z",
+        "cpu": {
+          "usage": {
+            "total": 16124680036088,
+            "per_cpu_usage": [
+              8036124966364,
+              8088555069724
+            ],
+            "user": 9729290000000,
+            "system": 6801320000000
+          },
+          "load_average": 0
+        },
+        "diskio": {
+          "io_service_bytes": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 798720,
+                "Read": 798720,
+                "Sync": 0,
+                "Total": 798720,
+                "Write": 0
+              }
+            }
+          ],
+          "io_serviced": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 89,
+                "Read": 89,
+                "Sync": 0,
+                "Total": 89,
+                "Write": 0
+              }
+            }
+          ],
+          "io_queued": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "sectors": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 1560
+              }
+            }
+          ],
+          "io_service_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 330895167,
+                "Read": 330895167,
+                "Sync": 0,
+                "Total": 330895167,
+                "Write": 0
+              }
+            }
+          ],
+          "io_wait_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 12565416,
+                "Read": 12565416,
+                "Sync": 0,
+                "Total": 12565416,
+                "Write": 0
+              }
+            }
+          ],
+          "io_merged": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Async": 0,
+                "Read": 0,
+                "Sync": 0,
+                "Total": 0,
+                "Write": 0
+              }
+            }
+          ],
+          "io_time": [
+            {
+              "major": 8,
+              "minor": 0,
+              "stats": {
+                "Count": 37
+              }
+            }
+          ]
+        },
+        "memory": {
+          "usage": 28364800,
+          "cache": 2932736,
+          "rss": 25309184,
+          "working_set": 28196864,
+          "failcnt": 0,
+          "container_data": {
+            "pgfault": 958361262,
+            "pgmajfault": 5
+          },
+          "hierarchical_data": {
+            "pgfault": 958361262,
+            "pgmajfault": 5
+          }
+        },
+        "network": {
+          "name": "",
+          "rx_bytes": 0,
+          "rx_packets": 0,
+          "rx_errors": 0,
+          "rx_dropped": 0,
+          "tx_bytes": 0,
+          "tx_packets": 0,
+          "tx_errors": 0,
+          "tx_dropped": 0,
+          "tcp": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          },
+          "tcp6": {
+            "Established": 0,
+            "SynSent": 0,
+            "SynRecv": 0,
+            "FinWait1": 0,
+            "FinWait2": 0,
+            "TimeWait": 0,
+            "Close": 0,
+            "CloseWait": 0,
+            "LastAck": 0,
+            "Listen": 0,
+            "Closing": 0
+          }
+        },
+        "task_stats": {
+          "nr_sleeping": 0,
+          "nr_running": 0,
+          "nr_stopped": 0,
+          "nr_uninterruptible": 0,
+          "nr_io_wait": 0
+        }
+      }
+    ]
+  }
+]

--- a/tests/checks/fixtures/kubernetes/pods_list_1.2.json
+++ b/tests/checks/fixtures/kubernetes/pods_list_1.2.json
@@ -140,7 +140,9 @@
         "resourceVersion": "456745",
         "creationTimestamp": "2016-06-16T13:56:07Z",
         "labels": {
-          "app": "dd-agent"
+          "app": "dd-agent",
+          "foo": "bar",
+          "bar": "baz"
         },
         "annotations": {
           "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"dd-agent\",\"uid\":\"12c56a58-33ca-11e6-ac8f-42010af00003\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"456736\"}}\n"
@@ -294,7 +296,8 @@
         "resourceVersion": "456747",
         "creationTimestamp": "2016-06-16T13:56:07Z",
         "labels": {
-          "app": "dd-agent"
+          "app": "dd-agent",
+          "k8s-app": "api"
         },
         "annotations": {
           "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"dd-agent\",\"uid\":\"12c56a58-33ca-11e6-ac8f-42010af00003\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"456736\"}}\n"

--- a/tests/checks/fixtures/kubernetes/pods_list_1.2.json
+++ b/tests/checks/fixtures/kubernetes/pods_list_1.2.json
@@ -1,595 +1,596 @@
 {
-   "kind":"PodList",
-   "apiVersion":"v1",
-   "metadata":{
-
-   },
-   "items":[
-      {
-         "metadata":{
-            "name":"fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node-29lx",
-            "namespace":"kube-system",
-            "selfLink":"/api/v1/pods/namespaces/fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node-29lx/kube-system",
-            "uid":"da7e41ef0372c29c65a24b417b5dd69f",
-            "creationTimestamp":null,
-            "labels":{
-               "k8s-app":"fluentd-logging"
-            },
-            "annotations":{
-               "kubernetes.io/config.hash":"da7e41ef0372c29c65a24b417b5dd69f",
-               "kubernetes.io/config.seen":"2016-03-22T20:25:12.519676312Z",
-               "kubernetes.io/config.source":"file"
-            }
-         },
-         "spec":{
-            "volumes":[
-               {
-                  "name":"varlog",
-                  "hostPath":{
-                     "path":"/var/log"
-                  }
-               },
-               {
-                  "name":"varlibdockercontainers",
-                  "hostPath":{
-                     "path":"/var/lib/docker/containers"
-                  }
-               }
-            ],
-            "containers":[
-               {
-                  "name":"fluentd-cloud-logging",
-                  "image":"gcr.io/google_containers/fluentd-gcp:1.18",
-                  "env":[
-                     {
-                        "name":"FLUENTD_ARGS",
-                        "value":"-q"
-                     }
-                  ],
-                  "resources":{
-                     "limits":{
-                        "memory":"200Mi"
-                     },
-                     "requests":{
-                        "cpu":"100m",
-                        "memory":"200Mi"
-                     }
-                  },
-                  "volumeMounts":[
-                     {
-                        "name":"varlog",
-                        "mountPath":"/var/log"
-                     },
-                     {
-                        "name":"varlibdockercontainers",
-                        "readOnly":true,
-                        "mountPath":"/var/lib/docker/containers"
-                     }
-                  ],
-                  "terminationMessagePath":"/dev/termination-log",
-                  "imagePullPolicy":"IfNotPresent"
-               }
-            ],
-            "restartPolicy":"Always",
-            "terminationGracePeriodSeconds":30,
-            "dnsPolicy":"Default",
-            "nodeName":"gke-cluster-remi-62c0dd29-node-29lx",
-            "securityContext":{
-
-            }
-         },
-         "status":{
-            "phase":"Pending"
-         }
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/namespaces/default/pods",
+    "resourceVersion": "495497"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "dd-agent",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/dd-agent",
+        "uid": "ca906dc1-29bd-11e6-ac8f-42010af00003",
+        "resourceVersion": "1522",
+        "creationTimestamp": "2016-06-03T19:03:00Z",
+        "annotations": {
+          "kubernetes.io/limit-ranger": "LimitRanger plugin set: cpu request for container dd-agent"
+        }
       },
-      {
-         "metadata":{
-            "name":"kube-proxy-gke-cluster-remi-62c0dd29-node-29lx",
-            "namespace":"kube-system",
-            "selfLink":"/api/v1/pods/namespaces/kube-proxy-gke-cluster-remi-62c0dd29-node-29lx/kube-system",
-            "uid":"f70c43857a22d5495bf204918d5ab984",
-            "creationTimestamp":null,
-            "annotations":{
-               "kubernetes.io/config.hash":"f70c43857a22d5495bf204918d5ab984",
-               "kubernetes.io/config.seen":"2016-03-22T20:25:12.519684352Z",
-               "kubernetes.io/config.source":"file"
+      "spec": {
+        "volumes": [
+          {
+            "name": "dockersocket",
+            "hostPath": {
+              "path": "/var/run/docker.sock"
             }
-         },
-         "spec":{
-            "volumes":[
-               {
-                  "name":"ssl-certs-host",
-                  "hostPath":{
-                     "path":"/usr/share/ca-certificates"
-                  }
-               },
-               {
-                  "name":"kubeconfig",
-                  "hostPath":{
-                     "path":"/var/lib/kube-proxy/kubeconfig"
-                  }
-               },
-               {
-                  "name":"varlog",
-                  "hostPath":{
-                     "path":"/var/log"
-                  }
-               }
-            ],
-            "containers":[
-               {
-                  "name":"kube-proxy",
-                  "image":"gcr.io/google_containers/kube-proxy:6a3c7bde4710fbeb04cee371779c437b",
-                  "command":[
-                     "/bin/sh",
-                     "-c",
-                     "kube-proxy --master=https://104.196.117.120 --kubeconfig=/var/lib/kube-proxy/kubeconfig --resource-container=\"\" --v=2  1\u003e\u003e/var/log/kube-proxy.log 2\u003e\u00261"
-                  ],
-                  "resources":{
-                     "requests":{
-                        "cpu":"200m"
-                     }
-                  },
-                  "volumeMounts":[
-                     {
-                        "name":"ssl-certs-host",
-                        "readOnly":true,
-                        "mountPath":"/etc/ssl/certs"
-                     },
-                     {
-                        "name":"varlog",
-                        "mountPath":"/var/log"
-                     },
-                     {
-                        "name":"kubeconfig",
-                        "mountPath":"/var/lib/kube-proxy/kubeconfig"
-                     }
-                  ],
-                  "terminationMessagePath":"/dev/termination-log",
-                  "imagePullPolicy":"IfNotPresent",
-                  "securityContext":{
-                     "privileged":true
-                  }
-               }
-            ],
-            "restartPolicy":"Always",
-            "terminationGracePeriodSeconds":30,
-            "dnsPolicy":"ClusterFirst",
-            "nodeName":"gke-cluster-remi-62c0dd29-node-29lx",
-            "hostNetwork":true,
-            "securityContext":{
-
+          },
+          {
+            "name": "procdir",
+            "hostPath": {
+              "path": "/proc"
             }
-         },
-         "status":{
-            "phase":"Pending"
-         }
-      },
-      {
-         "metadata":{
-            "name":"dd-agent-idydc",
-            "generateName":"dd-agent-",
-            "namespace":"default",
-            "selfLink":"/api/v1/namespaces/default/pods/dd-agent-idydc",
-            "uid":"adecdd57-f5c3-11e5-8f7c-42010af00098",
-            "resourceVersion":"173802",
-            "creationTimestamp":"2016-03-29T15:34:09Z",
-            "labels":{
-               "app":"dd-agent"
+          },
+          {
+            "name": "cgroups",
+            "hostPath": {
+              "path": "/sys/fs/cgroup"
+            }
+          },
+          {
+            "name": "default-token-racjk",
+            "secret": {
+              "secretName": "default-token-racjk"
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "dd-agent",
+            "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+            "ports": [
+              {
+                "name": "dogstatsdport",
+                "containerPort": 8125,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "PROBE_MODE",
+                "value": "true"
+              },
+              {
+                "name": "API_KEY",
+                "value": "51bdfb1e67a5b2097feeed5603f3cc7d"
+              },
+              {
+                "name": "SD_BACKEND",
+                "value": "docker"
+              },
+              {
+                "name": "SD_CONFIG_BACKEND",
+                "value": "etcd"
+              },
+              {
+                "name": "SD_BACKEND_HOST",
+                "value": "etcd-client"
+              },
+              {
+                "name": "SD_BACKEND_PORT",
+                "value": "2379"
+              },
+              {
+                "name": "LOG_LEVEL",
+                "value": "DEBUG"
+              }
+            ],
+            "resources": {
+              "requests": {
+                "cpu": "100m"
+              }
             },
-            "annotations":{
-               "kubernetes.io/config.seen":"2016-03-29T15:34:09.245209062Z",
-               "kubernetes.io/config.source":"api",
-               "kubernetes.io/created-by":"{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"dd-agent\",\"uid\":\"ade9d2d0-f5c3-11e5-8f7c-42010af00098\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"173799\"}}\n",
-               "kubernetes.io/limit-ranger":"LimitRanger plugin set: cpu request for container dd-agent"
-            }
-         },
-         "spec":{
-            "volumes":[
-               {
-                  "name":"dockersocket",
-                  "hostPath":{
-                     "path":"/var/run/docker.sock"
-                  }
-               },
-               {
-                  "name":"procdir",
-                  "hostPath":{
-                     "path":"/proc"
-                  }
-               },
-               {
-                  "name":"cgroups",
-                  "hostPath":{
-                     "path":"/sys/fs/cgroup"
-                  }
-               },
-               {
-                  "name":"default-token-tns4s",
-                  "secret":{
-                     "secretName":"default-token-tns4s"
-                  }
-               }
+            "volumeMounts": [
+              {
+                "name": "dockersocket",
+                "mountPath": "/var/run/docker.sock"
+              },
+              {
+                "name": "procdir",
+                "readOnly": true,
+                "mountPath": "/host/proc"
+              },
+              {
+                "name": "cgroups",
+                "readOnly": true,
+                "mountPath": "/host/sys/fs/cgroup"
+              },
+              {
+                "name": "default-token-racjk",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
             ],
-            "containers":[
-               {
-                  "name":"dd-agent",
-                  "image":"datadog/docker-dd-agent:kubernetes",
-                  "ports":[
-                     {
-                        "name":"dogstatsdport",
-                        "containerPort":8125,
-                        "protocol":"TCP"
-                     }
-                  ],
-                  "env":[
-                     {
-                        "name":"API_KEY",
-                        "value":"ff1801f67d79c9bce59eb9870e688eb1"
-                     }
-                  ],
-                  "resources":{
-                     "requests":{
-                        "cpu":"100m"
-                     }
-                  },
-                  "volumeMounts":[
-                     {
-                        "name":"dockersocket",
-                        "mountPath":"/var/run/docker.sock"
-                     },
-                     {
-                        "name":"procdir",
-                        "readOnly":true,
-                        "mountPath":"/host/proc"
-                     },
-                     {
-                        "name":"cgroups",
-                        "readOnly":true,
-                        "mountPath":"/host/sys/fs/cgroup"
-                     },
-                     {
-                        "name":"default-token-tns4s",
-                        "readOnly":true,
-                        "mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"
-                     }
-                  ],
-                  "terminationMessagePath":"/dev/termination-log",
-                  "imagePullPolicy":"Always"
-               }
-            ],
-            "restartPolicy":"Always",
-            "terminationGracePeriodSeconds":30,
-            "dnsPolicy":"ClusterFirst",
-            "serviceAccountName":"default",
-            "serviceAccount":"default",
-            "nodeName":"gke-cluster-remi-62c0dd29-node-29lx",
-            "securityContext":{
-
-            }
-         },
-         "status":{
-            "phase":"Running",
-            "conditions":[
-               {
-                  "type":"Ready",
-                  "status":"True",
-                  "lastProbeTime":null,
-                  "lastTransitionTime":"2016-03-29T15:34:10Z"
-               }
-            ],
-            "hostIP":"10.142.0.4",
-            "podIP":"10.88.0.3",
-            "startTime":"2016-03-29T15:34:09Z",
-            "containerStatuses":[
-               {
-                  "name":"dd-agent",
-                  "state":{
-                     "running":{
-                        "startedAt":"2016-03-29T15:34:10Z"
-                     }
-                  },
-                  "lastState":{
-
-                  },
-                  "ready":true,
-                  "restartCount":0,
-                  "image":"datadog/docker-dd-agent:kubernetes",
-                  "imageID":"docker://0a79b3a531ebf4654cb586cce3b570c2f61c9af9d907c8f344a9f61b554005d8",
-                  "containerID":"docker://ef20f4bb10087c626aae1fb32db18c3f8cee0d57f9acc63c85126d3294f1c659"
-               }
-            ]
-         }
+            "terminationMessagePath": "/dev/termination-log",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "nodeSelector": {
+          "ddagent": "probe"
+        },
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "securityContext": {}
       },
-      {
-         "metadata":{
-            "name":"kube-dns-v11-63tae",
-            "generateName":"kube-dns-v11-",
-            "namespace":"kube-system",
-            "selfLink":"/api/v1/namespaces/kube-system/pods/kube-dns-v11-63tae",
-            "uid":"5754714c-0054-11e6-9a89-42010af00098",
-            "resourceVersion":"516964",
-            "creationTimestamp":"2016-04-12T02:14:52Z",
-            "labels":{
-               "k8s-app":"kube-dns",
-               "kubernetes.io/cluster-service":"true",
-               "version":"v11"
-            },
-            "annotations":{
-               "kubernetes.io/config.seen":"2016-04-12T02:27:25.666678734Z",
-               "kubernetes.io/config.source":"api",
-               "kubernetes.io/created-by":"{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicationController\",\"namespace\":\"kube-system\",\"name\":\"kube-dns-v11\",\"uid\":\"41ccbc8b-f06c-11e5-8f7c-42010af00098\",\"apiVersion\":\"v1\",\"resourceVersion\":\"61\"}}\n"
-            }
-         },
-         "spec":{
-            "volumes":[
-               {
-                  "name":"etcd-storage",
-                  "emptyDir":{
-
-                  }
-               },
-               {
-                  "name":"default-token-pxp20",
-                  "secret":{
-                     "secretName":"default-token-pxp20"
-                  }
-               }
-            ],
-            "containers":[
-               {
-                  "name":"etcd",
-                  "image":"gcr.io/google_containers/etcd-amd64:2.2.1",
-                  "command":[
-                     "/usr/local/bin/etcd",
-                     "-data-dir",
-                     "/var/etcd/data",
-                     "-listen-client-urls",
-                     "http://127.0.0.1:2379,http://127.0.0.1:4001",
-                     "-advertise-client-urls",
-                     "http://127.0.0.1:2379,http://127.0.0.1:4001",
-                     "-initial-cluster-token",
-                     "skydns-etcd"
-                  ],
-                  "resources":{
-                     "limits":{
-                        "cpu":"100m",
-                        "memory":"500Mi"
-                     },
-                     "requests":{
-                        "cpu":"100m",
-                        "memory":"50Mi"
-                     }
-                  },
-                  "volumeMounts":[
-                     {
-                        "name":"etcd-storage",
-                        "mountPath":"/var/etcd/data"
-                     },
-                     {
-                        "name":"default-token-pxp20",
-                        "readOnly":true,
-                        "mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"
-                     }
-                  ],
-                  "terminationMessagePath":"/dev/termination-log",
-                  "imagePullPolicy":"IfNotPresent"
-               },
-               {
-                  "name":"kube2sky",
-                  "image":"gcr.io/google_containers/kube2sky:1.14",
-                  "args":[
-                     "--domain=cluster.local"
-                  ],
-                  "resources":{
-                     "limits":{
-                        "cpu":"100m",
-                        "memory":"200Mi"
-                     },
-                     "requests":{
-                        "cpu":"100m",
-                        "memory":"50Mi"
-                     }
-                  },
-                  "volumeMounts":[
-                     {
-                        "name":"default-token-pxp20",
-                        "readOnly":true,
-                        "mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"
-                     }
-                  ],
-                  "livenessProbe":{
-                     "httpGet":{
-                        "path":"/healthz",
-                        "port":8080,
-                        "scheme":"HTTP"
-                     },
-                     "initialDelaySeconds":60,
-                     "timeoutSeconds":5,
-                     "periodSeconds":10,
-                     "successThreshold":1,
-                     "failureThreshold":5
-                  },
-                  "readinessProbe":{
-                     "httpGet":{
-                        "path":"/readiness",
-                        "port":8081,
-                        "scheme":"HTTP"
-                     },
-                     "initialDelaySeconds":30,
-                     "timeoutSeconds":5,
-                     "periodSeconds":10,
-                     "successThreshold":1,
-                     "failureThreshold":3
-                  },
-                  "terminationMessagePath":"/dev/termination-log",
-                  "imagePullPolicy":"IfNotPresent"
-               },
-               {
-                  "name":"skydns",
-                  "image":"gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
-                  "args":[
-                     "-machines=http://127.0.0.1:4001",
-                     "-addr=0.0.0.0:53",
-                     "-ns-rotate=false",
-                     "-domain=cluster.local."
-                  ],
-                  "ports":[
-                     {
-                        "name":"dns",
-                        "containerPort":53,
-                        "protocol":"UDP"
-                     },
-                     {
-                        "name":"dns-tcp",
-                        "containerPort":53,
-                        "protocol":"TCP"
-                     }
-                  ],
-                  "resources":{
-                     "limits":{
-                        "cpu":"100m",
-                        "memory":"200Mi"
-                     },
-                     "requests":{
-                        "cpu":"100m",
-                        "memory":"50Mi"
-                     }
-                  },
-                  "volumeMounts":[
-                     {
-                        "name":"default-token-pxp20",
-                        "readOnly":true,
-                        "mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"
-                     }
-                  ],
-                  "terminationMessagePath":"/dev/termination-log",
-                  "imagePullPolicy":"IfNotPresent"
-               },
-               {
-                  "name":"healthz",
-                  "image":"gcr.io/google_containers/exechealthz:1.0",
-                  "args":[
-                     "-cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 \u003e/dev/null",
-                     "-port=8080"
-                  ],
-                  "ports":[
-                     {
-                        "containerPort":8080,
-                        "protocol":"TCP"
-                     }
-                  ],
-                  "resources":{
-                     "limits":{
-                        "cpu":"10m",
-                        "memory":"20Mi"
-                     },
-                     "requests":{
-                        "cpu":"10m",
-                        "memory":"20Mi"
-                     }
-                  },
-                  "volumeMounts":[
-                     {
-                        "name":"default-token-pxp20",
-                        "readOnly":true,
-                        "mountPath":"/var/run/secrets/kubernetes.io/serviceaccount"
-                     }
-                  ],
-                  "terminationMessagePath":"/dev/termination-log",
-                  "imagePullPolicy":"IfNotPresent"
-               }
-            ],
-            "restartPolicy":"Always",
-            "terminationGracePeriodSeconds":30,
-            "dnsPolicy":"Default",
-            "serviceAccountName":"default",
-            "serviceAccount":"default",
-            "nodeName":"gke-cluster-remi-62c0dd29-node-29lx",
-            "securityContext":{
-
-            }
-         },
-         "status":{
-            "phase":"Running",
-            "conditions":[
-               {
-                  "type":"Ready",
-                  "status":"True",
-                  "lastProbeTime":null,
-                  "lastTransitionTime":"2016-04-12T02:28:05Z"
-               }
-            ],
-            "hostIP":"10.142.0.4",
-            "podIP":"10.88.0.4",
-            "startTime":"2016-04-12T02:27:25Z",
-            "containerStatuses":[
-               {
-                  "name":"etcd",
-                  "state":{
-                     "running":{
-                        "startedAt":"2016-04-12T02:27:31Z"
-                     }
-                  },
-                  "lastState":{
-
-                  },
-                  "ready":true,
-                  "restartCount":0,
-                  "image":"gcr.io/google_containers/etcd-amd64:2.2.1",
-                  "imageID":"docker://202873aab189580883e6e7ec9b1479989db6fe8ce91a34bc3b786eb3d5db57c2",
-                  "containerID":"docker://89ee50ff6005d47354ba8a252248623ebca0297d36de16387826373be9e52a17"
-               },
-               {
-                  "name":"healthz",
-                  "state":{
-                     "running":{
-                        "startedAt":"2016-04-12T02:27:29Z"
-                     }
-                  },
-                  "lastState":{
-
-                  },
-                  "ready":true,
-                  "restartCount":0,
-                  "image":"gcr.io/google_containers/exechealthz:1.0",
-                  "imageID":"docker://d6fccb55b3994c00a4654e7795a51905d94fb22700edb326a7bb12cc9a29faaf",
-                  "containerID":"docker://e3e04eb19919e30da3b187cb901b49678a030e705b936473db1385cb2403f066"
-               },
-               {
-                  "name":"kube2sky",
-                  "state":{
-                     "running":{
-                        "startedAt":"2016-04-12T02:27:33Z"
-                     }
-                  },
-                  "lastState":{
-
-                  },
-                  "ready":true,
-                  "restartCount":0,
-                  "image":"gcr.io/google_containers/kube2sky:1.14",
-                  "imageID":"docker://c0b611ff3f70759cc39f10e61ded1973cb4dbfe9bc3ee86603d4ccc8fe279535",
-                  "containerID":"docker://512523fbe722384328ef5a44e475077e76758fc9935af4639c8874cadae70a3d"
-               },
-               {
-                  "name":"skydns",
-                  "state":{
-                     "running":{
-                        "startedAt":"2016-04-12T02:27:40Z"
-                     }
-                  },
-                  "lastState":{
-
-                  },
-                  "ready":true,
-                  "restartCount":0,
-                  "image":"gcr.io/google_containers/skydns:2015-10-13-8c72f8c",
-                  "imageID":"docker://763c92e53f311c40a922628a34daf0be4397463589a7d148cea8291f02c12a5d",
-                  "containerID":"docker://f5d58fe04da979421530b1e2125d9f2078d608798bea694a24d1dc9043774f3f"
-               }
-            ]
-         }
+      "status": {
+        "phase": "Pending"
       }
-   ]
+    },
+    {
+      "metadata": {
+        "name": "dd-agent-1rxlh",
+        "generateName": "dd-agent-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/dd-agent-1rxlh",
+        "uid": "12c7be82-33ca-11e6-ac8f-42010af00003",
+        "resourceVersion": "456745",
+        "creationTimestamp": "2016-06-16T13:56:07Z",
+        "labels": {
+          "app": "dd-agent"
+        },
+        "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"dd-agent\",\"uid\":\"12c56a58-33ca-11e6-ac8f-42010af00003\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"456736\"}}\n"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "dockersocket",
+            "hostPath": {
+              "path": "/var/run/docker.sock"
+            }
+          },
+          {
+            "name": "procdir",
+            "hostPath": {
+              "path": "/proc"
+            }
+          },
+          {
+            "name": "cgroups",
+            "hostPath": {
+              "path": "/sys/fs/cgroup"
+            }
+          },
+          {
+            "name": "default-token-racjk",
+            "secret": {
+              "secretName": "default-token-racjk"
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "dd-agent",
+            "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+            "ports": [
+              {
+                "name": "dogstatsdport",
+                "containerPort": 8125,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "API_KEY",
+                "value": "51bdfb1e67a5b2097feeed5603f3cc7d"
+              },
+              {
+                "name": "SD_BACKEND",
+                "value": "docker"
+              },
+              {
+                "name": "SD_CONFIG_BACKEND",
+                "value": "etcd"
+              },
+              {
+                "name": "SD_BACKEND_HOST",
+                "value": "etcd-client"
+              },
+              {
+                "name": "SD_BACKEND_PORT",
+                "value": "2379"
+              },
+              {
+                "name": "LOG_LEVEL",
+                "value": "DEBUG"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "1",
+                "memory": "128Mi"
+              },
+              "requests": {
+                "cpu": "250m",
+                "memory": "64Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "dockersocket",
+                "mountPath": "/var/run/docker.sock"
+              },
+              {
+                "name": "procdir",
+                "readOnly": true,
+                "mountPath": "/host/proc"
+              },
+              {
+                "name": "cgroups",
+                "readOnly": true,
+                "mountPath": "/host/sys/fs/cgroup"
+              },
+              {
+                "name": "default-token-racjk",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "kubernetes-massi-minion-k23m",
+        "securityContext": {}
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2016-06-16T13:56:08Z"
+          }
+        ],
+        "hostIP": "10.240.0.9",
+        "podIP": "10.244.0.5",
+        "startTime": "2016-06-16T13:56:07Z",
+        "containerStatuses": [
+          {
+            "name": "dd-agent",
+            "state": {
+              "running": {
+                "startedAt": "2016-06-16T13:56:08Z"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+            "imageID": "docker://22c8298aadea7bae69765758a88fc373118c9a0c332d23aa99869d4f84d75a8e",
+            "containerID": "docker://1d6e5db3abbfbb69718899748a882e2519da5b5d798b4b6bf1ec7dd6b5f26a60"
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "dd-agent-iw7mo",
+        "generateName": "dd-agent-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/dd-agent-iw7mo",
+        "uid": "12c88531-33ca-11e6-ac8f-42010af00003",
+        "resourceVersion": "456747",
+        "creationTimestamp": "2016-06-16T13:56:07Z",
+        "labels": {
+          "app": "dd-agent"
+        },
+        "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"dd-agent\",\"uid\":\"12c56a58-33ca-11e6-ac8f-42010af00003\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"456736\"}}\n"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "dockersocket",
+            "hostPath": {
+              "path": "/var/run/docker.sock"
+            }
+          },
+          {
+            "name": "procdir",
+            "hostPath": {
+              "path": "/proc"
+            }
+          },
+          {
+            "name": "cgroups",
+            "hostPath": {
+              "path": "/sys/fs/cgroup"
+            }
+          },
+          {
+            "name": "default-token-racjk",
+            "secret": {
+              "secretName": "default-token-racjk"
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "dd-agent",
+            "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+            "ports": [
+              {
+                "name": "dogstatsdport",
+                "containerPort": 8125,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "API_KEY",
+                "value": "51bdfb1e67a5b2097feeed5603f3cc7d"
+              },
+              {
+                "name": "SD_BACKEND",
+                "value": "docker"
+              },
+              {
+                "name": "SD_CONFIG_BACKEND",
+                "value": "etcd"
+              },
+              {
+                "name": "SD_BACKEND_HOST",
+                "value": "etcd-client"
+              },
+              {
+                "name": "SD_BACKEND_PORT",
+                "value": "2379"
+              },
+              {
+                "name": "LOG_LEVEL",
+                "value": "DEBUG"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "1",
+                "memory": "128Mi"
+              },
+              "requests": {
+                "cpu": "250m",
+                "memory": "64Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "dockersocket",
+                "mountPath": "/var/run/docker.sock"
+              },
+              {
+                "name": "procdir",
+                "readOnly": true,
+                "mountPath": "/host/proc"
+              },
+              {
+                "name": "cgroups",
+                "readOnly": true,
+                "mountPath": "/host/sys/fs/cgroup"
+              },
+              {
+                "name": "default-token-racjk",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "kubernetes-massi-minion-txyy",
+        "securityContext": {}
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2016-06-16T13:56:09Z"
+          }
+        ],
+        "hostIP": "10.240.0.5",
+        "podIP": "10.244.1.4",
+        "startTime": "2016-06-16T13:56:07Z",
+        "containerStatuses": [
+          {
+            "name": "dd-agent",
+            "state": {
+              "running": {
+                "startedAt": "2016-06-16T13:56:08Z"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+            "imageID": "docker://22c8298aadea7bae69765758a88fc373118c9a0c332d23aa99869d4f84d75a8e",
+            "containerID": "docker://9a4d1a5dc416b805f015efb2a0f310180ec3d9c7026ace523f29a1e5e8be2e2b"
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "name": "dd-agent-ntepl",
+        "generateName": "dd-agent-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/dd-agent-ntepl",
+        "uid": "12ceeaa9-33ca-11e6-ac8f-42010af00003",
+        "resourceVersion": "456746",
+        "creationTimestamp": "2016-06-16T13:56:07Z",
+        "labels": {
+          "app": "dd-agent"
+        },
+        "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"DaemonSet\",\"namespace\":\"default\",\"name\":\"dd-agent\",\"uid\":\"12c56a58-33ca-11e6-ac8f-42010af00003\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"456736\"}}\n"
+        }
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "dockersocket",
+            "hostPath": {
+              "path": "/var/run/docker.sock"
+            }
+          },
+          {
+            "name": "procdir",
+            "hostPath": {
+              "path": "/proc"
+            }
+          },
+          {
+            "name": "cgroups",
+            "hostPath": {
+              "path": "/sys/fs/cgroup"
+            }
+          },
+          {
+            "name": "default-token-racjk",
+            "secret": {
+              "secretName": "default-token-racjk"
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "dd-agent",
+            "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+            "ports": [
+              {
+                "name": "dogstatsdport",
+                "containerPort": 8125,
+                "protocol": "TCP"
+              }
+            ],
+            "env": [
+              {
+                "name": "API_KEY",
+                "value": "51bdfb1e67a5b2097feeed5603f3cc7d"
+              },
+              {
+                "name": "SD_BACKEND",
+                "value": "docker"
+              },
+              {
+                "name": "SD_CONFIG_BACKEND",
+                "value": "etcd"
+              },
+              {
+                "name": "SD_BACKEND_HOST",
+                "value": "etcd-client"
+              },
+              {
+                "name": "SD_BACKEND_PORT",
+                "value": "2379"
+              },
+              {
+                "name": "LOG_LEVEL",
+                "value": "DEBUG"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "1",
+                "memory": "128Mi"
+              },
+              "requests": {
+                "cpu": "250m",
+                "memory": "64Mi"
+              }
+            },
+            "volumeMounts": [
+              {
+                "name": "dockersocket",
+                "mountPath": "/var/run/docker.sock"
+              },
+              {
+                "name": "procdir",
+                "readOnly": true,
+                "mountPath": "/host/proc"
+              },
+              {
+                "name": "cgroups",
+                "readOnly": true,
+                "mountPath": "/host/sys/fs/cgroup"
+              },
+              {
+                "name": "default-token-racjk",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "kubernetes-massi-minion-ze6g",
+        "securityContext": {}
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2016-06-16T13:56:09Z"
+          }
+        ],
+        "hostIP": "10.240.0.4",
+        "podIP": "10.244.2.5",
+        "startTime": "2016-06-16T13:56:07Z",
+        "containerStatuses": [
+          {
+            "name": "dd-agent",
+            "state": {
+              "running": {
+                "startedAt": "2016-06-16T13:56:08Z"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "datadog/docker-dd-agent:massi_ingest_k8s_events",
+            "imageID": "docker://22c8298aadea7bae69765758a88fc373118c9a0c332d23aa99869d4f84d75a8e",
+            "containerID": "docker://32fc50ecfe24df055f6d56037acb966337eef7282ad5c203a1be58f2dd2fe743"
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/tests/checks/fixtures/kubernetes/proc_net_route.txt
+++ b/tests/checks/fixtures/kubernetes/proc_net_route.txt
@@ -1,0 +1,3 @@
+Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+eth0	00000000	0102080A	0003	0	0	0	00000000	0	0	0
+eth0	0002080A	00000000	0001	0	0	0	00FFFFFF	0	0	0

--- a/tests/checks/fixtures/kubernetes/proc_net_route.txt
+++ b/tests/checks/fixtures/kubernetes/proc_net_route.txt
@@ -1,3 +1,0 @@
-Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
-eth0	00000000	0102080A	0003	0	0	0	00000000	0	0	0
-eth0	0002080A	00000000	0001	0	0	0	00FFFFFF	0	0	0

--- a/tests/checks/mock/test_kubernetes.py
+++ b/tests/checks/mock/test_kubernetes.py
@@ -281,9 +281,16 @@ class TestKubernetes(AgentCheckTest):
     @mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list',
                 side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False)))
     def test_events(self, *args):
+        # default value for collect_events is False
         config = {'instances': [{'host': 'foo'}]}
         self.run_check(config)
+        self.assertEvent('hello-node-47289321-91tfd Scheduled on Bar', count=0, exact_match=False)
+
+        # again, with the feature enabled
+        config = {'instances': [{'host': 'bar', 'collect_events': True}]}
+        self.run_check(config, force_reload=True)
         self.assertEvent('hello-node-47289321-91tfd Scheduled on Bar', count=1, exact_match=False)
+
         # again, now the timestamp is set and the event is discarded b/c too old
         self.run_check(config)
         self.assertEvent('hello-node-47289321-91tfd Scheduled on Bar', count=0, exact_match=False)

--- a/tests/checks/mock/test_kubernetes.py
+++ b/tests/checks/mock/test_kubernetes.py
@@ -22,6 +22,8 @@ NET_ERRORS = "net_errors"
 DISK = "disk"
 DISK_USAGE = "disk_usage"
 PODS = "pods"
+LIM = "limits"
+REQ = "requests"
 
 METRICS = [
     ('kubernetes.memory.usage', MEM),
@@ -35,6 +37,10 @@ METRICS = [
     ('kubernetes.filesystem.usage_pct', DISK_USAGE),
     ('kubernetes.filesystem.usage', DISK_USAGE),
     ('kubernetes.pods.running', PODS),
+    ('kubernetes.cpu.limits', LIM),
+    ('kubernetes.cpu.requests', REQ),
+    ('kubernetes.memory.limits', LIM),
+    ('kubernetes.memory.requests', REQ),
 ]
 
 
@@ -198,25 +204,16 @@ class TestKubernetes(AgentCheckTest):
 
         expected_tags = [
             (['container_name:/kubelet', 'pod_name:no_pod'], [MEM, CPU, NET, DISK]),
-            (['container_name:k8s_POD.e2764897_kube-dns-v11-63tae_kube-system_5754714c-0054-11e6-9a89-42010af00098_c33e4b64', 'pod_name:kube-system/kube-dns-v11-63tae', 'kube_namespace:kube-system', 'kube_k8s-app:kube-dns', 'kube_version:v11', 'kube_kubernetes.io/cluster-service:true', 'kube_replication_controller:kube-dns-v11'], [MEM, CPU, FS, NET, NET_ERRORS]),
-            (['container_name:k8s_dd-agent.67c1e3c5_dd-agent-idydc_default_adecdd57-f5c3-11e5-8f7c-42010af00098_5154bb06', 'pod_name:default/dd-agent-idydc', 'kube_namespace:default', 'kube_app:dd-agent', 'kube_replication_controller:dd-agent'], [MEM, CPU, FS, NET, DISK]),
+            (['container_name:k8s_POD.35220667_dd-agent-1rxlh_default_12c7be82-33ca-11e6-ac8f-42010af00003_f5cf585f',
+              'pod_name:default/dd-agent-1rxlh', 'kube_namespace:default', 'kube_app:dd-agent',
+              'kube_replication_controller:dd-agent'], [MEM, CPU, FS, NET, NET_ERRORS]),
             (['container_name:/', 'pod_name:no_pod'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
-            (['container_name:/docker-daemon', 'pod_name:no_pod'], [MEM, CPU, DISK, NET]),
-            (['container_name:k8s_skydns.7ad23ad1_kube-dns-v11-63tae_kube-system_5754714c-0054-11e6-9a89-42010af00098_b082387b', 'pod_name:kube-system/kube-dns-v11-63tae', 'kube_namespace:kube-system', 'kube_k8s-app:kube-dns', 'kube_version:v11', 'kube_kubernetes.io/cluster-service:true', 'kube_replication_controller:kube-dns-v11'], [MEM, CPU, FS, NET]),
-
-            ([u'container_name:/system', 'pod_name:no_pod'], [MEM, CPU, NET, DISK]),
-
-            ([u'kube_k8s-app:kube-dns', u'kube_namespace:kube-system', u'kube_kubernetes.io/cluster-service:true', u'kube_replication_controller:kube-dns-v11', u'pod_name:kube-system/kube-dns-v11-63tae', u'kube_version:v11', u'container_name:k8s_kube2sky.8cbc016c_kube-dns-v11-63tae_kube-system_5754714c-0054-11e6-9a89-42010af00098_d6df3862'], [MEM, CPU, FS, NET]),
-            ([u'kube_namespace:default', u'kube_app:dd-agent', u'kube_replication_controller:dd-agent', u'container_name:k8s_POD.35220667_dd-agent-idydc_default_adecdd57-f5c3-11e5-8f7c-42010af00098_e2c005a0', u'pod_name:default/dd-agent-idydc'], [MEM, CPU, FS, NET, NET_ERRORS]),
-            ([u'kube_k8s-app:kube-dns', u'kube_namespace:kube-system', u'kube_kubernetes.io/cluster-service:true', u'kube_replication_controller:kube-dns-v11', u'pod_name:kube-system/kube-dns-v11-63tae', u'kube_version:v11', u'container_name:k8s_etcd.81a33530_kube-dns-v11-63tae_kube-system_5754714c-0054-11e6-9a89-42010af00098_e811864e'], [MEM, CPU, FS, DISK, NET]),
-            ([u'kube_namespace:kube-system', u'pod_name:kube-system/kube-proxy-gke-cluster-remi-62c0dd29-node-29lx', u'container_name:k8s_kube-proxy.cf23f4be_kube-proxy-gke-cluster-remi-62c0dd29-node-29lx_kube-system_f70c43857a22d5495bf204918d5ab984_4e315ef3', u'kube_replication_controller:kube-proxy-gke-cluster-remi-62c0dd29-node'], [MEM, CPU, FS, NET, DISK]),
-            ([u'kube_namespace:kube-system', u'pod_name:kube-system/fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node-29lx', u'kube_k8s-app:fluentd-logging', u'container_name:k8s_fluentd-cloud-logging.fe59dd68_fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node-29lx_kube-system_da7e41ef0372c29c65a24b417b5dd69f_3cacfb32', u'kube_replication_controller:fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node'], [MEM, CPU, FS, NET]),
-            ([u'kube_namespace:kube-system', u'container_name:k8s_POD.6059dfa2_kube-proxy-gke-cluster-remi-62c0dd29-node-29lx_kube-system_f70c43857a22d5495bf204918d5ab984_e17ace7a', u'pod_name:kube-system/kube-proxy-gke-cluster-remi-62c0dd29-node-29lx', u'kube_replication_controller:kube-proxy-gke-cluster-remi-62c0dd29-node'], [MEM, CPU, FS, NET, NET_ERRORS]),
-            ([u'kube_k8s-app:kube-dns', u'kube_namespace:kube-system', u'kube_kubernetes.io/cluster-service:true', u'container_name:k8s_healthz.4039147e_kube-dns-v11-63tae_kube-system_5754714c-0054-11e6-9a89-42010af00098_d8e1d132', u'kube_replication_controller:kube-dns-v11', u'pod_name:kube-system/kube-dns-v11-63tae', u'kube_version:v11'], [MEM, CPU, FS, NET]),
-            ([u'kube_namespace:kube-system', u'pod_name:kube-system/fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node-29lx', u'kube_k8s-app:fluentd-logging', u'container_name:k8s_POD.6059dfa2_fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node-29lx_kube-system_da7e41ef0372c29c65a24b417b5dd69f_b4d7ed62', u'kube_replication_controller:fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node'], [MEM, CPU, FS, NET, NET_ERRORS]),
-
-            (['kube_replication_controller:kube-dns-v11'], [PODS]),
+            (['container_name:/system', 'pod_name:no_pod'], [MEM, CPU, NET, DISK]),
+            (['container_name:k8s_dd-agent.7b520f3f_dd-agent-1rxlh_default_12c7be82-33ca-11e6-ac8f-42010af00003_321fecb4',
+              'pod_name:default/dd-agent-1rxlh', 'kube_namespace:default', 'kube_app:dd-agent',
+              'kube_replication_controller:dd-agent'], [LIM, REQ, MEM, CPU, NET, DISK, DISK_USAGE]),
             (['kube_replication_controller:dd-agent'], [PODS]),
+            ([], [LIM, REQ])  # container from kubernetes api doesn't have a corresponding entry in Cadvisor
         ]
 
         for m, _type in METRICS:
@@ -252,16 +249,8 @@ class TestKubernetes(AgentCheckTest):
         metric_suffix = ["count", "avg", "median", "max", "95percentile"]
 
         expected_tags = [
-            (['pod_name:kube-system/kube-dns-v11-63tae', 'kube_namespace:kube-system', 'kube_k8s-app:kube-dns', 'kube_version:v11', 'kube_kubernetes.io/cluster-service:true', 'kube_replication_controller:kube-dns-v11'], [MEM, CPU, FS, DISK, NET, NET_ERRORS]),
-            (['pod_name:default/dd-agent-idydc', 'kube_namespace:default', 'kube_app:dd-agent', 'kube_replication_controller:dd-agent'], [MEM, CPU, FS, NET, DISK]),
-            (['pod_name:no_pod'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
-
-            ([u'kube_namespace:default', u'kube_app:dd-agent', u'kube_replication_controller:dd-agent', u'pod_name:default/dd-agent-idydc'], [MEM, CPU, FS, NET, NET_ERRORS]),
-            ([u'kube_namespace:kube-system', u'pod_name:kube-system/kube-proxy-gke-cluster-remi-62c0dd29-node-29lx', u'kube_replication_controller:kube-proxy-gke-cluster-remi-62c0dd29-node'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
-            ([u'kube_namespace:kube-system', u'pod_name:kube-system/fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node-29lx', u'kube_k8s-app:fluentd-logging', u'kube_replication_controller:fluentd-cloud-logging-gke-cluster-remi-62c0dd29-node'], [MEM, CPU, FS, NET, NET_ERRORS]),
-
-            (['kube_replication_controller:kube-dns-v11'], [PODS]),
-            (['kube_replication_controller:dd-agent'], [PODS]),
+            (['pod_name:default/dd-agent-1rxlh', 'kube_namespace:default', 'kube_app:dd-agent',
+              'kube_replication_controller:dd-agent'], [MEM, CPU, NET, DISK, NET_ERRORS]),
         ]
 
         for m, _type in METRICS:

--- a/tests/checks/mock/test_kubernetes.py
+++ b/tests/checks/mock/test_kubernetes.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 # stdlib
 import mock
+import unittest
 
 # 3p
 import simplejson as json
@@ -10,6 +11,7 @@ import simplejson as json
 # project
 from tests.checks.common import AgentCheckTest, Fixtures
 from checks import AgentCheck
+from utils.kubeutil import KubeUtil
 
 CPU = "CPU"
 MEM = "MEM"
@@ -39,25 +41,29 @@ class TestKubernetes(AgentCheckTest):
 
     CHECK_NAME = 'kubernetes'
 
-    def test_fail_1_1(self):
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_json_auth')
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_metrics',
+                side_effect=lambda: json.loads(Fixtures.read_file("metrics_1.1.json")))
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list',
+                side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.1.json", string_escape=False)))
+    def test_fail_1_1(self, *args):
         # To avoid the disparition of some gauges during the second check
-        mocks = {
-            '_retrieve_metrics': lambda x: json.loads(Fixtures.read_file("metrics_1.1.json")),
-        }
         config = {
             "instances": [{"host": "foo"}]
         }
 
-        with mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list', side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.1.json", string_escape=False))):
-            with mock.patch('utils.dockerutil.DockerUtil.get_hostname', side_effect=lambda: 'foo'):
-                # Can't use run_check_twice due to specific metrics
-                self.run_check(config, mocks=mocks, force_reload=True)
-                self.assertServiceCheck("kubernetes.kubelet.check", status=AgentCheck.CRITICAL, tags=None, count=1)
+        # Can't use run_check_twice due to specific metrics
+        self.run_check(config, force_reload=True)
+        self.assertServiceCheck("kubernetes.kubelet.check", status=AgentCheck.CRITICAL, tags=None, count=1)
 
-    def test_metrics_1_1(self):
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_json_auth')
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_metrics',
+                side_effect=lambda: json.loads(Fixtures.read_file("metrics_1.1.json")))
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list',
+                side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.1.json", string_escape=False)))
+    def test_metrics_1_1(self, *args):
         # To avoid the disparition of some gauges during the second check
         mocks = {
-            '_retrieve_metrics': lambda x: json.loads(Fixtures.read_file("metrics_1.1.json")),
             '_perform_kubelet_checks': lambda x: None,
         }
         config = {
@@ -68,11 +74,8 @@ class TestKubernetes(AgentCheckTest):
                 }
             ]
         }
-        # parts of the json returned by the kubelet api is escaped, keep it untouched
-        with mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list', side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.1.json", string_escape=False))):
-            with mock.patch('utils.dockerutil.DockerUtil.get_hostname', side_effect=lambda: 'foo'):
-                # Can't use run_check_twice due to specific metrics
-                self.run_check_twice(config, mocks=mocks, force_reload=True)
+        # Can't use run_check_twice due to specific metrics
+        self.run_check_twice(config, mocks=mocks, force_reload=True)
 
         expected_tags = [
             (['container_name:/kubelet', 'pod_name:no_pod'], [MEM, CPU, NET, DISK]),
@@ -109,10 +112,14 @@ class TestKubernetes(AgentCheckTest):
 
         self.coverage_report()
 
-    def test_historate_1_1(self):
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_json_auth')
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_metrics',
+                side_effect=lambda: json.loads(Fixtures.read_file("metrics_1.1.json")))
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list',
+                side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.1.json", string_escape=False)))
+    def test_historate_1_1(self, *args):
         # To avoid the disparition of some gauges during the second check
         mocks = {
-            '_retrieve_metrics': lambda x: json.loads(Fixtures.read_file("metrics_1.1.json")),
             '_perform_kubelet_checks': lambda x: None,
         }
         config = {
@@ -124,12 +131,8 @@ class TestKubernetes(AgentCheckTest):
                 }
             ]
         }
-
-        # parts of the json returned by the kubelet api is escaped, keep it untouched
-        with mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list', side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.1.json", string_escape=False))):
-            with mock.patch('utils.dockerutil.DockerUtil.get_hostname', side_effect=lambda: 'foo'):
-                # Can't use run_check_twice due to specific metrics
-                self.run_check_twice(config, mocks=mocks, force_reload=True)
+        # Can't use run_check_twice due to specific metrics
+        self.run_check_twice(config, mocks=mocks, force_reload=True)
 
         metric_suffix = ["count", "avg", "median", "max", "95percentile"]
 
@@ -157,24 +160,28 @@ class TestKubernetes(AgentCheckTest):
 
         self.coverage_report()
 
-
-    def test_fail_1_2(self):
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_json_auth')
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_metrics',
+                side_effect=lambda: json.loads(Fixtures.read_file("metrics_1.2.json")))
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list',
+                side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False)))
+    def test_fail_1_2(self, *args):
         # To avoid the disparition of some gauges during the second check
-        mocks = {'_retrieve_metrics': lambda x: json.loads(Fixtures.read_file("metrics_1.2.json"))}
         config = {
             "instances": [{"host": "foo"}]
         }
 
-        with mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list', side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False))):
-            with mock.patch('utils.dockerutil.DockerUtil.get_hostname', side_effect=lambda: 'foo'):
-                # Can't use run_check_twice due to specific metrics
-                self.run_check(config, mocks=mocks, force_reload=True)
-                self.assertServiceCheck("kubernetes.kubelet.check", status=AgentCheck.CRITICAL)
+        # Can't use run_check_twice due to specific metrics
+        self.run_check(config, force_reload=True)
+        self.assertServiceCheck("kubernetes.kubelet.check", status=AgentCheck.CRITICAL)
 
-
-    def test_metrics_1_2(self):
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_json_auth')
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_metrics',
+                side_effect=lambda: json.loads(Fixtures.read_file("metrics_1.2.json")))
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list',
+                side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False)))
+    def test_metrics_1_2(self, *args):
         mocks = {
-            '_retrieve_metrics': lambda x: json.loads(Fixtures.read_file("metrics_1.2.json")),
             '_perform_kubelet_checks': lambda x: None,
         }
         config = {
@@ -185,11 +192,8 @@ class TestKubernetes(AgentCheckTest):
                 }
             ]
         }
-        # parts of the json returned by the kubelet api is escaped, keep it untouched
-        with mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list', side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False))):
-            with mock.patch('utils.dockerutil.DockerUtil.get_hostname', side_effect=lambda: 'foo'):
-                # Can't use run_check_twice due to specific metrics
-                self.run_check_twice(config, mocks=mocks, force_reload=True)
+        # Can't use run_check_twice due to specific metrics
+        self.run_check_twice(config, mocks=mocks, force_reload=True)
 
         expected_tags = [
             (['container_name:/kubelet', 'pod_name:no_pod'], [MEM, CPU, NET, DISK]),
@@ -219,13 +223,16 @@ class TestKubernetes(AgentCheckTest):
                 if _type in types:
                     self.assertMetric(m, count=1, tags=tags)
 
-
         self.coverage_report()
 
-    def test_historate_1_2(self):
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_json_auth')
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_metrics',
+                side_effect=lambda: json.loads(Fixtures.read_file("metrics_1.2.json")))
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list',
+                side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False)))
+    def test_historate_1_2(self, *args):
         # To avoid the disparition of some gauges during the second check
         mocks = {
-            '_retrieve_metrics': lambda x: json.loads(Fixtures.read_file("metrics_1.2.json")),
             '_perform_kubelet_checks': lambda x: None,
         }
         config = {
@@ -238,11 +245,8 @@ class TestKubernetes(AgentCheckTest):
             ]
         }
 
-        # parts of the json returned by the kubelet api is escaped, keep it untouched
-        with mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list', side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False))):
-            with mock.patch('utils.dockerutil.DockerUtil.get_hostname', side_effect=lambda: 'foo'):
-                # Can't use run_check_twice due to specific metrics
-                self.run_check_twice(config, mocks=mocks, force_reload=True)
+        # Can't use run_check_twice due to specific metrics
+        self.run_check_twice(config, mocks=mocks, force_reload=True)
 
         metric_suffix = ["count", "avg", "median", "max", "95percentile"]
 
@@ -266,3 +270,157 @@ class TestKubernetes(AgentCheckTest):
                         self.assertMetric("{0}.{1}".format(m, m_suffix), count=1, tags=tags)
 
         self.coverage_report()
+
+    @mock.patch('utils.kubeutil.KubeUtil.get_node_info',
+                side_effect=lambda: ('Foo', 'Bar'))
+    @mock.patch('utils.kubeutil.KubeUtil.filter_pods_list',
+                side_effect=lambda x, y: x)
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_json_auth',
+                side_effect=lambda x,y: json.loads(Fixtures.read_file("events.json", string_escape=False)))
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_metrics')
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list',
+                side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False)))
+    def test_events(self, *args):
+        config = {'instances': [{'host': 'foo'}]}
+        self.run_check(config)
+        self.assertEvent('hello-node-47289321-91tfd Scheduled on Bar', count=1, exact_match=False)
+        # again, now the timestamp is set and the event is discarded b/c too old
+        self.run_check(config)
+        self.assertEvent('hello-node-47289321-91tfd Scheduled on Bar', count=0, exact_match=False)
+
+
+class TestKubeutil(unittest.TestCase):
+    def setUp(self):
+        self.kubeutil = KubeUtil()
+
+    @mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list', side_effect=['foo'])
+    @mock.patch('utils.kubeutil.KubeUtil.extract_kube_labels')
+    def test_get_kube_labels(self, extract_kube_labels, retrieve_pods_list):
+        self.kubeutil.get_kube_labels(excluded_keys='bar')
+        retrieve_pods_list.assert_called_once()
+        extract_kube_labels.assert_called_once_with('foo', excluded_keys='bar')
+
+    def test_extract_kube_labels(self):
+        """
+        Test with both 1.1 and 1.2 version payloads
+        """
+        res = self.kubeutil.extract_kube_labels({}, ['foo'])
+        self.assertEqual(len(res), 0)
+
+        pods = json.loads(Fixtures.read_file("pods_list_1.1.json", string_escape=False))
+        res = self.kubeutil.extract_kube_labels(pods, ['foo'])
+        labels = set(inn for out in res.values() for inn in out)
+        self.assertEqual(len(labels), 8)
+        res = self.kubeutil.extract_kube_labels(pods, ['k8s-app'])
+        labels = set(inn for out in res.values() for inn in out)
+        self.assertEqual(len(labels), 6)
+
+        pods = json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False))
+        res = self.kubeutil.extract_kube_labels(pods, ['foo'])
+        labels = set(inn for out in res.values() for inn in out)
+        self.assertEqual(len(labels), 5)
+        res = self.kubeutil.extract_kube_labels(pods, ['k8s-app'])
+        labels = set(inn for out in res.values() for inn in out)
+        self.assertEqual(len(labels), 3)
+
+    def test_extract_meta(self):
+        """
+        Test with both 1.1 and 1.2 version payloads
+        """
+        res = self.kubeutil.extract_meta({}, 'foo')
+        self.assertEqual(len(res), 0)
+
+        pods = json.loads(Fixtures.read_file("pods_list_1.1.json", string_escape=False))
+        res = self.kubeutil.extract_meta(pods, 'foo')
+        self.assertEqual(len(res), 0)
+        res = self.kubeutil.extract_meta(pods, 'uid')
+        self.assertEqual(len(res), 6)
+
+        pods = json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False))
+        res = self.kubeutil.extract_meta(pods, 'foo')
+        self.assertEqual(len(res), 0)
+        res = self.kubeutil.extract_meta(pods, 'uid')
+        self.assertEqual(len(res), 4)
+
+    @mock.patch('utils.kubeutil.retrieve_json')
+    def test_retrieve_pods_list(self, retrieve_json):
+        self.kubeutil.retrieve_pods_list()
+        retrieve_json.assert_called_once_with(self.kubeutil.pods_list_url)
+
+    @mock.patch('utils.kubeutil.retrieve_json')
+    def test_retrieve_metrics(self, retrieve_json):
+        self.kubeutil.retrieve_metrics()
+        retrieve_json.assert_called_once_with(self.kubeutil.metrics_url)
+
+    def test_filter_pods_list(self):
+        """
+        Test with both 1.1 and 1.2 version payloads
+        """
+        res = self.kubeutil.filter_pods_list({}, 'foo')
+        self.assertEqual(len(res.get('items')), 0)
+
+        pods = json.loads(Fixtures.read_file("pods_list_1.1.json", string_escape=False))
+        res = self.kubeutil.filter_pods_list(pods, '10.240.0.9')
+        self.assertEqual(len(res.get('items')), 5)
+
+        pods = json.loads(Fixtures.read_file("pods_list_1.1.json", string_escape=False))
+        res = self.kubeutil.filter_pods_list(pods, 'foo')
+        self.assertEqual(len(res.get('items')), 0)
+
+        pods = json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False))
+        res = self.kubeutil.filter_pods_list(pods, '10.142.0.4')
+        self.assertEqual(len(res.get('items')), 2)
+
+        pods = json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False))
+        res = self.kubeutil.filter_pods_list(pods, 'foo')
+        self.assertEqual(len(res.get('items')), 0)
+
+    @mock.patch('utils.kubeutil.requests')
+    def test_retrieve_json_auth(self, r):
+        self.kubeutil.retrieve_json_auth('url', 'foo_tok')
+        r.get.assert_called_once_with('url', verify=False, timeout=10, headers={'Authorization': 'Bearer foo_tok'})
+
+        self.kubeutil.CA_CRT_PATH = __file__
+        self.kubeutil.retrieve_json_auth('url', 'foo_tok')
+        r.get.assert_called_with('url', verify=__file__, timeout=10, headers={'Authorization': 'Bearer foo_tok'})
+
+    def test_get_node_info(self):
+        with mock.patch('utils.kubeutil.KubeUtil._fetch_host_data') as f:
+            self.kubeutil.get_node_info()
+            f.assert_called_once()
+
+            f.reset_mock()
+
+            self.kubeutil._node_ip = 'foo'
+            self.kubeutil._node_name = 'bar'
+            ip, name = self.kubeutil.get_node_info()
+            self.assertEqual(ip, 'foo')
+            self.assertEqual(name, 'bar')
+            f.assert_not_called()
+
+    def test__fetch_host_data(self):
+        """
+        Test with both 1.1 and 1.2 version payloads
+        """
+        with mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list') as mock_pods:
+            self.kubeutil.host_name = 'kube-dns-v11-63tae'
+
+            mock_pods.return_value = json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False))
+            self.kubeutil._fetch_host_data()
+            self.assertEqual(self.kubeutil._node_ip, '10.142.0.4')
+            self.assertEqual(self.kubeutil._node_name, 'gke-cluster-remi-62c0dd29-node-29lx')
+
+            mock_pods.return_value = json.loads(Fixtures.read_file("pods_list_1.1.json", string_escape=False))
+            self.kubeutil._fetch_host_data()
+            self.assertEqual(self.kubeutil._node_ip, '10.142.0.4')
+            self.assertEqual(self.kubeutil._node_name, 'gke-cluster-remi-62c0dd29-node-29lx')
+
+    def test__get_default_router(self):
+        KubeUtil.NET_ROUTE_PATH = Fixtures.file('proc_net_route.txt')
+        self.assertEqual(KubeUtil._get_default_router(), '10.8.2.1')
+
+    def test_get_auth_token(self):
+        KubeUtil.AUTH_TOKEN_PATH = '/foo/bar'
+        self.assertIsNone(KubeUtil.get_auth_token())
+        KubeUtil.AUTH_TOKEN_PATH = Fixtures.file('proc_net_route.txt')  # any file could do the trick
+        self.assertIsNotNone(KubeUtil.get_auth_token())

--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -25,7 +25,7 @@ def is_k8s():
     return 'KUBERNETES_PORT' in os.environ
 
 
-class KubeUtil():
+class KubeUtil:
     __metaclass__ = Singleton
 
     DEFAULT_METHOD = 'http'
@@ -37,7 +37,6 @@ class KubeUtil():
     DEFAULT_MASTER_NAME = 'kubernetes'  # DNS name to reach the master from a pod.
     CA_CRT_PATH = '/run/secrets/kubernetes.io/serviceaccount/ca.crt'
     AUTH_TOKEN_PATH = '/run/secrets/kubernetes.io/serviceaccount/token'
-    NET_ROUTE_PATH = '/proc/net/route'
 
     POD_NAME_LABEL = "io.kubernetes.pod.name"
     NAMESPACE_LABEL = "io.kubernetes.pod.namespace"

--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -13,7 +13,8 @@ from util import check_yaml
 from utils.checkfiles import get_conf_path
 from utils.http import retrieve_json
 from utils.singleton import Singleton
-from utils.dockerutil import DockerUtil
+
+import requests
 
 log = logging.getLogger('collector')
 
@@ -33,6 +34,10 @@ class KubeUtil():
     DEFAULT_CADVISOR_PORT = 4194
     DEFAULT_KUBELET_PORT = 10255
     DEFAULT_MASTER_PORT = 8080
+    DEFAULT_MASTER_NAME = 'kubernetes'  # DNS name to reach the master from a pod.
+    CA_CRT_PATH = '/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+    AUTH_TOKEN_PATH = '/run/secrets/kubernetes.io/serviceaccount/token'
+    NET_ROUTE_PATH = '/proc/net/route'
 
     POD_NAME_LABEL = "io.kubernetes.pod.name"
     NAMESPACE_LABEL = "io.kubernetes.pod.namespace"
@@ -54,19 +59,26 @@ class KubeUtil():
 
         self.method = instance.get('method', KubeUtil.DEFAULT_METHOD)
         self.host = instance.get("host") or self.docker_util.get_hostname()
+        self._node_ip = self._node_name = None  # lazy evaluation
+        self.host_name = os.environ.get('HOSTNAME')
 
         self.cadvisor_port = instance.get('port', KubeUtil.DEFAULT_CADVISOR_PORT)
         self.kubelet_port = instance.get('kubelet_port', KubeUtil.DEFAULT_KUBELET_PORT)
 
-        self.metrics_url = urljoin(
-            '%s://%s:%d' % (self.method, self.host, self.cadvisor_port), KubeUtil.METRICS_PATH)
-        self.pods_list_url = urljoin(
-            '%s://%s:%d' % (self.method, self.host, self.kubelet_port), KubeUtil.PODS_LIST_PATH)
+        self.kubelet_api_url = '%s://%s:%d' % (self.method, self.host, self.kubelet_port)
+        self.cadvisor_url = '%s://%s:%d' % (self.method, self.host, self.cadvisor_port)
+        self.kubernetes_api_url = 'https://%s/api/v1' % self.DEFAULT_MASTER_NAME
 
-        self.kube_health_url = '%s://%s:%d/healthz' % (self.method, self.host, self.kubelet_port)
+        self.metrics_url = urljoin(self.cadvisor_url, KubeUtil.METRICS_PATH)
+        self.pods_list_url = urljoin(self.kubelet_api_url, KubeUtil.PODS_LIST_PATH)
+        self.kube_health_url = urljoin(self.kubelet_api_url, 'healthz')
+
+        # keep track of the latest k8s event we collected and posted
+        # default value is 0 but TTL for k8s events is one hour anyways
+        self.last_event_collection_ts = defaultdict(int)
 
     def get_kube_labels(self, excluded_keys=None):
-        pods = retrieve_json(self.pods_list_url)
+        pods = self.retrieve_pods_list()
         return self.extract_kube_labels(pods, excluded_keys=excluded_keys)
 
     def extract_kube_labels(self, pods_list, excluded_keys=None):
@@ -93,5 +105,101 @@ class KubeUtil():
 
         return kube_labels
 
+    def extract_meta(self, pods_list, field_name):
+        """
+        Exctract fields like `uid` or `name` from the `metadata` section of a
+        list of pods coming from the kubelet API.
+        """
+        uids = []
+        pods = pods_list.get("items") or []
+        for p in pods:
+            value = p.get('metadata', {}).get(field_name)
+            if value is not None:
+                uids.append(value)
+        return uids
+
     def retrieve_pods_list(self):
+        """
+        Retrieve the list of pods for this cluster querying the kubelet API.
+
+        TODO: the list of pods could be cached with some policy to be decided.
+        """
         return retrieve_json(self.pods_list_url)
+
+    def retrieve_metrics(self):
+        """
+        Retrieve metrics from Cadvisor.
+        """
+        return retrieve_json(self.metrics_url)
+
+    def filter_pods_list(self, pods_list, host_ip):
+        """
+        Filter out (in place) pods that are not running on the given host.
+        """
+        pod_items = pods_list.get('items') or []
+        log.debug('Found {} pods to filter'.format(len(pod_items)))
+
+        filtered_pods = []
+        for pod in pod_items:
+            status = pod.get('status', {})
+            if status.get('hostIP') == host_ip:
+                filtered_pods.append(pod)
+        log.debug('Pods after filtering: {}'.format(len(filtered_pods)))
+
+        pods_list['items'] = filtered_pods
+        return pods_list
+
+    def retrieve_json_auth(self, url, auth_token, timeout=10):
+        """
+        Kubernetes API requires authentication using a token available in
+        every pod.
+
+        We try to verify ssl certificate if available.
+        """
+        verify = self.CA_CRT_PATH if os.path.exists(self.CA_CRT_PATH) else False
+        log.debug('ssl validation: {}'.format(verify))
+        headers = {'Authorization': 'Bearer {}'.format(auth_token)}
+        log.debug('HTTP headers: {}'.format(headers))
+        r = requests.get(url, timeout=timeout, headers=headers, verify=verify)
+        r.raise_for_status()
+        return r.json()
+
+    def get_node_info(self):
+        """
+        Return the IP address and the hostname of the node where the pod is running.
+        """
+        if None in (self._node_ip, self._node_name):
+            self._fetch_host_data()
+        return self._node_ip, self._node_name
+
+    def _fetch_host_data(self):
+        """
+        Retrieve host name and IP address from the payload returned by the listing
+        pods endpoints from kubelet or kubernetes API.
+
+        The host IP address is different from the default router for the pod.
+        """
+        pod_items = self.retrieve_pods_list().get("items") or []
+        for pod in pod_items:
+            metadata = pod.get("metadata", {})
+            name = metadata.get("name")
+            if name == self.host_name:
+                status = pod.get('status', {})
+                spec = pod.get('spec', {})
+                # if not found, use an empty string - we use None as "not initialized"
+                self._node_ip = status.get('hostIP', '')
+                self._node_name = spec.get('nodeName', '')
+                break
+
+    @classmethod
+    def get_auth_token(cls):
+        """
+        Return a string containing the authorization token for the pod.
+        """
+        try:
+            with open(cls.AUTH_TOKEN_PATH) as f:
+                return f.read()
+        except IOError as e:
+            log.error('Unable to read token from {}: {}'.format(cls.AUTH_TOKEN_PATH, e))
+
+        return None

--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -110,6 +110,8 @@ class KubeUtil:
         """
         Exctract fields like `uid` or `name` from the `metadata` section of a
         list of pods coming from the kubelet API.
+
+        TODO: currently not in use, was added to support events filtering, consider to remove it.
         """
         uids = []
         pods = pods_list.get("items") or []
@@ -136,6 +138,8 @@ class KubeUtil:
     def filter_pods_list(self, pods_list, host_ip):
         """
         Filter out (in place) pods that are not running on the given host.
+
+        TODO: currently not in use, was added to support events filtering, consider to remove it.
         """
         pod_items = pods_list.get('items') or []
         log.debug('Found {} pods to filter'.format(len(pod_items)))

--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -160,7 +160,6 @@ class KubeUtil:
         verify = self.CA_CRT_PATH if os.path.exists(self.CA_CRT_PATH) else False
         log.debug('ssl validation: {}'.format(verify))
         headers = {'Authorization': 'Bearer {}'.format(auth_token)}
-        log.debug('HTTP headers: {}'.format(headers))
         r = requests.get(url, timeout=timeout, headers=headers, verify=verify)
         r.raise_for_status()
         return r.json()

--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -13,6 +13,7 @@ from util import check_yaml
 from utils.checkfiles import get_conf_path
 from utils.http import retrieve_json
 from utils.singleton import Singleton
+from utils.dockerutil import DockerUtil
 
 import requests
 
@@ -41,20 +42,21 @@ class KubeUtil:
     POD_NAME_LABEL = "io.kubernetes.pod.name"
     NAMESPACE_LABEL = "io.kubernetes.pod.namespace"
 
-    def __init__(self):
+    def __init__(self, instance=None):
         self.docker_util = DockerUtil()
-        try:
-            config_file_path = get_conf_path(KUBERNETES_CHECK_NAME)
-            check_config = check_yaml(config_file_path)
-            instance = check_config['instances'][0]
-        # kubernetes.yaml was not found
-        except IOError as ex:
-            log.error(ex.message)
-            instance = {}
-        except Exception:
-            log.error('Kubernetes configuration file is invalid. '
-                      'Trying connecting to kubelet with default settings anyway...')
-            instance = {}
+        if instance is None:
+            try:
+                config_file_path = get_conf_path(KUBERNETES_CHECK_NAME)
+                check_config = check_yaml(config_file_path)
+                instance = check_config['instances'][0]
+            # kubernetes.yaml was not found
+            except IOError as ex:
+                log.error(ex.message)
+                instance = {}
+            except Exception:
+                log.error('Kubernetes configuration file is invalid. '
+                          'Trying connecting to kubelet with default settings anyway...')
+                instance = {}
 
         self.method = instance.get('method', KubeUtil.DEFAULT_METHOD)
         self.host = instance.get("host") or self.docker_util.get_hostname()


### PR DESCRIPTION
## What
 * Fetch events from the Kubernetes API and feed them to Datadog.
 * Add new `limits` and `requests` metrics.

Logic recap:
 * ~~Each agent fetches the whole list of available events and discards those not regarding pods running on the same node.~~
 * If the `collect_events` config param is set to `True`, the agent fetches the whole list of available events
 * ~~The strategy above could be replaced with delegating~~ Users should delegate one and only one agent pod to collect and send all the events - that agent possibly being the one running on k8s master. This unfortunately doesn't work on GCE where the master is not part of the cluster but it's provided by the platform as an external service instead. How to achieve this part is left to the users.
 * To avoid duplicates, the timestamp of the oldest event seen is stored in the `Kubeutil` singleton and used to filter out older events. 

Open issues:
 * There are events not directly tied to Pods, like ReplicaSet events. Those are discarded for the moment.
 * There are serious concerns about flooding since there's no way at the moment to perform selection queries through the event API. We rely on the fact that k8s events currently have a TTL limited to 1 hour.