### PR TITLE
[wmi] set provider architecture when necessary

### DIFF
--- a/checks/libs/wmi/sampler.py
+++ b/checks/libs/wmi/sampler.py
@@ -334,16 +334,17 @@ class WMISampler(object):
         # shouldn't be used in other threads (can lead to memory/handle leaks if done
         # without a deep knowledge of COM's threading model). Because of this and given
         # that we run each query in its own thread, we don't cache connections
-        context = None
+        additional_args = []
         pythoncom.CoInitialize()
 
         if self.provider != ProviderArchitecture.DEFAULT:
             context = Dispatch("WbemScripting.SWbemNamedValueSet")
             context.Add("__ProviderArchitecture", self.provider)
+            additional_args = [None, "", 128, context]
 
         locator = Dispatch("WbemScripting.SWbemLocator")
         connection = locator.ConnectServer(
-            self.host, self.namespace, self.username, self.password, None, "", 128, context
+            self.host, self.namespace, self.username, self.password, *additional_args
         )
 
         return connection

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -52,7 +52,7 @@ def get_check(name, config_str):
     check_class = None
     classes = inspect.getmembers(check_module, inspect.isclass)
     for name, clsmember in classes:
-        if AgentCheck in clsmember.__bases__:
+        if issubclass(clsmember, AgentCheck) and clsmember != AgentCheck:
             check_class = clsmember
             break
     if check_class is None:


### PR DESCRIPTION
**[wmi] set provider architecture when necessary**

On Windows 2008, setting a WMI provider would cause an exception.
To prevent this from unecessarily happening, only proceed when the
provided value is not set to the default one.

**[debug] improve `run_check` compatibility**

Datadog Agent checks do not necessarily inherit directly from the
`AgentCheck` class. When it is the case, the `run_check` DEBUG method
would fail loading the check.
This happens with WMI checks for instance.

Allow the `run_check` DEBUG method to load any agent check that inherits
from the `AgentCheck`.