### PR TITLE
[mysql] Fix slave_running for mysql 5.7 with slave binlog

### DIFF
--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -535,35 +535,37 @@ class MySql(AgentCheck):
             # slaves will only be collected iff user has PROCESS privileges.
             slaves = self._collect_scalar('Slaves_connected', results)
 
-            if self._is_master(slaves, binlog_running):  # master
-                if slaves > 0 and binlog_running:
-                    slave_running_status = AgentCheck.OK
-                else:
-                    slave_running_status = AgentCheck.WARNING
-            elif slave_running:  # slave (or standalone)
-                if slave_running.lower().strip() == 'on':
-                    slave_running_status = AgentCheck.OK
-                else:
-                    slave_running_status = AgentCheck.CRITICAL
-            else:  # slave - with no `Slave_running`
-                # MySQL 5.7.x might not have 'Slave_running'. See: https://bugs.mysql.com/bug.php?id=78544
-                # look at replica vars collected at the top of if-block
-                if self._version_compatible(db, host, "5.7.0"):
-                    slave_io_running = self._collect_string('Slave_IO_Running', results)
-                    slave_sql_running = self._collect_string('Slave_SQL_Running', results)
-                    if slave_io_running:
-                        slave_io_running = (slave_io_running.lower().strip() == "yes")
-                    if slave_sql_running:
-                        slave_sql_running = (slave_sql_running.lower().strip() == "yes")
+            # MySQL 5.7.x might not have 'Slave_running'. See: https://bugs.mysql.com/bug.php?id=78544
+            # look at replica vars collected at the top of if-block
+            if self._version_compatible(db, host, "5.7.0"):
+                slave_io_running = self._collect_string('Slave_IO_Running', results)
+                slave_sql_running = self._collect_string('Slave_SQL_Running', results)
+                if slave_io_running:
+                    slave_io_running = (slave_io_running.lower().strip() == "yes")
+                if slave_sql_running:
+                    slave_sql_running = (slave_sql_running.lower().strip() == "yes")
 
-                    if not (slave_io_running is None and slave_sql_running is None):
-                        if slave_io_running and slave_sql_running:
-                            slave_running_status = AgentCheck.OK
-                        elif not slave_io_running and not slave_sql_running:
-                            slave_running_status = AgentCheck.CRITICAL
-                        else:
-                            # not everything is running smoothly
-                            slave_running_status = AgentCheck.WARNING
+                if not (slave_io_running is None and slave_sql_running is None):
+                    if slave_io_running and slave_sql_running:
+                        slave_running_status = AgentCheck.OK
+                    elif not slave_io_running and not slave_sql_running:
+                        slave_running_status = AgentCheck.CRITICAL
+                    else:
+                        # not everything is running smoothly
+                        slave_running_status = AgentCheck.WARNING
+
+            # if we don't yet have a status - inspect
+            if slave_running_status == AgentCheck.UNKNOWN:
+                if self._is_master(slaves, binlog_running):  # master
+                    if slaves > 0 and binlog_running:
+                        slave_running_status = AgentCheck.OK
+                    else:
+                        slave_running_status = AgentCheck.WARNING
+                elif slave_running:  # slave (or standalone)
+                    if slave_running.lower().strip() == 'on':
+                        slave_running_status = AgentCheck.OK
+                    else:
+                        slave_running_status = AgentCheck.CRITICAL
 
             # deprecated in favor of service_check("mysql.replication.slave_running")
             self.gauge(self.SLAVE_SERVICE_CHECK_NAME, (1 if slave_running_status == AgentCheck.OK else 0), tags=tags)


### PR DESCRIPTION
When a MySQL 5.7 is a slave _and_ has a running binlog with no
downstream slaves attached, this check assumed that the instance was a
master with no running slaves.

Fix it so that it checks for Slave_IO_Running and Slave_SQL_Running
before checking for Binlog_enabled and Slaves_connected.

This PR should supersede #2493 - it is essentially no more than a rebase of it. We first look at the slave variables available in most 5.7+ versions, and if we don't yet have concluded on a status, we then look at possible master, slave combinations.