### PR TITLE
[sdk] minor tweaks - location name, check loading

### DIFF
--- a/config.py
+++ b/config.py
@@ -738,14 +738,14 @@ def get_checksd_path(osname=None):
         return _unix_checksd_path()
 
 
-def get_3rd_party_path(osname=None):
+def get_dd_integrations_path(osname=None):
     if not osname:
         osname = get_os()
     if osname in ['windows', 'mac']:
         raise PathNotFound()
 
     cur_path = os.path.dirname(os.path.realpath(__file__))
-    path = os.path.join(cur_path, '../3rd-party')
+    path = os.path.join(cur_path, '../dd-integrations')
     if os.path.exists(path):
         return path
     raise PathNotFound(path)
@@ -905,10 +905,10 @@ def get_checks_places(osname, agentConfig):
     places = [lambda name: os.path.join(agentConfig['additional_checksd'], '%s.py' % name)]
 
     try:
-        third_party_path = get_3rd_party_path(osname)
-        places.append(lambda name: os.path.join(third_party_path, name, 'check.py'))
+        dd_integrations = get_dd_integrations_path(osname)
+        places.append(lambda name: os.path.join(dd_integrations, name, 'check.py'))
     except PathNotFound:
-        log.debug('No 3rd-party path found')
+        log.debug('No dd-integrations path found')
 
     places.append(lambda name: os.path.join(checksd_path, '%s.py' % name))
     return places

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -24,6 +24,9 @@ from utils.debug import get_check  # noqa -  FIXME 5.5.0 AgentCheck tests should
 log = logging.getLogger('tests')
 
 
+def _is_sdk():
+    return "SDK_TESTING" in os.environ
+
 def get_check_class(name):
     checksd_path = get_checksd_path(get_os())
     if checksd_path not in sys.path:
@@ -61,8 +64,8 @@ def load_class(check_name, class_name):
     raise Exception(u"Unable to import class {0} from the check module.".format(class_name))
 
 
-def load_check(name, config, agentConfig, is_sdk=False):
-    if not is_sdk:
+def load_check(name, config, agentConfig):
+    if not _is_sdk():
         checksd_path = get_checksd_path(get_os())
 
         # find (in checksd_path) and load the check module
@@ -142,15 +145,12 @@ class AgentCheckTest(unittest.TestCase):
 
         self.check = None
 
-    def is_sdk(self):
-        return "SDK_TESTING" in os.environ
-
     def is_travis(self):
         return "TRAVIS" in os.environ
 
     def load_check(self, config, agent_config=None):
         agent_config = agent_config or self.DEFAULT_AGENT_CONFIG
-        self.check = load_check(self.CHECK_NAME, config, agent_config, is_sdk=self.is_sdk())
+        self.check = load_check(self.CHECK_NAME, config, agent_config)
 
     def load_class(self, name):
         """

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -155,7 +155,7 @@ class TestConfig(unittest.TestCase):
 
 TMP_DIR = tempfile.gettempdir()
 DD_AGENT_TEST_DIR = 'dd-agent-tests'
-TEMP_3RD_PARTY_CHECKS_DIR = os.path.join(TMP_DIR, DD_AGENT_TEST_DIR, '3rd-party')
+TEMP_DD_INTEGRATIONS_CHECKS_DIR = os.path.join(TMP_DIR, DD_AGENT_TEST_DIR, 'dd-integrations')
 TEMP_ETC_CHECKS_DIR = os.path.join(TMP_DIR, DD_AGENT_TEST_DIR, 'etc', 'checks.d')
 TEMP_ETC_CONF_DIR = os.path.join(TMP_DIR, DD_AGENT_TEST_DIR, 'etc', 'conf.d')
 TEMP_AGENT_CHECK_DIR = os.path.join(TMP_DIR, DD_AGENT_TEST_DIR)
@@ -164,11 +164,11 @@ FIXTURE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtur
 
 @mock.patch('config.get_checksd_path', return_value=TEMP_AGENT_CHECK_DIR)
 @mock.patch('config.get_confd_path', return_value=TEMP_ETC_CONF_DIR)
-@mock.patch('config.get_3rd_party_path', return_value=TEMP_3RD_PARTY_CHECKS_DIR)
+@mock.patch('config.get_dd_integrations_path', return_value=TEMP_DD_INTEGRATIONS_CHECKS_DIR)
 class TestConfigLoadCheckDirectory(unittest.TestCase):
 
     TEMP_DIRS = [
-        '%s/test_check' % TEMP_3RD_PARTY_CHECKS_DIR,
+        '%s/test_check' % TEMP_DD_INTEGRATIONS_CHECKS_DIR,
         TEMP_ETC_CHECKS_DIR, TEMP_ETC_CONF_DIR, TEMP_AGENT_CHECK_DIR
     ]
 
@@ -262,7 +262,7 @@ class TestConfigLoadCheckDirectory(unittest.TestCase):
         copyfile('%s/valid_check_2.py' % FIXTURE_PATH,
             '%s/test_check.py' % TEMP_AGENT_CHECK_DIR)
         copyfile('%s/valid_check_1.py' % FIXTURE_PATH,
-            '%s/test_check/check.py' % TEMP_3RD_PARTY_CHECKS_DIR)
+            '%s/test_check/check.py' % TEMP_DD_INTEGRATIONS_CHECKS_DIR)
         checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
         self.assertEquals(1, len(checks['initialized_checks']))
         self.assertEquals('valid_check_1', checks['initialized_checks'][0].check(None))
@@ -271,7 +271,7 @@ class TestConfigLoadCheckDirectory(unittest.TestCase):
         copyfile('%s/valid_conf.yaml' % FIXTURE_PATH,
             '%s/test_check.yaml' % TEMP_ETC_CONF_DIR)
         copyfile('%s/valid_check_2.py' % FIXTURE_PATH,
-            '%s/test_check/check.py' % TEMP_3RD_PARTY_CHECKS_DIR)
+            '%s/test_check/check.py' % TEMP_DD_INTEGRATIONS_CHECKS_DIR)
         copyfile('%s/valid_check_1.py' % FIXTURE_PATH,
             '%s/test_check.py' % TEMP_ETC_CHECKS_DIR)
         checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")

--- a/tests/core/test_transaction.py
+++ b/tests/core/test_transaction.py
@@ -298,7 +298,6 @@ class TestTransaction(unittest.TestCase):
         self.assertEqual(trManager._finished_flushes, step)
         self.assertIs(trManager._trs_to_flush, None)
 
-    @attr('unix')
     def test_no_parallelism(self):
         step = 2
         trManager = TransactionManager(timedelta(seconds=0), MAX_QUEUE_SIZE,
@@ -312,7 +311,11 @@ class TestTransaction(unittest.TestCase):
             self.assertEqual(trManager._running_flushes, 1)
             self.assertEqual(trManager._finished_flushes, i)
             self.assertEqual(len(trManager._trs_to_flush), step - (i + 1))
-            time.sleep(1)
+            time.sleep(1.3)
+        # Once it's finished
+        self.assertEqual(trManager._running_flushes, 0)
+        self.assertEqual(trManager._finished_flushes, 2)
+        self.assertIs(trManager._trs_to_flush, None)
 
     def test_multiple_endpoints(self):
         config = {
@@ -338,3 +341,5 @@ class TestTransaction(unittest.TestCase):
         MetricTransaction({}, {})
         # 2 endpoints = 2 transactions
         self.assertEqual(len(trManager._transactions), 2)
+        self.assertEqual(trManager._transactions[0]._endpoint, 'https://app.datadoghq.com')
+        self.assertEqual(trManager._transactions[1]._endpoint, 'https://app.example.com')

--- a/tests/core/test_watchdog.py
+++ b/tests/core/test_watchdog.py
@@ -141,6 +141,14 @@ class MemoryHogTxManager(object):
 
 class PseudoAgent(object):
     """Same logic as the agent, simplified"""
+    AGENT_CONFIG = {
+        "bind_host": "localhost",
+        'endpoints': {
+            'https://app.datadoghq.com': ['api_key']
+        },
+        'forwarder_timeout': 5
+    }
+
     def busy_run(self):
         w = Watchdog(5)
         w.reset()
@@ -162,13 +170,13 @@ class PseudoAgent(object):
             w.reset()
 
     def slow_tornado(self):
-        a = Application(12345, {"bind_host": "localhost"})
+        a = Application(12345, self.AGENT_CONFIG)
         a._watchdog = Watchdog(4)
         a._tr_manager = MockTxManager()
         a.run()
 
     def fast_tornado(self):
-        a = Application(12345, {"bind_host": "localhost"})
+        a = Application(12345, self.AGENT_CONFIG)
         a._watchdog = Watchdog(6)
         a._tr_manager = MockTxManager()
         a.run()

--- a/transaction.py
+++ b/transaction.py
@@ -204,7 +204,7 @@ class TransactionManager(object):
                 log.debug("Flushing transaction %d", tr.get_id())
                 try:
                     tr.flush()
-                except Exception as e :
+                except Exception as e:
                     log.exception(e)
                     self.tr_error(tr)
                 self.flush_next()


### PR DESCRIPTION
`AgentCheckTest.load_check()` and `load_check()` in `tests.checks.common` are both needed, one by integration tests, the other by unit tests (respectively). We could maybe get rid of the former but it would involve too many changes at the moment. The proposed changes will allow both unit tests (if added in the SDK) and integration tests to correctly load the checks in the testing infrastructure.

Also, because integrations-core would've been dropped into `3rd-party`, and that is misleading, renaming to `dd-integrations`.