### PR TITLE
[docker_daemon] [ecs] introspection resilience

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -111,6 +111,8 @@ PERFORMANCE = "performance"
 FILTERED = "filtered"
 IMAGE = "image"
 
+ECS_INTROSPECT_DEFAULT_PORT = 51678
+
 
 def get_filters(include, exclude):
     # The reasoning is to check exclude first, so we can skip if there is no exclude
@@ -161,6 +163,8 @@ class DockerDaemon(AgentCheck):
             else:
                 self.docker_util = DockerUtil()
             self.docker_client = self.docker_util.client
+            self.docker_gateway = DockerUtil.get_gateway()
+
             if self.is_k8s():
                 self.kubeutil = KubeUtil()
             # We configure the check with the right cgroup settings for this host
@@ -432,13 +436,24 @@ class DockerDaemon(AgentCheck):
         ip = ecs_config.get('NetworkSettings', {}).get('IPAddress')
         ports = ecs_config.get('NetworkSettings', {}).get('Ports')
         port = ports.keys()[0].split('/')[0] if ports else None
+        if not ip and DockerUtil.is_dockerized():
+            if self.docker_gateway:
+                ip = self.docker_gateway
+                port = ECS_INTROSPECT_DEFAULT_PORT
+        elif not ip:
+            ip = "localhost"
+            port = ECS_INTROSPECT_DEFAULT_PORT
+
         ecs_tags = {}
-        if ip and port:
-            tasks = requests.get('http://%s:%s/v1/tasks' % (ip, port)).json()
-            for task in tasks.get('Tasks', []):
-                for container in task.get('Containers', []):
-                    tags = ['task_name:%s' % task['Family'], 'task_version:%s' % task['Version']]
-                    ecs_tags[container['DockerId']] = tags
+        try:
+            if ip and port:
+                tasks = requests.get('http://%s:%s/v1/tasks' % (ip, port)).json()
+                for task in tasks.get('Tasks', []):
+                    for container in task.get('Containers', []):
+                        tags = ['task_name:%s' % task['Family'], 'task_version:%s' % task['Version']]
+                        ecs_tags[container['DockerId']] = tags
+        except requests.exceptions.HTTPError as e:
+            self.log.warning("Unable to collect ECS task names: %s" % e)
 
         self.ecs_tags = ecs_tags
 

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -8,8 +8,6 @@ import os
 import socket
 import struct
 import time
-import socket
-import struct
 
 # 3rd party
 from docker import Client, tls
@@ -171,15 +169,7 @@ class DockerUtil:
         except Exception:
             log.critical("Unable to find docker host hostname. Trying default route")
 
-        try:
-            with open('/proc/net/route') as f:
-                for line in f.readlines():
-                    fields = line.strip().split()
-                    if fields[1] == '00000000':
-                        return socket.inet_ntoa(struct.pack('<L', int(fields[2], 16)))
-        except IOError, e:
-            log.error('Unable to open /proc/net/route: %s', e)
-        return None
+        return DockerUtil.get_gateway()
 
     @property
     def client(self):


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

ECS agent container no longer has the IP address or ports available when we inspect its container to infer the introspection point. The docker gateway, typically at `172.17.0.1` is fine for constructing the url to query the API. We can set it as a parameter in the config file, or we can extract it from the agent's own information.

Also, although rare, if the agent is not run dockerized, we can grab it `@localhost`

### Motivation

Our ECS task reporting broke due to our inability to query the endpoint.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
