### PR TITLE
[ceph] updated integration for compatibility with v10.2.2

### DIFF
--- a/tests/checks/fixtures/ceph/ceph_10.2.2.json
+++ b/tests/checks/fixtures/ceph/ceph_10.2.2.json
@@ -1,0 +1,388 @@
+{
+  "status": {
+    "election_epoch": 6,
+    "quorum": [
+      0,
+      1,
+      2
+    ],
+    "monmap": {
+      "epoch": 3,
+      "mons": [
+        {
+          "name": "ceph-admin",
+          "rank": 0,
+          "addr": "67.205.136.159:6789/0"
+        },
+        {
+          "name": "ceph-1",
+          "rank": 1,
+          "addr": "67.205.143.18:6789/0"
+        },
+        {
+          "name": "ceph-0",
+          "rank": 2,
+          "addr": "198.199.70.240:6789/0"
+        }
+      ],
+      "modified": "2016-08-29 13:54:46.945359",
+      "fsid": "e0efcf84-e8ed-4916-8ce1-9c70242d390a",
+      "created": "2016-08-28 21:14:41.698200"
+    },
+    "health": {
+      "detail": [],
+      "timechecks": {
+        "round_status": "finished",
+        "epoch": 6,
+        "round": 748,
+        "mons": [
+          {
+            "latency": 0.0,
+            "skew": 0.0,
+            "health": "HEALTH_OK",
+            "name": "ceph-admin"
+          },
+          {
+            "latency": 0.001112,
+            "skew": -0.00009,
+            "health": "HEALTH_OK",
+            "name": "ceph-1"
+          },
+          {
+            "latency": 0.00112,
+            "skew": 0.001728,
+            "health": "HEALTH_OK",
+            "name": "ceph-0"
+          }
+        ]
+      },
+      "health": {
+        "health_services": [
+          {
+            "mons": [
+              {
+                "last_updated": "2016-08-30 20:45:42.539499",
+                "name": "ceph-admin",
+                "avail_percent": 91,
+                "kb_total": 61798120,
+                "kb_avail": 56275036,
+                "health": "HEALTH_OK",
+                "kb_used": 2789532,
+                "store_stats": {
+                  "bytes_total": 20016367,
+                  "bytes_log": 3950816,
+                  "last_updated": "0.000000",
+                  "bytes_misc": 16065551,
+                  "bytes_sst": 0
+                }
+              },
+              {
+                "last_updated": "2016-08-30 20:45:47.287420",
+                "name": "ceph-1",
+                "avail_percent": 90,
+                "kb_total": 41159648,
+                "kb_avail": 37241396,
+                "health": "HEALTH_OK",
+                "kb_used": 1804876,
+                "store_stats": {
+                  "bytes_total": 24211216,
+                  "bytes_log": 6225920,
+                  "last_updated": "0.000000",
+                  "bytes_misc": 196624,
+                  "bytes_sst": 17788672
+                }
+              },
+              {
+                "last_updated": "2016-08-30 20:46:37.549784",
+                "name": "ceph-0",
+                "avail_percent": 90,
+                "kb_total": 41159648,
+                "kb_avail": 37234424,
+                "health": "HEALTH_OK",
+                "kb_used": 1811848,
+                "store_stats": {
+                  "bytes_total": 25259265,
+                  "bytes_log": 7274496,
+                  "last_updated": "0.000000",
+                  "bytes_misc": 196624,
+                  "bytes_sst": 17788145
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "overall_status": "HEALTH_ERR",
+      "summary": [
+        {
+          "severity": "HEALTH_ERR",
+          "summary": "1 full osd(s)"
+        },
+        {
+          "severity": "HEALTH_WARN",
+          "summary": "1 near full osd(s)"
+        }
+      ]
+    },
+    "pgmap": {
+      "bytes_total": 96589578240,
+      "num_pgs": 164,
+      "data_bytes": 36066820144,
+      "bytes_used": 88428388352,
+      "version": 1553,
+      "pgs_by_state": [
+        {
+          "count": 164,
+          "state_name": "active+clean"
+        }
+      ],
+      "bytes_avail": 8161189888
+    },
+    "quorum_names": [
+      "ceph-admin",
+      "ceph-1",
+      "ceph-0"
+    ],
+    "fsmap": {
+      "epoch": 1,
+      "by_rank": []
+    },
+    "osdmap": {
+      "osdmap": {
+        "full": true,
+        "nearfull": false,
+        "num_osds": 3,
+        "num_up_osds": 3,
+        "epoch": 18,
+        "num_in_osds": 3,
+        "num_remapped_pgs": 0
+      }
+    },
+    "fsid": "e0efcf84-e8ed-4916-8ce1-9c70242d390a"
+  },
+  "osd_perf": {
+    "osd_perf_infos": [
+      {
+        "id": 2,
+        "perf_stats": {
+          "apply_latency_ms": 136,
+          "commit_latency_ms": 89
+        }
+      },
+      {
+        "id": 1,
+        "perf_stats": {
+          "apply_latency_ms": 132,
+          "commit_latency_ms": 80
+        }
+      },
+      {
+        "id": 0,
+        "perf_stats": {
+          "apply_latency_ms": 111,
+          "commit_latency_ms": 62
+        }
+      }
+    ]
+  },
+  "health_detail": {
+    "detail": [
+      "osd.2 is full at 95%",
+      "osd.1 is near full at 94%"
+    ],
+    "timechecks": {
+      "round_status": "finished",
+      "epoch": 6,
+      "round": 748,
+      "mons": [
+        {
+          "latency": 0.0,
+          "skew": 0.0,
+          "health": "HEALTH_OK",
+          "name": "ceph-admin"
+        },
+        {
+          "latency": 0.001112,
+          "skew": -0.00009,
+          "health": "HEALTH_OK",
+          "name": "ceph-1"
+        },
+        {
+          "latency": 0.00112,
+          "skew": 0.001728,
+          "health": "HEALTH_OK",
+          "name": "ceph-0"
+        }
+      ]
+    },
+    "health": {
+      "health_services": [
+        {
+          "mons": [
+            {
+              "last_updated": "2016-08-30 20:45:42.539499",
+              "name": "ceph-admin",
+              "avail_percent": 91,
+              "kb_total": 61798120,
+              "kb_avail": 56275036,
+              "health": "HEALTH_OK",
+              "kb_used": 2789532,
+              "store_stats": {
+                "bytes_total": 20016367,
+                "bytes_log": 3950816,
+                "last_updated": "0.000000",
+                "bytes_misc": 16065551,
+                "bytes_sst": 0
+              }
+            },
+            {
+              "last_updated": "2016-08-30 20:45:47.287420",
+              "name": "ceph-1",
+              "avail_percent": 90,
+              "kb_total": 41159648,
+              "kb_avail": 37241396,
+              "health": "HEALTH_OK",
+              "kb_used": 1804876,
+              "store_stats": {
+                "bytes_total": 24211216,
+                "bytes_log": 6225920,
+                "last_updated": "0.000000",
+                "bytes_misc": 196624,
+                "bytes_sst": 17788672
+              }
+            },
+            {
+              "last_updated": "2016-08-30 20:46:37.549784",
+              "name": "ceph-0",
+              "avail_percent": 90,
+              "kb_total": 41159648,
+              "kb_avail": 37234424,
+              "health": "HEALTH_OK",
+              "kb_used": 1811848,
+              "store_stats": {
+                "bytes_total": 25259265,
+                "bytes_log": 7274496,
+                "last_updated": "0.000000",
+                "bytes_misc": 196624,
+                "bytes_sst": 17788145
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "overall_status": "HEALTH_ERR",
+    "summary": [
+      {
+        "severity": "HEALTH_ERR",
+        "summary": "1 full osd(s)"
+      },
+      {
+        "severity": "HEALTH_WARN",
+        "summary": "1 near full osd(s)"
+      }
+    ]
+  },
+  "osd_pool_stats": [
+    {
+      "pool_name": "rbd",
+      "recovery_rate": {},
+      "pool_id": 0,
+      "client_io_rate": {},
+      "recovery": {}
+    },
+    {
+      "pool_name": "scbench",
+      "recovery_rate": {},
+      "pool_id": 1,
+      "client_io_rate": {},
+      "recovery": {}
+    }
+  ],
+  "df_detail": {
+    "pools": [
+      {
+        "stats": {
+          "quota_objects": 0,
+          "bytes_used": 18144559128,
+          "max_avail": 2214021054,
+          "rd": 64499,
+          "rd_bytes": 270524220416,
+          "objects": 4327,
+          "dirty": 4327,
+          "kb_used": 17719297,
+          "quota_bytes": 0,
+          "raw_bytes_used": 36289118208,
+          "wr_bytes": 18144560128,
+          "wr": 4327
+        },
+        "name": "rbd",
+        "id": 0
+      },
+      {
+        "stats": {
+          "quota_objects": 0,
+          "bytes_used": 17922261016,
+          "max_avail": 2214021054,
+          "rd": 77132,
+          "rd_bytes": 323502476288,
+          "objects": 4274,
+          "dirty": 4274,
+          "kb_used": 17502209,
+          "quota_bytes": 0,
+          "raw_bytes_used": 35844521984,
+          "wr_bytes": 17922262016,
+          "wr": 4274
+        },
+        "name": "scbench",
+        "id": 1
+      }
+    ],
+    "stats": {
+      "total_objects": 8601,
+      "total_used_bytes": 88428388352,
+      "total_bytes": 96589578240,
+      "total_avail_bytes": 8161189888
+    }
+  },
+  "mon_status": {
+    "election_epoch": 6,
+    "name": "ceph-admin",
+    "outside_quorum": [],
+    "rank": 0,
+    "monmap": {
+      "epoch": 3,
+      "mons": [
+        {
+          "name": "ceph-admin",
+          "rank": 0,
+          "addr": "67.205.136.159:6789/0"
+        },
+        {
+          "name": "ceph-1",
+          "rank": 1,
+          "addr": "67.205.143.18:6789/0"
+        },
+        {
+          "name": "ceph-0",
+          "rank": 2,
+          "addr": "198.199.70.240:6789/0"
+        }
+      ],
+      "modified": "2016-08-29 13:54:46.945359",
+      "fsid": "e0efcf84-e8ed-4916-8ce1-9c70242d390a",
+      "created": "2016-08-28 21:14:41.698200"
+    },
+    "state": "leader",
+    "extra_probe_peers": [
+      "67.205.143.18:6789/0",
+      "198.199.70.240:6789/0"
+    ],
+    "sync_provider": [],
+    "quorum": [
+      0,
+      1,
+      2
+    ]
+  }
+}

--- a/tests/checks/mock/test_ceph.py
+++ b/tests/checks/mock/test_ceph.py
@@ -49,3 +49,33 @@ class TestCeph(AgentCheckTest):
                              'ceph_pool_name:%s' % pool]
             for metric in ['ceph.read_bytes', 'ceph.write_bytes', 'ceph.pct_used', 'ceph.num_objects']:
                 self.assertMetric(metric, count=1, tags=expected_tags)
+
+    def test_osd_status_metrics(self):
+        mocks = {
+            '_collect_raw': lambda x,y: json.loads(Fixtures.read_file('ceph_10.2.2.json')),
+        }
+        config = {
+            'instances': [{'host': 'foo'}]
+        }
+
+        self.run_check_twice(config, mocks=mocks, force_reload=True)
+        for osd in ['osd2']:
+            expected_tags = ['ceph_fsid:e0efcf84-e8ed-4916-8ce1-9c70242d390a','ceph_mon_state:leader',
+                             'ceph_osd:%s' % osd]
+
+            for metric in ['ceph.num_full_osds']:
+                self.assertMetric(metric, count=1, tags=expected_tags)
+
+        for osd in ['osd1']:
+            expected_tags = ['ceph_fsid:e0efcf84-e8ed-4916-8ce1-9c70242d390a','ceph_mon_state:leader',
+                             'ceph_osd:%s' % osd]
+
+            for metric in ['ceph.num_near_full_osds']:
+                self.assertMetric(metric, count=1, tags=expected_tags)
+
+        for pool in ['rbd', 'scbench']:
+            expected_tags = ['ceph_fsid:e0efcf84-e8ed-4916-8ce1-9c70242d390a','ceph_mon_state:leader',
+                 'ceph_pool:%s' % pool]
+            expected_metrics = ['ceph.read_op_per_sec', 'ceph.write_op_per_sec', 'ceph.op_per_sec']
+            for metric in expected_metrics:
+                self.assertMetric(metric, count=1, tags=expected_tags)


### PR DESCRIPTION
### What does this PR do?

Updates the Ceph integration for version 10.2.2

### Motivation

Gobstopper is working on a writeup of Ceph. After spinning up a 3-node cluster with the latest Jewel release, some metrics were not being reported. Additionally, we wanted to expand the number of metrics reported to include information on full and near full OSDs. Lastly, there was an inconsistency in the `pool_name` tag, which has been resolved.

### Testing

A test for the new metrics has been added, with additional test data pulled from a running 10.2.2 cluster.

### Additional Notes

Added default value of zero for operation rate metrics.