### PR TITLE
Add an HTTP timeout to many integrations.

### DIFF
--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -141,7 +141,7 @@ class HAProxy(AgentCheck):
 
         self.log.debug("HAProxy Fetching haproxy search data from: %s" % url)
 
-        r = requests.get(url, auth=auth, headers=headers(self.agentConfig), verify=verify)
+        r = requests.get(url, auth=auth, headers=headers(self.agentConfig), verify=verify, timeout=self.default_integration_http_timeout)
         r.raise_for_status()
 
         return r.content.splitlines()

--- a/checks.d/hdfs_datanode.py
+++ b/checks.d/hdfs_datanode.py
@@ -122,7 +122,7 @@ class HDFSDataNode(AgentCheck):
         self.log.debug('Attempting to connect to "%s"' % url)
 
         try:
-            response = requests.get(url)
+            response = requests.get(url, timeout=self.default_integration_http_timeout)
             response.raise_for_status()
             response_json = response.json()
 

--- a/checks.d/hdfs_namenode.py
+++ b/checks.d/hdfs_namenode.py
@@ -168,7 +168,7 @@ class HDFSNameNode(AgentCheck):
         self.log.debug('Attempting to connect to "%s"' % url)
 
         try:
-            response = requests.get(url)
+            response = requests.get(url, timeout=self.default_integration_http_timeout)
             response.raise_for_status()
             response_json = response.json()
 

--- a/checks.d/mapreduce.py
+++ b/checks.d/mapreduce.py
@@ -473,7 +473,7 @@ class MapReduceCheck(AgentCheck):
             url = urljoin(url, '?' + query)
 
         try:
-            response = requests.get(url)
+            response = requests.get(url, timeout=self.default_integration_http_timeout)
             response.raise_for_status()
             response_json = response.json()
 

--- a/checks.d/nginx.py
+++ b/checks.d/nginx.py
@@ -73,7 +73,7 @@ class Nginx(AgentCheck):
         try:
             self.log.debug(u"Querying URL: {0}".format(url))
             r = requests.get(url, auth=auth, headers=headers(self.agentConfig),
-                             verify=ssl_validation)
+                             verify=ssl_validation, timeout=self.default_integration_http_timeout)
             r.raise_for_status()
         except Exception:
             self.service_check(service_check_name, AgentCheck.CRITICAL,

--- a/checks.d/rabbitmq.py
+++ b/checks.d/rabbitmq.py
@@ -152,7 +152,7 @@ class RabbitMQ(AgentCheck):
 
     def _get_data(self, url, auth=None):
         try:
-            r = requests.get(url, auth=auth)
+            r = requests.get(url, auth=auth, timeout=self.default_integration_http_timeout)
             r.raise_for_status()
             data = r.json()
         except requests.exceptions.HTTPError as e:

--- a/checks.d/yarn.py
+++ b/checks.d/yarn.py
@@ -271,7 +271,7 @@ class YarnCheck(AgentCheck):
             url = urljoin(url, '?' + query)
 
         try:
-            response = requests.get(url)
+            response = requests.get(url, timeout=self.default_integration_http_timeout)
             response.raise_for_status()
             response_json = response.json()
 

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -322,6 +322,7 @@ class AgentCheck(object):
         self.agentConfig = agentConfig
         self.in_developer_mode = agentConfig.get('developer_mode') and psutil
         self._internal_profiling_stats = None
+        self.default_integration_http_timeout = float(agentConfig.get('default_integration_http_timeout', 9))
 
         self.hostname = agentConfig.get('checksd_hostname') or get_hostname(agentConfig)
         self.log = logging.getLogger('%s.%s' % (__name__, name))

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -31,6 +31,11 @@ api_key:
 # It will only be deleted if the forwarder queue becomes too big. (30 MB by default)
 # forwarder_timeout: 20
 
+# Set timeout in seconds for integrations that use HTTP to fetch metrics, since
+# unbounded timeouts can potentially block the collector indefinitely and cause
+# problems!
+# default_integration_http_timeout: 9
+
 # Add one "dd_check:checkname" tag per running check. It makes it possible to slice
 # and dice per monitored app (= running Agent Check) on Datadog's backend.
 # create_dd_check_tags: no
@@ -132,7 +137,7 @@ use_mount: no
 # Other                                                                      #
 # ========================================================================== #
 #
-# In some environments we may have the procfs file system mounted in a 
+# In some environments we may have the procfs file system mounted in a
 # miscellaneous location. The procfs_path configuration paramenter allows
 # us to override the standard default location '/proc'
 # procfs_path: /proc


### PR DESCRIPTION
### What's this PR do?
Adds a timeout to many integration's HTTP request methods.

### Motivation
We recently a problem with a cluster that caused the HTTP response to not return for awhile. It ended up repeatedly being killed by the watchdog and at one point even did this somehow:
```
2016-07-08 15:06:28 UTC | INFO | dd.collector | checks.collector(collector.py:539) | Finished run #1. Collection time: 146.23s. Emit time: 0.04s
```

This could've been easily avoided with a timeout!

O_o

### Notes
I picked 9 because it's < 10. Adding this an instance variable on the class — as is done in some other integrations — seemed Hard because i'd have to thread it through all the various functions that are called. Open to suggestions on this.

I came along in 2nd commit and added this to every place I found it missing that we used. I'd love to see this added to _all_ the integrations, but I'll leave that for someone else.