### PR TITLE
[docker] be resilient to dockerpy buggy api calls

### DIFF
--- a/tests/checks/mock/test_docker.py
+++ b/tests/checks/mock/test_docker.py
@@ -1,0 +1,26 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+# stdlib
+import mock
+import unittest
+
+from utils.dockerutil import DockerUtil
+
+
+class TestDockerutil(unittest.TestCase):
+    def setUp(self):
+        self.dockerutil = DockerUtil()
+
+    @mock.patch('utils.dockerutil.DockerUtil.client')
+    def test_get_events(self, mocked_client):
+        mocked_client.events.return_value = [
+            {'status': 'stop', 'id': '1234567890', 'from': '1234567890', 'time': 1423247867}
+        ]
+        events_generator, _ = self.dockerutil.get_events()
+        self.assertEqual(len(events_generator), 1)
+
+        # bug in dockerpy, we should be resilient
+        mocked_client.events.return_value = [u'an error from Docker API here']
+        events_generator, _ = self.dockerutil.get_events()
+        self.assertEqual(len(list(events_generator)), 0)


### PR DESCRIPTION
Due to a bug on docker-py, whenever the Docker api fails at returning a stream of events, the library returns a plain string instead of a Json as expected, thus raising warnings on collector's logs.

Waiting for https://github.com/docker/docker-py/pull/1082 to be merged, this PR increases agent resilience to this problem.

The fix was tested by couple of customers.