### PR TITLE
Improve service discovery to only reload checks that need it

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -19,6 +19,7 @@ import os
 import signal
 import sys
 import time
+from copy import copy
 
 # For pickle & PID files, see issue 293
 os.umask(022)
@@ -31,6 +32,7 @@ from config import (
     get_parsed_args,
     get_system_stats,
     load_check_directory,
+    load_check
 )
 from daemon import AgentSupervisor, Daemon
 from emitter import http_emitter
@@ -76,6 +78,7 @@ class Agent(Daemon):
         self._checksd = []
         self.collector_profile_interval = DEFAULT_COLLECTOR_PROFILE_INTERVAL
         self.check_frequency = None
+        # this flag can be set to True, False, or a list of checks (for partial reload)
         self.reload_configs_flag = False
         self.sd_backend = None
 
@@ -98,25 +101,84 @@ class Agent(Daemon):
         log.info("SIGHUP caught! Scheduling configuration reload before next collection run.")
         self.reload_configs_flag = True
 
-    def reload_configs(self):
-        """Reloads the agent configuration and checksd configurations."""
+    def reload_configs(self, checks_to_reload=set()):
+        """Reload the agent configuration and checksd configurations.
+           Can also reload only an explicit set of checks."""
         log.info("Attempting a configuration reload...")
-
-        # Stop checks
-        for check in self._checksd.get('initialized_checks', []):
-            check.stop()
-
-        # Reload checksd configs
         hostname = get_hostname(self._agentConfig)
-        self._checksd = load_check_directory(self._agentConfig, hostname)
+
+        # if no check was given, reload them all
+        if not checks_to_reload:
+            log.debug("No check list was passed, reloading every check")
+            # stop checks
+            for check in self._checksd.get('initialized_checks', []):
+                check.stop()
+
+            self._checksd = load_check_directory(self._agentConfig, hostname)
+        else:
+            new_checksd = copy(self._checksd)
+
+            self.refresh_specific_checks(hostname, new_checksd, checks_to_reload)
+            # once the reload is done, replace existing checks with the new ones
+            self._checksd = new_checksd
 
         # Logging
         num_checks = len(self._checksd['initialized_checks'])
         if num_checks > 0:
-            log.info("Successfully reloaded {num_checks} checks".
-                     format(num_checks=num_checks))
+            opt_msg = " (refreshed %s checks)" % len(checks_to_reload) if checks_to_reload else ''
+
+            msg = "Check reload was successful. Running {num_checks} checks{opt_msg}.".format(
+                num_checks=num_checks, opt_msg=opt_msg)
+            log.info(msg)
         else:
             log.info("No checksd configs found")
+
+    def refresh_specific_checks(self, hostname, checksd, checks):
+        """take a list of checks and for each of them:
+            - remove it from the init_failed_checks if it was there
+            - load a fresh config for it
+            - replace its old config with the new one in initialized_checks if there was one
+            - disable the check if no new config was found
+            - otherwise, append it to initialized_checks
+        """
+        for check_name in checks:
+            idx = None
+            for num, check in enumerate(checksd['initialized_checks']):
+                if check.name == check_name:
+                    idx = num
+                    # stop the existing check before reloading it
+                    check.stop()
+
+            if not idx and check_name in checksd['init_failed_checks']:
+                # if the check previously failed to load, pop it from init_failed_checks
+                checksd['init_failed_checks'].pop(check_name)
+
+            fresh_check = load_check(self._agentConfig, hostname, check_name)
+
+            # this is an error dict
+            # checks that failed to load are added to init_failed_checks
+            # and poped from initialized_checks
+            if isinstance(fresh_check, dict) and 'error' in fresh_check.keys():
+                checksd['init_failed_checks'][fresh_check.keys()[0]] = fresh_check.values()[0]
+                if idx:
+                    checksd['initialized_checks'].pop(idx)
+
+            elif not fresh_check:
+                # no instance left of it to monitor so the check was not loaded
+                if idx:
+                    checksd['initialized_checks'].pop(idx)
+                # the check was not previously running so we were trying to instantiate it and it failed
+                else:
+                    log.error("Configuration for check %s was not found, it won't be reloaded." % check_name)
+
+            # successfully reloaded check are added to initialized_checks
+            # (appended or replacing a previous version)
+            else:
+                if idx is not None:
+                    checksd['initialized_checks'][idx] = fresh_check
+                # it didn't exist before and doesn't need to be replaced so we append it
+                else:
+                    checksd['initialized_checks'].append(fresh_check)
 
     @classmethod
     def info(cls, verbose=None):
@@ -189,13 +251,16 @@ class Agent(Daemon):
                     log.warn("Cannot enable profiler: %s" % str(e))
 
             if self.reload_configs_flag:
-                self.reload_configs()
+                if isinstance(self.reload_configs_flag, set):
+                    self.reload_configs(checks_to_reload=self.reload_configs_flag)
+                else:
+                    self.reload_configs()
 
             # Do the work. Pass `configs_reloaded` to let the collector know if it needs to
             # look for the AgentMetrics check and pop it out.
             self.collector.run(checksd=self._checksd,
                                start_event=self.start_event,
-                               configs_reloaded=self.reload_configs_flag)
+                               configs_reloaded=True if self.reload_configs_flag else False)
 
             self.reload_configs_flag = False
 
@@ -215,7 +280,7 @@ class Agent(Daemon):
             # using ConfigStore.crawl_config_template
             if self._agentConfig.get('service_discovery') and self.sd_backend and \
                self.sd_backend.reload_check_configs:
-                self.reload_configs_flag = True
+                self.reload_configs_flag = self.sd_backend.reload_check_configs
                 self.sd_backend.reload_check_configs = False
 
             if profiled:

--- a/config.py
+++ b/config.py
@@ -1076,6 +1076,36 @@ def load_check_directory(agentConfig, hostname):
             'init_failed_checks': init_failed_checks,
             }
 
+
+def load_check(agentConfig, hostname, checkname):
+    """Same logic as load_check_directory except it loads one specific check"""
+    agentConfig['checksd_hostname'] = hostname
+    osname = get_os()
+    checks_places = get_checks_places(osname, agentConfig)
+    for config_path in _file_configs_paths(osname, agentConfig):
+        check_name = _conf_path_to_check_name(config_path)
+        if check_name == checkname:
+            conf_is_valid, check_config, invalid_check = _load_file_config(config_path, check_name, agentConfig)
+
+            if invalid_check and not conf_is_valid:
+                return invalid_check
+
+            # try to load the check and return the result
+            load_success, load_failure = load_check_from_places(check_config, check_name, checks_places, agentConfig)
+            return load_success.values()[0] or load_failure
+
+    # the check was not found, try with service discovery
+    for check_name, service_disco_check_config in _service_disco_configs(agentConfig).iteritems():
+        if check_name == checkname:
+            sd_init_config, sd_instances = service_disco_check_config
+            check_config = {'init_config': sd_init_config, 'instances': sd_instances}
+
+            # try to load the check and return the result
+            load_success, load_failure = load_check_from_places(check_config, check_name, checks_places, agentConfig)
+            return load_success.values()[0] or load_failure
+
+    return None
+
 #
 # logging
 

--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -55,12 +55,15 @@ def _get_check_tpls(image_name, **kwargs):
             return None
 
 
-def client_read(path):
+def client_read(path, **kwargs):
     """Return a mocked string that would normally be read from a config store (etcd, consul...)."""
     parts = path.split('/')
     config_parts = ['check_names', 'init_configs', 'instances']
     image, config_part = parts[-2], parts[-1]
-    return TestServiceDiscovery.mock_tpls.get(image)[0][config_parts.index(config_part)]
+    if 'all' in kwargs:
+        return {}
+    else:
+        return TestServiceDiscovery.mock_tpls.get(image)[0][config_parts.index(config_part)]
 
 
 def issue_read(identifier):

--- a/util.py
+++ b/util.py
@@ -32,7 +32,6 @@ except ImportError:
 # if a user actually uses them in a custom check
 # If you're this user, please use utils.pidfile or utils.platform instead
 # FIXME: remove them at a point (6.x)
-from utils.dockerutil import DockerUtil
 from utils.pidfile import PidFile  # noqa, see ^^^
 from utils.platform import Platform
 from utils.proxy import get_proxy
@@ -182,6 +181,7 @@ def get_hostname(config=None):
       * 'hostname -f' (on unix)
       * socket.gethostname()
     """
+    from utils.dockerutil import DockerUtil
     hostname = None
 
     # first, try the config
@@ -200,7 +200,7 @@ def get_hostname(config=None):
                 return gce_hostname
 
     # Try to get the docker hostname
-    docker_util = DockerUtil()
+    docker_util = DockerUtil(agentConfig=config)
     if hostname is None and docker_util.is_dockerized():
         docker_hostname = docker_util.get_hostname()
         if docker_hostname is not None and is_valid_hostname(docker_hostname):

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -8,15 +8,19 @@ import os
 import time
 
 # 3rd party
-from docker import Client
-from docker import tls
+from docker import Client, tls
+from docker.errors import NullResource
 
 # project
 from utils.singleton import Singleton
+from utils.service_discovery.config_stores import get_config_store
+
+DATADOG_ID = 'com.datadoghq.sd.check.id'
 
 
 class MountException(Exception):
     pass
+
 
 class CGroupException(Exception):
     pass
@@ -48,6 +52,12 @@ class DockerUtil:
 
         # At first run we'll just collect the events from the latest 60 secs
         self._latest_event_collection_ts = int(time.time()) - 60
+
+        # if agentConfig is passed it means service discovery is enabled and we need to get_config_store
+        if 'agentConfig' in kwargs:
+            self.config_store = get_config_store(kwargs['agentConfig'])
+        else:
+            self.config_store = None
 
         # Try to detect if we are on ECS
         self._is_ecs = False
@@ -93,7 +103,7 @@ class DockerUtil:
 
     def get_events(self):
         self.events = []
-        should_reload_conf = False
+        conf_reload_set = set()
         now = int(time.time())
 
         event_generator = self.client.events(since=self._latest_event_collection_ts,
@@ -101,8 +111,14 @@ class DockerUtil:
         self._latest_event_collection_ts = now
         for event in event_generator:
             try:
-                if event.get('status') in CONFIG_RELOAD_STATUS:
-                    should_reload_conf = True
+                if self.config_store and event.get('status') in CONFIG_RELOAD_STATUS:
+                    try:
+                        inspect = self.client.inspect_container(event.get('id'))
+                    except NullResource:
+                        inspect = {}
+                    checks = self._get_checks_from_inspect(inspect)
+                    if checks:
+                        conf_reload_set.update(set(checks))
                 self.events.append(event)
             except AttributeError:
                 # due to [0] it might happen that the returned `event` is not a dict as expected but a string,
@@ -111,7 +127,15 @@ class DockerUtil:
                 # [0]: https://github.com/docker/docker-py/pull/1082
                 log.debug('Unable to parse Docker event: %s', event)
 
-        return self.events, should_reload_conf
+        return self.events, conf_reload_set
+
+    def _get_checks_from_inspect(self, inspect):
+        """Get the list of checks applied to a container from the identifier_to_checks cache in the config store.
+        Use the DATADOG_ID label or the image."""
+        identifier = inspect.get('Config', {}).get('Labels', {}).get(DATADOG_ID) or \
+            inspect.get('Config', {}).get('Image')
+
+        return self.config_store.identifier_to_checks[identifier]
 
     def get_hostname(self):
         """Return the `Name` param from `docker info` to use as the hostname"""
@@ -221,7 +245,6 @@ class DockerUtil:
                     stat_file_path = os.path.join(mountpoint, subsystems[subsys])
                     if os.path.exists(stat_file_path):
                         return os.path.join(stat_file_path, '%(file)s')
-
 
         raise MountException("Cannot find Docker cgroup directory. Be sure your system is supported.")
 

--- a/utils/platform.py
+++ b/utils/platform.py
@@ -5,10 +5,6 @@
 # stdlib
 import sys
 
-# project
-from utils.dockerutil import DockerUtil
-
-_is_ecs = None
 
 class Platform(object):
     """
@@ -72,4 +68,5 @@ class Platform(object):
 
     @staticmethod
     def is_ecs_instance():
+        from utils.dockerutil import DockerUtil
         return DockerUtil().is_ecs()

--- a/utils/service_discovery/abstract_sd_backend.py
+++ b/utils/service_discovery/abstract_sd_backend.py
@@ -20,8 +20,9 @@ class AbstractSDBackend(object):
 
     def __init__(self, agentConfig=None):
         self.agentConfig = agentConfig
-        # this flag is used to know if check configs need to
+        # this variable is used to store the name of checks that need to
         # be reloaded at the end of the current collector run.
+        # If a full config reload is required, it is set to True.
         self.reload_check_configs = False
 
     @classmethod

--- a/utils/service_discovery/config_stores.py
+++ b/utils/service_discovery/config_stores.py
@@ -19,7 +19,7 @@ def get_config_store(agentConfig):
         return EtcdStore(agentConfig)
     elif agentConfig.get('sd_config_backend') == 'consul':
         return ConsulStore(agentConfig)
-    elif agentConfig.get('sd_config_backend') is None:
+    else:
         return StubStore(agentConfig)
 
 

--- a/utils/service_discovery/consul_config_store.py
+++ b/utils/service_discovery/consul_config_store.py
@@ -46,10 +46,13 @@ class ConsulStore(AbstractConfigStore):
 
     def client_read(self, path, **kwargs):
         """Retrieve a value from a consul key."""
-        recurse = kwargs.get('recursive', False)
+        recurse = kwargs.get('recursive') or kwargs.get('all', False)
         res = self.client.kv.get(path, recurse=recurse)
-        if kwargs.get('watch', False) is True:
+        if kwargs.get('watch', False):
             return res[0]
+        elif kwargs.get('all', False):
+            # we use it in _populate_identifier_to_checks
+            return [(child.get('Key'), child.get('Value')) for child in res[1]]
         else:
             if res[1] is not None:
                 return res[1].get('Value') if not recurse else res[1]

--- a/utils/service_discovery/etcd_config_store.py
+++ b/utils/service_discovery/etcd_config_store.py
@@ -44,9 +44,12 @@ class EtcdStore(AbstractConfigStore):
             res = self.client.read(
                 path,
                 timeout=kwargs.get('timeout', DEFAULT_TIMEOUT),
-                recursive=kwargs.get('recursive', False))
-            if kwargs.get('watch', False) is True:
+                recursive=kwargs.get('recursive') or kwargs.get('all', False))
+            if kwargs.get('watch', False):
                 return res.etcd_index
+            elif kwargs.get('all', False):
+                # we use it in _populate_identifier_to_checks
+                return [(child.key, child.value) for child in res.children]
             else:
                 return res.value
         except EtcdKeyNotFound:

--- a/utils/service_discovery/etcd_config_store.py
+++ b/utils/service_discovery/etcd_config_store.py
@@ -46,7 +46,8 @@ class EtcdStore(AbstractConfigStore):
                 timeout=kwargs.get('timeout', DEFAULT_TIMEOUT),
                 recursive=kwargs.get('recursive') or kwargs.get('all', False))
             if kwargs.get('watch', False):
-                return res.etcd_index
+                modified_indices = (res.modifiedIndex, ) + tuple(leaf.modifiedIndex for leaf in res.leaves)
+                return max(modified_indices)
             elif kwargs.get('all', False):
                 # we use it in _populate_identifier_to_checks
                 return [(child.key, child.value) for child in res.children]

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -57,8 +57,8 @@ class SDDockerBackend(AbstractSDBackend):
             if ip_addr:
                 return ip_addr
 
-        # try to get the bridge IP address
-        log.debug("No network found for container %s (%s), trying with IPAddress field" % (c_id[:12], c_img))
+        # try to get the bridge (default) IP address
+        log.debug("No network was specified for container %s (%s), trying with IPAddress field" % (c_id[:12], c_img))
         ip_addr = c_inspect.get('NetworkSettings', {}).get('IPAddress')
         if ip_addr:
             return ip_addr


### PR DESCRIPTION
# What does this PR do?

It makes configuration reload smarter.
The gist of it is that the agent now maintains a mapping `container_identifier <--> checks` and only reloads checks for which a docker event associated with an identifier in this mapping happened since the last collector run.

# Motivation

In environments where a lot of docker events happen, full config reload on any container event is not a good design. We noticed several cases where the agent triggered a reload at each run, making rate collection impossible (calculating rates requires values from several runs, and these are forgotten on each check reload).
Individual reload is a better option.

# Additional notes

In more details:
- the `identifier_to_checks` cache is built based on the content of the config store and the `auto_conf` folder. This cache is invalidated and refreshed when a template is modified in the K/V store.
- a full reload is triggered on two events: a `SIGHUP` is received by the collector or the agent detects a change in the config store.
- Changes to `auto_conf` files are not detected yet so an agent restart or a manual `SIGHUP` is still needed here.
- Incidentally this PR adds a `load_check` function that does the same thing as `load_check_directory` but for a single check which name was passed as a third parameter.
