### PR TITLE
[dev] locating the system python2 to create the virtualenv

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -60,7 +60,7 @@ desc 'Setup a development environment for the Agent'
 task 'setup_env' do
   `mkdir -p venv`
   `wget -O venv/virtualenv.py https://raw.github.com/pypa/virtualenv/1.11.6/virtualenv.py`
-  `python venv/virtualenv.py  --no-site-packages --no-pip --no-setuptools venv/`
+  `python venv/virtualenv.py -p python2 --no-site-packages --no-pip --no-setuptools venv/`
   `wget -O venv/ez_setup.py https://bootstrap.pypa.io/ez_setup.py`
   `venv/bin/python venv/ez_setup.py --version="20.9.0"`
   `wget -O venv/get-pip.py https://bootstrap.pypa.io/get-pip.py`


### PR DESCRIPTION
## What's this PR do?

Enforces the use of ``python2`` while creating the ``venv/`` virtualenv, during the execution of ``rake setup_env``.

## Motivation

Without the ``-p`` option, virtualenv uses the ``python`` system executable. Unfortunately I'm running a system (ArchLinux) that uses Python 3 as a default and because of that, the virtualenv is not properly created.