### PR TITLE
Add support for sum histogram_aggregates type

### DIFF
--- a/aggregator.py
+++ b/aggregator.py
@@ -258,13 +258,15 @@ class Histogram(Metric):
         min_ = self.samples[0]
         max_ = self.samples[-1]
         med = self.samples[int(round(length/2 - 1))]
-        avg = sum(self.samples) / float(length)
+        sum_ = sum(self.samples)
+        avg = sum_ / float(length)
 
         aggregators = [
             ('min', min_, MetricTypes.GAUGE),
             ('max', max_, MetricTypes.GAUGE),
             ('median', med, MetricTypes.GAUGE),
             ('avg', avg, MetricTypes.GAUGE),
+            ('sum', sum_, MetricTypes.GAUGE),
             ('count', self.count/interval, MetricTypes.RATE),
         ]
 

--- a/config.py
+++ b/config.py
@@ -274,7 +274,7 @@ def get_histogram_aggregates(configstr=None):
 
     try:
         vals = configstr.split(',')
-        valid_values = ['min', 'max', 'median', 'avg', 'count']
+        valid_values = ['min', 'max', 'median', 'avg', 'sum', 'count']
         result = []
 
         for val in vals:

--- a/tests/core/test_histogram.py
+++ b/tests/core/test_histogram.py
@@ -125,7 +125,7 @@ class TestHistogram(unittest.TestCase):
         )
 
     def test_custom_aggregate(self):
-        configstr = 'median, max'
+        configstr = 'median, max, sum'
         stats = MetricsAggregator(
             'myhost',
             histogram_aggregates=get_histogram_aggregates(configstr)
@@ -133,7 +133,7 @@ class TestHistogram(unittest.TestCase):
 
         self.assertEquals(
             sorted(stats.metric_config[Histogram]['aggregates']),
-            ['max', 'median'],
+            ['max', 'median', 'sum'],
             stats.metric_config[Histogram]
         )
 
@@ -142,7 +142,7 @@ class TestHistogram(unittest.TestCase):
 
         metrics = stats.flush()
 
-        self.assertEquals(len(metrics), 3, metrics)
+        self.assertEquals(len(metrics), 4, metrics)
 
         value_by_type = {}
         for k in metrics:
@@ -150,4 +150,5 @@ class TestHistogram(unittest.TestCase):
 
         self.assertEquals(value_by_type['median'], 9, value_by_type)
         self.assertEquals(value_by_type['max'], 19, value_by_type)
+        self.assertEquals(value_by_type['sum'], 190, value_by_type)
         self.assertEquals(value_by_type['95percentile'], 18, value_by_type)


### PR DESCRIPTION
### What does this PR do?

Support for a new histogram aggregate type, sum, which records the sum of all
values seen during the sampling period. Matches up with the [timing](https://github.com/etsy/statsd/blob/master/docs/metric_types.md#timing) option of the same name in the original statsd. 

### Motivation

Heavy users of statsd and have used `sum` there and went to enable it here and noticed it wasn't an option. 

/cc @jnunemaker