### PR TITLE
[status page] Remove proxy info from it

### DIFF
--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -770,15 +770,9 @@ class ForwarderStatus(AgentStatus):
         self.flush_count = flush_count
         self.transactions_received = transactions_received
         self.transactions_flushed = transactions_flushed
-        self.proxy_data = get_config(parse_args=False).get('proxy_settings')
         self.hidden_username = None
         self.hidden_password = None
         self.too_big_count = too_big_count
-        if self.proxy_data and self.proxy_data.get('user'):
-            username = self.proxy_data.get('user')
-            hidden = len(username) / 2 if len(username) <= 7 else len(username) - 4
-            self.hidden_username = '*' * 5 + username[hidden:]
-            self.hidden_password = '*' * 10
 
     def body_lines(self):
         lines = [
@@ -791,20 +785,6 @@ class ForwarderStatus(AgentStatus):
             ""
         ]
 
-        if self.proxy_data:
-            lines += [
-                "Proxy",
-                "=====",
-                "",
-                "  Host: %s" % self.proxy_data.get('host'),
-                "  Port: %s" % self.proxy_data.get('port')
-            ]
-            if self.proxy_data.get('user'):
-                lines += [
-                    "  Username: %s" % self.hidden_username,
-                    "  Password: %s" % self.hidden_password
-                ]
-
         return lines
 
     def has_error(self):
@@ -816,9 +796,6 @@ class ForwarderStatus(AgentStatus):
             'flush_count': self.flush_count,
             'queue_length': self.queue_length,
             'queue_size': self.queue_size,
-            'proxy_data': self.proxy_data,
-            'hidden_username': self.hidden_username,
-            'hidden_password': self.hidden_password,
             'too_big_count': self.too_big_count,
             'transactions_received': self.transactions_received,
             'transactions_flushed': self.transactions_flushed

--- a/win32/status.html
+++ b/win32/status.html
@@ -247,19 +247,6 @@
             <dt>Transactions rejected</dt>       <dd>{{ forwarder['too_big_count'] }}</dd>
           </dl>
 
-          {% if forwarder['proxy_data'] %}
-          <h3>Proxy</h3>
-
-          <dl>
-            <dt>Host</dt>     <dd>{{ forwarder['proxy_data']['host'] }}</dd>
-            <dt>Port</dt>     <dd>{{ forwarder['proxy_data']['port'] }}</dd>
-            {% if forwarder.get('hidden_username') %}
-            <dt>Username</dt>     <dd>{{ forwarder['hidden_username'] }}</dd>
-            <dt>Password</dt>     <dd>{{ forwarder['hidden_password'] }}</dd>
-            {% end %}
-          </dl>
-          {% end %}
-
           <!-- Dogstatsd -->
           <h2>DogstatsD</h2>
 


### PR DESCRIPTION
Reading the proxy settings is a bit costly as it reparse the whole
config file and we do it every time we persist the forwarder status.

This information is not that valuable as it will be collected by a
flare anyway. Let’s just remove it