### PR TITLE
Add events Spark Standalone support to the spark agent check

### DIFF
--- a/checks.d/spark.py
+++ b/checks.d/spark.py
@@ -71,15 +71,26 @@ spark.rdd.disk_used
 '''
 
 # stdlib
+import time
 from urlparse import urljoin, urlsplit, urlunsplit
 
 # 3rd party
 import requests
 from requests.exceptions import Timeout, HTTPError, InvalidURL, ConnectionError
 from simplejson import JSONDecodeError
+from bs4 import BeautifulSoup
 
 # Project
 from checks import AgentCheck
+
+# Switch that determines the mode Spark is running in. Can be either
+# 'yarn' or 'standalone'
+SPARK_CLUSTER_MODE = 'spark_cluster_mode'
+SPARK_STANDALONE_MODE = 'spark_standalone_mode'
+SPARK_YARN_MODE = 'spark_yarn_mode'
+
+SPARK_STANDALONE_MASTER = 'spark_standalone_master_uri'
+SPARK_STANDALONE_SERVICE_CHECK = 'spark_standalone_master'
 
 # Service Check Names
 YARN_SERVICE_CHECK = 'spark.resource_manager.can_connect'
@@ -88,10 +99,14 @@ SPARK_SERVICE_CHECK = 'spark.application_master.can_connect'
 # URL Paths
 YARN_APPS_PATH = 'ws/v1/cluster/apps'
 SPARK_APPS_PATH = 'api/v1/applications'
+SPARK_MASTER_STATE_PATH = "/json/"
+SPARK_MASTER_APP_PATH = "/app/"
 
 # Application type and states to collect
 YARN_APPLICATION_TYPES = 'SPARK'
-YARN_APPLICATION_STATES = 'RUNNING'
+APPLICATION_STATES = 'RUNNING'
+
+SOURCE_TYPE_NAME = 'spark.application.server'
 
 # Metric types
 INCREMENT = 'increment'
@@ -165,13 +180,12 @@ SPARK_RDD_METRICS = {
 
 
 class SparkCheck(AgentCheck):
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+        self.previous_jobs = {}
+        self.previous_stages = {}
 
     def check(self, instance):
-        # Get properties from conf file
-        rm_address = instance.get('resourcemanager_uri')
-        if rm_address is None:
-            raise Exception('The ResourceManager URL must be specified in the instance configuration')
-
         # Get additional tags from the conf file
         tags = instance.get('tags', [])
         if tags is None:
@@ -179,24 +193,7 @@ class SparkCheck(AgentCheck):
         else:
             tags = list(set(tags))
 
-        # Get the cluster name from the conf file
-        cluster_name = instance.get('cluster_name')
-        if cluster_name is None:
-            raise Exception('The cluster_name must be specified in the instance configuration')
-
-        tags.append('cluster_name:%s' % cluster_name)
-
-        # Get the running MR applications from YARN
-        running_apps = self._get_running_spark_apps(rm_address)
-
-        # Report success after gathering all metrics from ResourceManaager
-        self.service_check(YARN_SERVICE_CHECK,
-            AgentCheck.OK,
-            tags=['url:%s' % rm_address],
-            message='Connection to ResourceManager "%s" was successful' % rm_address)
-
-        # Get the ids of the running spark applications
-        spark_apps = self._get_spark_app_ids(running_apps)
+        spark_apps = self._get_running_apps(instance, tags)
 
         # Get the job metrics
         self._spark_job_metrics(spark_apps, tags)
@@ -211,8 +208,8 @@ class SparkCheck(AgentCheck):
         self._spark_rdd_metrics(spark_apps, tags)
 
         # Report success after gathering all metrics from the ApplicationMaster
-        if running_apps:
-            app_id, (app_name, tracking_url) = running_apps.items()[0]
+        if spark_apps:
+            app_id, (app_name, tracking_url) = spark_apps.items()[0]
             am_address = self._get_url_base(tracking_url)
 
             self.service_check(SPARK_SERVICE_CHECK,
@@ -220,14 +217,94 @@ class SparkCheck(AgentCheck):
                 tags=['url:%s' % am_address],
                 message='Connection to ApplicationMaster "%s" was successful' % am_address)
 
-    def _get_running_spark_apps(self, rm_address):
+    def _get_running_apps(self, instance, tags):
+        '''
+        Figures out what mode we're in and fetches running apps
+        '''
+        cluster_mode = instance.get(SPARK_CLUSTER_MODE)
+        if not cluster_mode:
+            raise Exception('No cluster mode specified. %s must be set to %s or %s', (SPARK_CLUSTER_MODE, SPARK_STANDALONE_MODE, SPARK_YARN_MODE))
+
+        if cluster_mode == SPARK_STANDALONE_MODE:
+            return self._standalone_init(instance)
+        elif cluster_mode == SPARK_YARN_MODE:
+            running_apps = self._yarn_init(instance, tags)
+            return self._get_spark_app_ids(running_apps)
+        else:
+            raise Exception("Invalid setting for %s. Received %s." % (SPARK_CLUSTER_MODE, cluster_mode))
+
+    def _standalone_init(self, instance):
+        spark_master_address = instance.get('spark_standalone_master_uri')
+        return self._standalone_get_running_spark_apps(spark_master_address)
+
+    def _yarn_init(self, instance, tags):
+        rm_address = instance.get('resourcemanager_uri')
+        if rm_address is None:
+            raise Exception('The ResourceManager URL must be specified in the instance configuration')
+
+        cluster_name = instance.get('cluster_name')
+        if cluster_name is None:
+            raise Exception('The cluster_name must be specified in the instance configuration')
+
+        tags.append('cluster_name:%s' % cluster_name)
+
+        running_apps = {}
+        running_apps = self._yarn_get_running_spark_apps(rm_address)
+
+        # Report success after gathering all metrics from ResourceManaager
+        self.service_check(YARN_SERVICE_CHECK,
+            AgentCheck.OK,
+            tags=['url:%s' % rm_address],
+            message='Connection to ResourceManager "%s" was successful' % rm_address)
+
+        return running_apps
+
+
+    def _standalone_get_running_spark_apps(self, spark_master_address):
         '''
         Return a dictionary of {app_id: (app_name, tracking_url)} for the running Spark applications
+        '''
+        metrics_json = self._rest_request_to_json(spark_master_address,
+            SPARK_MASTER_STATE_PATH,
+            SPARK_STANDALONE_SERVICE_CHECK)
+        running_apps = {}
+        if metrics_json.get('activeapps'):
+            for app in metrics_json['activeapps']:
+                app_id = app['id']
+                app_name = app['name']
+                # we need to parse through the html page to grab
+                # the application driver's link
+                app_url = self._get_standalone_app_url(app_id, spark_master_address)
+                if app_id and app_name and app_url:
+                    running_apps[app_id] = (app_name, app_url)
+        return running_apps
+
+    def _get_standalone_app_url(self, app_id, spark_master_address):
+        '''
+        Return the application URL from the app info page on the Spark master.
+        Due to a bug, we need to parse the HTML manually because we cannot
+        fetch JSON data from HTTP interface.
+        '''
+        app_page = self._rest_request(spark_master_address,
+            SPARK_MASTER_APP_PATH,
+            SPARK_STANDALONE_SERVICE_CHECK,
+            appId=app_id)
+        dom = BeautifulSoup(app_page.text, 'html.parser')
+        app_detail_ui_links = dom.find_all('a', string="Application Detail UI")
+        if app_detail_ui_links and len(app_detail_ui_links) == 1:
+            return app_detail_ui_links[0].attrs['href']
+
+    def _yarn_get_running_spark_apps(self, rm_address):
+        '''
+        Return a dictionary of {app_id: (app_name, tracking_url)} for the running Spark applications.
+
+        The `app_id` returned is that of the YARN application. This will eventually be mapped into
+        a Spark application ID.
         '''
         metrics_json = self._rest_request_to_json(rm_address,
             YARN_APPS_PATH,
             YARN_SERVICE_CHECK,
-            states=YARN_APPLICATION_STATES,
+            states=APPLICATION_STATES,
             applicationTypes=YARN_APPLICATION_TYPES)
 
         running_apps = {}
@@ -247,6 +324,8 @@ class SparkCheck(AgentCheck):
 
     def _get_spark_app_ids(self, running_apps):
         '''
+        Traverses the Spark application master in YARN to get a Spark application ID.
+
         Return a dictionary of {app_id: (app_name, tracking_url)} for Spark applications
         '''
         spark_apps = {}
@@ -254,6 +333,7 @@ class SparkCheck(AgentCheck):
             response = self._rest_request_to_json(tracking_url,
                 SPARK_APPS_PATH,
                 SPARK_SERVICE_CHECK)
+
             for app in response:
                 app_id = app.get('id')
                 app_name = app.get('name')
@@ -268,6 +348,8 @@ class SparkCheck(AgentCheck):
         Get metrics for each Spark job.
         Return a map from Stage IDs to Job IDs
         '''
+        new_jobs = {}
+
         for app_id, (app_name, tracking_url) in running_apps.iteritems():
 
             response = self._rest_request_to_json(tracking_url,
@@ -285,10 +367,44 @@ class SparkCheck(AgentCheck):
                 self._set_metrics_from_json(tags, job, SPARK_JOB_METRICS)
                 self._set_metric('spark.job.count', INCREMENT, 1, tags)
 
+                job_id = job['jobId']
+                previous_status = None
+                if app_id in self.previous_jobs and job_id in self.previous_jobs[app_id]:
+                    previous_status = self.previous_jobs[app_id][job_id]['status']
+                self._event_for_job_status_change(job, tags, previous_status)
+
+            # build index by mapping app ids to a mapping of job id => jobs
+            new_jobs[app_id] = dict((job['jobId'], job) for job in response)
+
+        self.previous_jobs = new_jobs
+
+    def _event_for_job_status_change(self, current_job, tags, previous_status):
+        job_name = current_job['name']
+        job_id = current_job['jobId']
+        current_status = current_job['status']
+        msg_title = "Spark job `%s` is now %s" % (job_name, current_status)
+
+        if previous_status:
+            if previous_status != current_status:
+                msg = "Spark job `%s` (ID %s) status changed from %s to %s." % (job_name, job_id, previous_status, current_status)
+            else: # want to bail early if the previous status is the same
+                return
+        else:
+            msg = "New Spark job `%s` (ID %s) has status %s." % (job_name, job_id, current_status)
+
+        self.event({
+            'timestamp': int(time.time()),
+            'source_type_name': SOURCE_TYPE_NAME,
+            'msg_title': msg_title,
+            'msg_text': msg,
+            'tags': tags
+        })
+
     def _spark_stage_metrics(self, running_apps, addl_tags):
         '''
         Get metrics for each Spark stage.
         '''
+        new_stages = {}
         for app_id, (app_name, tracking_url) in running_apps.iteritems():
 
             response = self._rest_request_to_json(tracking_url,
@@ -305,6 +421,40 @@ class SparkCheck(AgentCheck):
 
                 self._set_metrics_from_json(tags, stage, SPARK_STAGE_METRICS)
                 self._set_metric('spark.stage.count', INCREMENT, 1, tags)
+
+                stage_id = stage['stageId']
+                previous_status = None
+                if app_id in self.previous_stages and stage_id in self.previous_stages[app_id]:
+                    previous_status = self.previous_stages[app_id][stage_id]['status']
+                self._event_for_stage_status_change(stage, tags, previous_status)
+
+            # build index by mapping app ids to a mapping of job id => jobs
+            new_stages[app_id] = dict((stage['stageId'], stage) for stage in response)
+
+        self.previous_stages = new_stages
+
+    def _event_for_stage_status_change(self, current_stage, tags, previous_status):
+        stage_name = current_stage['name']
+        stage_id = current_stage['stageId']
+        current_status = current_stage['status']
+        msg_title = "Spark stage `%s` has status %s" % (stage_name, current_status)
+
+        if previous_status:
+            if previous_status != current_status:
+                msg = "Spark stage `%s` (ID %s) status changed from %s to %s." % (stage_name, stage_id, previous_status, current_status)
+            else: # want to bail early if the previous status is the same
+                return
+        else:
+            msg = "New Spark stage `%s` (ID %s) has status %s." % (stage_name, stage_id, current_status)
+
+        self.event({
+            'timestamp': int(time.time()),
+            'source_type_name': SOURCE_TYPE_NAME,
+            'msg_title': msg_title,
+            'msg_text': msg,
+            'tags': tags
+        })
+
 
     def _spark_executor_metrics(self, running_apps, addl_tags):
         '''
@@ -369,11 +519,11 @@ class SparkCheck(AgentCheck):
         else:
             self.log.error('Metric type "%s" unknown' % (metric_type))
 
-    def _rest_request_to_json(self, address, object_path, service_name, *args, **kwargs):
+    def _rest_request(self, address, object_path, service_name, *args, **kwargs):
         '''
-        Query the given URL and return the JSON response
+        Query the given URL and return the response
         '''
-        response_json = None
+        response = None
 
         service_check_tags = ['url:%s' % self._get_url_base(address)]
 
@@ -387,8 +537,6 @@ class SparkCheck(AgentCheck):
             for directory in args:
                 url = self._join_url_dir(url, directory)
 
-        self.log.debug('Attempting to connect to "%s"' % url)
-
         # Add kwargs as arguments
         if kwargs:
             query = '&'.join(['{0}={1}'.format(key, value) for key, value in kwargs.iteritems()])
@@ -397,7 +545,6 @@ class SparkCheck(AgentCheck):
         try:
             response = requests.get(url)
             response.raise_for_status()
-            response_json = response.json()
 
         except Timeout as e:
             self.service_check(service_name,
@@ -429,7 +576,11 @@ class SparkCheck(AgentCheck):
                 message=str(e))
             raise
 
-        return response_json
+        return response
+
+    def _rest_request_to_json(self, address, object_path, service_name, *args, **kwargs):
+        response = self._rest_request(address, object_path, service_name, *args, **kwargs)
+        return response.json()
 
     def _join_url_dir(self, url, *args):
         '''

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,3 +76,6 @@ dnspython==1.12.0
 # utils/service_discovery/config_stores.py
 python-etcd==0.4.2
 python-consul==0.4.7
+
+# checks.d/spark.py
+beautifulsoup4==4.5.1

--- a/tests/checks/mock/test_spark.py
+++ b/tests/checks/mock/test_spark.py
@@ -93,7 +93,8 @@ class SparkCheck(AgentCheckTest):
 
     SPARK_CONFIG = {
         'resourcemanager_uri': 'http://localhost:8088',
-        'cluster_name': CLUSTER_NAME
+        'cluster_name': CLUSTER_NAME,
+        'spark_cluster_mode': 'spark_yarn_mode'
     }
 
     SPARK_JOB_RUNNING_METRIC_VALUES = {


### PR DESCRIPTION
### What does this PR do?

Enabled Spark metrics to be gathered when clusters are provisioned using Spark's Standalone cluster mode. Currently the agent checks works when Spark is running with Apache YARN to provision its resources. This PR re-uses the bulk of the collection logic, but retrofits an adapter to locate application servers via Spark Standalone's APIs.

Events have also been added. The agent can now raise events when both jobs and stages have status transitions (ie, moving from WAITING to RUNNING to COMPLETED or FAILED).

### Testing Guidelines

Run the mock test using `nosetests`. Note that the test fit was only modified to continue force the agent to pretend it is using YARN. 