### PR TITLE
[http_check] log error when tags aren't formatted correctly

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -262,6 +262,17 @@ class HTTPCheck(NetworkCheck):
             running_time = time.time() - start
             # Store tags in a temporary list so that we don't modify the global tags data structure
             tags_list = list(tags)
+
+            # Check for ill-formatted tags that aren't string types and log an error
+            bad_tags = []
+            for tag in tags_list:
+                if type(tag) is not str:
+                    bad_tags.append(tag)
+
+            if bad_tags:
+                self.log.error('Tags not formatted correctly for %s. %s not of type string'
+                               % (addr,str(bad_tags)))
+
             tags_list.append('url:%s' % addr)
             self.gauge('network.http.response_time', running_time, tags=tags_list)
 

--- a/tests/checks/integration/test_http_check.py
+++ b/tests/checks/integration/test_http_check.py
@@ -146,6 +146,14 @@ CONFIG_HTTP_REDIRECTS = {
 
 FAKE_CERT = {'notAfter': 'Apr 12 12:00:00 2006 GMT'}
 
+BAD_TAGS_CONFIG = {
+    'instances': [{
+        'name': 'bad_tags_config',
+        'url': 'http://httpbin.org',
+        "tags": [{"env": "production"}]
+    }]
+}
+
 
 @attr(requires='network')
 class HTTPCheckTest(AgentCheckTest):
@@ -293,3 +301,6 @@ class HTTPCheckTest(AgentCheckTest):
             "Datadog Agent.",
             count=1
         )
+
+    def test_bad_tags(self):
+        self.run_check(BAD_TAGS_CONFIG)


### PR DESCRIPTION
### What does this PR do?

Logs an error message when the tags specified in the `http_check.yaml` are not string types
### Motivation

I worked on a support case where the customer's http check was not reporting any metrics or checks. It was unclear why at first since there were no errors and the endpoints were accessible. Upon further investigation, it was determined that the tags were not formatted correctly causing the metrics submission to silently fail. The problem was an extra space after the colon in the `key:value` tag pair as follows:

```
tags:
      - foo: bar
```

The yaml config here is still valid but the extra space causes each element of the tags list to be treated as a dictionary instead of a string, and thus the metrics can't be submitted with these tags. The tags should be formatted with no space between key and value:

```
tags:
      - foo:bar
```

Working on adding a test
