### PR TITLE
[core] upgrades supervisor to avoid supervisor bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ pyyaml==3.11
 requests==2.6.0
 # note: simplejson is used in many checks to inteface APIs
 simplejson==3.6.5
-supervisor==3.1.3
+supervisor==3.3.0
 tornado==3.2.2
 uptime==3.0.1
 


### PR DESCRIPTION
Supervisor 1.3.1 has a bug in it: https://github.com/Supervisor/supervisor/issues/562

This will upgrade it to fix the bug.