### PR TITLE
[ci] do not run integration tests if not relevant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,8 +103,6 @@ script:
   # Needed if no cache exists
   - mkdir -p $INTEGRATIONS_DIR
   - ls -al $INTEGRATIONS_DIR
-  - rm -rf /home/travis/virtualenv/python$TRAVIS_PYTHON_VERSION.9/lib/python$TRAVIS_PYTHON_VERSION/site-packages/pip-6.0.7.dist-info
-  - rm -rf /home/travis/virtualenv/python$TRAVIS_PYTHON_VERSION.9/lib/python$TRAVIS_PYTHON_VERSION/site-packages/setuptools-12.0.5.dist-info
   - 'rake ci:run'
   - ls -al $INTEGRATIONS_DIR
 


### PR DESCRIPTION
### What does this PR do?

This PR tries to avoid running a integration test for an agent check (and
only this, core integration tests, linter and core mocked tests are
always run) when it is not required.

To do this, we first lists all modified files, and then
- check if a check file was modified (in `checks.d`)
- check if a check test file was modified
- ignore fixtures and configuration

If any file other than the one listed above are modified, all tests will
be run. Otherwise, a list of modfied checks is built, and only these
tests will be run (with the core tests).

### Motivation

Faster Travis.