### PR TITLE
enable monitoring of SSL-ified redis servers

### DIFF
--- a/checks.d/redisdb.py
+++ b/checks.d/redisdb.py
@@ -127,7 +127,8 @@ class Redis(AgentCheck):
 
                 # Only send useful parameters to the redis client constructor
                 list_params = ['host', 'port', 'db', 'password', 'socket_timeout',
-                               'connection_pool', 'charset', 'errors', 'unix_socket_path']
+                               'connection_pool', 'charset', 'errors', 'unix_socket_path', 'ssl',
+                               'ssl_certfile', 'ssl_keyfile', 'ssl_ca_certs', 'ssl_cert_reqs']
 
                 # Set a default timeout (in seconds) if no timeout is specified in the instance config
                 instance['socket_timeout'] = instance.get('socket_timeout', 5)

--- a/conf.d/redisdb.yaml.example
+++ b/conf.d/redisdb.yaml.example
@@ -14,6 +14,18 @@ instances:
     # password: mypassword
     # socket_timeout: 5
 
+    # Optional SSL/TLS parameters
+    # ssl: False     # Optional (default to False)
+    # ssl_keyfile:   # Path to the client-side private keyfile
+    # ssl_certfile:  # Path to the client-side certificate file
+    # ssl_ca_certs:  #  Path to the ca_certs file
+    # ssl_cert_reqs: # Specifies whether a certificate is required from the
+    #                # other side of the connection, and whether it will be validated if
+    #                # provided.
+    #   * 0 for ssl.CERT_NONE (certificates ignored)
+    #   * 1 for ssl.CERT_OPTIONAL (not required, but validated if provided)
+    #   * 2 for ssl.CERT_REQUIRED (required and validated)
+
     # Optional extra tags added to all redis metrics
     # tags:
     #   - optional_tag1


### PR DESCRIPTION
Pass through ssl_* values from redisdb.yaml on to the redis constructor.

Hosted redis providers (e.g. redislabs.com) use SSL to protect the redis connections.  Passing through the ssl_* params enables monitoring of such providers.