### PR TITLE
[postgres] Allow 'host' config value be UNIX socket path

### DIFF
--- a/checks.d/postgres.py
+++ b/checks.d/postgres.py
@@ -584,6 +584,11 @@ SELECT s.schemaname,
                 elif port != '':
                     connection = pg.connect(host=host, port=port, user=user,
                         password=password, database=dbname, ssl=ssl)
+                elif host.startswith('/'):
+                    # If the hostname starts with /, it's probably a path
+                    # to a UNIX socket. This is similar behaviour to psql
+                    connection = pg.connect(unix_sock=host, user=user,
+                        password=password, database=dbname)
                 else:
                     connection = pg.connect(host=host, user=user, password=password,
                         database=dbname, ssl=ssl)

--- a/conf.d/postgres.yaml.example
+++ b/conf.d/postgres.yaml.example
@@ -11,6 +11,10 @@ instances:
 #      - optional_tag1
 #      - optional_tag2
 
+# Connect using a UNIX socket (host must begin with a /)
+#  - host: /run/postgresql/.s.PGSQL.5433
+#    dbname: db_name
+
 # Track per-relation (table) metrics
 # The list of relations/tables must be specified here.
 # Each relation generates many metrics (10 + 10 per index)


### PR DESCRIPTION
The PostgreSQL check has been changed to try to connect to the PostgreSQL database via a UNIX socket if the hostname provided in the configuration begins with a forward-slash ('/').

This behaviour is similar to the 'psql' command-line utility. From `psql(1)`:

```
  --host=hostname
      Specifies the host name of the machine on which the server is
      running. If the value begins with a slash, it is used as the
      directory for the Unix-domain socket.
```

With the difference being that we interpret it as an exact path, whereas psql interprets it as a directory to look for a socket with a particularly formatted name.

This addresses issue #2361. Arguably, a new configuration parameter, `unix_sock` or similar, should be added. I chose to do it this way as it touches less code, and is, as mentioned above, similar to how `psql` does things.

The documentation at `Datadog/documentation/content/integrations/postgresql.md` should also be updated with the new content of `postgres.yaml.example`.