### PR TITLE
[openstack] nova/neutron extend name search

### DIFF
--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -254,7 +254,7 @@ class KeystoneCatalog(object):
 
         neutron_endpoint = None
         for entry in catalog:
-            if entry['name'] == match:
+            if entry['name'] == match or 'Networking' in entry['name']:
                 valid_endpoints = {}
                 for ep in entry['endpoints']:
                     interface = ep.get('interface','')
@@ -283,7 +283,7 @@ class KeystoneCatalog(object):
         nova_match = 'novav21' if nova_version == 'v2.1' else 'nova'
 
         for entry in catalog:
-            if entry['name'] == nova_match:
+            if entry['name'] == nova_match or 'Compute' in entry['name']:
                 # Collect any endpoints on the public or internal interface
                 valid_endpoints = {}
                 for ep in entry['endpoints']:


### PR DESCRIPTION
Sometimes the check doesn't find the Neutron/Nova endpoint because the name is
not what is expected. This commit extends the current search by adding
one possible name for each component: 'Compute' for Nova and
'Networking' for Neuron.