### PR TITLE
[flare] do not use a new subdomain

### DIFF
--- a/config.py
+++ b/config.py
@@ -123,7 +123,7 @@ def get_url_endpoint(default_url, endpoint_type=None):
         endpoint_type
     )
     if endpoint_type == 'flare':
-        subdomain_replacement = "{0}.flare".format(formatted_version)
+        subdomain_replacement = "{0}-flare".format(formatted_version)
 
     # Replace https://app.datadoghq.com in https://5-2-0-app.agent.datadoghq.com
     return default_url.replace(subdomain, subdomain_replacement)

--- a/tests/core/test_flare.py
+++ b/tests/core/test_flare.py
@@ -82,7 +82,7 @@ class FlareTest(unittest.TestCase):
         conf = mock_config()
         self.assertEqual(f._case_id, 1337)
         self.assertEqual(f._api_key, conf['api_key'])
-        self.assertEqual(f._url, 'https://6-6-6.flare.datadoghq.com/support/flare')
+        self.assertEqual(f._url, 'https://6-6-6-flare.datadoghq.com/support/flare')
         self.assertEqual(f.tar_path, os.path.join(get_mocked_temp(), "datadog-agent-1.tar.bz2"))
 
     @mock.patch('utils.flare.requests.post', return_value=FakeResponse())
@@ -102,7 +102,7 @@ class FlareTest(unittest.TestCase):
         args, kwargs = mock_requests.call_args_list[0]
         self.assertEqual(
             args,
-            ('https://6-6-6.flare.datadoghq.com/support/flare/1337?api_key=APIKEY',)
+            ('https://6-6-6-flare.datadoghq.com/support/flare/1337?api_key=APIKEY',)
         )
         self.assertEqual(
             kwargs['files']['flare_file'].name,
@@ -129,7 +129,7 @@ class FlareTest(unittest.TestCase):
         args, kwargs = mock_requests.call_args_list[0]
         self.assertEqual(
             args,
-            ('https://6-6-6.flare.datadoghq.com/support/flare?api_key=APIKEY',)
+            ('https://6-6-6-flare.datadoghq.com/support/flare?api_key=APIKEY',)
         )
         self.assertEqual(
             kwargs['files']['flare_file'].name,
@@ -156,7 +156,7 @@ class FlareTest(unittest.TestCase):
         args, kwargs = mock_requests.call_args_list[0]
         self.assertEqual(
             args,
-            ('https://6-6-6.flare.datadoghq.com/support/flare/1337?api_key=APIKEY',)
+            ('https://6-6-6-flare.datadoghq.com/support/flare/1337?api_key=APIKEY',)
         )
         self.assertEqual(
             kwargs['files']['flare_file'].name,


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?
Change the flare url.

### Motivation

New subdomain requires new cert (ELB side), and even worse, setting a
new ELB. This is not what we want.