### PR TITLE
[core] clean debug logs and kill Dogstream-based DdForwarder

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -176,8 +176,6 @@ class Agent(Daemon):
 
         # Run the main loop.
         while self.run_forever:
-            log.debug("Found {num_checks} checks".format(num_checks=len(self._checksd['initialized_checks'])))
-
             # Setup profiling if necessary
             if self.in_developer_mode and not profiled:
                 try:

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -22,7 +22,7 @@ from checks.check_status import (
     STATUS_ERROR,
     STATUS_OK,
 )
-from checks.datadog import DdForwarder, Dogstreams
+from checks.datadog import Dogstreams
 from checks.ganglia import Ganglia
 from config import get_system_stats, get_version
 import checks.system.unix as u
@@ -228,7 +228,6 @@ class Collector(object):
         # Old-style metric checks
         self._ganglia = Ganglia(log) if self.agentConfig.get('ganglia_host', '') != '' else None
         self._dogstream = None if self.agentConfig.get('dogstreams') is None else Dogstreams.init(log, self.agentConfig)
-        self._ddforwarder = DdForwarder(log, self.agentConfig)
 
         # Agent performance metrics check
         self._agent_metrics = None
@@ -367,11 +366,6 @@ class Collector(object):
                 del dogstreamData['dogstreamEvents']
 
             payload.update(dogstreamData)
-        ddforwarderData = self._ddforwarder.check(self.agentConfig)
-
-        # metrics about the forwarder
-        if ddforwarderData:
-            payload['datadog'] = ddforwarderData
 
         # process collector of gohai (compliant with payload of legacy "resources checks")
         if not Platform.is_windows() and self._should_send_additional_data('processes'):

--- a/checks/datadog.py
+++ b/checks/datadog.py
@@ -7,8 +7,6 @@ from datetime import datetime
 import glob
 from itertools import groupby
 import os
-import re
-import sys
 import time
 import traceback
 
@@ -16,6 +14,7 @@ import traceback
 import modules
 from util import windows_friendly_colon_split
 from utils.tailfile import TailFile
+
 
 def partition(s, sep):
     pos = s.find(sep)
@@ -117,6 +116,7 @@ class Dogstreams(object):
             except Exception:
                 self.logger.exception("Error in parsing %s" % (dogstream.log_path))
         return output
+
 
 class Dogstream(object):
 
@@ -333,87 +333,3 @@ class Dogstream(object):
             return {"dogstream": output}
         else:
             return {}
-
-
-# Allow a smooth uninstall of previous version
-class RollupLP:
-    pass
-
-
-class DdForwarder(object):
-
-    QUEUE_SIZE = "queue_size"
-    QUEUE_COUNT = "queue_count"
-
-    RE_QUEUE_STAT = re.compile(r"\[.*\] Queue size: at (.*), (\d+) transaction\(s\), (\d+) KB")
-
-    def __init__(self, logger, config):
-        self.log_path = config.get('ddforwarder_log', '/var/log/ddforwarder.log')
-        self.logger = logger
-        self._gen = None
-
-    def _init_metrics(self):
-        self.metrics = {}
-
-    def _add_metric(self, name, value, ts):
-
-        if name in self.metrics:
-            self.metrics[name].append((ts, value))
-        else:
-            self.metrics[name] = [(ts, value)]
-
-    def _parse_line(self, line):
-
-        try:
-            m = self.RE_QUEUE_STAT.match(line)
-            if m is not None:
-                ts, count, size = m.groups()
-                self._add_metric(self.QUEUE_SIZE, size, round(float(ts)))
-                self._add_metric(self.QUEUE_COUNT, count, round(float(ts)))
-        except Exception as e:
-            self.logger.exception(e)
-
-    def check(self, agentConfig, move_end=True):
-
-        if self.log_path and os.path.isfile(self.log_path):
-
-            #reset metric points
-            self._init_metrics()
-
-            # Build our tail -f
-            if self._gen is None:
-                self._gen = TailFile(self.logger, self.log_path, self._parse_line).tail(line_by_line=False,
-                    move_end=move_end)
-
-            # read until the end of file
-            try:
-                self._gen.next()
-                self.logger.debug("Done ddforwarder check for file %s" % self.log_path)
-            except StopIteration as e:
-                self.logger.exception(e)
-                self.logger.warn("Can't tail %s file" % self.log_path)
-
-            return {'ddforwarder': self.metrics}
-        else:
-            self.logger.debug("Can't tail datadog forwarder log file: %s" % self.log_path)
-            return {}
-
-
-def testddForwarder():
-    import logging
-
-    logger = logging.getLogger("ddagent.checks.datadog")
-    logger.setLevel(logging.DEBUG)
-    logger.addHandler(logging.StreamHandler())
-
-    config = {'api_key':'my_apikey', 'ddforwarder_log': sys.argv[1]}
-    dd = DdForwarder(logger, config)
-    m = dd.check(config, move_end=False)
-    while True:
-        print m
-        time.sleep(5)
-        m = dd.check(config)
-
-
-if __name__ == '__main__':
-    testddForwarder()

--- a/checks/libs/wmi/sampler.py
+++ b/checks/libs/wmi/sampler.py
@@ -201,7 +201,6 @@ class WMISampler(object):
 
         try:
             if self.is_raw_perf_class and not self._previous_sample:
-                self.logger.debug(u"Querying for initial sample for raw performance counter.")
                 self._current_sample = self._query()
 
             self._previous_sample = self._current_sample
@@ -215,7 +214,6 @@ class WMISampler(object):
             raise
         else:
             self._sampling = False
-            self.logger.debug(u"Sample: {0}".format(self._current_sample))
 
     def __len__(self):
         """

--- a/config.py
+++ b/config.py
@@ -546,9 +546,6 @@ def get_config(parse_args=True, cfg_path=None, options=None):
         except ConfigParser.NoOptionError:
             pass
 
-        if config.has_option('datadog', 'ddforwarder_log'):
-            agentConfig['has_datadog'] = True
-
         # Dogstream config
         if config.has_option("Main", "dogstream_log"):
             # Older version, single log support


### PR DESCRIPTION
## 	[collector] remove useless debug logs
This commit:
- removes the creation of a Ganglia object when not enabled
- "       "   "        "  " Dogstreams "   "    "   "
- removes the `Sample: ...` debug logs for WMI

## [core] kill unused DdForwarder 🔥 🔥
