### PR TITLE
[iis] no warnings on 'Name' property 🔇

### DIFF
--- a/checks.d/iis.py
+++ b/checks.d/iis.py
@@ -102,8 +102,10 @@ class IIS(WinWMICheck):
             )
         except pythoncom.com_error as e:
             if '0x80041017' in str(e):
-                self.warning("You may be running IIS6/7 which reports metrics a \
-                             little differently. Try enabling the is_2008 flag for this instance.")
+                self.warning(
+                    u"You may be running IIS6/7 which reports metrics a "
+                    u"little differently. Try enabling the is_2008 flag for this instance."
+                )
             raise e
         else:
             self._submit_events(wmi_sampler, sites)
@@ -126,7 +128,7 @@ class IIS(WinWMICheck):
         for wmi_obj in wmi_sampler:
             tags = list(tags) if tags else []
 
-            # get site name
+            # Get site name
             sitename = wmi_obj['Name']
 
             # Skip any sites we don't specifically want.
@@ -137,7 +139,10 @@ class IIS(WinWMICheck):
 
             # Tag with `tag_queries` parameter
             for wmi_property, wmi_value in wmi_obj.iteritems():
-                # Tag with `tag_by` parameter
+                # No metric extraction on 'Name' property
+                if wmi_property == 'name':
+                    continue
+
                 try:
                     metrics.append(WMIMetric(wmi_property, float(wmi_value), tags))
                 except ValueError:
@@ -164,7 +169,6 @@ class IIS(WinWMICheck):
         for site in expected_sites:
             self.service_check(self.SERVICE_CHECK, AgentCheck.CRITICAL,
                                tags=['site:{0}'.format(self.normalize(site))])
-
 
     def _submit_metrics(self, wmi_metrics, metrics_by_property):
         for m in wmi_metrics:

--- a/tests/checks/mock/test_iis.py
+++ b/tests/checks/mock/test_iis.py
@@ -1,4 +1,8 @@
+# stdlib
 import re
+
+# 3p
+from mock import Mock
 
 # project
 from checks import AgentCheck
@@ -53,18 +57,19 @@ class IISTestCase(AgentCheckTest, TestCommonWMI):
         """
         Returns the right metrics and service checks
         """
-        # Run check
+        # Set up & run the check
         config = {
             'instances': [self.WIN_SERVICES_CONFIG]
         }
+        logger = Mock()
 
-        self.run_check_twice(config)
+        self.run_check_twice(config, mocks={'log': logger})
 
         # Test metrics
-
-        # normalize site-names
+        # ... normalize site-names
         ok_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][0])
         fail_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][1])
+
         for mname in self.IIS_METRICS:
             self.assertMetric(mname, tags=["mytag1", "mytag2", "site:{0}".format(ok_site_name)], count=1)
 
@@ -73,6 +78,9 @@ class IISTestCase(AgentCheckTest, TestCommonWMI):
                                 tags=["site:{0}".format(ok_site_name)], count=1)
         self.assertServiceCheck('iis.site_up', status=AgentCheck.CRITICAL,
                                 tags=["site:{0}".format(fail_site_name)], count=1)
+
+        # Check completed with no warnings
+        self.assertFalse(logger.warning.called)
 
         self.coverage_report()
 
@@ -90,7 +98,7 @@ class IISTestCase(AgentCheckTest, TestCommonWMI):
 
         # Test metrics
 
-        # normalize site-names
+        # Normalize site-names
         ok_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][0])
         fail_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][1])
         for mname in self.IIS_METRICS:


### PR DESCRIPTION
Do not log a warning about non digit property values for the 'Name'
property.
Test that the check completes with no warnings.