### PR TITLE
[marathon] Count running/pending deployments

### DIFF
--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -16,70 +16,70 @@ from checks import AgentCheck
 
 class Marathon(AgentCheck):
 
-	DEFAULT_TIMEOUT = 5
-	SERVICE_CHECK_NAME = 'marathon.can_connect'
+    DEFAULT_TIMEOUT = 5
+    SERVICE_CHECK_NAME = 'marathon.can_connect'
 
-	APP_METRICS = [
-		'backoffFactor',
-		'backoffSeconds',
-		'cpus',
-		'disk',
-		'instances',
-		'mem',
-		'taskRateLimit',
-		'tasksRunning',
-		'tasksStaged'
-	]
+    APP_METRICS = [
+        'backoffFactor',
+        'backoffSeconds',
+        'cpus',
+        'disk',
+        'instances',
+        'mem',
+        'taskRateLimit',
+        'tasksRunning',
+        'tasksStaged'
+    ]
 
-	def check(self, instance):
-		if 'url' not in instance:
-			raise Exception('Marathon instance missing "url" value.')
+    def check(self, instance):
+        if 'url' not in instance:
+            raise Exception('Marathon instance missing "url" value.')
 
-		# Load values from the instance config
-		url = instance['url']
-		user = instance.get('user')
-		password = instance.get('password')
-		if user is not None and password is not None:
-			auth = (user,password)
-		else:
-			auth = None
-		instance_tags = instance.get('tags', [])
-		default_timeout = self.init_config.get('default_timeout', self.DEFAULT_TIMEOUT)
-		timeout = float(instance.get('timeout', default_timeout))
+        # Load values from the instance config
+        url = instance['url']
+        user = instance.get('user')
+        password = instance.get('password')
+        if user is not None and password is not None:
+            auth = (user,password)
+        else:
+            auth = None
+        instance_tags = instance.get('tags', [])
+        default_timeout = self.init_config.get('default_timeout', self.DEFAULT_TIMEOUT)
+        timeout = float(instance.get('timeout', default_timeout))
 
-		response = self.get_json(urljoin(url, "v2/apps"), timeout, auth)
-		if response is not None:
-			self.gauge('marathon.apps', len(response['apps']), tags=instance_tags)
-			for app in response['apps']:
-				tags = ['app_id:' + app['id'], 'version:' + app['version']] + instance_tags
-				for attr in self.APP_METRICS:
-					if attr in app:
-						self.gauge('marathon.' + attr, app[attr], tags=tags)
+        response = self.get_json(urljoin(url, "v2/apps"), timeout, auth)
+        if response is not None:
+            self.gauge('marathon.apps', len(response['apps']), tags=instance_tags)
+            for app in response['apps']:
+                tags = ['app_id:' + app['id'], 'version:' + app['version']] + instance_tags
+                for attr in self.APP_METRICS:
+                    if attr in app:
+                        self.gauge('marathon.' + attr, app[attr], tags=tags)
 
-		response = self.get_json(urljoin(url, "v2/deployments"), timeout, auth)
-		if response is not None:
-			self.gauge('marathon.deployments', len(response), tags=instance_tags)
+        response = self.get_json(urljoin(url, "v2/deployments"), timeout, auth)
+        if response is not None:
+            self.gauge('marathon.deployments', len(response), tags=instance_tags)
 
-	def get_json(self, url, timeout, auth):
-		try:
-			r = requests.get(url, timeout=timeout, auth=auth)
-			r.raise_for_status()
-		except requests.exceptions.Timeout:
-			# If there's a timeout
-			self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-				message='%s timed out after %s seconds.' % (url, timeout),
-				tags = ["url:{0}".format(url)])
-			raise Exception("Timeout when hitting %s" % url)
+    def get_json(self, url, timeout, auth):
+        try:
+            r = requests.get(url, timeout=timeout, auth=auth)
+            r.raise_for_status()
+        except requests.exceptions.Timeout:
+            # If there's a timeout
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
+                message='%s timed out after %s seconds.' % (url, timeout),
+                tags = ["url:{0}".format(url)])
+            raise Exception("Timeout when hitting %s" % url)
 
-		except requests.exceptions.HTTPError:
-			self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-				message='%s returned a status of %s' % (url, r.status_code),
-				tags = ["url:{0}".format(url)])
-			raise Exception("Got %s when hitting %s" % (r.status_code, url))
+        except requests.exceptions.HTTPError:
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
+                message='%s returned a status of %s' % (url, r.status_code),
+                tags = ["url:{0}".format(url)])
+            raise Exception("Got %s when hitting %s" % (r.status_code, url))
 
-		else:
-			self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
-				tags = ["url:{0}".format(url)]
-			)
+        else:
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
+                tags = ["url:{0}".format(url)]
+            )
 
-		return r.json()
+        return r.json()

--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -43,6 +43,7 @@ class Marathon(AgentCheck):
             auth = (user,password)
         else:
             auth = None
+
         instance_tags = instance.get('tags', [])
         default_timeout = self.init_config.get('default_timeout', self.DEFAULT_TIMEOUT)
         timeout = float(instance.get('timeout', default_timeout))
@@ -56,9 +57,10 @@ class Marathon(AgentCheck):
                     if attr in app:
                         self.gauge('marathon.' + attr, app[attr], tags=tags)
 
-        response = self.get_json(urljoin(url, "v2/deployments"), timeout, auth)
-        if response is not None:
-            self.gauge('marathon.deployments', len(response), tags=instance_tags)
+        if instance.get('enable_deployment_metrics', False):
+            response = self.get_json(urljoin(url, "v2/deployments"), timeout, auth)
+            if response is not None:
+                self.gauge('marathon.deployments', len(response), tags=instance_tags)
 
     def get_json(self, url, timeout, auth):
         try:

--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -56,6 +56,10 @@ class Marathon(AgentCheck):
                     if attr in app:
                         self.gauge('marathon.' + attr, app[attr], tags=tags)
 
+        response = self.get_json(urljoin(url, "v2/deployments"), timeout, auth)
+        if response is not None:
+            self.gauge('marathon.deployments', len(response), tags=instance_tags)
+
     def get_json(self, url, timeout, auth):
         try:
             r = requests.get(url, timeout=timeout, auth=auth)

--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -16,70 +16,70 @@ from checks import AgentCheck
 
 class Marathon(AgentCheck):
 
-    DEFAULT_TIMEOUT = 5
-    SERVICE_CHECK_NAME = 'marathon.can_connect'
+	DEFAULT_TIMEOUT = 5
+	SERVICE_CHECK_NAME = 'marathon.can_connect'
 
-    APP_METRICS = [
-        'backoffFactor',
-        'backoffSeconds',
-        'cpus',
-        'disk',
-        'instances',
-        'mem',
-        'taskRateLimit',
-        'tasksRunning',
-        'tasksStaged'
-    ]
+	APP_METRICS = [
+		'backoffFactor',
+		'backoffSeconds',
+		'cpus',
+		'disk',
+		'instances',
+		'mem',
+		'taskRateLimit',
+		'tasksRunning',
+		'tasksStaged'
+	]
 
-    def check(self, instance):
-        if 'url' not in instance:
-            raise Exception('Marathon instance missing "url" value.')
+	def check(self, instance):
+		if 'url' not in instance:
+			raise Exception('Marathon instance missing "url" value.')
 
-        # Load values from the instance config
-        url = instance['url']
-        user = instance.get('user')
-        password = instance.get('password')
-        if user is not None and password is not None:
-            auth = (user,password)
-        else:
-            auth = None
-        instance_tags = instance.get('tags', [])
-        default_timeout = self.init_config.get('default_timeout', self.DEFAULT_TIMEOUT)
-        timeout = float(instance.get('timeout', default_timeout))
+		# Load values from the instance config
+		url = instance['url']
+		user = instance.get('user')
+		password = instance.get('password')
+		if user is not None and password is not None:
+			auth = (user,password)
+		else:
+			auth = None
+		instance_tags = instance.get('tags', [])
+		default_timeout = self.init_config.get('default_timeout', self.DEFAULT_TIMEOUT)
+		timeout = float(instance.get('timeout', default_timeout))
 
-        response = self.get_json(urljoin(url, "v2/apps"), timeout, auth)
-        if response is not None:
-            self.gauge('marathon.apps', len(response['apps']), tags=instance_tags)
-            for app in response['apps']:
-                tags = ['app_id:' + app['id'], 'version:' + app['version']] + instance_tags
-                for attr in self.APP_METRICS:
-                    if attr in app:
-                        self.gauge('marathon.' + attr, app[attr], tags=tags)
+		response = self.get_json(urljoin(url, "v2/apps"), timeout, auth)
+		if response is not None:
+			self.gauge('marathon.apps', len(response['apps']), tags=instance_tags)
+			for app in response['apps']:
+				tags = ['app_id:' + app['id'], 'version:' + app['version']] + instance_tags
+				for attr in self.APP_METRICS:
+					if attr in app:
+						self.gauge('marathon.' + attr, app[attr], tags=tags)
 
-        response = self.get_json(urljoin(url, "v2/deployments"), timeout, auth)
-        if response is not None:
-            self.gauge('marathon.deployments', len(response), tags=instance_tags)
+		response = self.get_json(urljoin(url, "v2/deployments"), timeout, auth)
+		if response is not None:
+			self.gauge('marathon.deployments', len(response), tags=instance_tags)
 
-    def get_json(self, url, timeout, auth):
-        try:
-            r = requests.get(url, timeout=timeout, auth=auth)
-            r.raise_for_status()
-        except requests.exceptions.Timeout:
-            # If there's a timeout
-            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                message='%s timed out after %s seconds.' % (url, timeout),
-                tags = ["url:{0}".format(url)])
-            raise Exception("Timeout when hitting %s" % url)
+	def get_json(self, url, timeout, auth):
+		try:
+			r = requests.get(url, timeout=timeout, auth=auth)
+			r.raise_for_status()
+		except requests.exceptions.Timeout:
+			# If there's a timeout
+			self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
+				message='%s timed out after %s seconds.' % (url, timeout),
+				tags = ["url:{0}".format(url)])
+			raise Exception("Timeout when hitting %s" % url)
 
-        except requests.exceptions.HTTPError:
-            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                message='%s returned a status of %s' % (url, r.status_code),
-                tags = ["url:{0}".format(url)])
-            raise Exception("Got %s when hitting %s" % (r.status_code, url))
+		except requests.exceptions.HTTPError:
+			self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
+				message='%s returned a status of %s' % (url, r.status_code),
+				tags = ["url:{0}".format(url)])
+			raise Exception("Got %s when hitting %s" % (r.status_code, url))
 
-        else:
-            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
-                tags = ["url:{0}".format(url)]
-            )
+		else:
+			self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
+				tags = ["url:{0}".format(url)]
+			)
 
-        return r.json()
+		return r.json()

--- a/conf.d/marathon.yaml.example
+++ b/conf.d/marathon.yaml.example
@@ -9,3 +9,4 @@ instances:
   #   if marathon is protected by basic auth
   #   user: "username"
   #   password: "password"
+  #   enable_deployment_metrics: #Optional. Set to true if you want to receive send deployment related metrics. Adds an extra API call to Marathon.

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -133,7 +133,7 @@ class Fixtures(object):
 
     @staticmethod
     def read_json_file(file_name, string_escape=True):
-			return json.loads(Fixtures.read_file(file_name, string_escape=string_escape))
+        return json.loads(Fixtures.read_file(file_name, string_escape=string_escape))
 
 class AgentCheckTest(unittest.TestCase):
     DEFAULT_AGENT_CONFIG = {

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -14,6 +14,7 @@ import sys
 import time
 import traceback
 import unittest
+import json
 
 # project
 from checks import AgentCheck
@@ -130,6 +131,9 @@ class Fixtures(object):
                 contents = contents.decode('string-escape')
             return contents.decode("utf-8")
 
+    @staticmethod
+    def read_json_file(file_name, string_escape=True):
+			return json.loads(Fixtures.read_file(file_name, string_escape=string_escape))
 
 class AgentCheckTest(unittest.TestCase):
     DEFAULT_AGENT_CONFIG = {

--- a/tests/checks/fixtures/marathon/apps.json
+++ b/tests/checks/fixtures/marathon/apps.json
@@ -1,0 +1,88 @@
+{
+  "apps": [
+    {
+      "id": "/my-app",
+      "cmd": "/usr/bin/run-app",
+      "args": null,
+      "user": null,
+      "env": {
+        "ENVIRONMENT": "development"
+      },
+      "instances": 10,
+      "cpus": 1.0,
+      "mem": 512,
+      "disk": 0,
+      "executor": "",
+      "constraints": [],
+      "ports": [
+        10002
+      ],
+      "portDefinitions": [
+        {
+          "port": 10002,
+          "protocol": "tcp",
+          "labels": {}
+        }
+      ],
+      "requirePorts": false,
+      "backoffSeconds": 1,
+      "backoffFactor": 1.15,
+      "maxLaunchDelaySeconds": 3600,
+      "container": {
+        "type": "DOCKER",
+        "volumes": [],
+        "docker": {
+          "image": "my-org/my-image:latest",
+          "network": "BRIDGE",
+          "portMappings": [
+            {
+              "containerPort": 80,
+              "hostPort": 0,
+              "servicePort": 10002,
+              "protocol": "tcp",
+              "labels": {}
+            }
+          ],
+          "privileged": false,
+          "parameters": [],
+          "forcePullImage": true
+        }
+      },
+      "healthChecks": [
+        {
+          "path": "/health",
+          "protocol": "HTTP",
+          "portIndex": 0,
+          "gracePeriodSeconds": 5,
+          "intervalSeconds": 10,
+          "timeoutSeconds": 20,
+          "maxConsecutiveFailures": 3,
+          "ignoreHttp1xx": false
+        }
+      ],
+      "readinessChecks": [],
+      "dependencies": [],
+      "upgradeStrategy": {
+        "minimumHealthCapacity": 0.5,
+        "maximumOverCapacity": 0.5
+      },
+      "labels": {
+        "HAPROXY_0_VHOST": "my-app.my-org.net",
+        "HAPROXY_GROUP": "my-app"
+      },
+      "acceptedResourceRoles": null,
+      "ipAddress": null,
+      "version": "2016-08-25T18:13:34.079Z",
+      "residency": null,
+      "versionInfo": {
+        "lastScalingAt": "2016-08-25T18:13:34.079Z",
+        "lastConfigChangeAt": "2016-08-25T16:58:48.416Z"
+      },
+      "tasksStaged": 5,
+      "tasksRunning": 10,
+      "tasksHealthy": 5,
+      "tasksUnhealthy": 0,
+      "deployments": []
+    }
+  ]
+}

--- a/tests/checks/fixtures/marathon/deployments.json
+++ b/tests/checks/fixtures/marathon/deployments.json
@@ -1,88 +1,87 @@
 [
-    {
-        "affectedApps": [
-            "/test/service/srv1",
-            "/test/db/mongo1",
-            "/test/frontend/app1"
-        ],
-        "currentStep": 2,
-        "currentActions": [
+  {
+    "affectedApps": [
+      "/test/service/srv1",
+      "/test/db/mongo1",
+      "/test/frontend/app1"
+    ],
+    "currentStep": 2,
+    "currentActions": [
+      {
+        "action": "RestartApplication",
+        "app": "/test/frontend/app1",
+        "readinessChecks": [
           {
-              "action": "RestartApplication",
-              "app": "/test/frontend/app1",
-              "readinessChecks": [
-                  {
-                      "lastResponse": {
-                          "body": "{}",
-                          "contentType": "application/json",
-                          "status": 500
-                      },
-                      "name": "myReadyCheck",
-                      "ready": false,
-                      "taskId": "test_frontend_app1.c9de6033"
-                  }
-              ]
-
+            "lastResponse": {
+              "body": "{}",
+              "contentType": "application/json",
+              "status": 500
+            },
+            "name": "myReadyCheck",
+            "ready": false,
+            "taskId": "test_frontend_app1.c9de6033"
           }
-        ],
-        "totalSteps": 9,
-        "id": "2e72dbf1-2b2a-4204-b628-e8bd160945dd",
-        "steps": [
-            [
-                {
-                    "action": "RestartApplication",
-                    "app": "/test/service/srv1"
-                }
-            ],
-            [
-                {
-                    "action": "RestartApplication",
-                    "app": "/test/db/mongo1"
-                }
-            ],
-            [
-                {
-                    "action": "RestartApplication",
-                    "app": "/test/frontend/app1"
-                }
-            ],
-            [
-                {
-                    "action": "KillAllOldTasksOf",
-                    "app": "/test/frontend/app1"
-                }
-            ],
-            [
-                {
-                    "action": "KillAllOldTasksOf",
-                    "app": "/test/db/mongo1"
-                }
-            ],
-            [
-                {
-                    "action": "KillAllOldTasksOf",
-                    "app": "/test/service/srv1"
-                }
-            ],
-            [
-                {
-                    "action": "ScaleApplication",
-                    "app": "/test/service/srv1"
-                }
-            ],
-            [
-                {
-                    "action": "ScaleApplication",
-                    "app": "/test/db/mongo1"
-                }
-            ],
-            [
-                {
-                    "action": "ScaleApplication",
-                    "app": "/test/frontend/app1"
-                }
-            ]
-        ],
-        "version": "2014-07-09T11:14:11.477Z"
-    }
+        ]
+      }
+    ],
+    "totalSteps": 9,
+    "id": "2e72dbf1-2b2a-4204-b628-e8bd160945dd",
+    "steps": [
+      [
+        {
+          "action": "RestartApplication",
+          "app": "/test/service/srv1"
+        }
+      ],
+      [
+        {
+          "action": "RestartApplication",
+          "app": "/test/db/mongo1"
+        }
+      ],
+      [
+        {
+          "action": "RestartApplication",
+          "app": "/test/frontend/app1"
+        }
+      ],
+      [
+        {
+          "action": "KillAllOldTasksOf",
+          "app": "/test/frontend/app1"
+        }
+      ],
+      [
+        {
+          "action": "KillAllOldTasksOf",
+          "app": "/test/db/mongo1"
+        }
+      ],
+      [
+        {
+          "action": "KillAllOldTasksOf",
+          "app": "/test/service/srv1"
+        }
+      ],
+      [
+        {
+          "action": "ScaleApplication",
+          "app": "/test/service/srv1"
+        }
+      ],
+      [
+        {
+          "action": "ScaleApplication",
+          "app": "/test/db/mongo1"
+        }
+      ],
+      [
+        {
+          "action": "ScaleApplication",
+          "app": "/test/frontend/app1"
+        }
+      ]
+    ],
+    "version": "2014-07-09T11:14:11.477Z"
+  }
 ]

--- a/tests/checks/fixtures/marathon/deployments.json
+++ b/tests/checks/fixtures/marathon/deployments.json
@@ -1,0 +1,88 @@
+[
+    {
+        "affectedApps": [
+            "/test/service/srv1",
+            "/test/db/mongo1",
+            "/test/frontend/app1"
+        ],
+        "currentStep": 2,
+        "currentActions": [
+          {
+              "action": "RestartApplication",
+              "app": "/test/frontend/app1",
+              "readinessChecks": [
+                  {
+                      "lastResponse": {
+                          "body": "{}",
+                          "contentType": "application/json",
+                          "status": 500
+                      },
+                      "name": "myReadyCheck",
+                      "ready": false,
+                      "taskId": "test_frontend_app1.c9de6033"
+                  }
+              ]
+
+          }
+        ],
+        "totalSteps": 9,
+        "id": "2e72dbf1-2b2a-4204-b628-e8bd160945dd",
+        "steps": [
+            [
+                {
+                    "action": "RestartApplication",
+                    "app": "/test/service/srv1"
+                }
+            ],
+            [
+                {
+                    "action": "RestartApplication",
+                    "app": "/test/db/mongo1"
+                }
+            ],
+            [
+                {
+                    "action": "RestartApplication",
+                    "app": "/test/frontend/app1"
+                }
+            ],
+            [
+                {
+                    "action": "KillAllOldTasksOf",
+                    "app": "/test/frontend/app1"
+                }
+            ],
+            [
+                {
+                    "action": "KillAllOldTasksOf",
+                    "app": "/test/db/mongo1"
+                }
+            ],
+            [
+                {
+                    "action": "KillAllOldTasksOf",
+                    "app": "/test/service/srv1"
+                }
+            ],
+            [
+                {
+                    "action": "ScaleApplication",
+                    "app": "/test/service/srv1"
+                }
+            ],
+            [
+                {
+                    "action": "ScaleApplication",
+                    "app": "/test/db/mongo1"
+                }
+            ],
+            [
+                {
+                    "action": "ScaleApplication",
+                    "app": "/test/frontend/app1"
+                }
+            ]
+        ],
+        "version": "2014-07-09T11:14:11.477Z"
+    }
+]

--- a/tests/checks/mock/test_marathon.py
+++ b/tests/checks/mock/test_marathon.py
@@ -10,14 +10,14 @@ from tests.checks.common import load_check, AgentCheckTest
 from tests.checks.common import Fixtures
 
 CONFIG = {
-    'init_config': {
-			'default_timeout': 5
-		},
-    'instances': [
-        {
-						'url': 'http://localhost:8080'
-        }
-    ]
+	'init_config': {
+	   'default_timeout': 5
+	},
+	'instances': [
+		{
+		      'url': 'http://localhost:8080'
+		}
+	]
 }
 
 class MarathonCheckTest(AgentCheckTest):

--- a/tests/checks/mock/test_marathon.py
+++ b/tests/checks/mock/test_marathon.py
@@ -1,0 +1,69 @@
+# stdlib
+import unittest
+from types import ListType
+
+# 3p
+from mock import patch, MagicMock
+
+# project
+from tests.checks.common import load_check, AgentCheckTest
+from tests.checks.common import Fixtures
+
+CONFIG = {
+    'init_config': {
+			'default_timeout': 5
+		},
+    'instances': [
+        {
+						'url': 'http://localhost:8080'
+        }
+    ]
+}
+
+class MarathonCheckTest(AgentCheckTest):
+	CHECK_NAME = 'marathon'
+
+	def test_empty_responses(self):
+		def side_effect(url, timeout, auth):
+			m = MagicMock()
+
+			if "v2/apps" in url:
+				return {"apps": []}
+			elif "v2/deployments" in url:
+				return []
+			else:
+				raise Exception("unknown url:" + url)
+
+		self.run_check(CONFIG, mocks={"get_json": side_effect})
+		self.assertMetric('marathon.apps', value=0)
+		self.assertMetric('marathon.deployments', value=0)
+
+	def test_has_apps(self):
+		def side_effect(url, timeout, auth):
+			m = MagicMock()
+
+			if "v2/apps" in url:
+				return Fixtures.read_json_file("apps.json")
+			elif "v2/deployments" in url:
+				return []
+			else:
+				raise Exception("unknown url:" + url)
+
+		self.run_check(CONFIG, mocks={"get_json": side_effect})
+		self.assertMetric('marathon.apps', value=1)
+		self.assertMetric('marathon.deployments', value=0)
+
+	def test_has_deployments(self):
+		def side_effect(url, timeout, auth):
+			m = MagicMock()
+
+			if "v2/apps" in url:
+				return Fixtures.read_json_file("apps.json")
+			elif "v2/deployments" in url:
+				return Fixtures.read_json_file("deployments.json")
+			else:
+				raise Exception("unknown url:" + url)
+
+		self.run_check(CONFIG, mocks={"get_json": side_effect})
+		self.assertMetric('marathon.apps', value=1)
+		self.assertMetric('marathon.deployments', value=1)

--- a/tests/checks/mock/test_marathon.py
+++ b/tests/checks/mock/test_marathon.py
@@ -1,69 +1,56 @@
-# stdlib
-import unittest
-from types import ListType
-
-# 3p
-from mock import patch, MagicMock
-
 # project
-from tests.checks.common import load_check, AgentCheckTest
+from tests.checks.common import AgentCheckTest
 from tests.checks.common import Fixtures
 
 CONFIG = {
-	'init_config': {
-	   'default_timeout': 5
-	},
-	'instances': [
-		{
-		      'url': 'http://localhost:8080'
-		}
-	]
+    'init_config': {
+        'default_timeout': 5
+    },
+    'instances': [
+        {
+            'url': 'http://localhost:8080'
+        }
+    ]
 }
 
 class MarathonCheckTest(AgentCheckTest):
-	CHECK_NAME = 'marathon'
+    CHECK_NAME = 'marathon'
 
-	def test_empty_responses(self):
-		def side_effect(url, timeout, auth):
-			m = MagicMock()
+    def test_empty_responses(self):
+        def side_effect(url, timeout, auth):
+            if "v2/apps" in url:
+                return {"apps": []}
+            elif "v2/deployments" in url:
+                return []
+            else:
+                raise Exception("unknown url:" + url)
 
-			if "v2/apps" in url:
-				return {"apps": []}
-			elif "v2/deployments" in url:
-				return []
-			else:
-				raise Exception("unknown url:" + url)
+        self.run_check(CONFIG, mocks={"get_json": side_effect})
+        self.assertMetric('marathon.apps', value=0)
+        self.assertMetric('marathon.deployments', value=0)
 
-		self.run_check(CONFIG, mocks={"get_json": side_effect})
-		self.assertMetric('marathon.apps', value=0)
-		self.assertMetric('marathon.deployments', value=0)
+    def test_has_apps(self):
+        def side_effect(url, timeout, auth):
+            if "v2/apps" in url:
+                return Fixtures.read_json_file("apps.json")
+            elif "v2/deployments" in url:
+                return []
+            else:
+                raise Exception("unknown url:" + url)
 
-	def test_has_apps(self):
-		def side_effect(url, timeout, auth):
-			m = MagicMock()
+        self.run_check(CONFIG, mocks={"get_json": side_effect})
+        self.assertMetric('marathon.apps', value=1)
+        self.assertMetric('marathon.deployments', value=0)
 
-			if "v2/apps" in url:
-				return Fixtures.read_json_file("apps.json")
-			elif "v2/deployments" in url:
-				return []
-			else:
-				raise Exception("unknown url:" + url)
+    def test_has_deployments(self):
+        def side_effect(url, timeout, auth):
+            if "v2/apps" in url:
+                return Fixtures.read_json_file("apps.json")
+            elif "v2/deployments" in url:
+                return Fixtures.read_json_file("deployments.json")
+            else:
+                raise Exception("unknown url:" + url)
 
-		self.run_check(CONFIG, mocks={"get_json": side_effect})
-		self.assertMetric('marathon.apps', value=1)
-		self.assertMetric('marathon.deployments', value=0)
-
-	def test_has_deployments(self):
-		def side_effect(url, timeout, auth):
-			m = MagicMock()
-
-			if "v2/apps" in url:
-				return Fixtures.read_json_file("apps.json")
-			elif "v2/deployments" in url:
-				return Fixtures.read_json_file("deployments.json")
-			else:
-				raise Exception("unknown url:" + url)
-
-		self.run_check(CONFIG, mocks={"get_json": side_effect})
-		self.assertMetric('marathon.apps', value=1)
-		self.assertMetric('marathon.deployments', value=1)
+        self.run_check(CONFIG, mocks={"get_json": side_effect})
+        self.assertMetric('marathon.apps', value=1)
+        self.assertMetric('marathon.deployments', value=1)


### PR DESCRIPTION
### What does this PR do?

Adds a new metric for to Marathon checks to count the number of deployments that are pending.

### Motivation

Basically, we'd like to track when that number stays high (e.g. > 1) so that we can alert on stuck deployments.

### Testing Guidelines

~~An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.~~

Added some tests, there was no real coverage for this guy.

### Additional Notes

I added a new helper method for loading a JSON fixture. I'm happy to pull that out, though, as it feels like it's extending this a little much.

