### PR TITLE
[http_check] log exceptions 🔊

### DIFF
--- a/checks/network_checks.py
+++ b/checks/network_checks.py
@@ -147,6 +147,9 @@ class NetworkCheck(AgentCheck):
                     self.resultsq.put((status, msg, sc_name, instance))
 
         except Exception:
+            self.log.exception(
+                u"Failed to process instance '%s'.", instance.get('Name', u"")
+            )
             result = (FAILURE, FAILURE, FAILURE, instance)
             self.resultsq.put(result)
 


### PR DESCRIPTION
When the HTTP check is misconfigured, the thread pool used for network
checks woud restart over and over without providing any usefull
information, i.e.

```
Running check http_check
Stopping Thread Pool
Starting Thread Pool
Stopping Thread Pool
Starting Thread Pool
received 0 payloads since last flush
```

Instead, exceptions should be logged so it is easier to troubleshoot.