### PR TITLE
[python_rq] added python-rq AgentCheck to collect queues and workers metrics

### DIFF
--- a/checks.d/python_rq.py
+++ b/checks.d/python_rq.py
@@ -1,0 +1,177 @@
+# stdlib
+from collections import defaultdict
+
+# 3rd party
+from redis import Redis
+
+# project
+from checks import AgentCheck
+
+
+# rq prefixes that are not user configurable
+QUEUE_PREFIX = 'rq:queue:'
+IN_PROGRESS_PREFIX = 'rq:wip:'
+DEFERRED_PREFIX = 'rq:deferred:'
+FINISHED_PREFIX = 'rq:finished:'
+
+# default queues names
+QUEUES_KEY = 'rq:queues'
+WORKERS_KEY = 'rq:workers'
+FAILED_QUEUE = 'failed'
+WORKERS_STATES = ['idle', 'started', 'suspended', 'busy']
+
+# metrics
+GAUGE_KEYS = {
+    # queues status
+    'jobs_enqueued': 'python_rq.queue.enqueued',
+    'jobs_in_progress': 'python_rq.queue.in_progress',
+    'jobs_deferred': 'python_rq.queue.deferred',
+    'jobs_finished': 'python_rq.queue.finished',
+    'jobs_failed': 'python_rq.queue.failed',
+
+    # workers status
+    'workers_status': 'python_rq.workers',
+}
+
+
+class RQCheck(AgentCheck):
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+        # reuse the Redis connections
+        self._connections = {}
+        # use only meaningful connection parameters
+        self._params = [
+            'host', 'port', 'db', 'password', 'socket_timeout',
+            'connection_pool', 'charset', 'errors', 'unix_socket_path'
+        ]
+        # set a default timeout (in seconds) if no timeout is specified in the instance config
+        for instance in instances:
+            instance['socket_timeout'] = instance.get('socket_timeout', 5)
+
+    def _generate_instance_key(self, instance):
+        """
+        For the given instance, it provides a unique tuple that can be used
+        to retrieve the Redis connection
+        """
+        if 'unix_socket_path' in instance:
+            return (instance.get('unix_socket_path'), instance.get('db'))
+        else:
+            return (instance.get('host'), instance.get('port'), instance.get('db'))
+
+    def _get_connection(self, instance):
+        """
+        Establish a connection with Redis only if (host, port) or (unix_socket_path) are
+        provided. In both cases a new connection is created and the handler is stored
+        in the class instance, so that it can be re-used again during the next check
+        """
+        if ('host' not in instance or 'port' not in instance) and 'unix_socket_path' not in instance:
+            raise Exception('You must specify a host/port couple or a unix_socket_path')
+
+        key = self._generate_instance_key(instance)
+        if key not in self._connections:
+            try:
+                # open and store the connection handler
+                connection_params = dict((k, instance[k]) for k in self._params if k in instance)
+                self._connections[key] = Redis(**connection_params)
+            except TypeError:
+                raise Exception('You need a redis library that supports authenticated connections. Try sudo easy_install redis.')
+        return self._connections[key]
+
+    def _get_workers_status(self, connection):
+        """
+        Returns a dictionary with the number of workers aggregated by their status. Possible
+        status are:
+            * started
+            * suspended
+            * busy
+            * idle
+        These values depend on the python-rq code and are not developer configurable
+        """
+        workers_keys = connection.smembers(WORKERS_KEY)
+        workers_status = defaultdict(int)
+
+        for key in workers_keys:
+            state = connection.hget(key, 'state')
+            workers_status[state] += 1
+
+        return workers_status
+
+    def _get_queues_names(self, connection):
+        """
+        Returns a list of names for the currently active queues. It
+        excludes the 'failed' queue because during the metric collection,
+        failed jobs are handled differently
+        """
+        names = []
+        queues = connection.smembers(QUEUES_KEY)
+        for queue in queues:
+            if FAILED_QUEUE not in queue:
+                name = queue.split(':')
+                if len(name) == 3:
+                    names.append(name[2])
+
+        return names
+
+    def _get_cardinality(self, connection, name, prefix):
+        """
+        Returns the cardinality of the given queue. Depending on
+        the type of the key, it uses the LLEN or ZCARD command
+        """
+        queue = '{}{}'.format(prefix, name)
+        if QUEUE_PREFIX in queue:
+            return connection.llen(queue)
+
+        return connection.zcard(queue)
+
+    def _check_queues(self, connection, queues=[], custom_tags=[]):
+        """
+        Agent check that collects metrics for each queue that is listed in the
+        'queues' parameter. If 'queues' is an empty list, metrics for all user
+        defined queues are collected.
+
+        When a job is scheduled, it is placed in a different Redis list (or set)
+        according to the job status. A hypothetical 'high_priority' queue, creates
+        the following queue:
+            - 'rq:queue:high_priority'
+            - 'rq:wip:high_priority'
+            - 'rq:deferred:high_priority'
+            - 'rq:finished:high_priority'
+        To achieve better metrics, all of them should be monitored and tagged according
+        to the queue name.
+        """
+        # collect metrics for each queue except the 'failed' one
+        for name in self._get_queues_names(connection):
+            if not queues or name in queues:
+                enqueued = self._get_cardinality(connection, name, QUEUE_PREFIX)
+                in_progress = self._get_cardinality(connection, name, IN_PROGRESS_PREFIX)
+                deferred = self._get_cardinality(connection, name, DEFERRED_PREFIX)
+                finished = self._get_cardinality(connection, name, FINISHED_PREFIX)
+                tags = ['queue:{}'.format(name)]
+
+                self.gauge(GAUGE_KEYS['jobs_enqueued'], enqueued, tags=tags)
+                self.gauge(GAUGE_KEYS['jobs_in_progress'], in_progress, tags=tags)
+                self.gauge(GAUGE_KEYS['jobs_deferred'], deferred, tags=tags)
+                self.gauge(GAUGE_KEYS['jobs_finished'], finished, tags=tags)
+
+        # collect metrics for the 'failed' queue that doesn't behave such as
+        # a user-defined queue
+        failed_jobs = self._get_cardinality(connection, FAILED_QUEUE, QUEUE_PREFIX)
+        self.gauge(GAUGE_KEYS['jobs_failed'], failed_jobs)
+
+    def _check_workers(self, connection, custom_tags=[]):
+        """
+        Agent check that collects workers metrics related to their current activity
+        """
+        status = self._get_workers_status(connection)
+        for state in WORKERS_STATES:
+            value = status.get(state, 0)
+            tags = ['status:{}'.format(state)] + custom_tags
+            self.gauge(GAUGE_KEYS['workers_status'], value, tags=tags)
+
+    def check(self, instance):
+        connection = self._get_connection(instance)
+        custom_tags = instance.get('tags', [])
+        queues = instance.get('queues', [])
+        # checks
+        self._check_queues(connection, queues, custom_tags)
+        self._check_workers(connection, custom_tags)

--- a/conf.d/python_rq.yaml.example
+++ b/conf.d/python_rq.yaml.example
@@ -1,0 +1,27 @@
+init_config:
+
+instances:
+  - host: localhost
+    port: 6379
+
+    # Can be used in lieu of host/port
+    #
+    # unix_socket_path: /var/run/redis/redis.sock # optional, can be used in lieu of host/port
+
+    # Addional connection options
+    #
+    # db: 0
+    # password: mypassword
+    # socket_timeout: 5
+
+    # Monitor only the following queues
+    #
+    # queues:
+    #   - high
+    #   - critical
+
+    # Optional extra tags added to all RQ metrics
+    # tags:
+    #   - optional_tag1
+    #   - optional_tag2
+    #

--- a/tests/checks/mock/test_python_rq.py
+++ b/tests/checks/mock/test_python_rq.py
@@ -1,0 +1,317 @@
+# stdlib
+import mock
+import unittest
+
+# project
+from tests.checks.common import AgentCheckTest, get_check_class
+
+
+class TestRQCheck(AgentCheckTest):
+    CHECK_NAME = 'python_rq'
+
+    def mock_get_workers_status(self, connection):
+        return {
+            'idle': 2,
+            'busy': 4,
+            'suspended': 1,
+            'started': 3,
+        }
+
+    def mock_get_queues_name(self, connection):
+        return ['low', 'high']
+
+    def mock_get_cardinality(self, connection, name, prefix):
+        if 'queue' in prefix:
+            return 5
+        elif 'wip' in prefix:
+            return 10
+        elif 'deferred' in prefix:
+            return 15
+        elif 'finished' in prefix:
+            return 20
+        else:
+            return 25
+
+    def test_improperly_configured(self):
+        """
+        Ensure that it raises an exception if the instance configuration
+        is improperly configured
+        """
+        config = {
+            'init_config': {},
+            'instances' : [{}]
+        }
+        self.assertRaises(Exception, self.run_check, config)
+
+    @mock.patch('redis.Redis')
+    def test_config_host_port_ok(self, *args):
+        """
+        Ensure that using just a 'host' and 'port' keywords is enough
+        to launch the check
+        """
+        config = {
+            'init_config': {},
+            'instances' : [{
+                'host': 'localhost',
+                'port': '6379',
+            }]
+        }
+        self.run_check(config)
+
+    @mock.patch('redis.Redis')
+    def test_config_unix_socket_ok(self, *args):
+        """
+        Ensure that using just a 'unix_socket_path' is enough to launch
+        the check
+        """
+        config = {
+            'init_config': {},
+            'instances' : [{
+                'unix_socket_path': '/var/run/redis/redis',
+            }]
+        }
+        self.run_check(config)
+
+    @mock.patch('redis.Redis')
+    def test_workers_metrics(self, *args):
+        """
+        Collects the metrics related to RQ workers. These metrics must
+        be tagged according to the worker status
+        """
+        mocks = {
+            '_get_workers_status': self.mock_get_workers_status,
+        }
+        config = {
+            'init_config': {},
+            'instances' : [{
+                'host': 'localhost',
+                'port': '6379',
+            }]
+        }
+        self.run_check(config, mocks=mocks)
+        self.assertMetric('python_rq.workers', value=2, tags=['status:idle'])
+        self.assertMetric('python_rq.workers', value=3, tags=['status:started'])
+        self.assertMetric('python_rq.workers', value=1, tags=['status:suspended'])
+        self.assertMetric('python_rq.workers', value=4, tags=['status:busy'])
+
+    @mock.patch('redis.Redis')
+    def test_failed_jobs_metrics(self, *args):
+        """
+        Collects the metrics related to the number of failed jobs
+        """
+        mocks = {
+            '_get_cardinality': self.mock_get_cardinality,
+        }
+        config = {
+            'init_config': {},
+            'instances' : [{
+                'host': 'localhost',
+                'port': '6379',
+            }]
+        }
+        self.run_check(config, mocks=mocks)
+        self.assertMetric('python_rq.queue.failed', value=5)
+
+    @mock.patch('redis.Redis')
+    def test_all_queues_status(self, *args):
+        """
+        Collects the metrics related to each queue, ensuring that if no
+        queues parameter is configured in the config file, all queues
+        are handled
+        """
+        mocks = {
+            '_get_queues_names': self.mock_get_queues_name,
+            '_get_cardinality': self.mock_get_cardinality,
+        }
+        config = {
+            'init_config': {},
+            'instances' : [{
+                'host': 'localhost',
+                'port': '6379',
+            }]
+        }
+        self.run_check(config, mocks=mocks)
+        self.assertMetric('python_rq.queue.enqueued', value=5, tags=['queue:low'])
+        self.assertMetric('python_rq.queue.in_progress', value=10, tags=['queue:low'])
+        self.assertMetric('python_rq.queue.deferred', value=15, tags=['queue:low'])
+        self.assertMetric('python_rq.queue.finished', value=20, tags=['queue:low'])
+
+        self.assertMetric('python_rq.queue.enqueued', value=5, tags=['queue:high'])
+        self.assertMetric('python_rq.queue.in_progress', value=10, tags=['queue:high'])
+        self.assertMetric('python_rq.queue.deferred', value=15, tags=['queue:high'])
+        self.assertMetric('python_rq.queue.finished', value=20, tags=['queue:high'])
+
+    @mock.patch('redis.Redis')
+    def test_chosen_queues_status(self, *args):
+        """
+        Collects the metrics related to each queue, ensuring that if queues
+        parameter is configured in the config file, only these queues are
+        handled
+        """
+        mocks = {
+            '_get_queues_names': self.mock_get_queues_name,
+            '_get_cardinality': self.mock_get_cardinality,
+        }
+        config = {
+            'init_config': {},
+            'instances' : [{
+                'host': 'localhost',
+                'port': '6379',
+                'queues': ['high'],
+            }]
+        }
+        self.run_check(config, mocks=mocks)
+        self.assertMetric('python_rq.queue.enqueued', count=0, tags=['queue:low'])
+        self.assertMetric('python_rq.queue.in_progress', count=0, tags=['queue:low'])
+        self.assertMetric('python_rq.queue.deferred', count=0, tags=['queue:low'])
+        self.assertMetric('python_rq.queue.finished', count=0, tags=['queue:low'])
+
+        self.assertMetric('python_rq.queue.enqueued', value=5, tags=['queue:high'])
+        self.assertMetric('python_rq.queue.in_progress', value=10, tags=['queue:high'])
+        self.assertMetric('python_rq.queue.deferred', value=15, tags=['queue:high'])
+        self.assertMetric('python_rq.queue.finished', value=20, tags=['queue:high'])
+
+
+class TestRQInternals(unittest.TestCase):
+    CHECK_NAME = 'python_rq'
+
+    def test_init_defaults(self):
+        """
+        Ensure that default values are properly set
+        """
+        # config
+        instances = [{
+            'host': 'localhost',
+            'port': '6379',
+        }]
+        # create check instance
+        RQCheck = get_check_class(TestRQInternals.CHECK_NAME)
+        rq_check = RQCheck(TestRQInternals.CHECK_NAME, {}, {}, instances)
+        # test
+        self.assertIn('socket_timeout', rq_check.instances[0])
+        self.assertEqual(rq_check.instances[0]['socket_timeout'], 5)
+
+    def test_get_workers_status(self):
+        """
+        Ensure that the workers status retrieval, returns the proper
+        dictionary
+        """
+        # mocks
+        workers = [
+            'rq:worker:host.10000',
+            'rq:worker:host.10001',
+            'rq:worker:host.10002',
+            'rq:worker:host.10003',
+            'rq:worker:host.10004',
+        ]
+        states = {
+            'rq:worker:host.10000': 'idle',
+            'rq:worker:host.10001': 'started',
+            'rq:worker:host.10002': 'busy',
+            'rq:worker:host.10003': 'suspended',
+            'rq:worker:host.10004': 'busy',
+        }
+        # config
+        instances = [{
+            'host': 'localhost',
+            'port': '6379',
+        }]
+        # create check instance
+        RQCheck = get_check_class(TestRQInternals.CHECK_NAME)
+        rq_check = RQCheck(TestRQInternals.CHECK_NAME, {}, {}, instances)
+        connection = mock.MagicMock()
+        connection.smembers.return_value = workers
+        connection.hget.side_effect = lambda x, y: states[x]
+        # test
+        result = rq_check._get_workers_status(connection)
+        self.assertEqual(result, {'idle': 1, 'started': 1, 'busy': 2, 'suspended': 1})
+
+    def test_get_queues_names(self):
+        """
+        Ensure that all queues names, except the 'failed' queue, are retrieved
+        """
+        # mocks
+        queues = [
+            'rq:queue:low',
+            'rq:queue:high',
+            'rq:queue:failed',
+        ]
+        # config
+        instances = [{
+            'host': 'localhost',
+            'port': '6379',
+        }]
+        # create check instance
+        RQCheck = get_check_class(TestRQInternals.CHECK_NAME)
+        rq_check = RQCheck(TestRQInternals.CHECK_NAME, {}, {}, instances)
+        connection = mock.MagicMock()
+        connection.smembers.return_value = queues
+        # test
+        result = rq_check._get_queues_names(connection)
+        self.assertEqual(result, ['low', 'high'])
+
+    def test_get_queues_with_wrong_names(self):
+        """
+        Ensure that if there is a queue with a wrong name it will be discarded,
+        while remaining queues are properly returned
+        """
+        # mocks
+        queues = [
+            'rq:queue:low',
+            'rq:queue:high',
+            'rq:queue:failed',
+            'rq:quite:fast:queue',
+            'rq:queue',
+            'really_wrong_queue',
+        ]
+        # config
+        instances = [{
+            'host': 'localhost',
+            'port': '6379',
+        }]
+        # create check instance
+        RQCheck = get_check_class(TestRQInternals.CHECK_NAME)
+        rq_check = RQCheck(TestRQInternals.CHECK_NAME, {}, {}, instances)
+        connection = mock.MagicMock()
+        connection.smembers.return_value = queues
+        # test
+        result = rq_check._get_queues_names(connection)
+        self.assertEqual(result, ['low', 'high'])
+
+    def test_get_cardinality_queue(self):
+        """
+        Ensure that any queues that begins with 'rq:queue' uses the Redis
+        LLEN command
+        """
+        # config
+        instances = [{
+            'host': 'localhost',
+            'port': '6379',
+        }]
+        # create check instance
+        RQCheck = get_check_class(TestRQInternals.CHECK_NAME)
+        rq_check = RQCheck(TestRQInternals.CHECK_NAME, {}, {}, instances)
+        connection = mock.MagicMock()
+        # test
+        rq_check._get_cardinality(connection, 'default', 'rq:queue:')
+        self.assertEqual(connection.llen.call_count, 1)
+
+    def test_get_cardinality_others(self):
+        """
+        Ensure that any queues that doesn't begin with 'rq:queue' uses the Redis
+        ZCARD command
+        """
+        # config
+        instances = [{
+            'host': 'localhost',
+            'port': '6379',
+        }]
+        # create check instance
+        RQCheck = get_check_class(TestRQInternals.CHECK_NAME)
+        rq_check = RQCheck(TestRQInternals.CHECK_NAME, {}, {}, instances)
+        connection = mock.MagicMock()
+        # test
+        rq_check._get_cardinality(connection, 'default', 'rq:wip:')
+        rq_check._get_cardinality(connection, 'default', 'rq:deferred:')
+        rq_check._get_cardinality(connection, 'default', 'rq:finished:')
+        self.assertEqual(connection.zcard.call_count, 3)


### PR DESCRIPTION
## python-rq check

This PR adds the [python-rq](http://python-rq.org/) agent check. RQ uses Redis as a backing service to store jobs states each time one of them is enqueued. Users may define their own queues and may choose how many workers are assigned to each queue.

The `AgentCheck` collects metrics so that developers are aware of the queues usage, while knowing how much their workers are busy. This is critical to decide when it's the time to spawn more workers or to assign more workers to a particular queue.
## Collected metrics
- `python_rq.queue.enqueued`
- `python_rq.queue.in_progress`
- `python_rq.queue.deferred`
- `python_rq.queue.finished`
- `python_rq.queue.failed`
- `python_rq.workers`

Queue metrics are tagged using the queue name (i.e. `queue:high`); workers metric is tagged using the current worker status (i.e. `status:idle`).
## Configuration file

It exposes the `queues` parameter so that users may decide to monitor only the chosen queues. If the value is not present, all queues are monitored.
## Notes
- no external requirements (it uses just `redis`)
- Redis connections are established and stored using the same approach available in the built-in `Redis` check
