### PR TITLE
[docker_daemon] fix disk metrics rounding issue

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -718,9 +718,10 @@ class DockerDaemon(AgentCheck):
             total = stats.get('docker.{0}.total'.format(mtype))
             free = stats.get('docker.{0}.free'.format(mtype))
             if used and total and free and ceil(total) < free + used:
-                self.log.error('used, free, and total disk metrics may be wrong, '
-                               'unable to calculate percentage.')
-                return {}
+                self.log.debug('used, free, and total disk metrics may be wrong, '
+                               'used: %s, free: %s, total: %s',
+                               used, free, total)
+                total = used + free
             try:
                 if isinstance(used, int):
                     percs['docker.{0}.percent'.format(mtype)] = round(100 * float(used) / float(total), 2)


### PR DESCRIPTION
Docker Status rounds the disk metrics, which means something like this
can happen:
```
[u'Data Space Used', u'5.238 GB']
[u'Data Space Available', u'18.12 GB']
[u'Data Space Total', u'23.35 GB']
```
So:
```
used = 5238000000
free = 18120000000
total = 23350000000
```

With `used + free > total` because of the rounding error.
In this case, this commits changes the default behavior to taking
`total` as `used + free` and calculating the disk percentage based on
that. (There should only be a small difference between `total` and `free + used`)