### PR TITLE
[wmi_check][test] Fix flaky `tag_queries` test

### DIFF
--- a/checks/wmi_check.py
+++ b/checks/wmi_check.py
@@ -93,7 +93,8 @@ class WinWMICheck(AgentCheck):
         if sampler[0][target_property] is None:
             self.log.error(
                 u"Incorrect 'target property' in `tag_queries` parameter:"
-                " `{wmi_property}` is not a property of `{wmi_class}`".format(
+                " `{wmi_property}` is empty or is not a property"
+                "of `{wmi_class}`".format(
                     wmi_property=target_property,
                     wmi_class=target_class,
                 )

--- a/tests/checks/integration/test_wmi_check.py
+++ b/tests/checks/integration/test_wmi_check.py
@@ -55,14 +55,15 @@ class WMICheckTest(AgentCheckTest):
     def test_check_with_tag_queries(self):
         instance = copy.deepcopy(INSTANCE)
         instance['filters'] = [{'Name': 'svchost%'}]
-        instance['tag_queries'] = [['IDProcess', 'Win32_Process', 'Handle', 'CommandLine']]
+        # `CreationDate` is a good property to test the tag queries but would obviously not be useful as a tag in DD
+        instance['tag_queries'] = [['IDProcess', 'Win32_Process', 'Handle', 'CreationDate']]
         self.run_check({'instances': [instance]})
 
         for metric in INSTANCE_METRICS:
             # No instance "number" (`#`) when tag_queries is specified
             self.assertMetricTag(metric, tag='name:svchost#1', count=0)
             self.assertMetricTag(metric, tag='name:svchost')
-            self.assertMetricTagPrefix(metric, tag_prefix='commandline:')
+            self.assertMetricTagPrefix(metric, tag_prefix='creationdate:')
 
     def test_invalid_class(self):
         instance = copy.deepcopy(INSTANCE)


### PR DESCRIPTION
### What does this PR do?

Fix flaky `tag_queries` test in wmi check integration test.

`CommandLine` is generally empty for the `svchost` processes, which
makes the check fail when used as a target property of `tag_queries`
(for good reasons IMO). Let's use a property that we're sure exists
and is not empty.

Also, make the error message clearer when the target property exists
but is empty.

### Motivation

Fix a flaky test, and have a better error message for missing/empty target properties
