### PR TITLE
[packaging] silence configcheck when starting

### DIFF
--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -130,7 +130,7 @@ start() {
         exit 3
     fi
 
-    su $AGENTUSER -c "$AGENTPATH configcheck" > /dev/null
+    su $AGENTUSER -c "$AGENTPATH configcheck" > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo -n $'\n'"Invalid check configuration. Please run sudo /etc/init.d/datadog-agent configtest for more details."
         echo -n $'\n'"Resuming starting process."$'\n'

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -125,7 +125,7 @@ case "$1" in
             $0 stop > /dev/null 2>&1
         fi
 
-        su $AGENTUSER -c "$AGENTPATH configcheck" > /dev/null
+        su $AGENTUSER -c "$AGENTPATH configcheck" > /dev/null 2>&1
         if [ $? -ne 0 ]; then
             log_daemon_msg "Invalid check configuration. Please run sudo /etc/init.d/datadog-agent configtest for more details."
             log_daemon_msg "Resuming starting process."


### PR DESCRIPTION
### What does this PR do?

Completely silence configcheck when starting.

### Motivation
Seeing useless DEBUG logs when restarting: 
```
Stopping Datadog Agent (stopping supervisord): datadog-agent.
2016-08-02 19:14:37,645 | DEBUG | dd.collector | utils.proxy(proxy.py:68) | No proxy configured
2016-08-02 19:14:37,653 | DEBUG | dd.collector | utils.dockerutil(dockerutil.py:67) | Couldn't find any configuration file for the docker_daemon check.
2016-08-02 19:14:37,657 | DEBUG | dd.collector | docker.auth.auth(auth.py:189) | File doesn't exist
2016-08-02 19:14:37,678 | DEBUG | dd.collector | utils.subprocess_output(subprocess_output.py:63) | Popen(['/bin/hostname', '-f'], close_fds = True, shell = False, stdout = <open file '<fdopen>', mode 'w+b' at 0x7f33765079c0>, stderr = <open file '<fdopen>', mode 'w+b' at 0x7f3376507a50>, stdin = None) called
Starting Datadog Agent (using supervisord): datadog-agent.
```
