### PR TITLE
[gohai][processes] Simplify payload

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -378,7 +378,7 @@ class Collector(object):
                         payload['resources'] = {
                             'processes': processes_payload,
                             'meta': {
-                                'host': payload['internalHostname'],
+                                'host': self.hostname,
                             }
                         }
                 except Exception:
@@ -626,7 +626,7 @@ class Collector(object):
             # Also post an event in the newsfeed
             payload['events']['System'] = [{
                 'api_key': self.agentConfig['api_key'],
-                'host': payload['internalHostname'],
+                'host': self.hostname,
                 'timestamp': now,
                 'event_type':'Agent Startup',
                 'msg_text': 'Version %s' % get_version()

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -47,20 +47,6 @@ FLUSH_LOGGING_PERIOD = 10
 FLUSH_LOGGING_INITIAL = 5
 DD_CHECK_TAG = 'dd_check:{0}'
 
-# Description of the format of the `processes` resource check, identical to the legacy check.
-# Sent on the first run of the collector, on subsequent runs the resources payload is sent w/o this desc.
-# The exact behavior of the aggregation functions is defined in the backend
-PROCESSES_FORMAT_DESCRIPTION = [
-    # [format_version, metric_name, type, agg, time_agg, server_agg, server_time_agg, group_on, time_group_on]
-    [2, 'user', 'str', 'append', 'append', 'append', 'append', False, False],
-    [2, 'pct_cpu', 'float', 'sum', 'avg', 'sum', 'avg', False, False],
-    [2, 'pct_mem', 'float', 'sum', 'avg', 'sum', 'avg', False, False],
-    [2, 'vsz', 'int', 'sum', 'avg', 'sum', 'avg', False, False],
-    [2, 'rss', 'int', 'sum', 'avg', 'sum', 'avg', False, False],
-    [2, 'family', 'str', None, None, 'append', 'append', True, True],
-    [2, 'ps_count', 'int', 'sum', 'avg', 'sum', 'avg', False, False],
-]
-
 
 class AgentPayload(collections.MutableMapping):
     """
@@ -386,11 +372,8 @@ class Collector(object):
                     processes_snaps = gohai_processes_json.get('processes')
                     if processes_snaps:
                         processes_payload = {
-                            'snaps': [processes_snaps],
-                            'format_version': 1
+                            'snaps': [processes_snaps]
                         }
-                        if self._is_first_run():
-                            processes_payload['format_description'] = PROCESSES_FORMAT_DESCRIPTION
 
                         payload['resources'] = {
                             'processes': processes_payload,

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -383,19 +383,21 @@ class Collector(object):
             if gohai_processes:
                 try:
                     gohai_processes_json = json.loads(gohai_processes)
-                    processes_payload = {
-                        'snaps': [gohai_processes_json.get('processes')],
-                        'format_version': 1
-                    }
-                    if self._is_first_run():
-                        processes_payload['format_description'] = PROCESSES_FORMAT_DESCRIPTION
-
-                    payload['resources'] = {
-                        'processes': processes_payload,
-                        'meta': {
-                            'host': payload['internalHostname'],
+                    processes_snaps = gohai_processes_json.get('processes')
+                    if processes_snaps:
+                        processes_payload = {
+                            'snaps': [processes_snaps],
+                            'format_version': 1
                         }
-                    }
+                        if self._is_first_run():
+                            processes_payload['format_description'] = PROCESSES_FORMAT_DESCRIPTION
+
+                        payload['resources'] = {
+                            'processes': processes_payload,
+                            'meta': {
+                                'host': payload['internalHostname'],
+                            }
+                        }
                 except Exception:
                     log.exception("Error running gohai processes collection")
 


### PR DESCRIPTION
- Only send a processes payload when gohai actually returns data
- Remove the `format_description` and `format_version` fields