### PR TITLE
[service discovery] Improve logging, test coverage and template variable interpolation

### DIFF
--- a/config.py
+++ b/config.py
@@ -829,18 +829,24 @@ def _service_disco_configs(agentConfig):
     """ Retrieve all the service disco configs and return their conf dicts
     """
     if agentConfig.get('service_discovery') and agentConfig.get('service_discovery_backend') in SD_BACKENDS:
-        sd_backend = get_sd_backend(agentConfig=agentConfig)
-        service_disco_configs = sd_backend.get_configs()
+        try:
+            log.info("Fetching service discovery check configurations.")
+            sd_backend = get_sd_backend(agentConfig=agentConfig)
+            service_disco_configs = sd_backend.get_configs()
+        except Exception:
+            log.exception("Loading service discovery configurations failed.")
     else:
         service_disco_configs = {}
 
     return service_disco_configs
+
 
 def _conf_path_to_check_name(conf_path):
     f = os.path.splitext(os.path.split(conf_path)[1])
     if f[1] and f[1] == ".default":
         f = os.path.splitext(f[0])
     return f[0]
+
 
 def get_checks_places(osname, agentConfig):
     """ Return a list of methods which, when called with a check name, will each return a check path to inspect

--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -31,7 +31,7 @@ class Response(object):
 
 def _get_container_inspect(c_id):
     """Return a mocked container inspect dict from self.container_inspects."""
-    for co, _, _ in TestServiceDiscovery.container_inspects:
+    for co, _, _, _ in TestServiceDiscovery.container_inspects:
         if co.get('Id') == c_id:
             return co
         return None
@@ -81,9 +81,9 @@ class TestServiceDiscovery(unittest.TestCase):
     }
     container_inspects = [
         # (inspect_dict, expected_ip, expected_port)
-        (docker_container_inspect, '172.17.0.21', ['80', '443']),
-        (kubernetes_container_inspect, None, ['6379']),  # arbitrarily defined in the mocked pod_list
-        (malformed_container_inspect, None, KeyError)
+        (docker_container_inspect, '172.17.0.21', 'port', '443'),
+        (kubernetes_container_inspect, None, 'port', '6379'),  # arbitrarily defined in the mocked pod_list
+        (malformed_container_inspect, None, 'port', KeyError)
     ]
 
     # templates with variables already extracted
@@ -152,7 +152,7 @@ class TestServiceDiscovery(unittest.TestCase):
 
     @mock.patch('utils.http.requests.get')
     @mock.patch('utils.kubeutil.check_yaml')
-    def test_get_host(self, mock_check_yaml, mock_get):
+    def test_get_host_address(self, mock_check_yaml, mock_get):
         kubernetes_config = {'instances': [{'kubelet_port': 1337}]}
         pod_list = {
             'items': [{
@@ -165,25 +165,64 @@ class TestServiceDiscovery(unittest.TestCase):
             }]
         }
 
+        # (inspect, tpl_var, expected_result)
+        ip_address_inspects = [
+            ({'NetworkSettings': {}}, 'host', None),
+            ({'NetworkSettings': {'IPAddress': ''}}, 'host', None),
+
+            ({'NetworkSettings': {'IPAddress': '127.0.0.1'}}, 'host', '127.0.0.1'),
+            ({'NetworkSettings': {'IPAddress': '127.0.0.1', 'Networks': {}}}, 'host', '127.0.0.1'),
+            ({'NetworkSettings': {
+                'IPAddress': '127.0.0.1',
+                'Networks': {'bridge': {'IPAddress': '127.0.0.1'}}}},
+             'host', '127.0.0.1'),
+            ({'NetworkSettings': {
+                'IPAddress': '',
+                'Networks': {'bridge': {'IPAddress': '127.0.0.1'}}}},
+             'host_bridge', '127.0.0.1'),
+            ({'NetworkSettings': {
+                'IPAddress': '127.0.0.1',
+                'Networks': {
+                    'bridge': {'IPAddress': '172.17.0.2'},
+                    'foo': {'IPAddress': '192.168.0.2'}}}},
+             'host', '127.0.0.1'),
+
+            ({'NetworkSettings': {'Networks': {}}}, 'host', None),
+            ({'NetworkSettings': {'Networks': {}}}, 'host_bridge', None),
+            ({'NetworkSettings': {'Networks': {'bridge': {}}}}, 'host', None),
+            ({'NetworkSettings': {'Networks': {'bridge': {}}}}, 'host_bridge', None),
+            ({'NetworkSettings': {
+                'Networks': {
+                    'bridge': {'IPAddress': '172.17.0.2'}
+                }}},
+             'host_bridge', '172.17.0.2'),
+            ({'NetworkSettings': {
+                'Networks': {
+                    'bridge': {'IPAddress': '172.17.0.2'},
+                    'foo': {'IPAddress': '192.168.0.2'}
+                }}},
+             'host_foo', '192.168.0.2')
+        ]
+
         mock_check_yaml.return_value = kubernetes_config
         mock_get.return_value = Response(pod_list)
 
-        for c_ins, expected_ip, _ in self.container_inspects:
+        for c_ins, tpl_var, expected_ip in ip_address_inspects:
             with mock.patch.object(AbstractConfigStore, '__init__', return_value=None):
                 with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
                     with mock.patch('utils.kubeutil.get_conf_path', return_value=None):
                         sd_backend = get_sd_backend(agentConfig=self.auto_conf_agentConfig)
-                        self.assertEqual(sd_backend._get_host(c_ins), expected_ip)
+                        self.assertEquals(sd_backend._get_host_address(c_ins, tpl_var), expected_ip)
                         clear_singletons(self.auto_conf_agentConfig)
 
-    def test_get_ports(self):
+    def test_get_port(self):
         with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
-            for c_ins, _, expected_ports in self.container_inspects:
+            for c_ins, _, var_tpl, expected_ports in self.container_inspects:
                 sd_backend = get_sd_backend(agentConfig=self.auto_conf_agentConfig)
-                if isinstance(expected_ports, list):
-                    self.assertEqual(sd_backend._get_ports(c_ins), expected_ports)
+                if isinstance(expected_ports, str):
+                    self.assertEquals(sd_backend._get_port(c_ins, var_tpl), expected_ports)
                 else:
-                    self.assertRaises(expected_ports, sd_backend._get_ports, c_ins)
+                    self.assertRaises(expected_ports, sd_backend._get_port, c_ins, var_tpl)
                 clear_singletons(self.auto_conf_agentConfig)
 
     @mock.patch('docker.Client.inspect_container', side_effect=_get_container_inspect)
@@ -191,8 +230,8 @@ class TestServiceDiscovery(unittest.TestCase):
     def test_get_check_configs(self, mock_inspect_container, mock_get_conf_tpls):
         """Test get_check_config with mocked container inspect and config template"""
         with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
-            with mock.patch.object(SDDockerBackend, '_get_host', return_value='127.0.0.1'):
-                with mock.patch.object(SDDockerBackend, '_get_ports', return_value=['1337']):
+            with mock.patch.object(SDDockerBackend, '_get_host_address', return_value='127.0.0.1'):
+                with mock.patch.object(SDDockerBackend, '_get_port', return_value='1337'):
                     c_id = self.docker_container_inspect.get('Id')
                     for image in self.mock_templates.keys():
                         sd_backend = get_sd_backend(agentConfig=self.auto_conf_agentConfig)
@@ -239,29 +278,78 @@ class TestServiceDiscovery(unittest.TestCase):
         ]
 
         with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
-            for agentConfig in self.agentConfigs:
-                sd_backend = get_sd_backend(agentConfig=agentConfig)
-                for tpl, res in valid_configs:
-                    init, instance, variables = tpl
-                    config = sd_backend._render_template(init, instance, variables)
-                    self.assertEquals(config, res)
-                for init, instance, variables in invalid_configs:
-                    config = sd_backend._render_template(init, instance, variables)
-                    self.assertEquals(config, None)
-                    clear_singletons(agentConfig)
+            with mock.patch.object(EtcdStore, 'get_client', return_value=None):
+                with mock.patch.object(ConsulStore, 'get_client', return_value=None):
+                    for agentConfig in self.agentConfigs:
+                        sd_backend = get_sd_backend(agentConfig=agentConfig)
+                        for tpl, res in valid_configs:
+                            init, instance, variables = tpl
+                            config = sd_backend._render_template(init, instance, variables)
+                            self.assertEquals(config, res)
+                        for init, instance, variables in invalid_configs:
+                            config = sd_backend._render_template(init, instance, variables)
+                            self.assertEquals(config, None)
+                            clear_singletons(agentConfig)
 
     def test_fill_tpl(self):
-        """Test _fill_tpl with mock _get_ports"""
+        """Test _fill_tpl with mocked docker client"""
+
         valid_configs = [
             # ((inspect, instance_tpl, variables, tags), (expected_instance_tpl, expected_var_values))
+            (({}, {'host': 'localhost'}, [], None), ({'host': 'localhost'}, {})),
             (
-                ({}, {'host': 'localhost'}, [], None),
+                ({'NetworkSettings': {'IPAddress': ''}}, {'host': 'localhost'}, [], None),
+                ({'host': 'localhost'}, {})
+            ),
+            (
+                ({'NetworkSettings': {'Networks': {}}}, {'host': 'localhost'}, [], None),
+                ({'host': 'localhost'}, {})
+            ),
+            (
+                ({'NetworkSettings': {'Networks': {'bridge': {}}}}, {'host': 'localhost'}, [], None),
                 ({'host': 'localhost'}, {})
             ),
             (
                 ({'NetworkSettings': {'IPAddress': '127.0.0.1'}},
                  {'host': '%%host%%', 'port': 1337}, ['host'], ['foo', 'bar:baz']),
-                ({'host': '%%host%%', 'port': 1337, 'tags': ['foo', 'bar:baz']}, {'host': '127.0.0.1'})
+                ({'host': '%%host%%', 'port': 1337, 'tags': ['foo', 'bar:baz']}, {'host': '127.0.0.1'}),
+            ),
+            (
+                ({'NetworkSettings': {'IPAddress': '127.0.0.1', 'Networks': {}}},
+                 {'host': '%%host%%', 'port': 1337}, ['host'], ['foo', 'bar:baz']),
+                ({'host': '%%host%%', 'port': 1337, 'tags': ['foo', 'bar:baz']}, {'host': '127.0.0.1'}),
+            ),
+            (
+                ({'NetworkSettings': {
+                    'IPAddress': '127.0.0.1',
+                    'Networks': {'bridge': {'IPAddress': '172.17.0.2'}}}
+                  },
+                 {'host': '%%host%%', 'port': 1337}, ['host'], ['foo', 'bar:baz']),
+                ({'host': '%%host%%', 'port': 1337, 'tags': ['foo', 'bar:baz']}, {'host': '127.0.0.1'}),
+            ),
+            (
+                ({'NetworkSettings': {
+                    'IPAddress': '',
+                    'Networks': {
+                        'bridge': {'IPAddress': '172.17.0.2'},
+                        'foo': {'IPAddress': '192.168.0.2'}
+                    }}
+                  },
+                 {'host': '%%host_bridge%%', 'port': 1337}, ['host_bridge'], ['foo', 'bar:baz']),
+                ({'host': '%%host_bridge%%', 'port': 1337, 'tags': ['foo', 'bar:baz']},
+                 {'host_bridge': '172.17.0.2'}),
+            ),
+            (
+                ({'NetworkSettings': {
+                    'IPAddress': '',
+                    'Networks': {
+                        'bridge': {'IPAddress': '172.17.0.2'},
+                        'foo': {'IPAddress': '192.168.0.2'}
+                    }}
+                  },
+                 {'host': '%%host_foo%%', 'port': 1337}, ['host_foo'], ['foo', 'bar:baz']),
+                ({'host': '%%host_foo%%', 'port': 1337, 'tags': ['foo', 'bar:baz']},
+                 {'host_foo': '192.168.0.2'}),
             ),
             (
                 ({'NetworkSettings': {'IPAddress': '127.0.0.1', 'Ports': {'42/tcp': None, '22/tcp': None}}},
@@ -271,25 +359,115 @@ class TestServiceDiscovery(unittest.TestCase):
                  {'host': '127.0.0.1', 'port_1': '42'})
             )
         ]
+
+        # should not fail but return something specific
+        edge_cases = [
+            # ((inspect, instance_tpl, variables, tags), (expected_instance_tpl, expected_var_values))
+
+            # specify bridge but there is also a default IPAddress (networks should be preferred)
+            (
+                ({'NetworkSettings': {
+                    'IPAddress': '127.0.0.1',
+                    'Networks': {'bridge': {'IPAddress': '172.17.0.2'}}}},
+                 {'host': '%%host_bridge%%', 'port': 1337}, ['host_bridge'], ['foo', 'bar:baz']),
+                ({'host': '%%host_bridge%%', 'port': 1337, 'tags': ['foo', 'bar:baz']},
+                 {'host_bridge': '172.17.0.2'})
+            ),
+            # specify index but there is a default IPAddress (there's a specifier, even if it's wrong, walking networks should be preferred)
+            (
+                ({'NetworkSettings': {
+                    'IPAddress': '127.0.0.1',
+                    'Networks': {'bridge': {'IPAddress': '172.17.0.2'}}}},
+                 {'host': '%%host_0%%', 'port': 1337}, ['host_0'], ['foo', 'bar:baz']),
+                ({'host': '%%host_0%%', 'port': 1337, 'tags': ['foo', 'bar:baz']}, {'host_0': '172.17.0.2'}),
+            ),
+            # missing key for host, bridge network should be preferred
+            (
+                ({'NetworkSettings': {'Networks': {
+                    'bridge': {'IPAddress': '127.0.0.1'},
+                    'foo': {'IPAddress': '172.17.0.2'}}}},
+                 {'host': '%%host_bar%%', 'port': 1337}, ['host_bar'], []),
+                ({'host': '%%host_bar%%', 'port': 1337}, {'host_bar': '127.0.0.1'}),
+            ),
+            # missing index for port
+            (
+                ({'NetworkSettings': {'IPAddress': '127.0.0.1', 'Ports': {'42/tcp': None, '22/tcp': None}}},
+                 {'host': '%%host%%', 'port': '%%port_2%%', 'tags': ['env:test']},
+                 ['host', 'port_2'], ['foo', 'bar:baz']),
+                ({'host': '%%host%%', 'port': '%%port_2%%', 'tags': ['env:test', 'foo', 'bar:baz']},
+                 {'host': '127.0.0.1', 'port_2': '42'})
+            )
+        ]
+
+        # should raise
+        invalid_config = [
+            # ((inspect, instance_tpl, variables, tags), expected_exception)
+
+            # template variable but no IPAddress available
+            (
+                ({'NetworkSettings': {'Networks': {}}},
+                 {'host': '%%host%%', 'port': 1337}, ['host'], ['foo', 'bar:baz']),
+                Exception,
+            ),
+            # index but no IPAddress available
+            (
+                ({'NetworkSettings': {'Networks': {}}},
+                 {'host': '%%host_0%%', 'port': 1337}, ['host_0'], ['foo', 'bar:baz']),
+                Exception,
+            ),
+            # key but no IPAddress available
+            (
+                ({'NetworkSettings': {'Networks': {}}},
+                 {'host': '%%host_foo%%', 'port': 1337}, ['host_foo'], ['foo', 'bar:baz']),
+                Exception,
+            ),
+
+            # template variable but no port available
+            (
+                ({'NetworkSettings': {'Networks': {}}},
+                 {'host': 'localhost', 'port': '%%port%%'}, ['port'], []),
+                Exception,
+            ),
+            # index but no port available
+            (
+                ({'NetworkSettings': {'Networks': {}}},
+                 {'host': 'localhost', 'port_0': '%%port%%'}, ['port_0'], []),
+                Exception,
+            ),
+            # key but no port available
+            (
+                ({'NetworkSettings': {'Networks': {}}},
+                 {'host': 'localhost', 'port': '%%port_foo%%'}, ['port_foo'], []),
+                Exception,
+            )
+        ]
+
         with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
-            for ac in self.agentConfigs:
-                sd_backend = get_sd_backend(agentConfig=ac)
-                try:
-                    for co in valid_configs:
-                        inspect, tpl, variables, tags = co[0]
-                        instance_tpl, var_values = sd_backend._fill_tpl(inspect, tpl, variables, tags)
-                        for key in instance_tpl.keys():
-                            if isinstance(instance_tpl[key], list):
-                                self.assertEquals(len(instance_tpl[key]), len(co[1][0].get(key)))
-                                for elem in instance_tpl[key]:
-                                    self.assertTrue(elem in co[1][0].get(key))
-                            else:
-                                self.assertEquals(instance_tpl[key], co[1][0].get(key))
-                        self.assertEquals(var_values, co[1][1])
-                    clear_singletons(ac)
-                except Exception:
-                    clear_singletons(ac)
-                    raise
+            with mock.patch.object(EtcdStore, 'get_client', return_value=None):
+                with mock.patch.object(ConsulStore, 'get_client', return_value=None):
+                    for ac in self.agentConfigs:
+                        sd_backend = get_sd_backend(agentConfig=ac)
+                        try:
+                            for co in valid_configs + edge_cases:
+                                inspect, tpl, variables, tags = co[0]
+                                instance_tpl, var_values = sd_backend._fill_tpl(inspect, tpl, variables, tags)
+                                for key in instance_tpl.keys():
+                                    if isinstance(instance_tpl[key], list):
+                                        self.assertEquals(len(instance_tpl[key]), len(co[1][0].get(key)))
+                                        for elem in instance_tpl[key]:
+                                            self.assertTrue(elem in co[1][0].get(key))
+                                    else:
+                                        self.assertEquals(instance_tpl[key], co[1][0].get(key))
+                                self.assertEquals(var_values, co[1][1])
+
+                            for co in invalid_config:
+                                inspect, tpl, variables, tags = co[0]
+                                self.assertRaises(co[1], sd_backend._fill_tpl(inspect, tpl, variables, tags))
+
+                            clear_singletons(ac)
+                        except Exception:
+                            clear_singletons(ac)
+                            raise
 
     # config_stores tests
 
@@ -297,7 +475,9 @@ class TestServiceDiscovery(unittest.TestCase):
         """Test _get_auto_config"""
         expected_tpl = {
             'redis': ('redisdb', None, {"host": "%%host%%", "port": "%%port%%"}),
-            'consul': ('consul', None, {"url": "http://%%host%%:%%port%%", "catalog_checks": True, "new_leader_checks": True}),
+            'consul': ('consul', None, {
+                "url": "http://%%host%%:%%port%%", "catalog_checks": True, "new_leader_checks": True
+            }),
             'foobar': None
         }
 

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -173,16 +173,3 @@ class AbstractConfigStore(object):
             self.previous_config_index = config_index
             return True
         return False
-
-
-class StubStore(AbstractConfigStore):
-    """Used when no valid config store was found. Allow to use auto_config."""
-    def _extract_settings(self, config):
-        pass
-
-    def get_client(self):
-        pass
-
-    def crawl_config_template(self):
-        # There is no user provided templates in auto_config mode
-        return False

--- a/utils/service_discovery/abstract_sd_backend.py
+++ b/utils/service_discovery/abstract_sd_backend.py
@@ -41,7 +41,7 @@ class AbstractSDBackend(object):
             for key in tpl:
                 # iterate over template variables found in the templates
                 for var in self.PLACEHOLDER_REGEX.findall(str(tpl[key])):
-                    var_value = variables[var.strip('%')]
+                    var_value = variables.get(var.strip('%'))
                     if var_value is not None:
                         # if the variable is found in a list (for example {'tags': ['%%tags%%', 'env:prod']})
                         # we need to iterate over its elements

--- a/utils/service_discovery/abstract_sd_backend.py
+++ b/utils/service_discovery/abstract_sd_backend.py
@@ -41,14 +41,25 @@ class AbstractSDBackend(object):
             for key in tpl:
                 # iterate over template variables found in the templates
                 for var in self.PLACEHOLDER_REGEX.findall(str(tpl[key])):
-                    if var.strip('%') in variables and variables[var.strip('%')]:
+                    var_value = variables[var.strip('%')]
+                    if var_value is not None:
                         # if the variable is found in a list (for example {'tags': ['%%tags%%', 'env:prod']})
                         # we need to iterate over its elements
                         if isinstance(tpl[key], list):
-                            for idx, val in enumerate(tpl[key]):
-                                tpl[key][idx] = val.replace(var, variables[var.strip('%')])
+                            # if the variable is also a list we can just combine both lists
+                            if isinstance(var_value, list):
+                                tpl[key].remove(var)
+                                tpl[key] += var_value
+                                # remove dups
+                                tpl[key] = list(set(tpl[key]))
+                            else:
+                                for idx, val in enumerate(tpl[key]):
+                                    tpl[key][idx] = val.replace(var, var_value)
                         else:
-                            tpl[key] = tpl[key].replace(var, variables[var.strip('%')])
+                            if isinstance(var_value, list):
+                                tpl[key] = var_value
+                            else:
+                                tpl[key] = tpl[key].replace(var, var_value)
                     else:
                         log.warning('Failed to interpolate variable {0} for the {1} parameter.'
                                     ' Dropping this configuration.'.format(var, key))

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -32,49 +32,100 @@ class SDDockerBackend(AbstractSDBackend):
             self.config_store = get_config_store(agentConfig=agentConfig)
 
         self.VAR_MAPPING = {
-            'host': self._get_host,
-            'port': self._get_ports,
+            'host': self._get_host_address,
+            'port': self._get_port,
             'tags': self._get_additional_tags,
         }
+
         AbstractSDBackend.__init__(self, agentConfig)
 
-    def _get_host(self, container_inspect):
-        """Extract the host IP from a docker inspect object, or the kubelet API."""
-        ip_addr = container_inspect.get('NetworkSettings', {}).get('IPAddress')
-        if not ip_addr:
-            if not is_k8s():
-                return
-            # kubernetes case
-            log.debug("Didn't find the IP address for container %s (%s), using the kubernetes way." %
-                      (container_inspect.get('Id', '')[:12], container_inspect.get('Config', {}).get('Image', '')))
-            pod_list = self.kubeutil.retrieve_pods_list().get('items', [])
-            c_id = container_inspect.get('Id')
-            for pod in pod_list:
-                pod_ip = pod.get('status', {}).get('podIP')
-                if pod_ip is None:
-                    continue
+    def _get_host_address(self, c_inspect, tpl_var):
+        """Extract the container IP from a docker inspect object, or the kubelet API."""
+        c_id, c_img = c_inspect.get('Id', ''), c_inspect.get('Config', {}).get('Image', '')
+        tpl_parts = tpl_var.split('_')
+
+        # a specifier was given
+        if len(tpl_parts) > 1:
+            networks = c_inspect.get('NetworkSettings', {}).get('Networks') or {}
+            ip_dict = {}
+            for net_name, net_desc in networks.iteritems():
+                ip = net_desc.get('IPAddress')
+                if ip:
+                    ip_dict[net_name] = ip
+            ip_addr = self._extract_ip_from_networks(ip_dict, tpl_var)
+            if ip_addr:
+                return ip_addr
+
+        # try to get the bridge IP address
+        log.debug("No network found for container %s (%s), trying with IPAddress field" % (c_id[:12], c_img))
+        ip_addr = c_inspect.get('NetworkSettings', {}).get('IPAddress')
+        if ip_addr:
+            return ip_addr
+
+        else:
+            if is_k8s():
+                # kubernetes case
+                log.debug("Couldn't find the IP address for container %s (%s), "
+                          "using the kubernetes way." % (c_id[:12], c_img))
+                pod_list = self.kubeutil.retrieve_pods_list().get('items', [])
+                for pod in pod_list:
+                    pod_ip = pod.get('status', {}).get('podIP')
+                    if pod_ip is None:
+                        continue
+                    else:
+                        c_statuses = pod.get('status', {}).get('containerStatuses', [])
+                        for status in c_statuses:
+                            # compare the container id with those of containers in the current pod
+                            if c_id == status.get('containerID', '').split('//')[-1]:
+                                return pod_ip
+
+        log.error("No IP address was found for container %s (%s)" % (c_id[:12], c_img))
+        return None
+
+    def _extract_ip_from_networks(self, ip_dict, tpl_var):
+        """Extract a single IP from a dictionary made of network names and IPs."""
+        if not ip_dict:
+            return None
+        tpl_parts = tpl_var.split('_')
+
+        # no specifier, try to pick the bridge key, falls back to the value of the last key
+        if len(tpl_parts) < 2:
+            log.debug("No key was passed for template variable %s." % tpl_var)
+            if 'bridge' in ip_dict:
+                log.debug("Using the bridge network instead.")
+                return ip_dict['bridge']
+            else:
+                last_key = sorted(ip_dict.iterkeys())[-1]
+                log.debug("Trying with the last key: '%s' instead." % last_key)
+                return ip_dict[last_key]
+        else:
+            res = ip_dict.get(tpl_parts[-1])
+            if res is None:
+                log.warning("The key passed for template variable %s was not found." % tpl_var)
+                if 'bridge' in ip_dict:
+                    log.warning("Using the bridge network instead.")
+                    return ip_dict['bridge']
                 else:
-                    c_statuses = pod.get('status', {}).get('containerStatuses', [])
-                    for status in c_statuses:
-                        # compare the container id with those of containers in the current pod
-                        if c_id == status.get('containerID', '').split('//')[-1]:
-                            ip_addr = pod_ip
+                    last_key = sorted(ip_dict.iterkeys())[-1]
+                    log.warning("Trying with the last key: '%s' instead." % last_key)
+                    return ip_dict[last_key]
+            else:
+                return res
 
-        return ip_addr
-
-    def _get_ports(self, container_inspect):
-        """Extract a list of available ports from a docker inspect object. Sort them numerically."""
+    def _get_port(self, container_inspect, tpl_var):
+        """Extract a port from a container_inspect or the k8s API given a template variable."""
         c_id = container_inspect.get('Id', '')
+
         try:
             ports = map(lambda x: x.split('/')[0], container_inspect['NetworkSettings']['Ports'].keys())
         except (IndexError, KeyError, AttributeError):
-            log.debug("Didn't find the port for container %s (%s), trying the kubernetes way." %
-                      (c_id[:12], container_inspect.get('Config', {}).get('Image', '')))
-            # first we try to get it from the docker API
-            # it works if the image has an EXPOSE instruction
+            # try to get ports from the docker API. Works if the image has an EXPOSE instruction
             ports = map(lambda x: x.split('/')[0], container_inspect['Config'].get('ExposedPorts', {}).keys())
+
             # if it failed, try with the kubernetes API
             if not ports and is_k8s():
+                log.debug("Didn't find the port for container %s (%s), trying the kubernetes way." %
+                          (c_id[:12], container_inspect.get('Config', {}).get('Image', '')))
                 co_statuses = self._get_kube_config(c_id, 'status').get('containerStatuses', [])
                 c_name = None
                 for co in co_statuses:
@@ -86,7 +137,27 @@ class SDDockerBackend(AbstractSDBackend):
                     if co.get('name') == c_name:
                         ports = map(lambda x: str(x.get('containerPort')), co.get('ports', []))
         ports = sorted(ports, key=lambda x: int(x))
-        return ports
+        return self._extract_port_from_list(ports, tpl_var)
+
+    def _extract_port_from_list(self, ports, tpl_var):
+        if not ports:
+            return None
+
+        tpl_parts = tpl_var.split('_')
+
+        if len(tpl_parts) == 1:
+            log.debug("No index was passed for template variable %s. "
+                      "Trying with the last element." % tpl_var)
+            return ports[-1]
+
+        try:
+            idx = tpl_parts[-1]
+            return ports[int(idx)]
+        except ValueError:
+            log.error("Index is not an integer. Using the last element instead.")
+        except IndexError:
+            log.error("Index is out of range. Using the last element instead.")
+        return ports[-1]
 
     def get_tags(self, c_inspect):
         """Extract useful tags from docker or platform APIs. These are collected by default."""
@@ -113,11 +184,15 @@ class SDDockerBackend(AbstractSDBackend):
 
         return tags
 
-    def _get_additional_tags(self, container_inspect):
+    def _get_additional_tags(self, container_inspect, tpl_var):
         tags = []
         if is_k8s():
             pod_metadata = self._get_kube_config(container_inspect.get('Id'), 'metadata')
             pod_spec = self._get_kube_config(container_inspect.get('Id'), 'spec')
+            if pod_metadata is None or pod_spec is None:
+                log.warning("Failed to fetch pod metadata or pod spec for container %s."
+                            " Additional Kubernetes tags may be missing." % container_inspect.get('Id', '')[:12])
+                return []
             tags.append('node_name:%s' % pod_spec.get('nodeName'))
             tags.append('pod_name:%s' % pod_metadata.get('name'))
         return tags
@@ -168,8 +243,8 @@ class SDDockerBackend(AbstractSDBackend):
                                 log.warning(conflict_init_msg.format(check_name))
                             configs[check_name][1].append(instance)
             except Exception:
-                log.exception('Building config for container %s based on image %s using service'
-                              ' discovery failed, leaving it alone.' % (cid[:12], image))
+                log.exception('Building config for container %s based on image %s using service '
+                              'discovery failed, leaving it alone.' % (cid[:12], image))
         return configs
 
     def _get_check_configs(self, c_id, image, trace_config=False):
@@ -245,34 +320,30 @@ class SDDockerBackend(AbstractSDBackend):
         return templates
 
     def _fill_tpl(self, inspect, instance_tpl, variables, tags=None):
-        """Add container tags to instance templates and build a """
-        """dict from template variable names and their values."""
+        """Add container tags to instance templates and build a
+           dict from template variable names and their values."""
         var_values = {}
+        c_id, c_image = inspect.get('Id', ''), inspect.get('Config', {}).get('Image', '')
 
         # add default tags to the instance
         if tags:
-            tags += instance_tpl.get('tags', [])
+            tpl_tags = instance_tpl.get('tags', [])
+            tags += tpl_tags if isinstance(tpl_tags, list) else [tpl_tags]
             instance_tpl['tags'] = list(set(tags))
 
-        for v in variables:
-            # variables can be suffixed with an index in case a list is found
-            var_parts = v.split('_')
-            if var_parts[0] in self.VAR_MAPPING:
+        for var in variables:
+            # variables can be suffixed with an index in case several values are found
+            if var.split('_')[0] in self.VAR_MAPPING:
                 try:
-                    res = self.VAR_MAPPING[var_parts[0]](inspect)
-                    if not res:
-                        raise ValueError("Invalid value for variable %s." % var_parts[0])
-                    # if an index is found in the variable, use it to select a value
-                    if len(var_parts) > 1 and isinstance(res, list) and int(var_parts[-1]) < len(res):
-                        var_values[v] = res[int(var_parts[-1])]
-                    # if no valid index was found but we have a list, return the last element
-                    elif isinstance(res, list):
-                        var_values[v] = res[-1]
-                    else:
-                        var_values[v] = res
+                    res = self.VAR_MAPPING[var.split('_')[0]](inspect, var)
+                    if res is None:
+                        raise ValueError("Invalid value for variable %s." % var)
+                    var_values[var] = res
                 except Exception as ex:
-                    log.error("Could not find a value for the template variable %s: %s" % (v, str(ex)))
+                    log.error("Could not find a value for the template variable %s for container %s "
+                              "(%s): %s" % (var, c_id[:12], c_image, str(ex)))
             else:
-                log.error("No method was found to interpolate template variable %s." % v)
+                log.error("No method was found to interpolate template variable %s for container %s "
+                          "(%s)." % (var, c_id[:12], c_image))
 
         return instance_tpl, var_values

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -154,9 +154,9 @@ class SDDockerBackend(AbstractSDBackend):
             idx = tpl_parts[-1]
             return ports[int(idx)]
         except ValueError:
-            log.error("Index is not an integer. Using the last element instead.")
+            log.error("Port index is not an integer. Using the last element instead.")
         except IndexError:
-            log.error("Index is out of range. Using the last element instead.")
+            log.error("Port index is out of range. Using the last element instead.")
         return ports[-1]
 
     def get_tags(self, c_inspect):


### PR DESCRIPTION
# What
- improve test coverage for service discovery and logging
- support ip address collection from networks when available (for docker > 1.9)
- make template variable interpolation more resilient
- add the ability to specify keys on top of indexes for template variables (eg: `host_bridge` will return the IP address of the host on its bridge network)
- kill some dead code