### PR TITLE
[elastic] improve hostname resolution

### DIFF
--- a/ci/elasticsearch.rb
+++ b/ci/elasticsearch.rb
@@ -36,6 +36,11 @@ namespace :ci do
     end
 
     task before_script: ['ci:common:before_script'] do
+      # Elasticsearch configuration
+      sh %(mkdir -p #{es_rootdir}/config)
+      sh %(cp $TRAVIS_BUILD_DIR/ci/resources/elasticsearch/elasticsearch.yml\
+           #{es_rootdir}/config/)
+      # Elasticsearch data
       sh %(mkdir -p $VOLATILE_DIR/es_data)
       pid = spawn %(#{es_rootdir}/bin/elasticsearch --path.data=$VOLATILE_DIR/es_data)
       Process.detach(pid)

--- a/ci/resources/elasticsearch/elasticsearch.yml
+++ b/ci/resources/elasticsearch/elasticsearch.yml
@@ -1,0 +1,2 @@
+node:
+  name: batman

--- a/tests/checks/integration/test_elastic.py
+++ b/tests/checks/integration/test_elastic.py
@@ -244,7 +244,7 @@ class TestElastic(AgentCheckTest):
             "api_key": "bar"
         }
 
-        tags = ['foo:bar', 'baz']
+        tags = [u"foo:bar", u"baz"]
         url = 'http://localhost:{0}'.format(port)
         bad_url = 'http://localhost:{0}'.format(bad_port)
 
@@ -262,7 +262,7 @@ class TestElastic(AgentCheckTest):
 
         default_tags = ["url:http://localhost:{0}".format(port)]
 
-        expected_metrics = STATS_METRICS
+        expected_metrics = dict(STATS_METRICS)
         CLUSTER_HEALTH_METRICS.update(CLUSTER_PENDING_TASKS)
         expected_metrics.update(CLUSTER_HEALTH_METRICS)
 
@@ -303,11 +303,19 @@ class TestElastic(AgentCheckTest):
             (local_hostname, default_tags)
         ]
 
+        stats_keys = (
+            set(expected_metrics.keys()) - set(CLUSTER_HEALTH_METRICS.keys()) -
+            set(CLUSTER_PENDING_TASKS.keys())
+        )
+
         for m_name, desc in expected_metrics.iteritems():
             for hostname, m_tags in contexts:
                 if (m_name in CLUSTER_HEALTH_METRICS
                         and hostname == local_hostname):
                     hostname = conf_hostname
+
+                if m_name in stats_keys:
+                    m_tags = m_tags + [u"node_name:batman"]
 
                 if desc[0] == "gauge":
                     self.assertMetric(


### PR DESCRIPTION
When the `cluster_stats` parameter is enabled in the user configuration,
the Datadog Agent's Elasticsearch check attempts to resolve and
attach with the corresponding metrics, the hostname of the different
nodes.

On Amazon Elasticsearch v1.5.2, the node objects
returned by the `_cluster/nodes/stats?all=true` endpoint returns the
following keys:
```
root@xxxx:~# cat node_stats.json| jq '.nodes[] | select(.name ==
"${hostname}") | keys
[
  "breakers",
  "fs",
  "indices",
  "jvm",
  "name",
  "os",
  "process",
  "thread_pool",
  "timestamp"
]
```

where `name` contains the hostname.