### PR TITLE
add issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+This issue queue is primarily intended for tracking features, bugs and work items associated with
+the dd-agent open-source project.
+
+Prior to submitting an issue please review the following:
+
+- [ ] [Troubleshooting](https://datadog.zendesk.com/hc/en-us/sections/200766955-Troubleshooting) section of our [Knowledge base](https://datadog.zendesk.com/hc/en-us).
+- [ ] Contact our [support](http://docs.datadoghq.com/help/) and [send them your logs](https://github.com/DataDog/dd-agent/wiki/Send-logs-to-support).
+- [ ] Finally, you can open a Github issue respecting this [convention](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md#commits-titles) (it helps us triage).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
+if you have not yet done so.*
+
+
+### What does this PR do?
+
+A brief description of the change being made with this pull request.
+
+### Motivation
+
+What inspired you to submit this pull request?
+
+### Testing Guidelines
+
+An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
+is available in our contribution guidelines.
+
+### Additional Notes
+
+Anything else we should know when reviewing?


### PR DESCRIPTION
### What does this PR do?

This PR adds templates for new issues and PRs so that formatting and pre-reqs are pre-populated. 

### Motivation

In order to speed up responses to issues and PRs, we want to ensure key information is included.

### Testing Guidelines

1. Create a new issue or PR via the Issue link in this repo.
1. Validate that the new issue or PR contains the template text.

### Additional Notes

N/A