### PR TITLE
[redisdb] Avoid exception when slowlog query returns empty `command`

### DIFF
--- a/checks.d/redisdb.py
+++ b/checks.d/redisdb.py
@@ -325,9 +325,16 @@ class Redis(AgentCheck):
             if slowlog['start_time'] > max_ts:
                 max_ts = slowlog['start_time']
 
-            command_tag = 'command:{0}'.format(slowlog['command'].split()[0])
+            slowlog_tags = list(tags)
+            command = slowlog['command'].split()
+            # When the "Garantia Data" custom Redis is used, redis-py returns
+            # an empty `command` field
+            # FIXME when https://github.com/andymccurdy/redis-py/pull/622 is released in redis-py
+            if command:
+                slowlog_tags.append('command:{0}'.format(command[0]))
+
             value = slowlog['duration']
-            self.histogram('redis.slowlog.micros', value, tags=tags + [command_tag])
+            self.histogram('redis.slowlog.micros', value, tags=slowlog_tags)
 
         self.last_timestamp_seen[ts_key] = max_ts
 


### PR DESCRIPTION
The `command` field can be empty with the current version of redis-py
querying a custom "Garantia Data" Redis version.

In this case, and until redis-py adds support for it, we just send the
histogram without the `command` tag, which is better than nothing.

Fixes #2629 

Thanks @fotinakis for reporting this issue!