### PR TITLE
[win32] plays well memory check timeouts

### DIFF
--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -157,7 +157,7 @@ class Memory(Check):
                 u"Timeout while querying Win32_PerfRawData_PerfOS_Memory WMI class."
                 u" Memory metrics will be returned at next iteration."
             )
-            return
+            return []
 
         if not (len(self.mem_wmi_sampler)):
             self.logger.info('Missing Win32_PerfRawData_PerfOS_Memory WMI class.'


### PR DESCRIPTION
When timing out, the memory check illegitimately returns `None` instead
of an empty list, causing an error in the collector 💀..
```
2016-05-17 15:19:23 Pacific Daylight Time | WARNING |
checks.collector(win32.pyc:148) | Timeout while querying
Win32_PerfRawData_PerfOS_Memory WMI class. Memory metrics will be
returned at next iteration.
2016-05-17 15:19:23 Pacific Daylight Time | ERROR |
checks.collector(collector.pyc:293) | Unable to fetch Windows system
metrics.
Traceback (most recent call last):
  File "checks\collector.pyc", line 286, in run
TypeError: 'NoneType' object is not iterable
```

Fix it.