### PR TITLE
[php5_fpm] allow Host header override

### DIFF
--- a/conf.d/php_fpm.yaml.example
+++ b/conf.d/php_fpm.yaml.example
@@ -19,6 +19,10 @@ instances:
     # Use this if you have basic authentication on these pages
     # user: bits
     # password: D4T4D0G
+    # 
+    # If your FPM pool is only accessible via a specific HTTP vhost, you can
+    # pass in a custom Host header like so
+    # http_host: such.production.host
     #
     # Array of custom tags
     # By default metrics and service check will be tagged by pool and host

--- a/util.py
+++ b/util.py
@@ -85,13 +85,16 @@ def get_os():
         return sys.platform
 
 
-def headers(agentConfig):
+def headers(agentConfig, **kwargs):
     # Build the request headers
-    return {
+    res = {
         'User-Agent': 'Datadog Agent/%s' % agentConfig['version'],
         'Content-Type': 'application/x-www-form-urlencoded',
         'Accept': 'text/html, */*',
     }
+    if 'http_host' in kwargs:
+        res['Host'] = kwargs['http_host']
+    return res
 
 
 def windows_friendly_colon_split(config_string):


### PR DESCRIPTION
### What does this PR do?

This PR allows you to override the Host HTTP header sent during requests to the fpm status and ping URLs.

### Motivation

In load-balanced configurations it's possible an FPM pool is only mapped to http://production.url/status and not http://localhost. But production.url points to some load balancer which distributes load across many different servers.

To be able to test local servers you need to be able to say "Connect to localhost, but tell it you're after production.url"

### Additional Notes

This change adds the Host HTTP header if defined, otherwise the check works as is. The check has integration tests, and from them I was unable to figure out how to make a check that demonstrates a failing and a working check based on differing Host headers.