### PR TITLE
Consul net latency

### DIFF
--- a/checks.d/consul.py
+++ b/checks.d/consul.py
@@ -16,6 +16,8 @@ from checks import AgentCheck
 import requests
 
 
+# More information in https://www.consul.io/docs/internals/coordinates.html,
+# code is based on the snippet there.
 def distance(a, b):
     a = a['Coord']
     b = b['Coord']

--- a/checks.d/consul.py
+++ b/checks.d/consul.py
@@ -365,9 +365,15 @@ class ConsulCheck(AgentCheck):
         if perform_network_latency_checks:
             self.check_network_latency(instance, agent_dc, main_tags)
 
+    def _get_coord_datacenters(self, instance):
+        return self.consul_request(instance, '/v1/coordinate/datacenters')
+
+    def _get_coord_nodes(self, instance):
+        return self.consul_request(instance, 'v1/coordinate/nodes')
+
     def check_network_latency(self, instance, agent_dc, main_tags):
 
-        datacenters = self.consul_request(instance, '/v1/coordinate/datacenters')
+        datacenters = self._get_coord_datacenters(instance)
         for datacenter in datacenters:
             name = datacenter['Datacenter']
             if name != agent_dc:
@@ -397,7 +403,7 @@ class ConsulCheck(AgentCheck):
                 self.gauge('consul.net.dc-latency.max', latencies[-1], hostname='', tags=tags)
 
         # Intra-datacenter
-        nodes = self.consul_request(instance, 'v1/coordinate/nodes')
+        nodes = self._get_coord_nodes(instance)
         for node in nodes:
             node_name = node['Node']
             latencies = []

--- a/checks.d/consul.py
+++ b/checks.d/consul.py
@@ -28,7 +28,7 @@ def distance(a, b):
 
     adjusted = rtt + a['Adjustment'] + b['Adjustment']
     if adjusted > 0.0:
-      rtt = adjusted
+        rtt = adjusted
 
     return rtt * 1000.0
 

--- a/checks.d/consul.py
+++ b/checks.d/consul.py
@@ -400,9 +400,9 @@ class ConsulCheck(AgentCheck):
                     median = latencies[half_n]
                 else:
                     median = (latencies[half_n - 1] + latencies[half_n]) / 2
-                self.gauge('consul.net.dc-latency.min', latencies[0], hostname='', tags=tags)
-                self.gauge('consul.net.dc-latency.median', median, hostname='', tags=tags)
-                self.gauge('consul.net.dc-latency.max', latencies[-1], hostname='', tags=tags)
+                self.gauge('consul.net.dc.latency.min', latencies[0], hostname='', tags=tags)
+                self.gauge('consul.net.dc.latency.median', median, hostname='', tags=tags)
+                self.gauge('consul.net.dc.latency.max', latencies[-1], hostname='', tags=tags)
 
         # Intra-datacenter
         nodes = self._get_coord_nodes(instance)
@@ -421,11 +421,11 @@ class ConsulCheck(AgentCheck):
                 median = latencies[half_n]
             else:
                 median = (latencies[half_n - 1] + latencies[half_n]) / 2
-            self.gauge('consul.net.latency.min', latencies[0], hostname=node_name, tags=main_tags)
-            self.gauge('consul.net.latency.p25', latencies[ceili(n * 0.25) - 1], hostname=node_name, tags=main_tags)
-            self.gauge('consul.net.latency.median', median, hostname=node_name, tags=main_tags)
-            self.gauge('consul.net.latency.p75', latencies[ceili(n * 0.75) - 1], hostname=node_name, tags=main_tags)
-            self.gauge('consul.net.latency.p90', latencies[ceili(n * 0.90) - 1], hostname=node_name, tags=main_tags)
-            self.gauge('consul.net.latency.p95', latencies[ceili(n * 0.95) - 1], hostname=node_name, tags=main_tags)
-            self.gauge('consul.net.latency.p99', latencies[ceili(n * 0.99) - 1], hostname=node_name, tags=main_tags)
-            self.gauge('consul.net.latency.max', latencies[-1], hostname=node_name, tags=main_tags)
+            self.gauge('consul.net.node.latency.min', latencies[0], hostname=node_name, tags=main_tags)
+            self.gauge('consul.net.node.latency.p25', latencies[ceili(n * 0.25) - 1], hostname=node_name, tags=main_tags)
+            self.gauge('consul.net.node.latency.median', median, hostname=node_name, tags=main_tags)
+            self.gauge('consul.net.node.latency.p75', latencies[ceili(n * 0.75) - 1], hostname=node_name, tags=main_tags)
+            self.gauge('consul.net.node.latency.p90', latencies[ceili(n * 0.90) - 1], hostname=node_name, tags=main_tags)
+            self.gauge('consul.net.node.latency.p95', latencies[ceili(n * 0.95) - 1], hostname=node_name, tags=main_tags)
+            self.gauge('consul.net.node.latency.p99', latencies[ceili(n * 0.99) - 1], hostname=node_name, tags=main_tags)
+            self.gauge('consul.net.node.latency.max', latencies[-1], hostname=node_name, tags=main_tags)

--- a/conf.d/consul.yaml.example
+++ b/conf.d/consul.yaml.example
@@ -23,9 +23,17 @@ instances:
       # Whether to perform checks against the Consul service Catalog
       catalog_checks: yes
 
+      # Whether to enable self leader checks. Each agent with this enabled will
+      # watch for itself to become the leader and will emit an event when that
+      # happens. It is safe/expected to enable this on all nodes in a consul
+      # cluster since only the new leader will emit the (single) event. This
+      # flag takes precedence over new_leader_checks.
+      self_leader_check: yes
+
       # Whether to enable new leader checks from this agent
       # Note: if this is set on multiple agents in the same cluster
-      # you will receive one event per leader change per agent
+      # you will receive one event per leader change per agent. See
+      # self_leader_check for a more robust option.
       new_leader_checks: yes
 
       # Services to restrict catalog querying to

--- a/conf.d/consul.yaml.example
+++ b/conf.d/consul.yaml.example
@@ -36,6 +36,12 @@ instances:
       # self_leader_check for a more robust option.
       new_leader_checks: yes
 
+      # Whether to enable network latency metrics collection. When enabled
+      # consul network coordinates will be retrieved and latency calculated for
+      # each node and between data centers.
+      # See https://www.consul.io/docs/internals/coordinates.html
+      network_latency_checks: yes
+
       # Services to restrict catalog querying to
       # The default settings query up to 50 services. So if you have more than
       # this many in your Consul service catalog, you will want to fill in the

--- a/tests/checks/mock/test_consul.py
+++ b/tests/checks/mock/test_consul.py
@@ -37,6 +37,15 @@ MOCK_CONFIG_SELF_LEADER_CHECK = {
     }]
 }
 
+MOCK_CONFIG_NETWORK_LATENCY_CHECKS = {
+    'init_config': {},
+    'instances' : [{
+        'url': 'http://localhost:8500',
+        'catalog_checks': True,
+        'network_latency_checks': True
+    }]
+}
+
 MOCK_BAD_CONFIG = {
     'init_config': {},
     'instances' : [{ # Multiple instances should cause it to fail
@@ -265,6 +274,89 @@ class TestCheckConsul(AgentCheckTest):
             }
         ]
 
+    def mock_get_coord_datacenters(self, instance):
+        return [{
+            "Datacenter": "dc1",
+            "Coordinates": [
+                {
+                    "Node": "host-1",
+                    "Coord": {
+                        "Vec": [
+                            0.036520147625677804,
+                            -0.00453289164613373,
+                            -0.020523210880196232,
+                            -0.02699760529719879,
+                            -0.02689207977655939,
+                            -0.01993826834797845,
+                            -0.013022029942846501,
+                            -0.002101656069659926
+                        ],
+                        "Error": 0.11137306578107628,
+                        "Adjustment": -0.00021065907491393056,
+                        "Height": 1.1109163532378512e-05
+                    }
+                }]
+        }, {
+            "Datacenter": "dc2",
+            "Coordinates": [
+                {
+                    "Node": "host-2",
+                    "Coord": {
+                        "Vec": [
+                            0.03548568620505946,
+                            -0.0038202417296129025,
+                            -0.01987440114252717,
+                            -0.026223108843980016,
+                            -0.026581965209197853,
+                            -0.01891384862245717,
+                            -0.013677323575279184,
+                            -0.0014257906933581217
+                        ],
+                        "Error": 0.06388569381495224,
+                        "Adjustment": -0.00036731776343708724,
+                        "Height": 8.962823816793629e-05
+                    }
+                }]
+
+        }]
+
+    def mock_get_coord_nodes(self, instance):
+        return [{
+            "Node": "host-1",
+            "Coord": {
+                "Vec": [
+                    0.007682993877165208,
+                    0.002411059340215172,
+                    0.0016420746641640123,
+                    0.0037411046929292906,
+                    0.004541946058965728,
+                    0.0032195622863890523,
+                    -0.0039447666794166095,
+                    -0.0021767019427297815
+                ],
+                "Error": 0.28019529748212335,
+                "Adjustment": -9.966407036439966e-05,
+                "Height": 0.00011777098790169723
+            }
+        }, {
+            "Node": "host-2",
+            "Coord": {
+                "Vec": [
+                    0.007725239390196322,
+                    0.0025160987581685982,
+                    0.0017412811939227935,
+                    0.003740935739394932,
+                    0.004628794642643524,
+                    0.003190871896051593,
+                    -0.004058197296573195,
+                    -0.002108437352702053
+                ],
+                "Error": 0.31518043241386984,
+                "Adjustment": -0.00012274366490350246,
+                "Height": 0.00015006836008626717
+            }
+        }]
+
     def mock_get_cluster_leader_A(self, instance):
         return '10.0.2.15:8300'
 
@@ -277,7 +369,9 @@ class TestCheckConsul(AgentCheckTest):
             'get_nodes_with_service': self.mock_get_nodes_with_service,
             'get_peers_in_cluster': self.mock_get_peers_in_cluster,
             '_get_local_config': self.mock_get_local_config,
-            '_get_cluster_leader': self.mock_get_cluster_leader_A
+            '_get_cluster_leader': self.mock_get_cluster_leader_A,
+            '_get_coord_datacenters': self.mock_get_coord_datacenters,
+            '_get_coord_nodes': self.mock_get_coord_nodes,
         }
 
     def test_bad_config(self):
@@ -419,3 +513,29 @@ class TestCheckConsul(AgentCheckTest):
         self.assertEqual(event['event_type'], 'consul.new_leader')
         self.assertIn('prev_consul_leader:%s' % other_url, event['tags'])
         self.assertIn('curr_consul_leader:%s' % our_url, event['tags'])
+
+    def test_network_latency_checks(self):
+        self.check = load_check(self.CHECK_NAME, MOCK_CONFIG_NETWORK_LATENCY_CHECKS,
+                                self.DEFAULT_AGENT_CONFIG)
+
+        mocks = self._get_consul_mocks()
+
+        # We start out as the leader, and stay that way
+        self.check._last_known_leader = self.mock_get_cluster_leader_A(None)
+
+        self.run_check(MOCK_CONFIG_SELF_LEADER_CHECK, mocks=mocks)
+
+        latency = [m for m in self.metrics if m[0].startswith('consul.net.')]
+        latency.sort()
+        # Make sure we have the expected number of metrics
+        self.assertEquals(19, len(latency))
+
+        # Only 3 dc-latency metrics since we only do source = self
+        dc = [m for m in latency if '.dc-latency.' in m[0]]
+        self.assertEquals(3, len(dc))
+        self.assertEquals(1.6746410750238774, dc[0][2])
+
+        # 16 latency metrics, 2 nodes * 8 metrics each
+        node = [m for m in latency if '.latency.' in m[0]]
+        self.assertEquals(16, len(node))
+        self.assertEquals(0.26577747932995816, node[0][2])

--- a/tests/checks/mock/test_consul.py
+++ b/tests/checks/mock/test_consul.py
@@ -381,7 +381,7 @@ class TestCheckConsul(AgentCheckTest):
         self.assertIn('prev_consul_leader:My Old Leader', event['tags'])
         self.assertIn('curr_consul_leader:My New Leader', event['tags'])
 
-    def testn_self_leader_event(self):
+    def test_self_leader_event(self):
         self.check = load_check(self.CHECK_NAME, MOCK_CONFIG_SELF_LEADER_CHECK, self.DEFAULT_AGENT_CONFIG)
         self.check._last_known_leader = 'My Old Leader'
 

--- a/tests/checks/mock/test_consul.py
+++ b/tests/checks/mock/test_consul.py
@@ -531,11 +531,11 @@ class TestCheckConsul(AgentCheckTest):
         self.assertEquals(19, len(latency))
 
         # Only 3 dc-latency metrics since we only do source = self
-        dc = [m for m in latency if '.dc-latency.' in m[0]]
+        dc = [m for m in latency if '.dc.latency.' in m[0]]
         self.assertEquals(3, len(dc))
         self.assertEquals(1.6746410750238774, dc[0][2])
 
         # 16 latency metrics, 2 nodes * 8 metrics each
-        node = [m for m in latency if '.latency.' in m[0]]
+        node = [m for m in latency if '.node.latency.' in m[0]]
         self.assertEquals(16, len(node))
         self.assertEquals(0.26577747932995816, node[0][2])


### PR DESCRIPTION
### What does this PR do?

This PR adds a new option to the consul check to include calculated network latencies based on https://www.consul.io/docs/internals/coordinates.html. Both inter and intra dc metrics are included. The dc to dc metrics are under `consul.net.dc-latency`, include `source_datacenter`/`dest_datacenter` tags, and are host-less. The node to node metrics are under `consul.net.latency`, are emitted per-host, and include a `consul_datacenter` tag.

### Motivation

Previously had access to this data in graphite and found it interesting/useful at times. It's nice to be able to see network latencies between hosts, racks, availability-zones, roles, etc using the host-level tags. 

### Additional Notes

This PR is a follow on to https://github.com/DataDog/dd-agent/pull/2647 which should be merged prior to merging this.