### PR TITLE
Network check corrections

### DIFF
--- a/checks/network_checks.py
+++ b/checks/network_checks.py
@@ -74,13 +74,14 @@ class NetworkCheck(AgentCheck):
         # to keep track of statuses
         names = []
         for inst in instances:
-            name = inst.get('name', None)
-            if not name:
+            inst_name = inst.get('name', None)
+            if not inst_name:
                 raise Exception("All instances should have a 'name' parameter,"
                                 " error on instance: {0}".format(inst))
-            if name in names:
+            if inst_name in names:
                 raise Exception("Duplicate names for instances with name {0}"
-                                .format(inst['name']))
+                                .format(inst_name))
+            names.append(inst_name)
 
     def stop(self):
         self.stop_pool()


### PR DESCRIPTION
When looking over the Network Check class, I noticed a few issues in the constructor for the class. This PR enables the duplication check and stops overwriting another method parameter.