### PR TITLE
Fix regression test; can't get tag when the connection's not actually…

### DIFF
--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -410,7 +410,6 @@ class ESCheck(AgentCheck):
             # retreive the cluster name from the data, and append it to the
             # master tag list.
             config.tags.append("cluster_name:{}".format(stats_data['cluster_name']))
-            config.service_check_tags.append("cluster_name:{}".format(stats_data['cluster_name']))
         self._process_stats_data(nodes_url, stats_data, stats_metrics, config)
 
         # Load clusterwise data

--- a/tests/checks/integration/test_elastic.py
+++ b/tests/checks/integration/test_elastic.py
@@ -411,7 +411,7 @@ class TestElastic(AgentCheckTest):
                     self.assertMetric(
                         m_name, tags=m_tags, count=1, hostname=hostname)
 
-        good_sc_tags = ['host:localhost', 'port:{0}'.format(port)] + cluster_tag
+        good_sc_tags = ['host:localhost', 'port:{0}'.format(port)]
         bad_sc_tags = ['host:localhost', 'port:{0}'.format(bad_port)]
 
         self.assertServiceCheckOK('elasticsearch.can_connect',

--- a/tests/checks/integration/test_elastic.py
+++ b/tests/checks/integration/test_elastic.py
@@ -412,7 +412,7 @@ class TestElastic(AgentCheckTest):
                         m_name, tags=m_tags, count=1, hostname=hostname)
 
         good_sc_tags = ['host:localhost', 'port:{0}'.format(port)] + cluster_tag
-        bad_sc_tags = ['host:localhost', 'port:{0}'.format(bad_port)] + cluster_tag
+        bad_sc_tags = ['host:localhost', 'port:{0}'.format(bad_port)]
 
         self.assertServiceCheckOK('elasticsearch.can_connect',
                                   tags=good_sc_tags + tags,


### PR DESCRIPTION

### What does this PR do?

Fixes unit test that was checking for the new cluster tag on the test to a bad port.