### PR TITLE
[disk] timeout on disk usage

### DIFF
--- a/tests/checks/mock/test_disk.py
+++ b/tests/checks/mock/test_disk.py
@@ -112,6 +112,10 @@ class TestCheckDisk(AgentCheckTest):
     @mock.patch('psutil.disk_usage', return_value=MockDiskMetrics())
     @mock.patch('os.statvfs', return_value=MockInodesMetrics())
     def test_psutil(self, mock_partitions, mock_usage, mock_inodes):
+        # Mocking
+        mock_usage.__name__ = "foo"
+
+        # Run check
         for tag_by in ['yes', 'no']:
             self.run_check({'instances': [{'tag_by_filesystem': tag_by}]},
                            force_reload=True)
@@ -128,6 +132,10 @@ class TestCheckDisk(AgentCheckTest):
     @mock.patch('psutil.disk_usage', return_value=MockDiskMetrics())
     @mock.patch('os.statvfs', return_value=MockInodesMetrics())
     def test_use_mount(self, mock_partitions, mock_usage, mock_inodes):
+        # Mocking
+        mock_usage.__name__ = "foo"
+
+        # Run check
         self.run_check({'instances': [{'use_mount': 'yes'}]})
 
         # Assert metrics


### PR DESCRIPTION
Timeout disk usage queries after 5 seconds with a warning and no data.
Recover at next iteration retrieving the existing query.