### PR TITLE
[kafka] bumping kafka-python package version to 1.2.5.

### DIFF
--- a/checks.d/kafka_consumer.py
+++ b/checks.d/kafka_consumer.py
@@ -6,8 +6,8 @@
 from collections import defaultdict
 
 # 3p
-from kafka.client import KafkaClient
-from kafka.common import OffsetRequest
+from kafka import KafkaClient
+from kafka.common import OffsetRequestPayload as OffsetRequest
 from kazoo.client import KazooClient
 from kazoo.exceptions import NoNodeError
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ pyro4==4.35 # required by adodbapi
 httplib2==0.9
 
 # checks.d/kafka_consumer.py
-kafka-python==0.9.3
+kafka-python==1.2.5
 
 # checks.d/postgres.py
 pg8000==1.10.1


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Bumps the version of the kafka-python package.

### Motivation

Improve support for newer kafka's.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

(none)
