### PR TITLE
[sqlserver] [skip ci] warn users about % char in yaml

### DIFF
--- a/conf.d/sqlserver.yaml.example
+++ b/conf.d/sqlserver.yaml.example
@@ -34,6 +34,8 @@ init_config:
     #   tag_by: db
 
 instances:
+    # Currently all '%' characters must be escaped as '%%'.
+
   - host: HOST,PORT
     username: my_username
     password: my_password

--- a/conf.d/sqlserver.yaml.example
+++ b/conf.d/sqlserver.yaml.example
@@ -34,7 +34,7 @@ init_config:
     #   tag_by: db
 
 instances:
-    # Currently all '%' characters must be escaped as '%%'.
+    # All '%' characters must be escaped as '%%'.
 
   - host: HOST,PORT
     username: my_username


### PR DESCRIPTION
The '%' character must be escaped as '%%' for adodbapi to make a
correct connection_string. Adding a comment to warn users in the
sqlserver.yaml.example file.

Only a comment, so [skip ci] is appropriate.