### PR TITLE
Copying of API Key Into datadog.conf Fixed

### DIFF
--- a/packaging/osx/install.sh
+++ b/packaging/osx/install.sh
@@ -64,7 +64,7 @@ $sudo_cmd hdiutil detach "/Volumes/datadog_agent" >/dev/null
 # Set the configuration
 if egrep 'api_key:( APIKEY)?$' "/opt/datadog-agent/etc/datadog.conf" > /dev/null 2>&1; then
     printf "\033[34m\n* Adding your API key to the Agent configuration: datadog.conf\n\033[0m\n"
-    $sudo_cmd sh -c "sed -i '' 's/api_key:.*/api_key: $apikey/' \"/opt/datadog-agent/etc/datadog.conf\""
+    $sudo_cmd sh -c "sed -i 's/api_key:.*/api_key: $apikey/' \"/opt/datadog-agent/etc/datadog.conf\""
     $sudo_cmd chown $real_user:admin "/opt/datadog-agent/etc/datadog.conf"
     $sudo_cmd chmod 640 /opt/datadog-agent/etc/datadog.conf
     printf "\033[34m* Restarting the Agent...\n\033[0m\n"


### PR DESCRIPTION
An apparently improper use of the `sed` command seems to break the copying of the API key into the `datadog.conf` file. This should be fixed with this revision.