### PR TITLE
Make sure the filter gets updated with the last timestamp on each

### DIFF
--- a/checks.d/win32_event_log.py
+++ b/checks.d/win32_event_log.py
@@ -120,6 +120,7 @@ class Win32EventLogWMI(WinWMICheck):
             and_props=['Message']
         )
 
+        wmi_sampler.reset_filter(new_filters=filters)
         try:
             wmi_sampler.sample()
         except TimeoutException:

--- a/checks/libs/wmi/sampler.py
+++ b/checks/libs/wmi/sampler.py
@@ -193,6 +193,11 @@ class WMISampler(object):
             self._formatted_filters = self._format_filter(filters, self._and_props)
         return self._formatted_filters
 
+    def reset_filter(self, new_filters):
+        self.filters = new_filters
+        # get rid of the formatted filters so they'll be recalculated
+        self._formatted_filters = None
+
     def sample(self):
         """
         Compute new samples.


### PR DESCRIPTION
What does this PR do?

PR fixes a customer problem whereby the CPU consumed by the Win32 event log check would increase linearly with time.

Motivation

Customer request

Testing Guidelines

An overview on testing
is available in our contribution guidelines.

Additional Notes

Reset WMI query filters before each run. Otherwise, all checks are done relative to when the agent was started, resulting in an ever-growing list of events to be parsed.

The WMI filter was attached to the (cached) sampler object. So, even though the filter was recomputed each time with a new "TimeGenerated >= " string, that was never actually used by the WMI query. So, each successive query returned any new entries, PLUS any entries that had already been retrieved. Processing the list then had a linearly increasing time (and space). Compounding it is the check to make sure the duplicate entries aren't reported, which then caused the (ever growing) list to be parsed again.