### PR TITLE
[mysql] Robust innodb engine status check

### DIFF
--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -901,7 +901,7 @@ class MySql(AgentCheck):
                          tables (must grant PROCESS): %s" % str(e))
             return {}
 
-        if (cursor.rowcount < 1)
+        if cursor.rowcount < 1:
             # No data from SHOW ENGINE STATUS, even though the engine is enabled.
             # EG: This could be an Aurora Read Instance
             self.warning("'SHOW ENGINE INNODB STATUS' returned no data.")

--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -896,13 +896,19 @@ class MySql(AgentCheck):
         try:
             with closing(db.cursor()) as cursor:
                 cursor.execute("SHOW /*!50000 ENGINE*/ INNODB STATUS")
-                innodb_status = cursor.fetchone()
-                innodb_status_text = innodb_status[2]
         except (pymysql.err.InternalError, pymysql.err.OperationalError, pymysql.err.NotSupportedError) as e:
             self.warning("Privilege error or engine unavailable accessing the INNODB status \
                          tables (must grant PROCESS): %s" % str(e))
             return {}
 
+        if (cursor.rowcount < 1)
+            # No data from SHOW ENGINE STATUS, even though the engine is enabled.
+            # EG: This could be an Aurora Read Instance
+            self.warning("'SHOW ENGINE INNODB STATUS' returned no data.")
+            return {}
+
+        innodb_status = cursor.fetchone()
+        innodb_status_text = innodb_status[2]
         results = defaultdict(int)
 
         # Here we now parse InnoDB STATUS one line at a time


### PR DESCRIPTION
### What does this PR do?

Fail gracefully when issuing the query for `SHOW ENGINE INNODB STATUS`: An empty set _can_ be returned, and produces an ERROR.

### Motivation

When monitoring RDS Aurora read instances, although the InnoDB engine is certainly enabled (passing the relevant checks), the engine status query returns an empty set. Presumably only the current Write instance maintains this data. 

The existing code path, issues & attempts to use the result set in the same `try` block. `fetchone()` produces an error on an empty set:

```
      - instance #13 [ERROR]: "'NoneType' object has no attribute '__getitem__'"
        Traceback (most recent call last):
          File "/opt/datadog-agent/agent/checks/__init__.py", line 750, in run
            self.check(copy.deepcopy(instance))
          File "/etc/dd-agent/checks.d/mysql.py", line 323, in check
            raise e
        TypeError: 'NoneType' object has no attribute '__getitem__'
```

This PR splits these responsibilities, allowing for a seperate rowcount test and failing gracefully with a WARN. Service health checks then don't alert.

```
      - instance #13 [WARNING]
          Warning: 'SHOW ENGINE INNODB STATUS' returned no data.
```

As you don't really know what instance is currently in which state, it's likely you'll want to always check for these metrics on every host within your Aurora cluster. I can't see any clear way to detect the current instance type from within MySQL: Would have been nice to do it within `_is_innodb_engine_enabled()`.

### Testing Guidelines

Aurora RDS Write + Read instance required. Manually testing query:

Primary/Write instance:
```
mysql> select @@aurora_version;
+------------------+
| @@aurora_version |
+------------------+
| 1.6              |
+------------------+
1 row in set (0.01 sec)

mysql> show engine innodb status;
<ACUTAL ROW DATA REMOVED>
1 row in set (0.00 sec)
```

Read instance:
```
mysql> select @@aurora_version;
+------------------+
| @@aurora_version |
+------------------+
| 1.6              |
+------------------+
1 row in set (0.00 sec)

mysql> show engine innodb status;
Empty set (0.00 sec)
```

### Additional Notes

- [RDS Aurora overview](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html)
- [Which DB instance you are connected to](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.BestPractices.html#Aurora.BestPractices.DeterminePrimaryInstanceConnection). `innodb_read_only` _could_ be a preferred approach for detection, but unsure how this is used on regular MySQL.
