### PR TITLE
[service discovery] Replace buggy image name extraction with get_identifier.

### DIFF
--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -60,30 +60,42 @@ def client_read(path):
     return TestServiceDiscovery.mock_tpls.get(image)[0][config_parts.index(config_part)]
 
 
+def issue_read(identifier):
+    return TestServiceDiscovery.mock_tpls.get(identifier)
+
+
 class TestServiceDiscovery(unittest.TestCase):
     docker_container_inspect = {
         u'Id': u'69ff25598b2314d1cdb7752cc3a659fb1c1352b32546af4f1454321550e842c0',
-        u'Image': u'6ffc02088cb870652eca9ccd4c4fb582f75b29af2879792ed09bb46fd1c898ef',
+        u'Image': u'nginx',
         u'Name': u'/nginx',
         u'NetworkSettings': {u'IPAddress': u'172.17.0.21', u'Ports': {u'443/tcp': None, u'80/tcp': None}}
     }
+    docker_container_inspect_with_label = {
+        u'Id': u'69ff25598b2314d1cdb7752cc3a659fb1c1352b32546af4f1454321550e842c0',
+        u'Image': u'nginx',
+        u'Name': u'/nginx',
+        u'NetworkSettings': {u'IPAddress': u'172.17.0.21', u'Ports': {u'443/tcp': None, u'80/tcp': None}},
+        u'Labels': {'datadog_id': 'custom-nginx'}
+    }
     kubernetes_container_inspect = {
         u'Id': u'389dc8a4361f3d6c866e9e9a7b6972b26a31c589c4e2f097375d55656a070bc9',
-        u'Image': u'de309495e6c7b2071bc60c0b7e4405b0d65e33e3a4b732ad77615d90452dd827',
+        u'Image': u'foo',
         u'Name': u'/k8s_sentinel.38057ab9_redis-master_default_27b84e1e-a81c-11e5-8347-42010af00002_f70875a1',
         u'Config': {u'ExposedPorts': {u'6379/tcp': {}}},
         u'NetworkSettings': {u'IPAddress': u'', u'Ports': None}
     }
     malformed_container_inspect = {
         u'Id': u'69ff25598b2314d1cdb7752cc3a659fb1c1352b32546af4f1454321550e842c0',
-        u'Image': u'6ffc02088cb870652eca9ccd4c4fb582f75b29af2879792ed09bb46fd1c898ef',
+        u'Image': u'foo',
         u'Name': u'/nginx'
     }
     container_inspects = [
-        # (inspect_dict, expected_ip, expected_port)
-        (docker_container_inspect, '172.17.0.21', ['80', '443']),
-        (kubernetes_container_inspect, None, ['6379']),  # arbitrarily defined in the mocked pod_list
-        (malformed_container_inspect, None, KeyError)
+        # (inspect_dict, expected_ip, expected_port, expected_ident)
+        (docker_container_inspect, '172.17.0.21', ['80', '443'], 'nginx'),
+        (docker_container_inspect_with_label, '172.17.0.21', ['80', '443'], 'custom-nginx'),
+        (kubernetes_container_inspect, None, ['6379'], 'foo'),  # arbitrarily defined in the mocked pod_list
+        (malformed_container_inspect, None, KeyError, 'foo')
     ]
 
     # templates with variables already extracted
@@ -114,7 +126,12 @@ class TestServiceDiscovery(unittest.TestCase):
             [('check_2', {}, {"host": "%%host%%", "port": "%%port%%"})]),
         'bad_image_0': ((['invalid template']), []),
         'bad_image_1': (('invalid template'), []),
-        'bad_image_2': (None, [])
+        'bad_image_2': (None, []),
+        'nginx': ('["nginx"]', '[{}]', '[{"host": "localhost"}]'),
+        'nginx:latest': ('["nginx"]', '[{}]', '[{"host": "localhost", "tags": ["foo"]}]'),
+        'custom-nginx': ('["nginx"]', '[{}]', '[{"host": "localhost"}]'),
+        'repo/custom-nginx': ('["nginx"]', '[{}]', '[{"host": "localhost", "tags": ["bar"]}]'),
+        'repo/dir:5000/custom-nginx:latest': ('["nginx"]', '[{}]', '[{"host": "local", "tags": ["foobar"]}]')
     }
 
     bad_mock_templates = {
@@ -168,7 +185,7 @@ class TestServiceDiscovery(unittest.TestCase):
         mock_check_yaml.return_value = kubernetes_config
         mock_get.return_value = Response(pod_list)
 
-        for c_ins, expected_ip, _ in self.container_inspects:
+        for c_ins, expected_ip, _, _ in self.container_inspects:
             with mock.patch.object(AbstractConfigStore, '__init__', return_value=None):
                 with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
                     with mock.patch('utils.kubeutil.get_conf_path', return_value=None):
@@ -178,7 +195,7 @@ class TestServiceDiscovery(unittest.TestCase):
 
     def test_get_ports(self):
         with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
-            for c_ins, _, expected_ports in self.container_inspects:
+            for c_ins, _, expected_ports, _ in self.container_inspects:
                 sd_backend = get_sd_backend(agentConfig=self.auto_conf_agentConfig)
                 if isinstance(expected_ports, list):
                     self.assertEqual(sd_backend._get_ports(c_ins), expected_ports)
@@ -318,3 +335,29 @@ class TestServiceDiscovery(unittest.TestCase):
         for image in invalid_config:
             tpl = self.mock_tpls.get(image)[1]
             self.assertEquals(tpl, config_store.get_check_tpls(image))
+
+    def test_get_config_id(self):
+        """Test get_config_id"""
+        with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
+            for c_ins, _, _, expected_ident in self.container_inspects:
+                sd_backend = get_sd_backend(agentConfig=self.auto_conf_agentConfig)
+                self.assertEqual(
+                    sd_backend.get_config_id(c_ins.get('Image'), c_ins.get('Labels', {})),
+                    expected_ident)
+                clear_singletons(self.auto_conf_agentConfig)
+
+    @mock.patch.object(AbstractConfigStore, '_issue_read', side_effect=issue_read)
+    def test_read_config_from_store(self, issue_read):
+        """Test read_config_from_store"""
+        valid_idents = [('nginx', 'nginx'), ('nginx:latest', 'nginx:latest'),
+                        ('custom-nginx', 'custom-nginx'), ('custom-nginx:latest', 'custom-nginx'),
+                        ('repo/custom-nginx:latest', 'custom-nginx'),
+                        ('repo/dir:5000/custom-nginx:latest', 'repo/dir:5000/custom-nginx:latest')]
+        invalid_idents = ['foo']
+        config_store = get_config_store(self.auto_conf_agentConfig)
+        for ident, expected_key in valid_idents:
+            tpl = config_store.read_config_from_store(ident)
+            # source is added after reading from the store
+            self.assertEquals(tpl, ('template',) + self.mock_tpls.get(expected_key))
+        for ident in invalid_idents:
+            self.assertEquals(config_store.read_config_from_store(ident), [])

--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -76,7 +76,7 @@ class TestServiceDiscovery(unittest.TestCase):
         u'Image': u'nginx',
         u'Name': u'/nginx',
         u'NetworkSettings': {u'IPAddress': u'172.17.0.21', u'Ports': {u'443/tcp': None, u'80/tcp': None}},
-        u'Labels': {'datadog_id': 'custom-nginx'}
+        u'Labels': {'com.datadoghq.sd.check.id': 'custom-nginx'}
     }
     kubernetes_container_inspect = {
         u'Id': u'389dc8a4361f3d6c866e9e9a7b6972b26a31c589c4e2f097375d55656a070bc9',

--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -93,15 +93,6 @@ class KubeUtil():
 
         return kube_labels
 
-    def get_pod_annotations(self, pod_name):
-        """Return the annotations for a pod."""
-        if pod_name:
-            pod_list = self.retrieve_pods_list()
-            for pod in pod_list.get('items') or []:
-                if pod.get('metadata').get('name') == pod_name:
-                    return pod.get('metadata', {}).get('annotations', {})
-        return {}
-
     def retrieve_pods_list(self):
         return retrieve_json(self.pods_list_url)
 

--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -93,6 +93,15 @@ class KubeUtil():
 
         return kube_labels
 
+    def get_pod_annotations(self, pod_name):
+        """Return the annotations for a pod."""
+        if pod_name:
+            pod_list = self.retrieve_pods_list()
+            for pod in pod_list.get('items') or []:
+                if pod.get('metadata').get('name') == pod_name:
+                    return pod.get('metadata', {}).get('annotations', {})
+        return {}
+
     def retrieve_pods_list(self):
         return retrieve_json(self.pods_list_url)
 

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -106,7 +106,7 @@ class AbstractConfigStore(object):
 
         if len(check_names) != len(init_config_tpls) or len(check_names) != len(instance_tpls):
             log.error('Malformed configuration template: check_names, init_configs '
-                      'and instances are not all the same length. Container with identifier {0} '
+                      'and instances are not all the same length. Container with identifier {} '
                       'will not be configured by the service discovery'.format(identifier))
             return []
 
@@ -125,7 +125,7 @@ class AbstractConfigStore(object):
                 source = CONFIG_FROM_TEMPLATE
                 check_names, init_config_tpls, instance_tpls = res
             else:
-                log.debug("Could not find directory {0} in the config store, "
+                log.debug("Could not find directory {} in the config store, "
                           "trying to convert to the old format...".format(identifier))
                 legacy_ident = identifier.split(':')[0].split('/')[-1]
                 res = self._issue_read(legacy_ident)
@@ -137,7 +137,7 @@ class AbstractConfigStore(object):
         except (KeyError, TimeoutError, json.JSONDecodeError) as ex:
             # this is kind of expected, it means that no template was provided for this container
             if isinstance(ex, KeyError):
-                log.debug("Could not find directory {0} in the config store, "
+                log.debug("Could not find directory {} in the config store, "
                           "trying to auto-configure a check...".format(identifier))
             # this case is not expected, the agent can't reach the config store
             if isinstance(ex, TimeoutError):

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -20,6 +20,9 @@ CONFIG_FROM_AUTOCONF = 'auto-configuration'
 CONFIG_FROM_FILE = 'YAML file'
 CONFIG_FROM_TEMPLATE = 'template'
 TRACE_CONFIG = 'trace_config'  # used for tracing config load by service discovery
+CHECK_NAMES = 'check_names'
+INIT_CONFIGS = 'init_configs'
+INSTANCES = 'instances'
 
 
 class KeyNotFound(Exception):
@@ -59,7 +62,8 @@ class AbstractConfigStore(object):
         raise NotImplementedError()
 
     def _get_auto_config(self, image_name):
-        if image_name in self.auto_conf_images:
+        # use the image name, ignore the tag
+        if image_name.split(':')[0] in self.auto_conf_images:
             check_name = self.auto_conf_images[image_name]
 
             # get the check class to verify it matches
@@ -75,26 +79,26 @@ class AbstractConfigStore(object):
 
         return None
 
-    def get_check_tpls(self, image, **kwargs):
-        """Retrieve template configs for an image from the config_store or auto configuration."""
-        # TODO: make mixing both sources possible
+    def get_check_tpls(self, identifier, **kwargs):
+        """Retrieve template configs for an identifier from the config_store or auto configuration."""
         templates = []
         trace_config = kwargs.get(TRACE_CONFIG, False)
 
         # this flag is used when no valid configuration store was provided
         # it makes the method skip directly to the auto_conf
         if kwargs.get('auto_conf') is True:
-            auto_config = self._get_auto_config(image)
+            # in auto config mode, identifier is the image name
+            auto_config = self._get_auto_config(identifier)
             if auto_config is not None:
                 source = CONFIG_FROM_AUTOCONF
                 if trace_config:
                     return [(source, auto_config)]
                 return [auto_config]
             else:
-                log.debug('No auto config was found for image %s, leaving it alone.' % image)
+                log.debug('No auto config was found for image %s, leaving it alone.' % identifier)
                 return []
         else:
-            config = self.read_config_from_store(image)
+            config = self.read_config_from_store(identifier)
             if config:
                 source, check_names, init_config_tpls, instance_tpls = config
             else:
@@ -102,8 +106,8 @@ class AbstractConfigStore(object):
 
         if len(check_names) != len(init_config_tpls) or len(check_names) != len(instance_tpls):
             log.error('Malformed configuration template: check_names, init_configs '
-                      'and instances are not all the same length. Image {0} '
-                      'will not be configured by the service discovery'.format(image))
+                      'and instances are not all the same length. Container with identifier {0} '
+                      'will not be configured by the service discovery'.format(identifier))
             return []
 
         for idx, c_name in enumerate(check_names):
@@ -113,44 +117,64 @@ class AbstractConfigStore(object):
                 templates.append((c_name, init_config_tpls[idx], instance_tpls[idx]))
         return templates
 
-    def read_config_from_store(self, image):
+    def read_config_from_store(self, identifier):
         """Try to read from the config store, falls back to auto-config in case of failure."""
         try:
-            check_names = json.loads(
-                self.client_read(path.join(self.sd_template_dir, image, 'check_names').lstrip('/')))
-            init_config_tpls = json.loads(
-                self.client_read(path.join(self.sd_template_dir, image, 'init_configs').lstrip('/')))
-            instance_tpls = json.loads(
-                self.client_read(path.join(self.sd_template_dir, image, 'instances').lstrip('/')))
-            source = CONFIG_FROM_TEMPLATE
-        except (KeyNotFound, TimeoutError, json.JSONDecodeError) as ex:
-            # first case is kind of expected, it means that no template was provided for this container
-            if isinstance(ex, KeyNotFound):
+            res = self._issue_read(identifier)
+            if res and len(res) == 3:
+                source = CONFIG_FROM_TEMPLATE
+                check_names, init_config_tpls, instance_tpls = res
+            else:
                 log.debug("Could not find directory {0} in the config store, "
-                          "trying to auto-configure a check...".format(image))
+                          "trying to convert to the old format...".format(identifier))
+                legacy_ident = identifier.split(':')[0].split('/')[-1]
+                res = self._issue_read(legacy_ident)
+                if res and len(res) == 3:
+                    source = CONFIG_FROM_TEMPLATE
+                    check_names, init_config_tpls, instance_tpls = res
+                else:
+                    raise KeyError
+        except (KeyError, TimeoutError, json.JSONDecodeError) as ex:
+            # this is kind of expected, it means that no template was provided for this container
+            if isinstance(ex, KeyError):
+                log.debug("Could not find directory {0} in the config store, "
+                          "trying to auto-configure a check...".format(identifier))
             # this case is not expected, the agent can't reach the config store
-            elif isinstance(ex, TimeoutError):
+            if isinstance(ex, TimeoutError):
                 log.warning("Connection to the config backend timed out. Is it reachable?\n"
-                            "Trying to auto-configure a check for the image %s..." % image)
+                            "Trying to auto-configure a check for the container with ident %s." % identifier)
             # the template is reachable but invalid
             elif isinstance(ex, json.JSONDecodeError):
-                log.error('Could not decode the JSON configuration template. '
-                          'Trying to auto-configure a check for the image %s...' % image)
-            # In any case cases we try to read from auto-config templates
-            auto_config = self._get_auto_config(image)
+                log.error('Could not decode the JSON configuration template '
+                          'for the container with ident %s...' % identifier)
+                return []
+            # try to read from auto-config templates
+            auto_config = self._get_auto_config(identifier)
             if auto_config is not None:
                 # create list-format config based on an autoconf template
                 check_names, init_config_tpls, instance_tpls = map(lambda x: [x], auto_config)
                 source = CONFIG_FROM_AUTOCONF
             else:
-                log.debug('No auto config was found for image %s, leaving it alone.' % image)
+                log.debug('No config was found for container with ident %s, leaving it alone.' % identifier)
                 return []
         except Exception as ex:
             log.warning(
                 'Fetching the value for {0} in the config store failed, this check '
-                'will not be configured by the service discovery. Error: {1}'.format(image, str(ex)))
+                'will not be configured by the service discovery. Error: {1}'.format(identifier, str(ex)))
             return []
         return source, check_names, init_config_tpls, instance_tpls
+
+    def _issue_read(self, identifier):
+        try:
+            check_names = json.loads(
+                self.client_read(path.join(self.sd_template_dir, identifier, CHECK_NAMES).lstrip('/')))
+            init_config_tpls = json.loads(
+                self.client_read(path.join(self.sd_template_dir, identifier, INIT_CONFIGS).lstrip('/')))
+            instance_tpls = json.loads(
+                self.client_read(path.join(self.sd_template_dir, identifier, INSTANCES).lstrip('/')))
+            return [check_names, init_config_tpls, instance_tpls]
+        except KeyError:
+            return None
 
     def crawl_config_template(self):
         """Return whether or not configuration templates have changed since the previous crawl"""

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -160,7 +160,7 @@ class SDDockerBackend(AbstractSDBackend):
                         else:
                             configs[check_name] = (init_config, [instance])
                     else:
-                        conflict_init_msg = 'Different versions of `init_config` found for check {0}. ' \
+                        conflict_init_msg = 'Different versions of `init_config` found for check {}. ' \
                             'Keeping the first one found.'
                         if trace_config:
                             if configs[check_name][1][0] != init_config:
@@ -177,7 +177,7 @@ class SDDockerBackend(AbstractSDBackend):
 
     def get_config_id(self, image, labels):
         """Look for a DATADOG_ID label, return its value or the image name if missing"""
-        return labels.get(DATADOG_ID) if DATADOG_ID in labels else image
+        return labels.get(DATADOG_ID) or image
 
     def _get_check_configs(self, c_id, identifier, trace_config=False):
         """Retrieve configuration templates and fill them with data pulled from docker and tags."""

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -13,7 +13,6 @@ from utils.service_discovery.abstract_sd_backend import AbstractSDBackend
 from utils.service_discovery.config_stores import get_config_store, TRACE_CONFIG
 
 DATADOG_ID = 'com.datadoghq.sd.check.id'
-POD_NAME_LABEL = 'io.kubernetes.pod.name'
 log = logging.getLogger(__name__)
 
 
@@ -147,7 +146,7 @@ class SDDockerBackend(AbstractSDBackend):
         for image, cid, labels in containers:
             try:
                 # value of the DATADOG_ID tag or the image name if the label is missing
-                identifier = self.get_config_id(cid, image, labels)
+                identifier = self.get_config_id(image, labels)
                 check_configs = self._get_check_configs(cid, identifier, trace_config=trace_config) or []
                 for conf in check_configs:
                     if trace_config and conf is not None:
@@ -176,13 +175,8 @@ class SDDockerBackend(AbstractSDBackend):
                               ' discovery failed, leaving it alone.' % (cid[:12], image))
         return configs
 
-    def get_config_id(self, cid, image, labels):
+    def get_config_id(self, image, labels):
         """Look for a DATADOG_ID label, return its value or the image name if missing"""
-        # in kubernetes this must be set in annotations as labels can't be set to containers
-        if is_k8s():
-            pod_name = labels.get(POD_NAME_LABEL)
-            annotations = self.kubeutil.get_pod_annotations(pod_name)
-            return annotations.get(DATADOG_ID) or image
         return labels.get(DATADOG_ID) or image
 
     def _get_check_configs(self, c_id, identifier, trace_config=False):

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -13,6 +13,7 @@ from utils.service_discovery.abstract_sd_backend import AbstractSDBackend
 from utils.service_discovery.config_stores import get_config_store, TRACE_CONFIG
 
 DATADOG_ID = 'com.datadoghq.sd.check.id'
+POD_NAME_LABEL = 'io.kubernetes.pod.name'
 log = logging.getLogger(__name__)
 
 
@@ -146,7 +147,7 @@ class SDDockerBackend(AbstractSDBackend):
         for image, cid, labels in containers:
             try:
                 # value of the DATADOG_ID tag or the image name if the label is missing
-                identifier = self.get_config_id(image, labels)
+                identifier = self.get_config_id(cid, image, labels)
                 check_configs = self._get_check_configs(cid, identifier, trace_config=trace_config) or []
                 for conf in check_configs:
                     if trace_config and conf is not None:
@@ -175,8 +176,13 @@ class SDDockerBackend(AbstractSDBackend):
                               ' discovery failed, leaving it alone.' % (cid[:12], image))
         return configs
 
-    def get_config_id(self, image, labels):
+    def get_config_id(self, cid, image, labels):
         """Look for a DATADOG_ID label, return its value or the image name if missing"""
+        # in kubernetes this must be set in annotations as labels can't be set to containers
+        if is_k8s():
+            pod_name = labels.get(POD_NAME_LABEL)
+            annotations = self.kubeutil.get_pod_annotations(pod_name)
+            return annotations.get(DATADOG_ID) or image
         return labels.get(DATADOG_ID) or image
 
     def _get_check_configs(self, c_id, identifier, trace_config=False):

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -12,7 +12,7 @@ from utils.kubeutil import KubeUtil, is_k8s
 from utils.service_discovery.abstract_sd_backend import AbstractSDBackend
 from utils.service_discovery.config_stores import get_config_store, TRACE_CONFIG
 
-DATADOG_ID = 'datadog_id'
+DATADOG_ID = 'com.datadoghq.sd.check.id'
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
# Why
To make it possible to associate explicitly a configuration template with a container, and fix the image name extraction.

# What
- This PR makes it possible to assign a `datadog_id` label to containers that specify the config store key associated with the configuration template for said container. If such label is not applied, falls back to image name matching.
- The image name matching has also been fixed, it didn't play well with private image repositories serving on a custom port. To avoid breaking backward compatibility we still fall back to the old format. The new resolution order is: `configuration file --> container label --> full image name --> legacy image name --> auto-config`

# Related issues/PRs
- supersedes #2583 
- fixes #2576