### PR TITLE
Make sure the filter gets updated with the last timestamp on each

### DIFF
--- a/checks.d/process.py
+++ b/checks.d/process.py
@@ -33,7 +33,8 @@ ATTR_TO_METRIC = {
     'r_bytes':          'ioread_bytes',  # FIXME: namespace me correctly (6.x) io.w_count
     'w_bytes':          'iowrite_bytes',  # FIXME: namespace me correctly (6.x) io.w_bytes
     'ctx_swtch_vol':    'voluntary_ctx_switches',  # FIXME: namespace me correctly (6.x), ctx_swt.voluntary
-    'ctx_swtch_invol':  'involuntary_ctx_switches'  # FIXME: namespace me correctly (6.x), ctx_swt.involuntary
+    'ctx_swtch_invol':  'involuntary_ctx_switches',  # FIXME: namespace me correctly (6.x), ctx_swt.involuntary
+    'run_time':         'run_time'
 }
 
 ATTR_TO_METRIC_RATE = {
@@ -263,6 +264,13 @@ class ProcessCheck(AgentCheck):
                 st['majflt'].append(None)
                 st['cmajflt'].append(None)
 
+            #calculate process run time
+            create_time = self.psutil_wrapper(p, 'create_time', None)
+            if create_time is not None:
+                now = time.time()
+                run_time = now - create_time
+                st['run_time'].append(run_time)
+
         return st
 
     def get_pagefault_stats(self, pid):
@@ -329,8 +337,14 @@ class ProcessCheck(AgentCheck):
             vals = [x for x in proc_state[attr] if x is not None]
             # skip []
             if vals:
+                if attr == 'run_time':
+                    self.gauge('system.processes.%s.avg' % mname, sum(vals)/len(vals), tags=tags)
+                    self.gauge('system.processes.%s.max' % mname, max(vals), tags=tags)
+                    self.gauge('system.processes.%s.min' % mname, min(vals), tags=tags)
+
                 # FIXME 6.x: change this prefix?
-                self.gauge('system.processes.%s' % mname, sum(vals), tags=tags)
+                else:
+                    self.gauge('system.processes.%s' % mname, sum(vals), tags=tags)
 
         for attr, mname in ATTR_TO_METRIC_RATE.iteritems():
             vals = [x for x in proc_state[attr] if x is not None]

--- a/checks.d/win32_event_log.py
+++ b/checks.d/win32_event_log.py
@@ -120,6 +120,7 @@ class Win32EventLogWMI(WinWMICheck):
             and_props=['Message']
         )
 
+        wmi_sampler.reset_filter(new_filters=filters)
         try:
             wmi_sampler.sample()
         except TimeoutException:

--- a/checks/libs/wmi/sampler.py
+++ b/checks/libs/wmi/sampler.py
@@ -193,6 +193,11 @@ class WMISampler(object):
             self._formatted_filters = self._format_filter(filters, self._and_props)
         return self._formatted_filters
 
+    def reset_filter(self, new_filters):
+        self.filters = new_filters
+        # get rid of the formatted filters so they'll be recalculated
+        self._formatted_filters = None
+
     def sample(self):
         """
         Compute new samples.

--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -130,7 +130,7 @@ start() {
         exit 3
     fi
 
-    su $AGENTUSER -c "$AGENTPATH configcheck" > /dev/null
+    su $AGENTUSER -c "$AGENTPATH configcheck" > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo -n $'\n'"Invalid check configuration. Please run sudo /etc/init.d/datadog-agent configtest for more details."
         echo -n $'\n'"Resuming starting process."$'\n'

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -125,7 +125,7 @@ case "$1" in
             $0 stop > /dev/null 2>&1
         fi
 
-        su $AGENTUSER -c "$AGENTPATH configcheck" > /dev/null
+        su $AGENTUSER -c "$AGENTPATH configcheck" > /dev/null 2>&1
         if [ $? -ne 0 ]; then
             log_daemon_msg "Invalid check configuration. Please run sudo /etc/init.d/datadog-agent configtest for more details."
             log_daemon_msg "Resuming starting process."

--- a/tests/checks/integration/test_process.py
+++ b/tests/checks/integration/test_process.py
@@ -140,7 +140,10 @@ class ProcessCheckTest(AgentCheckTest):
         'system.processes.number',
         'system.processes.open_file_descriptors',
         'system.processes.threads',
-        'system.processes.voluntary_ctx_switches'
+        'system.processes.voluntary_ctx_switches',
+        'system.processes.run_time.avg',
+        'system.processes.run_time.max',
+        'system.processes.run_time.min',
     ]
 
     PAGEFAULT_STAT = [
@@ -466,5 +469,8 @@ class ProcessCheckTest(AgentCheckTest):
         self.assertServiceCheckOK('process.up', count=1, tags=['process:moved_procfs'])
 
         self.assertMetric('system.processes.number', at_least=1, tags=expected_tags)
+        self.assertMetric('system.processes.run_time.avg', at_least=1, tags=expected_tags)
+        self.assertMetric('system.processes.run_time.max', at_least=1, tags=expected_tags)
+        self.assertMetric('system.processes.run_time.min', at_least=1, tags=expected_tags)
 
         self.coverage_report()


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

PR fixes a customer problem whereby the CPU consumed by the Win32 event log check would increase linearly with time.


### Motivation

Customer request

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes



Reset WMI query filters before each run.  Otherwise, all checks are done relative to when the agent was started, resulting in an ever-growing list of events to be parsed.

The WMI filter was attached to the (cached) sampler object.  So, even though the filter was recomputed each time with a new "TimeGenerated >= " string, that was never actually used by the WMI query.  So, each successive query returned any new entries, PLUS any entries that had already been retrieved.  Processing the list then had a linearly increasing time (and space).  Compounding it is the check to make sure the duplicate entries aren't reported, which then caused the (ever growing) list to be parsed again.