### PR TITLE
Implement consul self_leader_check

### DIFF
--- a/conf.d/consul.yaml.example
+++ b/conf.d/consul.yaml.example
@@ -23,9 +23,17 @@ instances:
       # Whether to perform checks against the Consul service Catalog
       catalog_checks: yes
 
+      # Whether to enable self leader checks. Each agent with this enabled will
+      # watch for itself to become the leader and will emit an event when that
+      # happens. It is safe/expected to enable this on all nodes in a consul
+      # cluster since only the new leader will emit the (single) event. This
+      # flag takes precedence over new_leader_checks.
+      self_leader_check: yes
+
       # Whether to enable new leader checks from this agent
       # Note: if this is set on multiple agents in the same cluster
-      # you will receive one event per leader change per agent
+      # you will receive one event per leader change per agent. See
+      # self_leader_check for a more robust option.
       new_leader_checks: yes
 
       # Services to restrict catalog querying to

--- a/tests/checks/mock/test_consul.py
+++ b/tests/checks/mock/test_consul.py
@@ -381,7 +381,7 @@ class TestCheckConsul(AgentCheckTest):
         self.assertIn('prev_consul_leader:My Old Leader', event['tags'])
         self.assertIn('curr_consul_leader:My New Leader', event['tags'])
 
-    def testn_self_leader_event(self):
+    def test_self_leader_event(self):
         self.check = load_check(self.CHECK_NAME, MOCK_CONFIG_SELF_LEADER_CHECK, self.DEFAULT_AGENT_CONFIG)
         self.check._last_known_leader = 'My Old Leader'
 


### PR DESCRIPTION
A mechanism for detecting leadership changes that can be enabled on all server nodes in a cluster. It will emit a single event from the new leader. This avoids the need to designate a single agent as the watcher for leadership changes, all agents can watch themselves.