### PR TITLE
[wmi] set a `provider` to request data

### DIFF
--- a/checks.d/iis.py
+++ b/checks.d/iis.py
@@ -61,12 +61,12 @@ class IIS(WinWMICheck):
     def check(self, instance):
         # Connect to the WMI provider
         host = instance.get('host', "localhost")
+        provider = instance.get('provider')
         user = instance.get('username', "")
         password = instance.get('password', "")
         instance_tags = instance.get('tags', [])
         sites = instance.get('sites', ['_Total'])
         is_2008 = _is_affirmative(instance.get('is_2008', False))
-
 
         instance_hash = hash_mutable(instance)
         instance_key = self._get_instance_key(host, self.NAMESPACE, self.CLASS, instance_hash)
@@ -82,7 +82,7 @@ class IIS(WinWMICheck):
             instance_key,
             self.CLASS, properties,
             filters=filters,
-            host=host, namespace=self.NAMESPACE,
+            host=host, namespace=self.NAMESPACE, provider=provider,
             username=user, password=password
         )
 

--- a/checks.d/wmi_check.py
+++ b/checks.d/wmi_check.py
@@ -26,6 +26,7 @@ class WMICheck(WinWMICheck):
         # Connection information
         host = instance.get('host', "localhost")
         namespace = instance.get('namespace', "root\\cimv2")
+        provider = instance.get('provider')
         username = instance.get('username', "")
         password = instance.get('password', "")
 
@@ -48,7 +49,7 @@ class WMICheck(WinWMICheck):
             instance_key,
             wmi_class, properties,
             tag_by=tag_by, filters=filters,
-            host=host, namespace=namespace,
+            host=host, namespace=namespace, provider=provider,
             username=username, password=password,
         )
 

--- a/checks/libs/wmi/sampler.py
+++ b/checks/libs/wmi/sampler.py
@@ -47,18 +47,57 @@ class CaseInsensitiveDict(dict):
         return super(CaseInsensitiveDict, self).get(key.lower())
 
 
+class ProviderArchitectureMeta(type):
+    """
+    Metaclass for ProviderArchitecture.
+    """
+    def __contains__(cls, provider):
+        """
+        Support `Enum` style `contains`.
+        """
+        return provider in cls._AVAILABLE_PROVIDER_ARCHITECTURES
+
+
+class ProviderArchitecture(object):
+    """
+    Enumerate WMI Provider Architectures.
+    """
+    __metaclass__ = ProviderArchitectureMeta
+
+    # Available Provider Architecture(s)
+    DEFAULT = 0
+    _32BIT = 32
+    _64BIT = 64
+    _AVAILABLE_PROVIDER_ARCHITECTURES = frozenset([DEFAULT, _32BIT, _64BIT])
+
+
 class WMISampler(object):
     """
     WMI Sampler.
     """
+    # Properties
+    _provider = None
+    _formatted_filters = None
+
+    # Type resolution state
+    _property_counter_types = None
+
+    # Samples
+    _current_sample = None
+    _previous_sample = None
+
+    # Sampling state
+    _sampling = False
 
     def __init__(self, logger, class_name, property_names, filters="", host="localhost",
-                 namespace="root\\cimv2", username="", password="", and_props=[], timeout_duration=10):
+                 namespace="root\\cimv2", provider=None,
+                 username="", password="", and_props=[], timeout_duration=10):
         self.logger = logger
 
         # Connection information
         self.host = host
         self.namespace = namespace
+        self.provider = provider
         self.username = username
         self.password = password
 
@@ -86,17 +125,40 @@ class WMISampler(object):
         self.property_names = property_names
         self.filters = filters
         self._and_props = and_props
-        self._formatted_filters = None
-        self.property_counter_types = None
         self._timeout_duration = timeout_duration
         self._query = timeout(timeout_duration)(self._query)
 
-        # Samples
-        self.current_sample = None
-        self.previous_sample = None
+    @property
+    def provider(self):
+        """
+        Return the WMI provider.
+        """
+        return self._provider
 
-        # Sampling state
-        self._sampling = False
+    @provider.setter
+    def provider(self, value):
+        """
+        Validate and set a WMI provider. Default to `ProviderArchitecture.DEFAULT`
+        """
+        result = None
+
+        # `None` defaults to `ProviderArchitecture.DEFAULT`
+        defaulted_value = value or ProviderArchitecture.DEFAULT
+
+        try:
+            parsed_value = int(defaulted_value)
+        except ValueError:
+            pass
+        else:
+            if parsed_value in ProviderArchitecture:
+                result = parsed_value
+
+        if result is None:
+            self.logger.error(
+                u"Invalid '%s' WMI Provider Architecture. The parameter is ignored.", value
+            )
+
+        self._provider = result or ProviderArchitecture.DEFAULT
 
     @property
     def connection(self):
@@ -138,12 +200,12 @@ class WMISampler(object):
         self._sampling = True
 
         try:
-            if self.is_raw_perf_class and not self.previous_sample:
+            if self.is_raw_perf_class and not self._previous_sample:
                 self.logger.debug(u"Querying for initial sample for raw performance counter.")
-                self.current_sample = self._query()
+                self._current_sample = self._query()
 
-            self.previous_sample = self.current_sample
-            self.current_sample = self._query()
+            self._previous_sample = self._current_sample
+            self._current_sample = self._query()
         except TimeoutException:
             self.logger.debug(
                 u"Query timeout after {timeout}s".format(
@@ -153,7 +215,7 @@ class WMISampler(object):
             raise
         else:
             self._sampling = False
-            self.logger.debug(u"Sample: {0}".format(self.current_sample))
+            self.logger.debug(u"Sample: {0}".format(self._current_sample))
 
     def __len__(self):
         """
@@ -165,7 +227,7 @@ class WMISampler(object):
                 u"Sampling `WMISampler` object has no len()"
             )
 
-        return len(self.current_sample)
+        return len(self._current_sample)
 
     def __iter__(self):
         """
@@ -180,7 +242,7 @@ class WMISampler(object):
         if self.is_raw_perf_class:
             # Format required
             for previous_wmi_object, current_wmi_object in \
-                    izip(self.previous_sample, self.current_sample):
+                    izip(self._previous_sample, self._current_sample):
                 formatted_wmi_object = self._format_property_values(
                     previous_wmi_object,
                     current_wmi_object
@@ -188,7 +250,7 @@ class WMISampler(object):
                 yield formatted_wmi_object
         else:
             #  No format required
-            for wmi_object in self.current_sample:
+            for wmi_object in self._current_sample:
                 yield wmi_object
 
     def __getitem__(self, index):
@@ -196,27 +258,27 @@ class WMISampler(object):
         Get the specified formatted WMI Object from the current sample.
         """
         if self.is_raw_perf_class:
-            previous_wmi_object = self.previous_sample[index]
-            current_wmi_object = self.current_sample[index]
+            previous_wmi_object = self._previous_sample[index]
+            current_wmi_object = self._current_sample[index]
             formatted_wmi_object = self._format_property_values(
                 previous_wmi_object,
                 current_wmi_object
             )
             return formatted_wmi_object
         else:
-            return self.current_sample[index]
+            return self._current_sample[index]
 
     def __eq__(self, other):
         """
         Equality operator is based on the current sample.
         """
-        return self.current_sample == other
+        return self._current_sample == other
 
     def __str__(self):
         """
         Stringify the current sample's WMI Objects.
         """
-        return str(self.current_sample)
+        return str(self._current_sample)
 
     def _get_property_calculator(self, counter_type):
         """
@@ -245,7 +307,7 @@ class WMISampler(object):
         formatted_wmi_object = CaseInsensitiveDict()
 
         for property_name, property_raw_value in current.iteritems():
-            counter_type = self.property_counter_types.get(property_name)
+            counter_type = self._property_counter_types.get(property_name)
             property_formatted_value = property_raw_value
 
             if counter_type:
@@ -262,10 +324,10 @@ class WMISampler(object):
         """
         self.logger.debug(
             u"Connecting to WMI server "
-            u"(host={host}, namespace={namespace}, username={username}).".format(
-                host=self.host,
-                namespace=self.namespace,
-                username=self.username
+            u"(host={host}, namespace={namespace}, provider={provider}, username={username})."
+            .format(
+                host=self.host, namespace=self.namespace,
+                provider=self.provider, username=self.username
             )
         )
 
@@ -274,11 +336,16 @@ class WMISampler(object):
         # shouldn't be used in other threads (can lead to memory/handle leaks if done
         # without a deep knowledge of COM's threading model). Because of this and given
         # that we run each query in its own thread, we don't cache connections
+        context = None
         pythoncom.CoInitialize()
+
+        if self.provider != ProviderArchitecture.DEFAULT:
+            context = Dispatch("WbemScripting.SWbemNamedValueSet")
+            context.Add("__ProviderArchitecture", self.provider)
+
         locator = Dispatch("WbemScripting.SWbemLocator")
         connection = locator.ConnectServer(
-            self.host, self.namespace,
-            self.username, self.password
+            self.host, self.namespace, self.username, self.password, None, "", 128, context
         )
 
         return connection
@@ -388,9 +455,9 @@ class WMISampler(object):
 
             # For the first query, cache the qualifiers to determine each
             # propertie's "CounterType"
-            includes_qualifiers = self.is_raw_perf_class and self.property_counter_types is None
+            includes_qualifiers = self.is_raw_perf_class and self._property_counter_types is None
             if includes_qualifiers:
-                self.property_counter_types = CaseInsensitiveDict()
+                self._property_counter_types = CaseInsensitiveDict()
                 query_flags |= flag_use_amended_qualifiers
 
             raw_results = self.get_connection().ExecQuery(wql, "WQL", query_flags)
@@ -435,7 +502,7 @@ class WMISampler(object):
                 # if the "CounterType" hasn't already been cached.
                 should_get_qualifier_type = (
                     includes_qualifiers and
-                    wmi_property.Name not in self.property_counter_types
+                    wmi_property.Name not in self._property_counter_types
                 )
 
                 if should_get_qualifier_type:
@@ -449,7 +516,7 @@ class WMISampler(object):
                     # Therefore, they're ignored.
                     if "CounterType" in qualifiers:
                         counter_type = qualifiers["CounterType"]
-                        self.property_counter_types[wmi_property.Name] = counter_type
+                        self._property_counter_types[wmi_property.Name] = counter_type
 
                         self.logger.debug(
                             u"Caching property qualifier CounterType: "

--- a/conf.d/iis.yaml.example
+++ b/conf.d/iis.yaml.example
@@ -9,6 +9,11 @@ instances:
   # instance per host. Note: If you also want to check the counters on the
   # current machine, you will have to create an instance with empty params.
   #
+  # The optional `provider` parameter allows to specify a WMI provider
+  # (default to `32` on Datadog Agent 32-bit or `64`). It is used to request
+  # WMI data from the non-default provider. Available options are: `32` or `64`.
+  # For more information: https://msdn.microsoft.com/en-us/library/aa393067(v=vs.85).aspx
+  #
   # The `sites` parameter allows you to specify a list of sites you want to
   # read metrics from. With sites specified, metrics will be tagged with the
   # site name. If you don't define any sites, the check will pull the

--- a/conf.d/wmi_check.yaml.example
+++ b/conf.d/wmi_check.yaml.example
@@ -18,7 +18,7 @@ instances:
   # `namespace` is the optionnal WMI namespace to connect to (default to `cimv2`).
   #
   # `provider` is the optional WMI provider (default to `32` on Datadog Agent 32-bit or `64`).
-  # Usefull to request WMI data from the non-default provider. Available options are: `32` or `64`.
+  # It is used to request WMI data from the non-default provider. Available options are: `32` or `64`.
   # For more information: https://msdn.microsoft.com/en-us/library/aa393067(v=vs.85).aspx
   #
   # `metrics` is a list of metrics you want to capture, with each item in the

--- a/conf.d/wmi_check.yaml.example
+++ b/conf.d/wmi_check.yaml.example
@@ -17,6 +17,10 @@ instances:
   #
   # `namespace` is the optionnal WMI namespace to connect to (default to `cimv2`).
   #
+  # `provider` is the optional WMI provider (default to `32` on Datadog Agent 32-bit or `64`).
+  # Usefull to request WMI data from the non-default provider. Available options are: `32` or `64`.
+  # For more information: https://msdn.microsoft.com/en-us/library/aa393067(v=vs.85).aspx
+  #
   # `metrics` is a list of metrics you want to capture, with each item in the
   # list being a set of [WMI property name, metric name, metric type].
   #
@@ -29,13 +33,11 @@ instances:
   # - The metric type is from the standard choices for all agent checks, such
   #   as gauge, rate, histogram or counter.
   #
-  #
   # `filters` is a list of filters on the WMI query you may want. For example,
   # for a process-based WMI class you may want metrics for only certain
   # processes running on your machine, so you could add a filter for each
   # process name. You can also use the '%' character as a wildcard.
   # See below for examples.
-  #
   #
   # `tag_by` optionally lets you tag each metric with a property from the
   # WMI class you're using. This is only useful when you will have multiple


### PR DESCRIPTION
### Changes
**[wmi] set a `provider` to request data**

`WMISampler` class has a new `provider` attribute to specify a WMI
provider to request data from.
Available options are:
* (Default) `ProviderArchitecture.DEFAULT`
   Request from the provider corresponding to the version of the Datadog
   Agent version installed, i.e. 32-bit on Datadog Agent 32-bit or
   64-bit otherwise.
* `ProviderArchitecture._32BIT`
  Request from the 32-bit provider.
* `ProviderArchitecture._64BIT`
  Request from the 64-bit provider.

**[wmi_check] support `provider` option**

Add a `provider` option to the WMI check's YAML configuration file.
Instructs the check to request WMI data from the specified provider.
Available options are: `32` or `64`.

**[iis] support `provider` option**

Add a `provider` option to the WMI check's YAML configuration file.
Instructs the check to request WMI data from the specified provider.
Available options are: `32` or `64`.

### Next ?

WMI fallbacks to the default provider when no data is available in the provided one. Thus, I reckon it would make sense to default to the 64-bit provider directly. Any thought ?

