### PR TITLE
[core] always default to ipv6, then fallback to ipv4.

### DIFF
--- a/ddagent.py
+++ b/ddagent.py
@@ -226,6 +226,7 @@ class AgentTransaction(Transaction):
                 'body': self._data,
                 'headers': self._headers,
                 'validate_cert': not self._application.skip_ssl_validation,
+                'allow_ipv6': True,
             }
 
             # Remove headers that were passed by the emitter. Those don't apply anymore


### PR DESCRIPTION
## Why
On older `tornado` versions (including the `dd-agent` default) the `allow_ipv6` option would default to `True` when using the `curl_httpclient` (expected), but would actually default to `False` when using the `simple_httpclient`. Since our default http client is the simple one, this implies that by default our ipv6 support requires enabling the curl client. This PR should address this.

Note: on newer tornado's the weird behavior was corrected, but doing this explicitly will hurt no one. 

 