### PR TITLE
[network] Add monotonic counts for some metrics

### DIFF
--- a/checks.d/network.py
+++ b/checks.d/network.py
@@ -169,7 +169,9 @@ class Network(AgentCheck):
             for regex, metric in regex_list:
                 value = re.match(regex, line)
                 if value:
-                    self.rate(metric, self._parse_value(value.group(1)))
+                    parsed_value =  self._parse_value(value.group(1))
+                    self.rate(metric, parsed_value)
+                    self.monotonic_count('{}_count'.format(metric), parsed_value)
 
     def _check_linux(self, instance):
         proc_location = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
@@ -285,7 +287,9 @@ class Network(AgentCheck):
             }
 
             for key, metric in tcp_metrics_name.iteritems():
-                self.rate(metric, self._parse_value(tcp_metrics[key]))
+                value = self._parse_value(tcp_metrics[key])
+                self.rate(metric, value)
+                self.monotonic_count('{}_count'.format(metric), value)
 
             assert(udp_metrics['Udp:'] == 'Udp:')
 
@@ -299,7 +303,9 @@ class Network(AgentCheck):
             }
             for key, metric in udp_metrics_name.iteritems():
                 if key in udp_metrics:
-                    self.rate(metric, self._parse_value(udp_metrics[key]))
+                    value = self._parse_value(udp_metrics[key])
+                    self.rate(metric, value)
+                    self.monotonic_count('{}_count'.format(metric), value)
 
         except IOError:
             # On Openshift, /proc/net/snmp is only readable by root


### PR DESCRIPTION
### What does this PR do?

Add monotonic counts for tcp segments and udp datagrams. This allows more
precise counting of incoming and outgoing segments and datagrams for a given
time period.

The following metrics are affected:
- system.net.tcp.retrans_segs
- system.net.tcp.in_segs
- system.net.tcp.out_segs
- system.net.udp.in_datagrams
- system.net.udp.no_ports
- system.net.udp.in_errors
- system.net.udp.out_datagrams
- system.net.udp.rcv_buf_errors
- system.net.udp.snd_buf_errors
- system.net.tcp.retrans_packs
- system.net.tcp.sent_packs
- system.net.tcp.rcv_packs

For backwards compatibility, the new metrics are suffixed with `_count`.
### Motivation

This fixes #2630. It allows graphing and alerting on the precise number of segments, datagrams, or errors in a set time period.
