### PR TITLE
Fix a small problem that prevented marathon full path from being properly built 

### DIFF
--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -47,7 +47,7 @@ class Marathon(AgentCheck):
         default_timeout = self.init_config.get('default_timeout', self.DEFAULT_TIMEOUT)
         timeout = float(instance.get('timeout', default_timeout))
 
-        response = self.get_json(urljoin(url, "/v2/apps"), timeout, auth)
+        response = self.get_json(urljoin(url, "v2/apps"), timeout, auth)
         if response is not None:
             self.gauge('marathon.apps', len(response['apps']), tags=instance_tags)
             for app in response['apps']:


### PR DESCRIPTION
…properly built when the base url included a path.

As tested in the REPL, the fix will properly join base url's and paths:
```
  >>> urljoin("http://marathon.mesos", "v2/apps")
  'http://marathon.mesos/v2/apps'

  >>> urljoin("http://marathon.mesos/service/marathon/", "v2/apps")
  'http://marathon.mesos/service/marathon/v2/apps'

  >>> urljoin("http://marathon.mesos", "v2/apps")
  'http://marathon.mesos/v2/apps'

  >>> urljoin("http://marathon.mesos/", "v2/apps")
  'http://marathon.mesos/v2/apps'

  >>> urljoin("http://marathon.mesos:8080", "v2/apps")
  'http://marathon.mesos:8080/v2/apps'

  >>> urljoin("http://marathon.mesos:8080/", "v2/apps")
  'http://marathon.mesos:8080/v2/apps'
```
Care needs to be taken to include a trailing slash in the base URL when there is a path included.
```
  >>> urljoin("http://marathon.mesos/service/marathon", "v2/apps")
  'http://marathon.mesos/service/v2/apps' # This is wrong. Include trailing slash to fix.
```