### PR TITLE
[docker_daemon] Add 5 opt-in checks for container & volume counts

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -207,6 +207,11 @@ class DockerDaemon(AgentCheck):
             # Other options
             self.collect_image_stats = _is_affirmative(instance.get('collect_images_stats', False))
             self.collect_container_size = _is_affirmative(instance.get('collect_container_size', False))
+            self.collect_container_count = _is_affirmative(instance.get('collect_container_count', False))
+            self.collect_dead_container_count = _is_affirmative(instance.get('collect_dead_container_count', False))
+            self.collect_exited_container_count = _is_affirmative(instance.get('collect_exited_container_count', False))
+            self.collect_volume_count = _is_affirmative(instance.get('collect_volume_count', False))
+            self.collect_dangling_volume_count = _is_affirmative(instance.get('collect_dangling_volume_count', False))
             self.collect_events = _is_affirmative(instance.get('collect_events', True))
             self.collect_image_size = _is_affirmative(instance.get('collect_image_size', False))
             self.collect_disk_stats = _is_affirmative(instance.get('collect_disk_stats', False))
@@ -260,6 +265,21 @@ class DockerDaemon(AgentCheck):
 
         if self.collect_container_size:
             self._report_container_size(containers_by_id)
+
+        if self.collect_container_count:
+            self._report_container_count_by_state(containers_by_id)
+
+        if self.collect_dead_container_count:
+            self._report_container_count_by_state(containers_by_id, state="Dead")
+
+        if self.collect_exited_container_count:
+            self._report_container_count_by_state(containers_by_id, state="Exited")
+
+        if self.collect_volume_count:
+            self._report_volume_count()
+
+        if self.collect_dangling_volume_count:
+            self._report_volume_count(filters={'dangling': True})
 
         # Collect disk stats from Docker info command
         if self.collect_disk_stats:
@@ -491,13 +511,33 @@ class DockerDaemon(AgentCheck):
             tags = self._get_tags(container, PERFORMANCE)
             m_func = FUNC_MAP[GAUGE][self.use_histogram]
             if "SizeRw" in container:
-
                 m_func(self, 'docker.container.size_rw', container['SizeRw'],
                        tags=tags)
             if "SizeRootFs" in container:
                 m_func(
                     self, 'docker.container.size_rootfs', container['SizeRootFs'],
                     tags=tags)
+
+    def _report_container_count_by_state(self, containers_by_id, state="Any"):
+        count = 0
+        tags = {}
+        filterlambda = lambda x: not self._is_container_excluded(x) and state is "Any" or container["State"] is state
+        filtered = list(filter(filterlambda, containers_by_id))
+        tags = self._get_tags(filtered[0], PERFORMANCE)
+
+        m_func = FUNC_MAP[GAUGE][self.use_histogram]
+        # Report docker.container.count if state is "Any", otherwise
+        # report docker.container.state_STATE.count
+        suffix = ".state_{}".format(state.lower()) if state is not "Any" else ""
+        m_func(self, 'docker.container{}.count'.format(suffix), len(filtered), tags=tags)
+
+    def _report_volume_count(self, filters={}):
+        volumes = self.docker_client.volumes(filters=filters)
+        count = len(volumes['Volumes'])
+
+        m_func = FUNC_MAP[GAUGE][self.use_histogram]
+        suffix = '.' + '-'.join(sorted(filters.keys())) if len(filters) is not 0 else ''
+        m_func(self, 'docker.volumes{}.count'.format(suffix), count)
 
     def _report_image_size(self, images):
         for image in images:

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -45,6 +45,31 @@ instances:
     #
     # collect_container_size: false
 
+    # Collect the total container count with the docker.containers.count metric.
+    # Defaults to false.
+    #
+    # collect_container_count: false
+
+    # Collect the count of all containers in Dead state with the docker.container.state_dead.count metric.
+    # Defaults to false.
+    #
+    # collect_dead_container_count: false
+
+    # Collect the count of all containers in Exited state with the docker.container.state_exited.count metric.
+    # Defaults to false.
+    #
+    # collect_exited_container_count: false
+
+    # Collect the total volume count with the docker.volumes.count metric.
+    # Defaults to false.
+    #
+    # collect_volume_count: false
+
+    # Collect the count of all dangling volumes with the docker.volumes.dangling.count metric.
+    # Defaults to false.
+    #
+    # collect_dangling_volume_count: false
+
     # Collect images stats
     # Number of available active images and intermediate images as gauges.
     # Defaults to false.

--- a/tests/checks/integration/test_docker_daemon.py
+++ b/tests/checks/integration/test_docker_daemon.py
@@ -466,6 +466,11 @@ class TestCheckDockerDaemon(AgentCheckTest):
                 "collect_labels_as_tags": ["label1"],
                 "collect_image_size": True,
                 "collect_images_stats": True,
+                "collect_container_count": True,
+                "collect_dead_container_count": True,
+                "collect_exited_container_count": True
+                "collect_volume_count": True
+                "collect_dangling_volume_count": True
             },
             ],
         }

--- a/tests/checks/integration/test_docker_daemon.py
+++ b/tests/checks/integration/test_docker_daemon.py
@@ -468,9 +468,9 @@ class TestCheckDockerDaemon(AgentCheckTest):
                 "collect_images_stats": True,
                 "collect_container_count": True,
                 "collect_dead_container_count": True,
-                "collect_exited_container_count": True
-                "collect_volume_count": True
-                "collect_dangling_volume_count": True
+                "collect_exited_container_count": True,
+                "collect_volume_count": True,
+                "collect_dangling_volume_count": True,
             },
             ],
         }


### PR DESCRIPTION
### What does this PR do?

This pull request adds 5 new metrics:
- `docker.containers.count` – equivalent to `docker ps -a | wc -l`
- `docker.containers.state_dead.count` – count of all dead containers
- `docker.containers.state_exited.count` – count of all exited containers
- `docker.volumes.count` – count of all volumes
- `docker.volumes.dangling.count` – count of all dangling volumes

Each metric has its own toggle in the settings so you can opt in to each on its own.
### Motivation

We've been battling a bit of weirdness with containers and volumes lying around. We use ephemeral docker containers for some operations but found that volumes would be lying around in the "dangling" state, and that some containers weren't properly cleaned up.
### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.
### Additional Notes

I went with one monolithic commit here because the code was too close together for Git to play nicely with cherry-picking the commits. Let me know if that wasn't the right way to go and I can make 5 distinct commits.
