### PR TITLE
[redis] use time delta to compute master_link_down_since_seconds

### DIFF
--- a/checks.d/redisdb.py
+++ b/checks.d/redisdb.py
@@ -274,7 +274,7 @@ class Redis(AgentCheck):
                 down_seconds = 0
             else:
                 status = AgentCheck.CRITICAL
-                down_seconds = info[LINK_DOWN_KEY]
+                down_seconds = time.time() - info[LINK_DOWN_KEY]
 
             self.service_check('redis.replication.master_link_status', status, tags=tags)
             self.gauge('redis.replication.master_link_down_since_seconds', down_seconds, tags=tags)


### PR DESCRIPTION
The value for `master_link_down_since_seconds` returned from the Redis INFO command is the timestamp in seconds at which the master went down. We should take the difference between this and the current time before submitting the metric to Datadog.