### PR TITLE
[collector][logging] Log check starts with info level on first run only

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -380,12 +380,15 @@ class Collector(object):
             if res:
                 metrics.extend(res)
 
+        # Use `info` log level for some messages on the first run only, then `debug`
+        log_method = log.info if self._is_first_run() else log.debug
+
         # checks.d checks
         check_statuses = []
         for check in self.initialized_checks_d:
             if not self.continue_running:
                 return
-            log.info("Running check %s" % check.name)
+            log_method("Running check %s" % check.name)
             instance_statuses = []
             metric_count = 0
             event_count = 0

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -381,14 +381,14 @@ class Collector(object):
                 metrics.extend(res)
 
         # Use `info` log level for some messages on the first run only, then `debug`
-        log_method = log.info if self._is_first_run() else log.debug
+        log_at_first_run = log.info if self._is_first_run() else log.debug
 
         # checks.d checks
         check_statuses = []
         for check in self.initialized_checks_d:
             if not self.continue_running:
                 return
-            log_method("Running check %s" % check.name)
+            log_at_first_run("Running check %s", check.name)
             instance_statuses = []
             metric_count = 0
             event_count = 0


### PR DESCRIPTION
### What does this PR do?

Lower log level of the `Running check xxxx` message after the first run of the collector.

### Motivation

Since we removed the LaconicFilter (see #2605) the collector is filled
with `Running check xxxx` messages that get logged for every check
at every run. It fills up the logs too quickly for an info-level logging.

### Testing

`rake run` on my dev env, looked at the collector logs: it works
