### PR TITLE
Michael/kafka log all consumers

### DIFF
--- a/checks.d/kafka_consumer.py
+++ b/checks.d/kafka_consumer.py
@@ -32,11 +32,11 @@ class KafkaCheck(AgentCheck):
     def _get_all_consumers_offsets(zk_conn, zk_prefix):
         consumer_offsets = {}
         topics = defaultdict(set)
-        consumers_zk_path = zk_path + '/consumers/
+        consumers_zk_path = zk_path + '/consumers/'
         for consumer_group in zk_conn.get_children(consumers_zk_path):
             consumer_offsets_path = consumers_zk_path + consumer_group + '/offsets'
             for topic in zk_conn.get_children(consumer_offsets_path):
-                consumer_topics_path = consumer_offsets_path + '/' topic
+                consumer_topics_path = consumer_offsets_path + '/' + topic
                 for partition in zk_conn.get_children(consumer_topics_path):
                     try:
                        consumer_offset = int(zk_conn.get(consumer_topics_path + '/' + partition)[0])
@@ -59,10 +59,10 @@ class KafkaCheck(AgentCheck):
                        consumer_offset = int(zk_conn.get(zk_path)[0])
                        key = (consumer_group, topic, partition)
                        consumer_offsets[key] = consumer_offset
-                       except NoNodeError:
-                           self.log.warn('No zookeeper node at %s' % zk_path)
-                       except Exception:
-                           self.log.exception('Could not read consumer offset from %s' % zk_path)
+                    except NoNodeError:
+                       self.log.warn('No zookeeper node at %s' % zk_path)
+                    except Exception:
+                       self.log.exception('Could not read consumer offset from %s' % zk_path)
 
     def check(self, instance):
         consumer_groups = self.read_config(instance, 'consumer_groups',
@@ -80,9 +80,9 @@ class KafkaCheck(AgentCheck):
 
         try:
             # Query Zookeeper for consumer offsets
-            if consumer_groups[0].topic == "*"
+            if consumer_groups[0].topic == '*':
                 topics = _get_all_consumers_offsets(zk_conn, zk_prefix)
-            else
+            else:
                 topics = _get_consumers_offsets_by_config(consumer_groups, zk_conn, zk_path_tmpl)
         finally:
             try:

--- a/checks.d/kafka_consumer.py
+++ b/checks.d/kafka_consumer.py
@@ -29,23 +29,34 @@ class KafkaCheck(AgentCheck):
         self.kafka_timeout = int(
             init_config.get('kafka_timeout', DEFAULT_KAFKA_TIMEOUT))
 
-    def _get_all_consumers_offsets(zk_conn, zk_prefix):
+    def _get_all_consumers_offsets(self, zk_conn, zk_prefix):
         consumer_offsets = {}
         topics = defaultdict(set)
-        consumers_zk_path = zk_path + '/consumers/'
-        for consumer_group in zk_conn.get_children(consumers_zk_path):
+        consumers_zk_path = zk_prefix + '/consumers/'
+        for consumer_group in self._try_get_children(zk_conn, consumers_zk_path):
             consumer_offsets_path = consumers_zk_path + consumer_group + '/offsets'
-            for topic in zk_conn.get_children(consumer_offsets_path):
+            for topic in self._try_get_children(zk_conn, consumer_offsets_path):
                 consumer_topics_path = consumer_offsets_path + '/' + topic
-                for partition in zk_conn.get_children(consumer_topics_path):
+                partitions = self._try_get_children(zk_conn, consumer_topics_path)
+                topics[topic.encode('unicode_escape')].update(set([int(x) for x in partitions]))
+
+                for partition in partitions:
                     try:
                        consumer_offset = int(zk_conn.get(consumer_topics_path + '/' + partition)[0])
-                       key = (consumer_group, topic, partition)
-                       consumer_offsets[key] = consumer_offset
-                    except Exception:
-                           self.log.exception('Could not read consumer offset from %s' % consumer_topics_path + '/' + partition)
+                       key = (consumer_group.decode('unicode_escape'), topic.decode('unicode_escape'), int(partition))
+                       consumer_offsets[key] = int(consumer_offset)
+                    except NoNodeError:
+                           self.log.warn('Could not read consumer offset from %s' % consumer_topics_path + '/' + partition)
+        return topics, consumer_offsets
 
-    def _get_consumers_offsets_by_config(consumer_groups, zk_conn, zk_path_tmpl):
+    def _try_get_children(self, zk_conn, zk_path):
+        try:
+           return zk_conn.get_children(zk_path)
+        except NoNodeError:
+           self.log.warn('No zookeeper node at %s' % zk_path)
+           return []
+
+    def _get_consumers_offsets_by_config(self,consumer_groups, zk_conn, zk_path_tmpl):
         consumer_offsets = {}
         topics = defaultdict(set)
         for consumer_group, topic_partitions in consumer_groups.iteritems():
@@ -63,6 +74,7 @@ class KafkaCheck(AgentCheck):
                        self.log.warn('No zookeeper node at %s' % zk_path)
                     except Exception:
                        self.log.exception('Could not read consumer offset from %s' % zk_path)
+        return topics, consumer_offsets
 
     def check(self, instance):
         consumer_groups = self.read_config(instance, 'consumer_groups',
@@ -80,10 +92,10 @@ class KafkaCheck(AgentCheck):
 
         try:
             # Query Zookeeper for consumer offsets
-            if consumer_groups[0].topic == '*':
-                topics = _get_all_consumers_offsets(zk_conn, zk_prefix)
+            if 'none' in consumer_groups:
+                topics, consumer_offsets = self._get_all_consumers_offsets(zk_conn, zk_prefix)
             else:
-                topics = _get_consumers_offsets_by_config(consumer_groups, zk_conn, zk_path_tmpl)
+                topics, consumer_offsets = self._get_consumers_offsets_by_config(consumer_groups, zk_conn, zk_path_tmpl)
         finally:
             try:
                 zk_conn.stop()
@@ -100,7 +112,6 @@ class KafkaCheck(AgentCheck):
             for topic, partitions in topics.items():
                 offset_responses = kafka_conn.send_offset_request([
                     OffsetRequest(topic, p, -1, 1) for p in partitions])
-
                 for resp in offset_responses:
                     broker_offsets[(resp.topic, resp.partition)] = resp.offsets[0]
         finally:


### PR DESCRIPTION
If no consumer_groups is defined in configuration it
will ask zookeeper and get all consumer_groups, topics
and partitions offset and lag.

If the consumer_groups are defined as none:
all offsets in kafka will be used, otherwise none will be used

sim
