### PR TITLE
[win32_event_log] Fix small regression on `msg_text` selection

### DIFF
--- a/checks.d/win32_event_log.py
+++ b/checks.d/win32_event_log.py
@@ -206,9 +206,9 @@ class LogEvent(object):
             msg_text = "\n".join(msg_text_fields)
         else:
             # Override when verbosity
-            if 'Message' in self.event:
+            if self.event.get('Message'):
                 msg_text = "{message}\n".format(message=self.event['Message'])
-            elif 'InsertionStrings' in self.event:
+            elif self.event.get('InsertionStrings'):
                 msg_text = "\n".join([i_str for i_str in self.event['InsertionStrings']
                                       if i_str.strip()])
 


### PR DESCRIPTION
When the windows event `Message` evaluates to a "false" value, do not
select its value as the event's `msg_text`.

Same behavior for the `InsertionStrings`.

Fixes the integration test. This small regression was introduced in #2136.