### PR TITLE
[openstack] openstack should pick-up on proxy settings set on agent

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -31,7 +31,6 @@ from requests.packages.urllib3.packages.ssl_match_hostname import \
 from checks.network_checks import EventType, NetworkCheck, Status
 from config import _is_affirmative
 from util import headers as agent_headers
-from utils.proxy import get_proxy
 
 DEFAULT_EXPECTED_CODE = "(1|2|3)\d\d"
 CONTENT_LENGTH = 200
@@ -152,19 +151,19 @@ class HTTPCheck(NetworkCheck):
 
     def __init__(self, name, init_config, agentConfig, instances):
         self.ca_certs = init_config.get('ca_certs', get_ca_certs_path())
-        proxy_settings = get_proxy(agentConfig)
+
         self.proxies = {
             "http": None,
             "https": None,
         }
-        if proxy_settings:
+        if self.proxy_settings:
             uri = "{host}:{port}".format(
-                host=proxy_settings['host'],
-                port=proxy_settings['port'])
-            if proxy_settings['user'] and proxy_settings['password']:
+                host=self.proxy_settings['host'],
+                port=self.proxy_settings['port'])
+            if self.proxy_settings['user'] and self.proxy_settings['password']:
                 uri = "{user}:{password}@{uri}".format(
-                    user=proxy_settings['user'],
-                    password=proxy_settings['password'],
+                    user=self.proxy_settings['user'],
+                    password=self.proxy_settings['password'],
                     uri=uri)
             self.proxies['http'] = "http://{uri}".format(uri=uri)
             self.proxies['https'] = "https://{uri}".format(uri=uri)

--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -154,25 +154,6 @@ class HTTPCheck(NetworkCheck):
 
         self.ca_certs = init_config.get('ca_certs', get_ca_certs_path())
 
-        self.proxies = {
-            "http": None,
-            "https": None,
-        }
-        if self.proxy_settings:
-            uri = "{host}:{port}".format(
-                host=self.proxy_settings['host'],
-                port=self.proxy_settings['port'])
-            if self.proxy_settings['user'] and self.proxy_settings['password']:
-                uri = "{user}:{password}@{uri}".format(
-                    user=self.proxy_settings['user'],
-                    password=self.proxy_settings['password'],
-                    uri=uri)
-            self.proxies['http'] = "http://{uri}".format(uri=uri)
-            self.proxies['https'] = "https://{uri}".format(uri=uri)
-        else:
-            self.proxies['http'] = environ.get('HTTP_PROXY', None)
-            self.proxies['https'] = environ.get('HTTPS_PROXY', None)
-
         self.proxies['no'] = environ.get('no_proxy',
                                          environ.get('NO_PROXY', None)
                                          )

--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -150,6 +150,8 @@ class HTTPCheck(NetworkCheck):
     SC_SSL_CERT = 'http.ssl_cert'
 
     def __init__(self, name, init_config, agentConfig, instances):
+        NetworkCheck.__init__(self, name, init_config, agentConfig, instances)
+
         self.ca_certs = init_config.get('ca_certs', get_ca_certs_path())
 
         self.proxies = {
@@ -174,8 +176,6 @@ class HTTPCheck(NetworkCheck):
         self.proxies['no'] = environ.get('no_proxy',
                                          environ.get('NO_PROXY', None)
                                          )
-
-        NetworkCheck.__init__(self, name, init_config, agentConfig, instances)
 
     def _load_conf(self, instance):
         # Fetches the conf

--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -355,6 +355,7 @@ class OpenStackCheck(AgentCheck):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
 
         self._ssl_verify = init_config.get("ssl_verify", True)
+        self._use_proxy = init_config.get("use_agent_proxy", True)
         self.keystone_server_url = init_config.get("keystone_server_url")
         if not self.keystone_server_url:
             raise IncompleteConfig()
@@ -373,7 +374,7 @@ class OpenStackCheck(AgentCheck):
             "http": None,
             "https": None,
         }
-        if self.proxy_settings:
+        if self.proxy_settings and self._use_proxy:
             uri = "{host}:{port}".format(
                 host=self.proxy_settings['host'],
                 port=self.proxy_settings['port'])

--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -143,7 +143,7 @@ class OpenStackProjectScope(object):
         try:
             auth_resp = cls.request_auth_token(auth_scope, identity, keystone_server_url, ssl_verify, proxy_config)
         except (requests.exceptions.HTTPError, requests.exceptions.Timeout, requests.exceptions.ConnectionError):
-            exception_msg = "Failed kaystone auth with identity:{id} scope:{scope} @{url}".format(
+            exception_msg = "Failed keystone auth with identity:{id} scope:{scope} @{url}".format(
                 id=identity,
                 scope=auth_scope,
                 url=keystone_server_url)
@@ -357,7 +357,6 @@ class OpenStackCheck(AgentCheck):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
 
         self._ssl_verify = init_config.get("ssl_verify", True)
-        self._use_proxy = init_config.get("use_agent_proxy", True)
         self.keystone_server_url = init_config.get("keystone_server_url")
         if not self.keystone_server_url:
             raise IncompleteConfig()
@@ -370,23 +369,6 @@ class OpenStackCheck(AgentCheck):
 
         # Mapping of Nova-managed servers to tags
         self.external_host_tags = {}
-
-        # Set proxy settings
-        self.proxies = {
-            "http": None,
-            "https": None,
-        }
-        if self.proxy_settings and self._use_proxy:
-            uri = "{host}:{port}".format(
-                host=self.proxy_settings['host'],
-                port=self.proxy_settings['port'])
-            if self.proxy_settings['user'] and self.proxy_settings['password']:
-                uri = "{user}:{password}@{uri}".format(
-                    user=self.proxy_settings['user'],
-                    password=self.proxy_settings['password'],
-                    uri=uri)
-            self.proxies['http'] = "http://{uri}".format(uri=uri)
-            self.proxies['https'] = "https://{uri}".format(uri=uri)
 
     def _make_request_with_auth_fallback(self, url, headers=None, verify=True, params=None):
         """

--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -16,8 +16,10 @@ import simplejson as json
 
 SOURCE_TYPE = 'openstack'
 
+V21_NOVA_API_VERSION = 'v2.1'
+
 DEFAULT_KEYSTONE_API_VERSION = 'v3'
-DEFAULT_NOVA_API_VERSION = 'v2.1'
+DEFAULT_NOVA_API_VERSION = V21_NOVA_API_VERSION
 DEFAULT_NEUTRON_API_VERSION = 'v2.0'
 
 DEFAULT_API_REQUEST_TIMEOUT = 5 # seconds
@@ -302,7 +304,7 @@ class KeystoneCatalog(object):
         nova_version = nova_api_version or DEFAULT_NOVA_API_VERSION
         catalog = json_resp.get('token', {}).get('catalog', [])
 
-        nova_match = 'novav21' if nova_version == 'v2.1' else 'nova'
+        nova_match = 'novav21' if nova_version == V21_NOVA_API_VERSION else 'nova'
 
         for entry in catalog:
             if entry['name'] == nova_match or 'Compute' in entry['name']:
@@ -526,7 +528,7 @@ class OpenStackCheck(AgentCheck):
 
     def get_all_hypervisor_ids(self, filter_by_host=None):
         nova_version = self.init_config.get("nova_api_version", DEFAULT_NOVA_API_VERSION)
-        if nova_version == "v2.1":
+        if nova_version >= V21_NOVA_API_VERSION:
             url = '{0}/os-hypervisors'.format(self.get_nova_endpoint())
             headers = {'X-Auth-Token': self.get_auth_token()}
 

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -30,6 +30,7 @@ import yaml
 # project
 from checks import check_status
 from util import get_hostname, get_next_id, yLoader
+from utils.proxy import get_proxy
 from utils.platform import Platform
 from utils.profile import pretty_statistics
 if Platform.is_windows():
@@ -346,6 +347,8 @@ class AgentCheck(object):
         self._instance_metadata = []
         self.svc_metadata = []
         self.historate_dict = {}
+        self.proxy_settings = get_proxy(self.agentConfig)
+
 
     def instance_count(self):
         """ Return the number of instances that are configured for this check. """

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -347,8 +347,25 @@ class AgentCheck(object):
         self._instance_metadata = []
         self.svc_metadata = []
         self.historate_dict = {}
-        self.proxy_settings = get_proxy(self.agentConfig)
 
+        # Set proxy settings
+        self.proxy_settings = get_proxy(self.agentConfig)
+        self._use_proxy = False if init_config is None else init_config.get("use_agent_proxy", True)
+        self.proxies = {
+            "http": None,
+            "https": None,
+        }
+        if self.proxy_settings and self._use_proxy:
+            uri = "{host}:{port}".format(
+                host=self.proxy_settings['host'],
+                port=self.proxy_settings['port'])
+            if self.proxy_settings['user'] and self.proxy_settings['password']:
+                uri = "{user}:{password}@{uri}".format(
+                    user=self.proxy_settings['user'],
+                    password=self.proxy_settings['password'],
+                    uri=uri)
+            self.proxies['http'] = "http://{uri}".format(uri=uri)
+            self.proxies['https'] = "https://{uri}".format(uri=uri)
 
     def instance_count(self):
         """ Return the number of instances that are configured for this check. """

--- a/conf.d/openstack.yaml.example
+++ b/conf.d/openstack.yaml.example
@@ -27,6 +27,9 @@ init_config:
       # need to set to false when using self-signed certs
       # ssl_verify: true
 
+     # Whether the dd-agent proxy should be used for openstack API requests (if set)
+     # use_agent_proxy: true
+
 instances:
     - name: instance_1 # A required unique identifier for this instance
 

--- a/conf.d/openstack.yaml.example
+++ b/conf.d/openstack.yaml.example
@@ -27,7 +27,7 @@ init_config:
       # need to set to false when using self-signed certs
       # ssl_verify: true
 
-     # Whether the dd-agent proxy should be used for openstack API requests (if set)
+     # Whether the dd-agent proxy should also be used for openstack API requests (if set)
      # use_agent_proxy: true
 
 instances:


### PR DESCRIPTION
## Why
Customers often have boxes that must route http/https traffic through a proxy. Their keystone server, and openstack API calls might have to use the proxy. The openstack check should be proxy aware, this check aims to provide that functionality.

Also, in case the keystone/openstack servers happen to be in the LAN and not require the proxy (even though the agent might), we also introduce a `use_agent_proxy` flag to the openstack config to override the behavior at will.

Also improving support for openstack Mitaka. On mitaka (despite being v2.1) the nova endpoints don't match the `novav21` pattern, instead they match directly to nova. The small changes to how we deal with nova endpoint versions should allow us to get the endpoints if the right `nova_api_version` is overridden in the YAML. Same goes for the hypervisors stats.  

Note: all checks should really potentially be able to make calls via the proxy defined for the agent, so I've added a property to the `AgentCheck` class to provide easy access to the agent's proxy settings.