### PR TITLE
[Event log] Unicode everything

### DIFF
--- a/checks.d/win32_event_log.py
+++ b/checks.d/win32_event_log.py
@@ -203,17 +203,17 @@ class LogEvent(object):
 
             msg_text_fields.append("```\n%%%")
 
-            msg_text = "\n".join(msg_text_fields)
+            msg_text = u"\n".join(msg_text_fields)
         else:
             # Override when verbosity
             if self.event.get('Message'):
-                msg_text = "{message}\n".format(message=self.event['Message'])
+                msg_text = u"{message}\n".format(message=self.event['Message'])
             elif self.event.get('InsertionStrings'):
-                msg_text = "\n".join([i_str for i_str in self.event['InsertionStrings']
+                msg_text = u"\n".join([i_str for i_str in self.event['InsertionStrings']
                                       if i_str.strip()])
 
         if self.notify_list:
-            msg_text += "\n{notify_list}".format(
+            msg_text += u"\n{notify_list}".format(
                 notify_list=' '.join([" @" + n for n in self.notify_list]))
 
         return msg_text


### PR DESCRIPTION


Otherwise the check can fail with
```
Traceback (most recent call last):
  File "checks\__init__.pyc", line 750, in run
  File "C:\Program Files (x86)\Datadog\Datadog Agent\files\..\checks.d\win32_event_log.py", line 147, in check
  File "C:\Program Files (x86)\Datadog\Datadog Agent\files\..\checks.d\win32_event_log.py", line 240, in to_event_dict
  File "C:\Program Files (x86)\Datadog\Datadog Agent\files\..\checks.d\win32_event_log.py", line 210, in _msg_text
UnicodeEncodeError: 'ascii' codec can't encode character u'\u200e' in position 31: ordinal not in range(128)
```