### PR TITLE
query leader.mesos by default for mesos master check

### DIFF
--- a/conf.d/mesos_master.yaml.example
+++ b/conf.d/mesos_master.yaml.example
@@ -2,4 +2,4 @@ init_config:
   default_timeout: 10
 
 instances:
-  - url: "http://localhost:5050"
+  - url: "http://leader.mesos:5050"


### PR DESCRIPTION
Only the leader report metrics so it makes sense, also this way we can use the default file in docker since localhost doesn't resolve to the mesos metrics api in a container if `--net=host` is not used.