### PR TITLE
Add 'accepting_conns' gauge metric to memcached agent check

### DIFF
--- a/checks.d/mcache.py
+++ b/checks.d/mcache.py
@@ -79,7 +79,8 @@ class Memcache(AgentCheck):
         "curr_connections",
         "connection_structures",
         "threads",
-        "pointer_size"
+        "pointer_size",
+        "accepting_conns"
     ]
 
     RATES = [


### PR DESCRIPTION
The accepting_conns metric indicates whether the Memcached server is able to accept new connections or not (**source:** http://www.pal-blog.de/entwicklung/perl/memcached-statistics-stats-command.html)
