### PR TITLE
[redis] Fix tags on redis connect check.

### DIFF
--- a/checks.d/redisdb.py
+++ b/checks.d/redisdb.py
@@ -157,12 +157,12 @@ class Redis(AgentCheck):
 
         tags = sorted(tags.union(tags_to_add))
 
-        return tags, tags_to_add
+        return tags
 
     def _check_db(self, instance, custom_tags=None):
         conn = self._get_conn(instance)
 
-        tags, tags_to_add = self._get_tags(custom_tags, instance)
+        tags = self._get_tags(custom_tags, instance)
 
         # Ping the database for info, and track the latency.
         # Process the service check: the check passes if we can connect to Redis
@@ -288,7 +288,7 @@ class Redis(AgentCheck):
         """
         conn = self._get_conn(instance)
 
-        tags, _ = self._get_tags(custom_tags, instance)
+        tags = self._get_tags(custom_tags, instance)
 
         if not instance.get(MAX_SLOW_ENTRIES_KEY):
             try:

--- a/checks.d/redisdb.py
+++ b/checks.d/redisdb.py
@@ -171,15 +171,15 @@ class Redis(AgentCheck):
         try:
             info = conn.info()
             status = AgentCheck.OK
-            self.service_check('redis.can_connect', status, tags=tags_to_add)
+            self.service_check('redis.can_connect', status, tags=tags)
             self._collect_metadata(info)
         except ValueError:
             status = AgentCheck.CRITICAL
-            self.service_check('redis.can_connect', status, tags=tags_to_add)
+            self.service_check('redis.can_connect', status, tags=tags)
             raise
         except Exception:
             status = AgentCheck.CRITICAL
-            self.service_check('redis.can_connect', status, tags=tags_to_add)
+            self.service_check('redis.can_connect', status, tags=tags)
             raise
 
         latency_ms = round((time.time() - start) * 1000, 2)

--- a/tests/checks/integration/test_redisdb.py
+++ b/tests/checks/integration/test_redisdb.py
@@ -78,7 +78,7 @@ class TestRedis(AgentCheckTest):
         instance = {
             'host': 'localhost',
             'port': port,
-            'tags': [ "foo:bar" ]
+            'tags': ["foo:bar"]
         }
 
         db = redis.Redis(port=port, db=14)  # Datadog's test db
@@ -141,7 +141,7 @@ class TestRedis(AgentCheckTest):
             service_checks_count,
             service_checks)
         self.assertEquals(
-            len([sc for sc in service_checks if "foo:bar"] in sc['tags']]),
+            len([sc for sc in service_checks if "foo:bar" in sc['tags']]),
             service_checks_count,
             service_checks)
 

--- a/tests/checks/integration/test_redisdb.py
+++ b/tests/checks/integration/test_redisdb.py
@@ -77,7 +77,8 @@ class TestRedis(AgentCheckTest):
 
         instance = {
             'host': 'localhost',
-            'port': port
+            'port': port,
+            'tags': [ "foo:bar" ]
         }
 
         db = redis.Redis(port=port, db=14)  # Datadog's test db
@@ -137,6 +138,10 @@ class TestRedis(AgentCheckTest):
             service_checks)
         self.assertEquals(
             len([sc for sc in service_checks if "redis_port:%s" % port in sc['tags']]),
+            service_checks_count,
+            service_checks)
+        self.assertEquals(
+            len([sc for sc in service_checks if "foo:bar"] in sc['tags']]),
             service_checks_count,
             service_checks)
 


### PR DESCRIPTION
### What does this PR do?

Adjusts the `redis.can_connect` tags to include the those specified in the config file.

### Motivation
At present the `redis.can_connect` service check does not include the tags specified in the config file. I don't see why this is the case, so I figured I'd send a PR as a way of asking. That way if it's an oversight we've already got a fix lined up. :)

### Testing Guidelines

Added a test assertion for the tag.

### Additional Notes

Let me know if the tag is intended to be left out!

