### PR TITLE
Reset generator if dogstreams can't read a file

### DIFF
--- a/checks/datadog.py
+++ b/checks/datadog.py
@@ -186,6 +186,8 @@ class Dogstream(object):
             except StopIteration as e:
                 self.logger.exception(e)
                 self.logger.warn("Can't tail %s file" % self.log_path)
+                # reset generator to try again during the next check interval
+                self._gen = None
 
             check_output = self._aggregate(self._values)
             if self._events:

--- a/tests/core/test_datadog.py
+++ b/tests/core/test_datadog.py
@@ -192,6 +192,25 @@ class TestDogstream(TailTestCase):
         actual_output = self.dogstream.check(self.config, move_end=False)
         self.assertEquals(expected_output, actual_output)
 
+    def test_dogstream_io_error(self):
+        log_data = [
+            ('test_metric.e 1000000000 10 metric_type=gauge'),
+        ]
+        expected_output = {"dogstream":
+            [('test_metric.e', 1000000000, 10, self.gauge)]
+        }
+
+        self._write_log(log_data)
+
+        # Simulate missing file by making it unreadable
+        os.chmod(self.log_file.name, 0000)
+        actual_output = self.dogstream.check(self.config, move_end=False)
+        self.assertEquals({}, actual_output)
+        os.chmod(self.log_file.name, 0600)
+        actual_output = self.dogstream.check(self.config, move_end=False)
+        self.assertEquals(expected_output, actual_output)
+
+
     def test_dogstream_log_path_globbing(self):
         """Make sure that globbed dogstream logfile matching works."""
         # Create a tmpfile to serve as a prefix for the other temporary


### PR DESCRIPTION
### What does this PR do?

It resets the dogstream tail generator when an exception occurs. This allows the generator to be recreated on the next check.
### Motivation

Previously, once the generator failed, it would never be re-created. This would mean that if a file did not exist when the generator was created, it would never be checked.

Fixes #2261
