### PR TITLE
[disk] another timeout on disk usage

### DIFF
--- a/tests/checks/mock/test_disk.py
+++ b/tests/checks/mock/test_disk.py
@@ -10,7 +10,6 @@ from tests.checks.common import AgentCheckTest, Fixtures
 
 DEFAULT_DEVICE_NAME = '/dev/sda1'
 
-
 class MockPart(object):
     def __init__(self, device=DEFAULT_DEVICE_NAME, fstype='ext4',
                  mountpoint='/'):
@@ -114,6 +113,8 @@ class TestCheckDisk(AgentCheckTest):
     def test_psutil(self, mock_partitions, mock_usage, mock_inodes):
         # Mocking
         mock_usage.__name__ = "foo"
+        mock_inodes.__name__ = "foo"
+        mock_partitions.__name__ = "foo"
 
         # Run check
         for tag_by in ['yes', 'no']:
@@ -134,6 +135,8 @@ class TestCheckDisk(AgentCheckTest):
     def test_use_mount(self, mock_partitions, mock_usage, mock_inodes):
         # Mocking
         mock_usage.__name__ = "foo"
+        mock_inodes.__name__ = "foo"
+        mock_partitions.__name__ = "foo"
 
         # Run check
         self.run_check({'instances': [{'use_mount': 'yes'}]})
@@ -149,6 +152,9 @@ class TestCheckDisk(AgentCheckTest):
                 return_value=(Fixtures.read_file('debian-df-Tk'), "", 0))
     @mock.patch('os.statvfs', return_value=MockInodesMetrics())
     def test_no_psutil_debian(self, mock_df_output, mock_statvfs):
+        mock_statvfs.__name__ = "foo"
+        mock_df_output.__name__ = "foo"
+
         self.run_check({'instances': [{'use_mount': 'no',
                                        'excluded_filesystems': ['tmpfs']}]},
                        mocks={'_psutil': lambda: False})
@@ -165,6 +171,9 @@ class TestCheckDisk(AgentCheckTest):
                 return_value=(Fixtures.read_file('freebsd-df-Tk'), "", 0))
     @mock.patch('os.statvfs', return_value=MockInodesMetrics())
     def test_no_psutil_freebsd(self, mock_df_output, mock_statvfs):
+        mock_statvfs.__name__ = "foo"
+        mock_df_output.__name__ = "foo"
+
         self.run_check({'instances': [{'use_mount': 'no',
                                        'excluded_filesystems': ['devfs'],
                                        'excluded_disk_re': 'zroot/.+'}]},
@@ -180,6 +189,9 @@ class TestCheckDisk(AgentCheckTest):
                 return_value=(Fixtures.read_file('centos-df-Tk'), "", 0))
     @mock.patch('os.statvfs', return_value=MockInodesMetrics())
     def test_no_psutil_centos(self, mock_df_output, mock_statvfs):
+        mock_statvfs.__name__ = "foo"
+        mock_df_output.__name__ = "foo"
+
         self.run_check({'instances': [{'use_mount': 'no',
                                        'excluded_filesystems': ['devfs', 'tmpfs'],
                                        'excluded_disks': ['/dev/sda1']}]},


### PR DESCRIPTION
### What does this PR do?

In #2714, we solved a problem with disk usage where nfs mounts would hang. In some cases, we're still seeing them hanging, because `os.statvfs` is being called in another place as well.

This adds a timeout wrapper to that second call, as well.