### PR TITLE
discovery: fix getting host ip for overlay network

### DIFF
--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -42,6 +42,10 @@ class SDDockerBackend(AbstractSDBackend):
         """Extract the host IP from a docker inspect object, or the kubelet API."""
         ip_addr = container_inspect.get('NetworkSettings', {}).get('IPAddress')
         if not ip_addr:
+            # overlay network case
+            nets = container_inspect.get('NetworkSettings', {}).get('Networks')
+            if nets: ip_addr = nets[nets.keys()[0]].get('IPAddress')
+        if not ip_addr:
             if not is_k8s():
                 return
             # kubernetes case


### PR DESCRIPTION
Getting container %%host%% variable is broken for overlay multihost docker network.
Here is example of NetworkSettings for container, launched in overlay network with swarm: https://gist.github.com/awasilyev/d1194c638a96667478998c0f74f53a2b

This pr tries to solve this case by checking ip address for the first network defined in Network section.