### PR TITLE
[service_discovery][etcd] Use a correct index to determine last update

### DIFF
--- a/utils/service_discovery/etcd_config_store.py
+++ b/utils/service_discovery/etcd_config_store.py
@@ -46,7 +46,8 @@ class EtcdStore(AbstractConfigStore):
                 timeout=kwargs.get('timeout', DEFAULT_TIMEOUT),
                 recursive=kwargs.get('recursive', False))
             if kwargs.get('watch', False) is True:
-                return res.etcd_index
+                modified_indices = (res.modifiedIndex, ) + tuple(leaf.modifiedIndex for leaf in res.leaves)
+                return max(modified_indices)
             else:
                 return res.value
         except EtcdKeyNotFound:


### PR DESCRIPTION
### What does this PR do?

Fix the reload logic when the `etcd` config store is used: trigger a config reload only on changes that affect the `sd_template_dir`.

### Motivation

When the datastore is heavily used, it's usually updated quite often. In such cases a checks' reload would be triggered on every collection run, which is problematic for `rate` metrics as they can only be computed when the same check runs twice. 

### Testing

Haven't tested this on an actual agent, but I've used the `etcd` python client we use + an etcd datastore to make sure I was interpreting the returned values correctly.

### Additional Notes

The `res.etcd_index` value that was previously used is the
`X-Etcd-Index` header of etcd's http response.

According to etcd's docs this index is the current index of the whole
cluster, so any modification on any key increments this value.

Instead, we parse the `modifiedIndex` of all the returned keys
instead, and we take the max index as the correct index.

Links:
https://coreos.com/etcd/docs/latest/api.html
https://github.com/jplana/python-etcd/blob/0.4.2/src/etcd/__init__.py#L63