### PR TITLE
[CI] run multiple instances of pylint

### DIFF
--- a/ci/default.rb
+++ b/ci/default.rb
@@ -54,7 +54,7 @@ namespace :ci do
         sh %(flake8)
         sh %(find . -name '*.py' -not\
                \\( -path '*.cache*' -or -path '*embedded*' -or -path '*venv*' -or -path '*.git*' \\)\
-               | xargs -n 1 pylint --rcfile=./.pylintrc)
+               | xargs -n 100 -P 8 pylint --rcfile=./.pylintrc)
       end
     end
 


### PR DESCRIPTION
### What does this PR do?

Adds the `-P` option to `xargs` to run more than one `pylint` process in parallel. The `--jobs` options offered by `pylint` was the first choice but it's buggy, so the fallback to `xargs`.

### Motivation

The execution is sequential so on Travis one core is sitting during the checks. Moreover, `pylint` has a huge overhead at startup that in our case is multiplied by the number of files to process, ~270. 

The first problem is addressed by the `-P` option passed to `xargs`, the second one is addressed by letting each `pylint` instance inspect 100 files per run (`-n 100` passed to `xargs`).
