### PR TITLE
Allow `connection_timeout` to be set for MySQL checks

### DIFF
--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -375,7 +375,11 @@ class MySql(AgentCheck):
             ssl = dict(ssl) if ssl else None
 
             if defaults_file != '':
-                db = pymysql.connect(read_default_file=defaults_file, ssl=ssl)
+                db = pymysql.connect(
+                    read_default_file=defaults_file,
+                    ssl=ssl,
+                    connect_timeout=connect_timeout
+                )
             elif mysql_sock != '':
                 self.service_check_tags = [
                     'server:{0}'.format(mysql_sock),

--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -294,7 +294,7 @@ class MySql(AgentCheck):
             procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
             psutil.PROCFS_PATH = procfs_path
 
-        host, port, user, password, mysql_sock, defaults_file, tags, options, queries, ssl = \
+        host, port, user, password, mysql_sock, defaults_file, tags, options, queries, ssl, connect_timeout = \
             self._get_config(instance)
 
         self._set_qcache_stats()
@@ -303,7 +303,7 @@ class MySql(AgentCheck):
             raise Exception("Mysql host and user are needed.")
 
         with self._connect(host, port, mysql_sock, user,
-                           password, defaults_file, ssl) as db:
+                           password, defaults_file, ssl, connect_timeout) as db:
             try:
                 # Metadata collection
                 self._collect_metadata(db, host)
@@ -330,9 +330,10 @@ class MySql(AgentCheck):
         options = instance.get('options', {})
         queries = instance.get('queries', [])
         ssl = instance.get('ssl', {})
+        connect_timeout = instance.get('connect_timeout', None)
 
         return (self.host, self.port, user, password, self.mysql_sock,
-                self.defaults_file, tags, options, queries, ssl)
+                self.defaults_file, tags, options, queries, ssl, connect_timeout)
 
     def _set_qcache_stats(self):
         host_key = self._get_host_key()
@@ -363,7 +364,7 @@ class MySql(AgentCheck):
         return hostkey
 
     @contextmanager
-    def _connect(self, host, port, mysql_sock, user, password, defaults_file, ssl):
+    def _connect(self, host, port, mysql_sock, user, password, defaults_file, ssl, connect_timeout):
         self.service_check_tags = [
             'server:%s' % (mysql_sock if mysql_sock != '' else host),
             'port:%s' % ('unix_socket' if port == 0 else port)
@@ -383,7 +384,8 @@ class MySql(AgentCheck):
                 db = pymysql.connect(
                     unix_socket=mysql_sock,
                     user=user,
-                    passwd=password
+                    passwd=password,
+                    connect_timeout=connect_timeout
                 )
             elif port:
                 db = pymysql.connect(
@@ -391,14 +393,16 @@ class MySql(AgentCheck):
                     port=port,
                     user=user,
                     passwd=password,
-                    ssl=ssl
+                    ssl=ssl,
+                    connect_timeout=connect_timeout
                 )
             else:
                 db = pymysql.connect(
                     host=host,
                     user=user,
                     passwd=password,
-                    ssl=ssl
+                    ssl=ssl,
+                    connect_timeout=connect_timeout
                 )
             self.log.debug("Connected to MySQL")
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,

--- a/conf.d/mysql.yaml.example
+++ b/conf.d/mysql.yaml.example
@@ -7,6 +7,7 @@ instances:
     # port: 3306             # Optional
     # sock: /path/to/sock    # Connect via Unix Socket
     # defaults_file: my.cnf  # Alternate configuration mechanism
+    # connect_timeout: None  # Optional integer seconds
     # tags:                  # Optional
     #   - optional_tag1
     #   - optional_tag2


### PR DESCRIPTION
### What does this PR do?

Allow a connection timeout to be used on when connecting to MySQL instances.

### Motivation

When monitoring more than one instance of MySQL, if the host becomes unavailable, it'll block all the other MySQL instance checks. This block can be longer than the polling period, and you get false alerts and service checks.

Use case: Monitoring many RDS instances from a single host. A failover event occurs, causing connection issues to a single box temporarily. This connection hang (while the Master is being rotated), also blocks all the other monitored instances. 

### Testing Guidelines

Unsure how to a reasonable test case. Other than pull a remote host down, or disable networking.

### Additional Notes

Defaults to the original no-timeout '[None](https://github.com/PyMySQL/PyMySQL/blob/pymysql-0.6.6/pymysql/connections.py#L822)' behaviour. When the original behaviour is used, the OS socket defaults on [sock.settimeout()](https://docs.python.org/2/library/socket.html#socket.socket.settimeout) are used. Which could be a long time.

Also, `read_timeout` + `write_timeout` could also occur (once connected, and issuing SQL), but the bundled version of `pymysql` (v0.6.6) isn't new enough to contain these parameters. ([v0.7.3](https://github.com/PyMySQL/PyMySQL/blob/397fb74cf47232d2f388d013778cf0ff967618e1/CHANGELOG#L34) required). 
