### PR TITLE
[redis] add a ssl option

### DIFF
--- a/checks.d/redisdb.py
+++ b/checks.d/redisdb.py
@@ -127,7 +127,7 @@ class Redis(AgentCheck):
 
                 # Only send useful parameters to the redis client constructor
                 list_params = ['host', 'port', 'db', 'password', 'socket_timeout',
-                               'connection_pool', 'charset', 'errors', 'unix_socket_path']
+                               'connection_pool', 'charset', 'errors', 'unix_socket_path', 'ssl']
 
                 # Set a default timeout (in seconds) if no timeout is specified in the instance config
                 instance['socket_timeout'] = instance.get('socket_timeout', 5)

--- a/conf.d/redisdb.yaml.example
+++ b/conf.d/redisdb.yaml.example
@@ -42,3 +42,6 @@ instances:
 
     # Collect INFO COMMANDSTATS output as metrics.
     # command_stats: False
+
+    # Use a SSL connection
+    # ssl: False


### PR DESCRIPTION
### What does this PR do?

Add the `ssl` option to the agent.

### Motivation

It's needed when connecting to an Azure instance, cf
http://blog.syntaxc4.net/post/2014/12/12/connecting-to-azure-redis-cache-service-from-python.aspx
