### PR TITLE
[dns_check] Allow querying a custom record type

### DIFF
--- a/checks.d/dns_check.py
+++ b/checks.d/dns_check.py
@@ -51,12 +51,14 @@ class DNSCheck(AgentCheck):
         if nameserver is not None:
             resolver.nameservers = [nameserver]
 
+        record_type = instance.get('record_type', 'A')
+
         status = AgentCheck.CRITICAL
         start_time = time.time()
         try:
-            self.log.debug('Resolving hostname %s...' % hostname)
-            answer = resolver.query(hostname)
-            assert(answer.rrset.items[0].address)
+            self.log.debug('Querying "%s" record for hostname "%s"...' % (record_type, hostname))
+            answer = resolver.query(hostname, rdtype=record_type)
+            assert(answer.rrset.items[0].to_text())
             end_time = time.time()
         except dns.exception.Timeout:
             self.log.error('DNS resolution of %s timed out' % hostname)

--- a/conf.d/dns_check.yaml.example
+++ b/conf.d/dns_check.yaml.example
@@ -5,3 +5,7 @@ instances:
     - hostname: www.example.org
       nameserver: 127.0.0.1
       timeout: 8
+
+      # Specify an (optional) `record_type` to customize the record type
+      # queried by the check (default: "A")
+      # record_type: A


### PR DESCRIPTION
New `record_type` optional parameter in the configuration.

Along with tests: runs of the check in `test_invalid_config` now reload
the config correctly and test that the expected exception is raised.