### PR TITLE
[disk] `use_df` parameter to force use `df`

### DIFF
--- a/checks.d/disk.py
+++ b/checks.d/disk.py
@@ -36,9 +36,11 @@ class Disk(AgentCheck):
 
     def check(self, instance):
         """Get disk space/inode stats"""
+        use_df = Platform.is_unix() and _is_affirmative(instance.get('use_df', False))
+
         # Windows and Mac will always have psutil
         # (we have packaged for both of them)
-        if self._psutil():
+        if self._psutil() and not use_df:
             if Platform.is_linux():
                 procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
                 psutil.PROCFS_PATH = procfs_path

--- a/conf.d/disk.yaml.default
+++ b/conf.d/disk.yaml.default
@@ -8,30 +8,30 @@ instances:
   # The use_mount parameter will instruct the check to collect disk
   # and fs metrics using mount points instead of volumes
   - use_mount: no
-    # The (optional) excluded_filesystems parameter will instruct the check to
-    # ignore disks using these filesystems
+    # The (optional) `excluded_filesystems` parameter will instruct the check to
+    # ignore disks using these filesystems.
     # excluded_filesystems:
     #   - tmpfs
 
-    # The (optional) excluded_disks parameter will instruct the check to
-    # ignore this list of disks
+    # The (optional) `excluded_disks` parameter will instruct the check to
+    # ignore this list of disks.
     # excluded_disks:
     #   - /dev/sda1
     #   - /dev/sda2
     #
-    # The (optional) excluded_disk_re parameter will instruct the check to
-    # ignore all disks matching this regex
+    # The (optional) `excluded_disk_re` parameter will instruct the check to
+    # ignore all disks matching this regex.
     # excluded_disk_re: /dev/sde.*
     #
-    # The (optional) tag_by_filesystem parameter will instruct the check to
+    # The (optional) `tag_by_filesystem` parameter will instruct the check to
     # tag all disks with their filesystem (for ex: filesystem:nfs)
     # tag_by_filesystem: no
     #
-    # The (optional) excluded_mountpoint_re parameter will instruct the check to
-    # ignore all mountpoints matching this regex
+    # The (optional) `excluded_mountpoint_re` parameter will instruct the check to
+    # ignore all mountpoints matching this regex.
     # excluded_mountpoint_re: /mnt/somebody-elses-problem.*
     #
-    # The (optional) all_partitions parameter will instruct the check to
+    # The (optional) `all_partitions` parameter will instruct the check to
     # get metrics for all partitions. use_mount should be set to yes (to avoid
     # collecting empty device names) when using this option.
     # all_partitions: no

--- a/tests/checks/mock/test_disk.py
+++ b/tests/checks/mock/test_disk.py
@@ -137,6 +137,21 @@ class TestCheckDisk(AgentCheckTest):
 
         self.coverage_report()
 
+    def test_use_df(self):
+        """
+        `use_df` instructs the check to use the `df` command instead of
+        the `psutil` module.
+        """
+        # Set up the check, mock
+        collect_metrics_manually = mock.Mock()
+        self.run_check(
+            {'instances': [{'use_df': 'yes'}]},
+            mocks={'collect_metrics_manually': collect_metrics_manually}
+        )
+
+        # Metrics are collected "manually"
+        self.assertTrue(collect_metrics_manually.called)
+
     @mock.patch('utils.subprocess_output.get_subprocess_output',
                 return_value=(Fixtures.read_file('debian-df-Tk'), "", 0))
     @mock.patch('os.statvfs', return_value=MockInodesMetrics())


### PR DESCRIPTION
`psutil.disk_usage` method uses the `statvfs` POSIX API to resolve the
disks' usage. **Problem?** This call can hang "forever" when a file
system is listed but not available. Worse, it can’t get interrupted or
killed, making the Watchdog helpless.

I attached more references to this problem below.

> Basically if you have a network filesystem listed in /proc/mounts and
  it is unreachable (e.g. because there is no network), statvfs will
  hang on stat’ing the network directory, even if you called statvfs on
  a completely different directory

To workaround this issue, add an optional `use_df` parameter to instruct
the check to use the `df` command instead of the `psutil` module. `df`
uses the `statvfs` POSIX API too, but prints an appropriate error message
when it fails instead of hanging.

**References**
https://sourceware.org/ml/libc-hacker/2003-09/msg00056.html
http://ilostmynotes.blogspot.com/2014/05/cross-platform-python-method-for.html
https://www.redhat.com/archives/rhl-list/2004-March/msg01647.html

cc @gmmeyer 