### PR TITLE
Added an option to disable following redirects.

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -200,15 +200,16 @@ class HTTPCheck(NetworkCheck):
         weakcipher = _is_affirmative(instance.get('weakciphers', False))
         ignore_ssl_warning = _is_affirmative(instance.get('ignore_ssl_warning', False))
         skip_proxy = _is_affirmative(instance.get('no_proxy', False))
+        follow_redirects = _is_affirmative(instance.get('follow_redirects', True))
 
         return url, username, password, http_response_status_code, timeout, include_content,\
             headers, response_time, content_match, tags, ssl, ssl_expire, instance_ca_certs,\
-            weakcipher, ignore_ssl_warning, skip_proxy
+            weakcipher, ignore_ssl_warning, skip_proxy, follow_redirects
 
     def _check(self, instance):
         addr, username, password, http_response_status_code, timeout, include_content, headers,\
             response_time, content_match, tags, disable_ssl_validation,\
-            ssl_expire, instance_ca_certs, weakcipher, ignore_ssl_warning, skip_proxy = self._load_conf(instance)
+            ssl_expire, instance_ca_certs, weakcipher, ignore_ssl_warning, skip_proxy, follow_redirects = self._load_conf(instance)
         start = time.time()
 
         service_checks = []
@@ -246,7 +247,8 @@ class HTTPCheck(NetworkCheck):
                     base_addr, WeakCiphersHTTPSConnection.SUPPORTED_CIPHERS))
 
             r = sess.request('GET', addr, auth=auth, timeout=timeout, headers=headers, proxies=instance_proxy,
-                             verify=False if disable_ssl_validation else instance_ca_certs)
+                             verify=False if disable_ssl_validation else instance_ca_certs,
+                             allow_redirects=follow_redirects)
 
         except (socket.timeout, requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
             length = int((time.time() - start) * 1000)

--- a/conf.d/http_check.yaml.example
+++ b/conf.d/http_check.yaml.example
@@ -48,6 +48,13 @@ instances:
     #
     # collect_response_time: true
 
+    # The (optional) follow_redirects will instruct the check on how to handle
+    # redirects. If set to false, the check will not follow redirects and
+    # return the redirect HTTP response code
+    # Defaults to true
+    #
+    # follow_redirects: true
+
     # The (optional) disable_ssl_validation will instruct the check
     # to skip the validation of the SSL certificate of the URL being tested.
     # This is mostly useful when checking SSL connections signed with


### PR DESCRIPTION
Some http_checks look to make sure that connecting to one link does actually result in a temporary or permanent redirect. This change allows disabling the python requests module from following redirects.