### PR TITLE
[mongo] Only try to connect ReplicationInfo metrics when we can

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -828,44 +828,49 @@ class MongoDb(AgentCheck):
             except Exception, e:
                 self.log.warning('Failed to record `top` metrics %s' % str(e))
 
-        # Fetch information analogous to Mongo's db.getReplicationInfo()
-        localdb = cli['local']
 
-        oplog_data = {}
+        if 'local' in dbnames: # it might not be if we are connectiing through mongos
+            # Fetch information analogous to Mongo's db.getReplicationInfo()
+            localdb = cli['local']
 
-        for ol_collection_name in ("oplog.rs", "oplog.$main"):
-            ol_metadata = localdb.system.namespaces.find_one({"name": "local.%s" % ol_collection_name})
+            oplog_data = {}
+
+            for ol_collection_name in ("oplog.rs", "oplog.$main"):
+                ol_metadata = localdb.system.namespaces.find_one({"name": "local.%s" % ol_collection_name})
+                if ol_metadata:
+                    break
+
             if ol_metadata:
-                break
-
-        if ol_metadata:
-            try:
-                oplog_data['logSizeMB'] = round(
-                    ol_metadata['options']['size'] / 2.0 ** 20, 2
-                )
-
-                oplog = localdb[ol_collection_name]
-
-                oplog_data['usedSizeMB'] = round(
-                    localdb.command("collstats", ol_collection_name)['size'] / 2.0 ** 20, 2
-                )
-
-                op_asc_cursor = oplog.find().sort("$natural", pymongo.ASCENDING).limit(1)
-                op_dsc_cursor = oplog.find().sort("$natural", pymongo.DESCENDING).limit(1)
-
                 try:
-                    first_timestamp = op_asc_cursor[0]['ts'].as_datetime()
-                    last_timestamp = op_dsc_cursor[0]['ts'].as_datetime()
-                    oplog_data['timeDiff'] = total_seconds(last_timestamp - first_timestamp)
-                except (IndexError, KeyError):
-                    # if the oplog collection doesn't have any entries
-                    # if an object in the collection doesn't have a ts value, we ignore it
-                    pass
-            except KeyError:
-                # encountered an error trying to access options.size for the oplog collection
-                self.log.warning(u"Failed to record `ReplicationInfo` metrics.")
+                    oplog_data['logSizeMB'] = round(
+                        ol_metadata['options']['size'] / 2.0 ** 20, 2
+                    )
 
-        for (m, value) in oplog_data.iteritems():
-            submit_method, metric_name_alias = \
-                self._resolve_metric('oplog.%s' % m, metrics_to_collect)
-            submit_method(self, metric_name_alias, value, tags=tags)
+                    oplog = localdb[ol_collection_name]
+
+                    oplog_data['usedSizeMB'] = round(
+                        localdb.command("collstats", ol_collection_name)['size'] / 2.0 ** 20, 2
+                    )
+
+                    op_asc_cursor = oplog.find().sort("$natural", pymongo.ASCENDING).limit(1)
+                    op_dsc_cursor = oplog.find().sort("$natural", pymongo.DESCENDING).limit(1)
+
+                    try:
+                        first_timestamp = op_asc_cursor[0]['ts'].as_datetime()
+                        last_timestamp = op_dsc_cursor[0]['ts'].as_datetime()
+                        oplog_data['timeDiff'] = total_seconds(last_timestamp - first_timestamp)
+                    except (IndexError, KeyError):
+                        # if the oplog collection doesn't have any entries
+                        # if an object in the collection doesn't have a ts value, we ignore it
+                        pass
+                except KeyError:
+                    # encountered an error trying to access options.size for the oplog collection
+                    self.log.warning(u"Failed to record `ReplicationInfo` metrics.")
+
+            for (m, value) in oplog_data.iteritems():
+                submit_method, metric_name_alias = \
+                    self._resolve_metric('oplog.%s' % m, metrics_to_collect)
+                submit_method(self, metric_name_alias, value, tags=tags)
+
+        else:
+            self.log.debug('"local" database not in dbnames. Not collecting ReplicationInfo metrics')


### PR DESCRIPTION
Fix #2520
If you connect to mongo through mongos, there won’t be a `local`
database. But we shouldn’t fail the check if this happens as other
metrics would still be available.