### PR TITLE
[core] Hostname logic refactoring

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -36,13 +36,13 @@ from config import (
 )
 from daemon import AgentSupervisor, Daemon
 from emitter import http_emitter
-from util import (
-    EC2,
-    get_hostname,
-    Watchdog,
-)
-from utils.flare import Flare
+
+# utils
+from util import Watchdog
+from utils.cloud_metadata import EC2
 from utils.configcheck import configcheck, sd_configcheck
+from utils.flare import Flare
+from utils.hostname import get_hostname
 from utils.jmx import jmx_command
 from utils.pidfile import PidFile
 from utils.profile import AgentProfiler

--- a/checks.d/docker.py
+++ b/checks.d/docker.py
@@ -12,8 +12,10 @@ import os
 import re
 import time
 from urlparse import urlsplit
-from util import json
 from collections import defaultdict
+
+# 3rd party
+import simplejson as json
 
 # project
 from checks import AgentCheck

--- a/checks.d/jenkins.py
+++ b/checks.d/jenkins.py
@@ -11,8 +11,6 @@ from xml.etree.ElementTree import ElementTree
 
 # project
 from checks import AgentCheck
-from util import get_hostname
-
 
 class Skip(Exception):
     """
@@ -178,7 +176,7 @@ class Jenkins(AgentCheck):
 
         for job_dir in job_dirs:
             for output in self._get_build_results(instance.get('name'), job_dir):
-                output['host'] = get_hostname(self.agentConfig)
+                output['host'] = self.hostname
                 if create_event:
                     self.log.debug("Creating event for job: %s" % output['job_name'])
                     self.event(output)

--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -8,7 +8,6 @@ from urlparse import urljoin
 
 # project
 from checks import AgentCheck
-from util import get_hostname
 
 # 3p
 import requests
@@ -862,7 +861,7 @@ class OpenStackCheck(AgentCheck):
         """
         Returns a best guess for the hostname registered with OpenStack for this host
         """
-        return self.init_config.get("os_host") or get_hostname(self.agentConfig)
+        return self.init_config.get("os_host") or self.hostname
 
     def get_servers_managed_by_hypervisor(self):
         return self.get_all_server_ids(filter_by_host=self.get_my_hostname())

--- a/checks.d/tokumx.py
+++ b/checks.d/tokumx.py
@@ -18,7 +18,6 @@ from pymongo import (
 
 # project
 from checks import AgentCheck
-from util import get_hostname
 
 DEFAULT_TIMEOUT = 10
 
@@ -244,7 +243,6 @@ class TokuMX(AgentCheck):
                 return 'Rollback'
 
         status = get_state_description(state)
-        hostname = get_hostname(agentConfig)
         msg_title = "%s is %s" % (server, status)
         msg = "TokuMX %s just reported as %s" % (server, status)
 
@@ -253,7 +251,7 @@ class TokuMX(AgentCheck):
             'event_type': 'tokumx',
             'msg_title': msg_title,
             'msg_text': msg,
-            'host': hostname
+            'host': self.hostname
         })
 
     def _get_ssl_params(self, instance):

--- a/checks.d/zk.py
+++ b/checks.d/zk.py
@@ -79,7 +79,6 @@ import struct
 
 # project
 from checks import AgentCheck
-from util import get_hostname
 
 
 class ZKConnectionFailure(Exception):
@@ -131,7 +130,7 @@ class ZookeeperCheck(AgentCheck):
         tags = instance.get('tags', [])
         cx_args = (host, port, timeout)
         sc_tags = ["host:{0}".format(host), "port:{0}".format(port)]
-        hostname = get_hostname(self.agentConfig)
+        hostname = self.hostname
         report_instance_mode = instance.get("report_instance_mode", True)
 
         zk_version = None  # parse_stat will parse and set version string

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -29,7 +29,8 @@ import yaml
 
 # project
 from checks import check_status
-from util import get_hostname, get_next_id, yLoader
+from util import get_next_id, yLoader
+from utils.hostname import get_hostname
 from utils.proxy import get_proxy
 from utils.platform import Platform
 from utils.profile import pretty_statistics

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -29,15 +29,13 @@ import checks.system.unix as u
 import checks.system.win32 as w32
 import modules
 from util import (
-    EC2,
-    GCE,
-    get_os,
     get_uuid,
     Timer,
 )
+from utils.cloud_metadata import GCE, EC2
 from utils.logger import log_exceptions
 from utils.jmx import JMXFiles
-from utils.platform import Platform
+from utils.platform import Platform, get_os
 from utils.subprocess_output import get_subprocess_output
 
 log = logging.getLogger(__name__)

--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -21,7 +21,7 @@ except ImportError:
 
 # project
 from checks import Check
-from util import get_hostname
+from utils.hostname import get_hostname
 from utils.platform import Platform
 from utils.subprocess_output import get_subprocess_output
 

--- a/config.py
+++ b/config.py
@@ -23,8 +23,8 @@ import traceback
 from urlparse import urlparse
 
 # project
-from util import check_yaml, get_os
-from utils.platform import Platform
+from util import check_yaml
+from utils.platform import Platform, get_os
 from utils.proxy import get_proxy
 from utils.service_discovery.config import extract_agent_config
 from utils.service_discovery.config_stores import CONFIG_FROM_FILE, TRACE_CONFIG

--- a/ddagent.py
+++ b/ddagent.py
@@ -28,6 +28,7 @@ import zlib
 os.umask(022)
 
 # 3p
+import simplejson as json
 try:
     import pycurl
 except ImportError:
@@ -51,12 +52,11 @@ from config import (
 import modules
 from transaction import Transaction, TransactionManager
 from util import (
-    get_hostname,
-    get_tornado_ioloop,
     get_uuid,
-    json,
     Watchdog,
 )
+
+from utils.hostname import get_hostname
 from utils.logger import RedactedLogRecord
 
 
@@ -515,7 +515,7 @@ class Application(tornado.web.Application):
         log.info("Listening on port %d" % self._port)
 
         # Register callbacks
-        self.mloop = get_tornado_ioloop()
+        self.mloop = tornado.ioloop.IOLoop.current()
 
         logging.getLogger().setLevel(get_logging_config()['log_level'] or logging.INFO)
 

--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -42,7 +42,8 @@ from checks.check_status import DogstatsdStatus
 from checks.metric_types import MetricTypes
 from config import get_config, get_version
 from daemon import AgentSupervisor, Daemon
-from util import chunks, get_hostname, get_uuid, plural
+from util import chunks, get_uuid, plural
+from utils.hostname import get_hostname
 from utils.pidfile import PidFile
 from utils.net import inet_pton
 from utils.net import IPV6_V6ONLY, IPPROTO_IPV6

--- a/graphite.py
+++ b/graphite.py
@@ -11,6 +11,9 @@ import struct
 from tornado.ioloop import IOLoop
 from tornado.tcpserver import TCPServer
 
+# project
+from utils.hostname import get_hostname
+
 log = logging.getLogger(__name__)
 
 
@@ -112,7 +115,6 @@ class GraphiteConnection(object):
         self.stream.read_bytes(4, self._on_read_header)
 
 def start_graphite_listener(port):
-    from util import get_hostname
     echo_server = GraphiteServer(None, get_hostname(None))
     echo_server.listen(port)
     IOLoop.instance().start()

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -18,8 +18,10 @@ import unittest
 # project
 from checks import AgentCheck
 from config import get_checksd_path
-from util import get_hostname, get_os
+
 from utils.debug import get_check  # noqa -  FIXME 5.5.0 AgentCheck tests should not use this
+from utils.hostname import get_hostname
+from utils.platform import get_os
 
 log = logging.getLogger('tests')
 

--- a/tests/checks/integration/test_haproxy.py
+++ b/tests/checks/integration/test_haproxy.py
@@ -7,7 +7,7 @@ from nose.plugins.attrib import attr
 # project
 from checks import AgentCheck
 from tests.checks.common import AgentCheckTest
-from util import get_hostname
+from utils.hostname import get_hostname
 
 
 @attr(requires='haproxy')

--- a/tests/checks/mock/test_kubernetes.py
+++ b/tests/checks/mock/test_kubernetes.py
@@ -12,7 +12,8 @@ import simplejson as json
 # project
 from tests.checks.common import AgentCheckTest, Fixtures
 from checks import AgentCheck
-from utils.kubeutil import KubeUtil, is_k8s
+from utils.kubeutil import KubeUtil
+from utils.platform import Platform
 
 CPU = "CPU"
 MEM = "MEM"
@@ -426,6 +427,6 @@ class TestKubeutil(unittest.TestCase):
 
     def test_is_k8s(self):
         os.unsetenv('KUBERNETES_PORT')
-        self.assertFalse(is_k8s())
+        self.assertFalse(Platform.is_k8s())
         os.environ['KUBERNETES_PORT'] = '999'
-        self.assertTrue(is_k8s())
+        self.assertTrue(Platform.is_k8s())

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -15,7 +15,7 @@ from checks import (
 )
 from checks.collector import Collector
 from tests.checks.common import load_check
-from util import get_hostname
+from utils.hostname import get_hostname
 from utils.ntp import NTPUtil
 from utils.proxy import get_proxy
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -12,7 +12,8 @@ import ntpath
 
 # project
 from config import get_config, load_check_directory, _conf_path_to_check_name
-from util import is_valid_hostname, windows_friendly_colon_split
+from util import windows_friendly_colon_split
+from utils.hostname import is_valid_hostname
 from utils.pidfile import PidFile
 from utils.platform import Platform
 

--- a/tests/core/test_ec2.py
+++ b/tests/core/test_ec2.py
@@ -6,7 +6,7 @@ import types
 import unittest
 
 # project
-from util import EC2
+from utils.cloud_metadata import EC2
 
 
 class TestEC2(unittest.TestCase):

--- a/transaction.py
+++ b/transaction.py
@@ -9,9 +9,12 @@ from operator import attrgetter
 import sys
 import time
 
+# 3rd party
+from tornado import ioloop
+
 # project
 from checks.check_status import ForwarderStatus
-from util import get_tornado_ioloop, plural
+from util import plural
 
 log = logging.getLogger(__name__)
 
@@ -213,7 +216,7 @@ class TransactionManager(object):
             # Otherwise, schedule a flush as soon as possible (throttling)
             elif self._running_flushes < self._MAX_PARALLELISM:
                 # Wait a little bit more
-                tornado_ioloop = get_tornado_ioloop()
+                tornado_ioloop = ioloop.IOLoop.current()
                 if tornado_ioloop._running:
                     tornado_ioloop.add_timeout(time.time() + delay,
                                                lambda: self.flush_next())

--- a/util.py
+++ b/util.py
@@ -9,17 +9,12 @@ import os
 import platform
 import re
 import signal
-import socket
 import sys
 import time
-import types
-import urllib2
 import uuid
 
 # 3p
-import simplejson as json
 import yaml  # noqa, let's guess, probably imported somewhere
-from tornado import ioloop
 try:
     from yaml import CLoader as yLoader
     from yaml import CDumper as yDumper
@@ -30,16 +25,12 @@ except ImportError:
 
 # These classes are now in utils/, they are just here for compatibility reasons,
 # if a user actually uses them in a custom check
-# If you're this user, please use utils.pidfile or utils.platform instead
+# If you're this user, please use utils/* instead
 # FIXME: remove them at a point (6.x)
 from utils.pidfile import PidFile  # noqa, see ^^^
-from utils.platform import Platform
-from utils.proxy import get_proxy
-from utils.subprocess_output import get_subprocess_output
+from utils.platform import Platform, get_os # noqa, see ^^^
+from utils.proxy import get_proxy # noqa, see ^^^
 
-
-VALID_HOSTNAME_RFC_1123_PATTERN = re.compile(r"^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$")
-MAX_HOSTNAME_LEN = 255
 COLON_NON_WIN_PATH = re.compile(':(?!\\\\)')
 
 log = logging.getLogger(__name__)
@@ -52,11 +43,6 @@ def plural(count):
         return ""
     return "s"
 
-
-def get_tornado_ioloop():
-        return ioloop.IOLoop.current()
-
-
 def get_uuid():
     # Generate a unique name that will stay constant between
     # invocations, such as platform.node() + uuid.getnode()
@@ -67,22 +53,6 @@ def get_uuid():
     # Note that this is not foolproof but we can reconcile servers
     # on the back-end if need be, based on mac addresses.
     return uuid.uuid5(uuid.NAMESPACE_DNS, platform.node() + str(uuid.getnode())).hex
-
-
-def get_os():
-    "Human-friendly OS name"
-    if sys.platform == 'darwin':
-        return 'mac'
-    elif sys.platform.find('freebsd') != -1:
-        return 'freebsd'
-    elif sys.platform.find('linux') != -1:
-        return 'linux'
-    elif sys.platform.find('win32') != -1:
-        return 'windows'
-    elif sys.platform.find('sunos') != -1:
-        return 'solaris'
-    else:
-        return sys.platform
 
 
 def headers(agentConfig, **kwargs):
@@ -135,24 +105,6 @@ def get_next_id(name):
     return current_id
 
 
-def is_valid_hostname(hostname):
-    if hostname.lower() in set([
-        'localhost',
-        'localhost.localdomain',
-        'localhost6.localdomain6',
-        'ip6-localhost',
-    ]):
-        log.warning("Hostname: %s is local" % hostname)
-        return False
-    if len(hostname) > MAX_HOSTNAME_LEN:
-        log.warning("Hostname: %s is too long (max length is  %s characters)" % (hostname, MAX_HOSTNAME_LEN))
-        return False
-    if VALID_HOSTNAME_RFC_1123_PATTERN.match(hostname) is None:
-        log.warning("Hostname: %s is not complying with RFC 1123" % hostname)
-        return False
-    return True
-
-
 def check_yaml(conf_path):
     with open(conf_path) as f:
         check_config = yaml.load(f.read(), Loader=yLoader)
@@ -171,323 +123,6 @@ def check_yaml(conf_path):
             raise Exception('You need to have at least one instance defined in the YAML file for this check')
         else:
             return check_config
-
-
-def get_hostname(config=None):
-    """
-    Get the canonical host name this agent should identify as. This is
-    the authoritative source of the host name for the agent.
-
-    Tries, in order:
-
-      * agent config (datadog.conf, "hostname:")
-      * 'hostname -f' (on unix)
-      * socket.gethostname()
-    """
-    from utils.dockerutil import DockerUtil
-    hostname = None
-
-    # first, try the config
-    if config is None:
-        from config import get_config
-        config = get_config(parse_args=True)
-    config_hostname = config.get('hostname')
-    if config_hostname and is_valid_hostname(config_hostname):
-        return config_hostname
-
-    # Try to get GCE instance name
-    if hostname is None:
-        gce_hostname = GCE.get_hostname(config)
-        if gce_hostname is not None:
-            if is_valid_hostname(gce_hostname):
-                return gce_hostname
-
-    # Try to get the docker hostname
-    if hostname is None and DockerUtil.is_dockerized():
-        docker_util = DockerUtil(agentConfig=config)
-        docker_hostname = docker_util.get_hostname()
-        if docker_hostname is not None and is_valid_hostname(docker_hostname):
-            hostname = docker_hostname
-
-    # then move on to os-specific detection
-    if hostname is None:
-        def _get_hostname_unix():
-            try:
-                # try fqdn
-                out, _, rtcode = get_subprocess_output(['/bin/hostname', '-f'], log)
-                if rtcode == 0:
-                    return out.strip()
-            except Exception:
-                return None
-
-        os_name = get_os()
-        if os_name in ['mac', 'freebsd', 'linux', 'solaris']:
-            unix_hostname = _get_hostname_unix()
-            if unix_hostname and is_valid_hostname(unix_hostname):
-                hostname = unix_hostname
-
-    # if we have an ec2 default hostname, see if there's an instance-id available
-    if (Platform.is_ecs_instance()) or (hostname is not None and EC2.is_default(hostname)):
-        instanceid = EC2.get_instance_id(config)
-        if instanceid:
-            hostname = instanceid
-
-    # fall back on socket.gethostname(), socket.getfqdn() is too unreliable
-    if hostname is None:
-        try:
-            socket_hostname = socket.gethostname()
-        except socket.error:
-            socket_hostname = None
-        if socket_hostname and is_valid_hostname(socket_hostname):
-            hostname = socket_hostname
-
-    if hostname is None:
-        log.critical('Unable to reliably determine host name. You can define one in datadog.conf or in your hosts file')
-        raise Exception('Unable to reliably determine host name. You can define one in datadog.conf or in your hosts file')
-    else:
-        return hostname
-
-
-class GCE(object):
-    URL = "http://169.254.169.254/computeMetadata/v1/?recursive=true"
-    TIMEOUT = 0.1 # second
-    SOURCE_TYPE_NAME = 'google cloud platform'
-    metadata = None
-    EXCLUDED_ATTRIBUTES = ["kube-env", "startup-script", "sshKeys", "user-data",
-    "cli-cert", "ipsec-cert", "ssl-cert"]
-
-
-    @staticmethod
-    def _get_metadata(agentConfig):
-        if GCE.metadata is not None:
-            return GCE.metadata
-
-        if not agentConfig['collect_instance_metadata']:
-            log.info("Instance metadata collection is disabled. Not collecting it.")
-            GCE.metadata = {}
-            return GCE.metadata
-
-        socket_to = None
-        try:
-            socket_to = socket.getdefaulttimeout()
-            socket.setdefaulttimeout(GCE.TIMEOUT)
-        except Exception:
-            pass
-
-        try:
-            opener = urllib2.build_opener()
-            opener.addheaders = [('X-Google-Metadata-Request','True')]
-            GCE.metadata = json.loads(opener.open(GCE.URL).read().strip())
-
-        except Exception:
-            GCE.metadata = {}
-
-        try:
-            if socket_to is None:
-                socket_to = 3
-            socket.setdefaulttimeout(socket_to)
-        except Exception:
-            pass
-        return GCE.metadata
-
-
-
-    @staticmethod
-    def get_tags(agentConfig):
-        if not agentConfig['collect_instance_metadata']:
-            return None
-
-        try:
-            host_metadata = GCE._get_metadata(agentConfig)
-            tags = []
-
-            for key, value in host_metadata['instance'].get('attributes', {}).iteritems():
-                if key in GCE.EXCLUDED_ATTRIBUTES:
-                    continue
-                tags.append("%s:%s" % (key, value))
-
-            tags.extend(host_metadata['instance'].get('tags', []))
-            tags.append('zone:%s' % host_metadata['instance']['zone'].split('/')[-1])
-            tags.append('instance-type:%s' % host_metadata['instance']['machineType'].split('/')[-1])
-            tags.append('internal-hostname:%s' % host_metadata['instance']['hostname'])
-            tags.append('instance-id:%s' % host_metadata['instance']['id'])
-            tags.append('project:%s' % host_metadata['project']['projectId'])
-            tags.append('numeric_project_id:%s' % host_metadata['project']['numericProjectId'])
-
-            GCE.metadata['hostname'] = host_metadata['instance']['hostname'].split('.')[0]
-
-            return tags
-        except Exception:
-            return None
-
-    @staticmethod
-    def get_hostname(agentConfig):
-        try:
-            host_metadata = GCE._get_metadata(agentConfig)
-            hostname = host_metadata['instance']['hostname']
-            if agentConfig.get('gce_updated_hostname'):
-                return hostname
-            else:
-                return hostname.split('.')[0]
-        except Exception:
-            return None
-
-    @staticmethod
-    def get_host_aliases(agentConfig):
-        try:
-            host_metadata = GCE._get_metadata(agentConfig)
-            project_id = host_metadata['project']['projectId']
-            instance_name = host_metadata['instance']['hostname'].split('.')[0]
-            return ['%s.%s' % (instance_name, project_id)]
-        except Exception:
-            return None
-
-
-class EC2(object):
-    """Retrieve EC2 metadata
-    """
-    EC2_METADATA_HOST = "http://169.254.169.254"
-    METADATA_URL_BASE = EC2_METADATA_HOST + "/latest/meta-data"
-    INSTANCE_IDENTITY_URL = EC2_METADATA_HOST + "/latest/dynamic/instance-identity/document"
-    TIMEOUT = 0.1  # second
-    DEFAULT_PREFIXES = [u'ip-', u'domu']
-    metadata = {}
-
-    class NoIAMRole(Exception):
-        """
-        Instance has no associated IAM role.
-        """
-        pass
-
-    @staticmethod
-    def is_default(hostname):
-        hostname = hostname.lower()
-        for prefix in EC2.DEFAULT_PREFIXES:
-            if hostname.startswith(prefix):
-                return True
-        return False
-
-    @staticmethod
-    def get_iam_role():
-        """
-        Retrieve instance's IAM role.
-        Raise `NoIAMRole` when unavailable.
-        """
-        try:
-            return urllib2.urlopen(EC2.METADATA_URL_BASE + "/iam/security-credentials/").read().strip()
-        except urllib2.HTTPError as err:
-            if err.code == 404:
-                raise EC2.NoIAMRole()
-            raise
-
-    @staticmethod
-    def get_tags(agentConfig):
-        """
-        Retrieve AWS EC2 tags.
-        """
-        if not agentConfig['collect_instance_metadata']:
-            log.info("Instance metadata collection is disabled. Not collecting it.")
-            return []
-
-        EC2_tags = []
-        socket_to = None
-        try:
-            socket_to = socket.getdefaulttimeout()
-            socket.setdefaulttimeout(EC2.TIMEOUT)
-        except Exception:
-            pass
-
-        try:
-            iam_role = EC2.get_iam_role()
-            iam_params = json.loads(urllib2.urlopen(EC2.METADATA_URL_BASE + "/iam/security-credentials/" + unicode(iam_role)).read().strip())
-            instance_identity = json.loads(urllib2.urlopen(EC2.INSTANCE_IDENTITY_URL).read().strip())
-            region = instance_identity['region']
-
-            import boto.ec2
-            proxy_settings = get_proxy(agentConfig) or {}
-            connection = boto.ec2.connect_to_region(
-                region,
-                aws_access_key_id=iam_params['AccessKeyId'],
-                aws_secret_access_key=iam_params['SecretAccessKey'],
-                security_token=iam_params['Token'],
-                proxy=proxy_settings.get('host'), proxy_port=proxy_settings.get('port'),
-                proxy_user=proxy_settings.get('user'), proxy_pass=proxy_settings.get('password')
-            )
-
-            tag_object = connection.get_all_tags({'resource-id': EC2.metadata['instance-id']})
-
-            EC2_tags = [u"%s:%s" % (tag.name, tag.value) for tag in tag_object]
-            if agentConfig.get('collect_security_groups') and EC2.metadata.get('security-groups'):
-                EC2_tags.append(u"security-group-name:{0}".format(EC2.metadata.get('security-groups')))
-
-        except EC2.NoIAMRole:
-            log.warning(
-                u"Unable to retrieve AWS EC2 custom tags: "
-                u"an IAM role associated with the instance is required"
-            )
-        except Exception:
-            log.exception("Problem retrieving custom EC2 tags")
-
-        try:
-            if socket_to is None:
-                socket_to = 3
-            socket.setdefaulttimeout(socket_to)
-        except Exception:
-            pass
-
-        return EC2_tags
-
-    @staticmethod
-    def get_metadata(agentConfig):
-        """Use the ec2 http service to introspect the instance. This adds latency if not running on EC2
-        """
-        # >>> import urllib2
-        # >>> urllib2.urlopen('http://169.254.169.254/latest/', timeout=1).read()
-        # 'meta-data\nuser-data'
-        # >>> urllib2.urlopen('http://169.254.169.254/latest/meta-data', timeout=1).read()
-        # 'ami-id\nami-launch-index\nami-manifest-path\nhostname\ninstance-id\nlocal-ipv4\npublic-keys/\nreservation-id\nsecurity-groups'
-        # >>> urllib2.urlopen('http://169.254.169.254/latest/meta-data/instance-id', timeout=1).read()
-        # 'i-deadbeef'
-
-        # Every call may add TIMEOUT seconds in latency so don't abuse this call
-        # python 2.4 does not support an explicit timeout argument so force it here
-        # Rather than monkey-patching urllib2, just lower the timeout globally for these calls
-
-        if not agentConfig['collect_instance_metadata']:
-            log.info("Instance metadata collection is disabled. Not collecting it.")
-            return {}
-
-        socket_to = None
-        try:
-            socket_to = socket.getdefaulttimeout()
-            socket.setdefaulttimeout(EC2.TIMEOUT)
-        except Exception:
-            pass
-
-        for k in ('instance-id', 'hostname', 'local-hostname', 'public-hostname', 'ami-id', 'local-ipv4', 'public-keys/', 'public-ipv4', 'reservation-id', 'security-groups'):
-            try:
-                v = urllib2.urlopen(EC2.METADATA_URL_BASE + "/" + unicode(k)).read().strip()
-                assert type(v) in (types.StringType, types.UnicodeType) and len(v) > 0, "%s is not a string" % v
-                EC2.metadata[k.rstrip('/')] = v
-            except Exception:
-                pass
-
-        try:
-            if socket_to is None:
-                socket_to = 3
-            socket.setdefaulttimeout(socket_to)
-        except Exception:
-            pass
-
-        return EC2.metadata
-
-    @staticmethod
-    def get_instance_id(agentConfig):
-        try:
-            return EC2.get_metadata(agentConfig).get("instance-id", None)
-        except Exception:
-            return None
-
 
 class Watchdog(object):
     """

--- a/utils/cloud_metadata.py
+++ b/utils/cloud_metadata.py
@@ -1,0 +1,219 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+import logging
+import types
+
+# 3rd party
+import requests
+
+# project
+from utils.proxy import get_proxy
+
+log = logging.getLogger(__name__)
+
+class GCE(object):
+    URL = "http://169.254.169.254/computeMetadata/v1/?recursive=true"
+    TIMEOUT = 0.3 # second
+    SOURCE_TYPE_NAME = 'google cloud platform'
+    metadata = None
+    EXCLUDED_ATTRIBUTES = ["kube-env", "startup-script", "sshKeys", "user-data",
+    "cli-cert", "ipsec-cert", "ssl-cert"]
+
+
+    @staticmethod
+    def _get_metadata(agentConfig):
+        if GCE.metadata is not None:
+            return GCE.metadata
+
+        if not agentConfig['collect_instance_metadata']:
+            log.info("Instance metadata collection is disabled. Not collecting it.")
+            GCE.metadata = {}
+            return GCE.metadata
+
+        try:
+            GCE.metadata = requests.get(
+                GCE.URL,
+                timeout=GCE.TIMEOUT,
+                headers={'X-Google-Metadata-Request': True}
+            ).json()
+        except Exception:
+            GCE.metadata = {}
+
+        return GCE.metadata
+
+
+
+    @staticmethod
+    def get_tags(agentConfig):
+        if not agentConfig['collect_instance_metadata']:
+            return None
+
+        try:
+            host_metadata = GCE._get_metadata(agentConfig)
+            tags = []
+
+            for key, value in host_metadata['instance'].get('attributes', {}).iteritems():
+                if key in GCE.EXCLUDED_ATTRIBUTES:
+                    continue
+                tags.append("%s:%s" % (key, value))
+
+            tags.extend(host_metadata['instance'].get('tags', []))
+            tags.append('zone:%s' % host_metadata['instance']['zone'].split('/')[-1])
+            tags.append('instance-type:%s' % host_metadata['instance']['machineType'].split('/')[-1])
+            tags.append('internal-hostname:%s' % host_metadata['instance']['hostname'])
+            tags.append('instance-id:%s' % host_metadata['instance']['id'])
+            tags.append('project:%s' % host_metadata['project']['projectId'])
+            tags.append('numeric_project_id:%s' % host_metadata['project']['numericProjectId'])
+
+            GCE.metadata['hostname'] = host_metadata['instance']['hostname'].split('.')[0]
+
+            return tags
+        except Exception:
+            return None
+
+    @staticmethod
+    def get_hostname(agentConfig):
+        try:
+            host_metadata = GCE._get_metadata(agentConfig)
+            hostname = host_metadata['instance']['hostname']
+            if agentConfig.get('gce_updated_hostname'):
+                return hostname
+            else:
+                return hostname.split('.')[0]
+        except Exception:
+            return None
+
+    @staticmethod
+    def get_host_aliases(agentConfig):
+        try:
+            host_metadata = GCE._get_metadata(agentConfig)
+            project_id = host_metadata['project']['projectId']
+            instance_name = host_metadata['instance']['hostname'].split('.')[0]
+            return ['%s.%s' % (instance_name, project_id)]
+        except Exception:
+            return None
+
+class EC2(object):
+    """Retrieve EC2 metadata
+    """
+    EC2_METADATA_HOST = "http://169.254.169.254"
+    METADATA_URL_BASE = EC2_METADATA_HOST + "/latest/meta-data"
+    INSTANCE_IDENTITY_URL = EC2_METADATA_HOST + "/latest/dynamic/instance-identity/document"
+    TIMEOUT = 0.1  # second
+    DEFAULT_PREFIXES = [u'ip-', u'domu']
+    metadata = {}
+
+    class NoIAMRole(Exception):
+        """
+        Instance has no associated IAM role.
+        """
+        pass
+
+    @staticmethod
+    def is_default(hostname):
+        hostname = hostname.lower()
+        for prefix in EC2.DEFAULT_PREFIXES:
+            if hostname.startswith(prefix):
+                return True
+        return False
+
+    @staticmethod
+    def get_iam_role():
+        """
+        Retrieve instance's IAM role.
+        Raise `NoIAMRole` when unavailable.
+        """
+        try:
+            r = requests.get(EC2.METADATA_URL_BASE + "/iam/security-credentials/")
+            r.raise_for_status()
+            return r.content.strip()
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                raise EC2.NoIAMRole()
+            raise
+
+    @staticmethod
+    def get_tags(agentConfig):
+        """
+        Retrieve AWS EC2 tags.
+        """
+        if not agentConfig['collect_instance_metadata']:
+            log.info("Instance metadata collection is disabled. Not collecting it.")
+            return []
+
+        EC2_tags = []
+
+        try:
+            iam_role = EC2.get_iam_role()
+            iam_url = EC2.METADATA_URL_BASE + "/iam/security-credentials/" + unicode(iam_role)
+            iam_params = requests.get(iam_url, timeout=EC2.TIMEOUT).json()
+            instance_identity = requests.get(EC2.INSTANCE_IDENTITY_URL, timeout=EC2.TIMEOUT).json()
+            region = instance_identity['region']
+
+            import boto.ec2
+            proxy_settings = get_proxy(agentConfig) or {}
+            connection = boto.ec2.connect_to_region(
+                region,
+                aws_access_key_id=iam_params['AccessKeyId'],
+                aws_secret_access_key=iam_params['SecretAccessKey'],
+                security_token=iam_params['Token'],
+                proxy=proxy_settings.get('host'), proxy_port=proxy_settings.get('port'),
+                proxy_user=proxy_settings.get('user'), proxy_pass=proxy_settings.get('password')
+            )
+
+            tag_object = connection.get_all_tags({'resource-id': EC2.metadata['instance-id']})
+
+            EC2_tags = [u"%s:%s" % (tag.name, tag.value) for tag in tag_object]
+            if agentConfig.get('collect_security_groups') and EC2.metadata.get('security-groups'):
+                EC2_tags.append(u"security-group-name:{0}".format(EC2.metadata.get('security-groups')))
+
+        except EC2.NoIAMRole:
+            log.warning(
+                u"Unable to retrieve AWS EC2 custom tags: "
+                u"an IAM role associated with the instance is required"
+            )
+        except Exception:
+            log.exception("Problem retrieving custom EC2 tags")
+
+        return EC2_tags
+
+    @staticmethod
+    def get_metadata(agentConfig):
+        """Use the ec2 http service to introspect the instance. This adds latency if not running on EC2
+        """
+        # >>> import requests
+        # >>> requests.get('http://169.254.169.254/latest/', timeout=1).content
+        # 'dynamic\nmeta-data\nuser-data'
+        # >>> requests.get('http://169.254.169.254/latest/meta-data', timeout=1).content
+        # 'ami-id\nami-launch-index\nami-manifest-path\nblock-device-mapping/\nhostname\niam/\ninstance-action\ninstance-id\ninstance-type\nlocal-hostname\nlocal-ipv4\nmac\nmetrics/\nnetwork/\nplacement/\nprofile\npublic-hostname\npublic-ipv4\npublic-keys/\nreservation-id\nsecurity-groups\nservices/'
+        # >>> requests.get('http://169.254.169.254/latest/meta-data/instance-id', timeout=1).content
+        # 'i-deadbeef'
+
+        # Every call may add TIMEOUT seconds in latency so don't abuse this call
+        # python 2.4 does not support an explicit timeout argument so force it here
+        # Rather than monkey-patching urllib2, just lower the timeout globally for these calls
+
+        if not agentConfig['collect_instance_metadata']:
+            log.info("Instance metadata collection is disabled. Not collecting it.")
+            return {}
+
+        for k in ('instance-id', 'hostname', 'local-hostname', 'public-hostname', 'ami-id', 'local-ipv4', 'public-keys/', 'public-ipv4', 'reservation-id', 'security-groups'):
+            try:
+                url = EC2.METADATA_URL_BASE + "/" + unicode(k)
+                v = requests.get(url, timeout=EC2.TIMEOUT).content.strip()
+                assert type(v) in (types.StringType, types.UnicodeType) and len(v) > 0, "%s is not a string" % v
+                EC2.metadata[k.rstrip('/')] = v
+            except Exception:
+                pass
+
+        return EC2.metadata
+
+    @staticmethod
+    def get_instance_id(agentConfig):
+        try:
+            return EC2.get_metadata(agentConfig).get("instance-id", None)
+        except Exception:
+            return None

--- a/utils/configcheck.py
+++ b/utils/configcheck.py
@@ -12,7 +12,7 @@ from config import (
     load_check_directory,
     get_confd_path
 )
-from util import get_hostname
+from utils.hostname import get_hostname
 from utils.dockerutil import DockerUtil
 from utils.service_discovery.config_stores import get_config_store, SD_CONFIG_BACKENDS, TRACE_CONFIG
 

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -10,7 +10,7 @@ import sys
 
 # datadog
 from config import get_checksd_path, get_confd_path
-from util import get_os
+from utils.platform import get_os
 
 
 def run_check(name, path=None):

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -43,7 +43,7 @@ from config import (
     get_url_endpoint,
 )
 from jmxfetch import JMXFetch
-from util import get_hostname
+from utils.hostname import get_hostname
 from utils.jmx import jmx_command, JMXFiles
 from utils.platform import Platform
 from utils.configcheck import configcheck, sd_configcheck

--- a/utils/hostname.py
+++ b/utils/hostname.py
@@ -1,0 +1,116 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+import logging
+import re
+import socket
+
+# project
+from utils.cloud_metadata import EC2, GCE
+from utils.dockerutil import DockerUtil
+from utils.kubeutil import KubeUtil
+from utils.platform import Platform
+from utils.subprocess_output import get_subprocess_output
+
+VALID_HOSTNAME_RFC_1123_PATTERN = re.compile(r"^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$")
+MAX_HOSTNAME_LEN = 255
+
+log = logging.getLogger(__name__)
+
+def is_valid_hostname(hostname):
+    if hostname.lower() in set([
+        'localhost',
+        'localhost.localdomain',
+        'localhost6.localdomain6',
+        'ip6-localhost',
+    ]):
+        log.warning("Hostname: %s is local" % hostname)
+        return False
+    if len(hostname) > MAX_HOSTNAME_LEN:
+        log.warning("Hostname: %s is too long (max length is  %s characters)" % (hostname, MAX_HOSTNAME_LEN))
+        return False
+    if VALID_HOSTNAME_RFC_1123_PATTERN.match(hostname) is None:
+        log.warning("Hostname: %s is not complying with RFC 1123" % hostname)
+        return False
+    return True
+
+def _get_hostname_unix():
+    try:
+        # try fqdn
+        out, _, rtcode = get_subprocess_output(['/bin/hostname', '-f'], log)
+        if rtcode == 0:
+            return out.strip()
+    except Exception:
+        return None
+
+def get_hostname(config=None):
+    """
+    Get the canonical host name this agent should identify as. This is
+    the authoritative source of the host name for the agent.
+
+    Tries, in order:
+
+      * agent config (datadog.conf, "hostname:")
+      * 'hostname -f' (on unix)
+      * socket.gethostname()
+    """
+    hostname = None
+
+    # first, try the config
+    if config is None:
+        from config import get_config
+        config = get_config(parse_args=True)
+    config_hostname = config.get('hostname')
+    if config_hostname and is_valid_hostname(config_hostname):
+        return config_hostname
+
+    # Try to get GCE instance name
+    gce_hostname = GCE.get_hostname(config)
+    if gce_hostname is not None:
+        if is_valid_hostname(gce_hostname):
+            return gce_hostname
+
+    # Try to get the docker hostname
+    if Platform.is_containerized():
+
+        # First we try from the Docker API
+        docker_util = DockerUtil()
+        docker_hostname = docker_util.get_hostname(use_default_gw=False)
+        if docker_hostname is not None and is_valid_hostname(docker_hostname):
+            hostname = docker_hostname
+
+        elif Platform.is_k8s(): # Let's try from the kubelet
+            kube_util = KubeUtil()
+            _, kube_hostname = kube_util.get_node_info()
+            if kube_hostname is not None and is_valid_hostname(kube_hostname):
+                hostname = kube_hostname
+
+    # then move on to os-specific detection
+    if hostname is None:
+        if Platform.is_unix() or Platform.is_solaris():
+            unix_hostname = _get_hostname_unix()
+            if unix_hostname and is_valid_hostname(unix_hostname):
+                hostname = unix_hostname
+
+    # if we have an ec2 default hostname, see if there's an instance-id available
+    if (Platform.is_ecs_instance()) or (hostname is not None and EC2.is_default(hostname)):
+        instanceid = EC2.get_instance_id(config)
+        if instanceid:
+            hostname = instanceid
+
+    # fall back on socket.gethostname(), socket.getfqdn() is too unreliable
+    if hostname is None:
+        try:
+            socket_hostname = socket.gethostname()
+        except socket.error:
+            socket_hostname = None
+        if socket_hostname and is_valid_hostname(socket_hostname):
+            hostname = socket_hostname
+
+    if hostname is None:
+        log.critical('Unable to reliably determine host name. You can define one in datadog.conf or in your hosts file')
+        raise Exception('Unable to reliably determine host name. You can define one in datadog.conf or in your hosts file')
+
+    return hostname

--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -21,11 +21,6 @@ log = logging.getLogger('collector')
 
 KUBERNETES_CHECK_NAME = 'kubernetes'
 
-
-def is_k8s():
-    return 'KUBERNETES_PORT' in os.environ
-
-
 class KubeUtil:
     __metaclass__ = Singleton
 
@@ -183,7 +178,12 @@ class KubeUtil:
 
         The host IP address is different from the default router for the pod.
         """
-        pod_items = self.retrieve_pods_list().get("items") or []
+        try:
+            pod_items = self.retrieve_pods_list().get("items") or []
+        except Exception as e:
+            log.warning("Unable to retrieve pod list %s. Not fetching host data", str(e))
+            return
+
         for pod in pod_items:
             metadata = pod.get("metadata", {})
             name = metadata.get("name")

--- a/utils/platform.py
+++ b/utils/platform.py
@@ -3,8 +3,24 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 # stdlib
+import os
 import sys
 
+
+def get_os():
+    "Human-friendly OS name"
+    if sys.platform == 'darwin':
+        return 'mac'
+    elif sys.platform.find('freebsd') != -1:
+        return 'freebsd'
+    elif sys.platform.find('linux') != -1:
+        return 'linux'
+    elif sys.platform.find('win32') != -1:
+        return 'windows'
+    elif sys.platform.find('sunos') != -1:
+        return 'solaris'
+    else:
+        return sys.platform
 
 class Platform(object):
     """
@@ -70,3 +86,11 @@ class Platform(object):
     def is_ecs_instance():
         from utils.dockerutil import DockerUtil
         return DockerUtil().is_ecs()
+
+    @staticmethod
+    def is_containerized():
+        return os.environ.get("DOCKER_DD_AGENT") == "yes"
+
+    @staticmethod
+    def is_k8s():
+        return 'KUBERNETES_PORT' in os.environ

--- a/win32/agent.py
+++ b/win32/agent.py
@@ -33,7 +33,7 @@ import dogstatsd
 from emitter import http_emitter
 from jmxfetch import JMXFetch
 import modules
-from util import get_hostname
+from utils.hostname import get_hostname
 from utils.jmx import JMXFiles
 from utils.profile import AgentProfiler
 


### PR DESCRIPTION

### What does this PR do?

This PR:
- Moves hostname logic in it’s own util module
- Moves cloud metadata logic in it’s own util module
- Add a new way to determine the hostname using the kubelet
- Some code cleaning/consolidating

### Motivation

Needed to have another way to find the hostname when running kubernetes but i realized that this logic could benefit from refactoring so i did.
