### PR TITLE
[iis] Fix metrics tagging when multiple sites are specified on instance

### DIFF
--- a/checks.d/iis.py
+++ b/checks.d/iis.py
@@ -111,7 +111,7 @@ class IIS(WinWMICheck):
             self._submit_events(wmi_sampler, sites)
             self._submit_metrics(metrics, metrics_by_property)
 
-    def _extract_metrics(self, wmi_sampler, sites, tags):
+    def _extract_metrics(self, wmi_sampler, sites, instance_tags):
         """
         Extract and tag metrics from the WMISampler.
 
@@ -126,7 +126,7 @@ class IIS(WinWMICheck):
         metrics = []
 
         for wmi_obj in wmi_sampler:
-            tags = list(tags) if tags else []
+            tags = list(instance_tags) if instance_tags else []
 
             # Get site name
             sitename = wmi_obj['Name']

--- a/tests/checks/mock/test_iis.py
+++ b/tests/checks/mock/test_iis.py
@@ -21,7 +21,7 @@ class IISTestCase(AgentCheckTest, TestCommonWMI):
     WIN_SERVICES_CONFIG = {
         'host': ".",
         'tags': ["mytag1", "mytag2"],
-        'sites': ["Default Web Site", "Failing site"]
+        'sites': ["Default Web Site", "Working site", "Failing site"]
     }
 
     IIS_METRICS = [
@@ -67,15 +67,17 @@ class IISTestCase(AgentCheckTest, TestCommonWMI):
 
         # Test metrics
         # ... normalize site-names
-        ok_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][0])
-        fail_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][1])
+        default_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][0])
+        ok_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][1])
+        fail_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][2])
 
-        for mname in self.IIS_METRICS:
-            self.assertMetric(mname, tags=["mytag1", "mytag2", "site:{0}".format(ok_site_name)], count=1)
+        for site_name in [default_site_name, ok_site_name]:
+            for mname in self.IIS_METRICS:
+                self.assertMetric(mname, tags=["mytag1", "mytag2", "site:{0}".format(site_name)], count=1)
 
-        # Test service checks
-        self.assertServiceCheck('iis.site_up', status=AgentCheck.OK,
-                                tags=["site:{0}".format(ok_site_name)], count=1)
+            self.assertServiceCheck('iis.site_up', status=AgentCheck.OK,
+                                    tags=["site:{0}".format(site_name)], count=1)
+
         self.assertServiceCheck('iis.site_up', status=AgentCheck.CRITICAL,
                                 tags=["site:{0}".format(fail_site_name)], count=1)
 
@@ -99,16 +101,21 @@ class IISTestCase(AgentCheckTest, TestCommonWMI):
         # Test metrics
 
         # Normalize site-names
-        ok_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][0])
-        fail_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][1])
-        for mname in self.IIS_METRICS:
-            self.assertMetric(mname, tags=["mytag1", "mytag2", "site:{0}".format(ok_site_name)], count=1)
+        default_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][0])
+        ok_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][1])
+        fail_site_name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", config['instances'][0]['sites'][2])
 
-        # Test service checks
-        self.assertServiceCheck('iis.site_up', status=AgentCheck.OK,
-                                tags=["site:{0}".format(ok_site_name)], count=1)
+        for site_name in [default_site_name, ok_site_name]:
+            for mname in self.IIS_METRICS:
+                self.assertMetric(mname, tags=["mytag1", "mytag2", "site:{0}".format(site_name)], count=1)
+
+            self.assertServiceCheck('iis.site_up', status=AgentCheck.OK,
+                                    tags=["site:{0}".format(site_name)], count=1)
+
         self.assertServiceCheck('iis.site_up', status=AgentCheck.CRITICAL,
                                 tags=["site:{0}".format(fail_site_name)], count=1)
+
+        self.coverage_report()
 
     def test_check_without_sites_specified(self):
         """

--- a/tests/core/test_wmi.py
+++ b/tests/core/test_wmi.py
@@ -180,8 +180,9 @@ class SWbemServices(object):
         if query == ("Select ServiceUptime,TotalBytesSent,TotalBytesReceived,TotalBytesTransferred,CurrentConnections,TotalFilesSent,TotalFilesReceived,"  # noqa
                      "TotalConnectionAttemptsAllInstances,TotalGetRequests,TotalPostRequests,TotalHeadRequests,TotalPutRequests,TotalDeleteRequests,"  # noqa
                      "TotalOptionsRequests,TotalTraceRequests,TotalNotFoundErrors,TotalLockedErrors,TotalAnonymousUsers,TotalNonAnonymousUsers,TotalCGIRequests,"  # noqa
-                     "TotalISAPIExtensionRequests from Win32_PerfFormattedData_W3SVC_WebService WHERE ( Name = 'Failing site' ) OR ( Name = 'Default Web Site' )"):  # noqa
+                     "TotalISAPIExtensionRequests from Win32_PerfFormattedData_W3SVC_WebService WHERE ( Name = 'Failing site' ) OR ( Name = 'Working site' ) OR ( Name = 'Default Web Site' )"):  # noqa
             results += load_fixture("win32_perfformatteddata_w3svc_webservice", ("Name", "Default Web Site"))  # noqa
+            results += load_fixture("win32_perfformatteddata_w3svc_webservice", ("Name", "Working site"))  # noqa
 
         if query == ("Select ServiceUptime,TotalBytesSent,TotalBytesReceived,TotalBytesTransferred,CurrentConnections,TotalFilesSent,TotalFilesReceived,"  # noqa
                      "TotalConnectionAttemptsAllInstances,TotalGetRequests,TotalPostRequests,TotalHeadRequests,TotalPutRequests,TotalDeleteRequests,"  # noqa
@@ -189,8 +190,9 @@ class SWbemServices(object):
                      "TotalISAPIExtensionRequests from Win32_PerfFormattedData_W3SVC_WebService WHERE ( Name = '_Total' )"):  # noqa
             results += load_fixture("win32_perfformatteddata_w3svc_webservice", ("Name", "_Total"))  # noqa
 
-        if query == ("Select * from Win32_PerfFormattedData_W3SVC_WebService WHERE ( Name = 'Failing site' ) OR ( Name = 'Default Web Site' )"):  # noqa
+        if query == ("Select * from Win32_PerfFormattedData_W3SVC_WebService WHERE ( Name = 'Failing site' ) OR ( Name = 'Working site' ) OR ( Name = 'Default Web Site' )"):  # noqa
             results += load_fixture("win32_perfformatteddata_w3svc_webservice_2008", ("Name", "Default Web Site"))  # noqa
+            results += load_fixture("win32_perfformatteddata_w3svc_webservice_2008", ("Name", "Working Site"))  # noqa
 
         if query == ("Select Name,State from Win32_Service WHERE ( Name = 'WSService' ) OR ( Name = 'WinHttpAutoProxySvc' )"):  # noqa
             results += load_fixture("win32_service_up", ("Name", "WinHttpAutoProxySvc"))


### PR DESCRIPTION
Before this commit, the check would tag metrics from sites of the same instance with multiple `site:` tags on each metric.

Fix this behavior and improve existing tests to catch the issue.