### PR TITLE
Allow multiple gauge values within the same MetricAggregator instance.

### DIFF
--- a/aggregator.py
+++ b/aggregator.py
@@ -892,9 +892,9 @@ class MetricsAggregator(Aggregator):
         hostname = hostname if hostname is not None else self.hostname
 
         if tags is None:
-            context = (name, tuple(), hostname, device_name)
+            context = (name, tuple(), hostname, device_name, timestamp)
         else:
-            context = (name, tuple(sorted(set(tags))), hostname, device_name)
+            context = (name, tuple(sorted(set(tags))), hostname, device_name, timestamp)
         if context not in self.metrics:
             metric_class = self.metric_type_to_class[mtype]
             self.metrics[context] = metric_class(self.formatter, name, tags,


### PR DESCRIPTION
Adds the provided timestamp to the metric instance's context.
Use of multiple gauge values for a single metric requires the timestamps to be passed explicitly.


Problem:  
Currently calling self.gauge() with the same metric name, hostname, and tags but different timestamp only retains the last call's value.

Use case:
Upstream API that provides data has a variable delay before values are available.  When data is available, it provides multiple values for different timestamps all at once.

Proposed solution:
Includes the provided timestamp as part of the metric instance's context to allow multiple instances that differ only by timestamp.  

Notes about solution:
This technically affects all metrics, potentially changing the way the previous metric instance is selected.  The updated code only affects previous implementations if and only if the timestamp parameter is specified.  The timestamp parameter is currently only used by the gauge metric.