### PR TITLE
add system.processes.mem.pct metric to process check

### DIFF
--- a/checks.d/process.py
+++ b/checks.d/process.py
@@ -34,7 +34,8 @@ ATTR_TO_METRIC = {
     'w_bytes':          'iowrite_bytes',  # FIXME: namespace me correctly (6.x) io.w_bytes
     'ctx_swtch_vol':    'voluntary_ctx_switches',  # FIXME: namespace me correctly (6.x), ctx_swt.voluntary
     'ctx_swtch_invol':  'involuntary_ctx_switches',  # FIXME: namespace me correctly (6.x), ctx_swt.involuntary
-    'run_time':         'run_time'
+    'run_time':         'run_time',
+    'mem_pct':          'mem.pct'
 }
 
 ATTR_TO_METRIC_RATE = {
@@ -222,6 +223,9 @@ class ProcessCheck(AgentCheck):
             meminfo = self.psutil_wrapper(p, 'memory_info', ['rss', 'vms'])
             st['rss'].append(meminfo.get('rss'))
             st['vms'].append(meminfo.get('vms'))
+
+            mem_percent = self.psutil_wrapper(p, 'memory_percent', None)
+            st['mem_pct'].append(mem_percent)
 
             # will fail on win32 and solaris
             shared_mem = self.psutil_wrapper(p, 'memory_info_ex', ['shared']).get('shared')

--- a/tests/checks/integration/test_process.py
+++ b/tests/checks/integration/test_process.py
@@ -134,6 +134,7 @@ class ProcessCheckTest(AgentCheckTest):
         'system.processes.ioread_count',
         'system.processes.iowrite_bytes',
         'system.processes.iowrite_count',
+        'system.processes.mem.pct',
         'system.processes.mem.real',
         'system.processes.mem.rss',
         'system.processes.mem.vms',


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Adds `system.processes.mem.pct `metric to the agent process check

### Motivation

Requested here: https://trello.com/c/H1Tz2Ksd/2103-process-check-metric-for-memory-usage-as-percentage

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes



