### PR TITLE
Bump docker-py to 1.8.1 for network features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -68,7 +68,7 @@ pyvmomi==6.0.0
 snakebite==1.3.11
 
 # utils/platform.py
-docker-py==1.3.1
+docker-py==1.8.1
 
 # checks.d/dns_check.py
 dnspython==1.12.0


### PR DESCRIPTION
Docker recently introduced networks, docker-py 1.3.1 doesn't support them, let's upgrade to the most recent version.

tested successfully

related: https://github.com/DataDog/omnibus-software/pull/55