### PR TITLE
[core] don't use docker hostname if it's a EC2 one

### DIFF
--- a/tests/core/test_ec2.py
+++ b/tests/core/test_ec2.py
@@ -24,3 +24,9 @@ class TestEC2(unittest.TestCase):
         if "instance-id" in d:
             assert d["instance-id"].startswith("i-"), d
         assert end - start <= 1.15, "It took %s seconds to get ec2 metadata" % (end-start)
+
+    def test_is_default_hostname(self):
+        for hostname in ['ip-172-31-16-235', 'domU-12-31-38-00-A4-A2', 'domU-12-31-39-02-14-35']:
+            self.assertTrue(EC2.is_default(hostname))
+        for hostname in ['i-672d49da', 'localhost', 'robert.redf.org']:
+            self.assertFalse(EC2.is_default(hostname))

--- a/util.py
+++ b/util.py
@@ -204,7 +204,7 @@ def get_hostname(config=None):
     if hostname is None and docker_util.is_dockerized():
         docker_hostname = docker_util.get_hostname()
         if docker_hostname is not None and is_valid_hostname(docker_hostname):
-            return docker_hostname
+            hostname = docker_hostname
 
     # then move on to os-specific detection
     if hostname is None:
@@ -224,7 +224,7 @@ def get_hostname(config=None):
                 hostname = unix_hostname
 
     # if we have an ec2 default hostname, see if there's an instance-id available
-    if (Platform.is_ecs_instance()) or (hostname is not None and True in [hostname.lower().startswith(p) for p in [u'ip-', u'domu']]):
+    if (Platform.is_ecs_instance()) or (hostname is not None and EC2.is_default(hostname)):
         instanceid = EC2.get_instance_id(config)
         if instanceid:
             hostname = instanceid
@@ -243,6 +243,7 @@ def get_hostname(config=None):
         raise Exception('Unable to reliably determine host name. You can define one in datadog.conf or in your hosts file')
     else:
         return hostname
+
 
 class GCE(object):
     URL = "http://169.254.169.254/computeMetadata/v1/?recursive=true"
@@ -346,6 +347,7 @@ class EC2(object):
     METADATA_URL_BASE = EC2_METADATA_HOST + "/latest/meta-data"
     INSTANCE_IDENTITY_URL = EC2_METADATA_HOST + "/latest/dynamic/instance-identity/document"
     TIMEOUT = 0.1  # second
+    DEFAULT_PREFIXES = [u'ip-', u'domu']
     metadata = {}
 
     class NoIAMRole(Exception):
@@ -353,6 +355,14 @@ class EC2(object):
         Instance has no associated IAM role.
         """
         pass
+
+    @staticmethod
+    def is_default(hostname):
+        hostname = hostname.lower()
+        for prefix in EC2.DEFAULT_PREFIXES:
+            if hostname.startswith(prefix):
+                return True
+        return False
 
     @staticmethod
     def get_iam_role():


### PR DESCRIPTION
Docker info sometimes returns default EC2 hostnames and `get_hostname`
wasn't checking whether it was possible to use the instance id.
This commits change this behavior by allowing `get_hostname` to check
the docker proposed hostname before using it.