### PR TITLE
[disk] handle multilines df output

### DIFF
--- a/checks.d/disk.py
+++ b/checks.d/disk.py
@@ -250,7 +250,7 @@ class Disk(AgentCheck):
         for parts in devices:
             if len(parts) == 1:
                 previous = parts[0]
-            elif previous and self._is_number(parts[0]):
+            elif previous is not None:
                 # collate with previous line
                 parts.insert(0, previous)
                 previous = None

--- a/tests/checks/fixtures/disk/centos-df-Tk
+++ b/tests/checks/fixtures/disk/centos-df-Tk
@@ -1,0 +1,6 @@
+Filesystem Type   1K-blocks   Used      Available  Use%  Mounted on
+/dev/sda3  ext4   93421512    70963180  17706052   81%   /
+tmpfs      tmpfs  32969616    0         32969616   0%    /dev/shm
+/dev/sda1  ext4   512752      90460     395412     19%   /boot
+10.1.5.223:/vil/cor
+           nfs     1020054752 56080768  963973984  6%    /cor


### PR DESCRIPTION
### What does this PR do?

remove missing method `_is_number` in `disk` check.

### Motivation

Fix https://github.com/DataDog/dd-agent/issues/2732

### Additional Notes

The previous method was:
```python
try:
    float(my_var)
except:
    return False
return True
```