### PR TITLE
[process] Use configured proc path when getting pagefault stats

### DIFF
--- a/checks.d/process.py
+++ b/checks.d/process.py
@@ -276,9 +276,10 @@ class ProcessCheck(AgentCheck):
 
         # http://man7.org/linux/man-pages/man5/proc.5.html
         try:
-            data = file_to_string('/proc/%s/stat' % pid)
+            data = file_to_string('/%s/%s/stat' % (psutil.PROCFS_PATH, pid))
         except Exception:
-            self.log.debug('error getting proc stats: file_to_string failed for /proc/%s/stat' % pid)
+            self.log.debug('error getting proc stats: file_to_string failed'
+                           'for /%s/%s/stat' % (psutil.PROCFS_PATH, pid))
             return None
 
         return map(lambda i: int(i), data.split()[9:13])


### PR DESCRIPTION
### What does this PR do?

Uses the configured proc path (`psutil.PROCFS_PATH` which is set during the check's initialization) when getting pagefault stats instead of `/proc`. 

### Motivation

I found https://github.com/DataDog/dd-agent/pull/2482 (makes proc path configurable) after wanting to run the process integration in docker with, and noticed the page fault stats still used '/proc' which means the integration wouldn't be able to get accurate stats if proc path was something else. 


