### PR TITLE
[core] avoid calls to service discovery from dogstatsd

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -18,6 +18,7 @@ from utils.dockerutil import DockerUtil, MountException
 from utils.kubeutil import KubeUtil
 from utils.platform import Platform
 from utils.service_discovery.sd_backend import get_sd_backend
+from utils.service_discovery.config_stores import get_config_store
 
 
 EVENT_TYPE = 'docker'
@@ -154,10 +155,12 @@ class DockerDaemon(AgentCheck):
         try:
             instance = self.instances[0]
 
-            # if service discovery is enabled dockerutil will need a reference
-            # to the config store. We need to pass it agentConfig for that
+            # if service discovery is enabled dockerutil will need a reference to the config store
             if self._service_discovery:
-                self.docker_util = DockerUtil(agentConfig=self.agentConfig)
+                self.docker_util = DockerUtil(
+                    agentConfig=self.agentConfig,
+                    config_store=get_config_store(self.agentConfig)
+                )
             else:
                 self.docker_util = DockerUtil()
             self.docker_client = self.docker_util.client

--- a/util.py
+++ b/util.py
@@ -203,8 +203,8 @@ def get_hostname(config=None):
                 return gce_hostname
 
     # Try to get the docker hostname
-    docker_util = DockerUtil(agentConfig=config)
-    if hostname is None and docker_util.is_dockerized():
+    if hostname is None and DockerUtil.is_dockerized():
+        docker_util = DockerUtil(agentConfig=config)
         docker_hostname = docker_util.get_hostname()
         if docker_hostname is not None and is_valid_hostname(docker_hostname):
             hostname = docker_hostname


### PR DESCRIPTION
### What does this PR do?

Dogstatsd calls util.get_hostname that in turn was making calls to service discovery related code. This PR remove this behavior.

### Motivation

Although it was just calling the constructor of the config store class as a side effect, it's better to keep things separated.

### Testing Guidelines

We should make sure the hostname is still resolved the same way to avoid breaking things. This was tested locally with and without docker and the results are satisfying.

### Additional Notes

🙈 