### PR TITLE
Use docker hostname instead of default route to query cadvisor & kubelet

### DIFF
--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -46,6 +46,7 @@ FUNC_MAP = {
     RATE: {True: HISTORATE, False: RATE}
 }
 
+
 class Kubernetes(AgentCheck):
     """ Collect metrics and events from kubelet """
 

--- a/tests/checks/mock/test_kubernetes.py
+++ b/tests/checks/mock/test_kubernetes.py
@@ -49,6 +49,7 @@ class TestKubernetes(AgentCheckTest):
         }
 
         with mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list', side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.1.json", string_escape=False))):
+            with mock.patch('utils.dockerutil.DockerUtil.get_hostname', side_effect=lambda: 'foo'):
                 # Can't use run_check_twice due to specific metrics
                 self.run_check(config, mocks=mocks, force_reload=True)
                 self.assertServiceCheck("kubernetes.kubelet.check", status=AgentCheck.CRITICAL, tags=None, count=1)
@@ -69,6 +70,7 @@ class TestKubernetes(AgentCheckTest):
         }
         # parts of the json returned by the kubelet api is escaped, keep it untouched
         with mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list', side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.1.json", string_escape=False))):
+            with mock.patch('utils.dockerutil.DockerUtil.get_hostname', side_effect=lambda: 'foo'):
                 # Can't use run_check_twice due to specific metrics
                 self.run_check_twice(config, mocks=mocks, force_reload=True)
 
@@ -125,6 +127,7 @@ class TestKubernetes(AgentCheckTest):
 
         # parts of the json returned by the kubelet api is escaped, keep it untouched
         with mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list', side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.1.json", string_escape=False))):
+            with mock.patch('utils.dockerutil.DockerUtil.get_hostname', side_effect=lambda: 'foo'):
                 # Can't use run_check_twice due to specific metrics
                 self.run_check_twice(config, mocks=mocks, force_reload=True)
 
@@ -163,6 +166,7 @@ class TestKubernetes(AgentCheckTest):
         }
 
         with mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list', side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False))):
+            with mock.patch('utils.dockerutil.DockerUtil.get_hostname', side_effect=lambda: 'foo'):
                 # Can't use run_check_twice due to specific metrics
                 self.run_check(config, mocks=mocks, force_reload=True)
                 self.assertServiceCheck("kubernetes.kubelet.check", status=AgentCheck.CRITICAL)
@@ -183,6 +187,7 @@ class TestKubernetes(AgentCheckTest):
         }
         # parts of the json returned by the kubelet api is escaped, keep it untouched
         with mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list', side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False))):
+            with mock.patch('utils.dockerutil.DockerUtil.get_hostname', side_effect=lambda: 'foo'):
                 # Can't use run_check_twice due to specific metrics
                 self.run_check_twice(config, mocks=mocks, force_reload=True)
 
@@ -235,6 +240,7 @@ class TestKubernetes(AgentCheckTest):
 
         # parts of the json returned by the kubelet api is escaped, keep it untouched
         with mock.patch('utils.kubeutil.KubeUtil.retrieve_pods_list', side_effect=lambda: json.loads(Fixtures.read_file("pods_list_1.2.json", string_escape=False))):
+            with mock.patch('utils.dockerutil.DockerUtil.get_hostname', side_effect=lambda: 'foo'):
                 # Can't use run_check_twice due to specific metrics
                 self.run_check_twice(config, mocks=mocks, force_reload=True)
 

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -104,12 +104,10 @@ class DockerUtil():
 
     def get_hostname(self):
         """Return the `Name` param from `docker info` to use as the hostname"""
-        if self.is_dockerized():
-            try:
-                return self.client.info().get("Name")
-            except Exception:
-                log.critical("Unable to find docker host hostname")
-
+        try:
+            return self.client.info().get("Name")
+        except Exception:
+            log.critical("Unable to find docker host hostname")
         return None
 
     @property


### PR DESCRIPTION
Using the default route works fine in most cases, but if the user has a virtual network set up (like Calico) it won't point to the real host.
The docker host name is more reliable.

`_get_default_router` is not used anywhere else, so I killed it.