### PR TITLE
[docker_daemon] filters were including filtering  into regex compiled…

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -121,13 +121,26 @@ def get_filters(include, exclude):
     exclude_patterns = []
     include_patterns = []
 
+    def append_filter_regex(rule, patterns):
+        split = rule.split(':')
+        if len(split) < 2:
+            return None
+
+        regex = ':'.join(split[1:])
+        patterns.append(re.compile(regex))
+
+        return split[0]
+
+
     # Compile regex
     for rule in exclude:
-        exclude_patterns.append(re.compile(rule))
-        filtered_tag_names.append(rule.split(':')[0])
+        filter_tag = append_filter_regex(rule, exclude_patterns)
+        if filter_tag:
+            filtered_tag_names.append(filter_tag)
     for rule in include:
-        include_patterns.append(re.compile(rule))
-        filtered_tag_names.append(rule.split(':')[0])
+        filter_tag = append_filter_regex(rule, include_patterns)
+        if filter_tag:
+            filtered_tag_names.append(filter_tag)
 
     return set(exclude_patterns), set(include_patterns), set(filtered_tag_names)
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

There's an issue with the way we include/exclude containers. The current logic would include the tag key in the regex by doing `re.compile(rule)` and therefore not match.

### Motivation

Bugfix.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?

… expression.