### PR TITLE
kernel 4+ won't error out on status now

### DIFF
--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -183,7 +183,7 @@ case "$1" in
         major=$(echo "$( uname -r )" | cut -d"." -f1)
         minor=$(echo "$( uname -r )" | cut -d"." -f2)
         # If major version 3, and minor version 18+, OR major version 4+
-        if ( [ !$DOCKER_DD_AGENT ] && ( [ $major -eq 3 ] && [ $minor -ge 18 ] ) || [ $major -gt 3 ] ); then
+        if [ "$DOCKER_DD_AGENT" != "" ] && ( ( [ $major -eq 3 ] && [ $minor -ge 18 ] ) || [ $major -gt 3 ] ); then
             RED='\033[0;31m' # Red Text
             NC='\033[0m' # No Color
             echo "${RED}Warning: Known bug in Linux Kernel 3.18+ causes 'status' to fail.${NC}"

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -183,7 +183,7 @@ case "$1" in
         major=$(echo "$( uname -r )" | cut -d"." -f1)
         minor=$(echo "$( uname -r )" | cut -d"." -f2)
         # If major version 3, and minor version 18+, OR major version 4+
-        if ( [ $major -eq 3 ] && [ $minor -ge 18 ] ) || [ $major -gt 3 ]; then
+        if ( [ !$DOCKER_DD_AGENT ] && ( [ $major -eq 3 ] && [ $minor -ge 18 ] ) || [ $major -gt 3 ] ); then
             RED='\033[0;31m' # Red Text
             NC='\033[0m' # No Color
             echo "${RED}Warning: Known bug in Linux Kernel 3.18+ causes 'status' to fail.${NC}"


### PR DESCRIPTION
On Kernel 3.18+ on some distributions that also use overlayfs, certain commands will fail. However, they'll work fine if they're not using overlayfs.

This is a stopgap solution, so that the commands will work on our docker testing environments.