### PR TITLE
[elastic][tests]❌ `cluster_name` service check tag

### DIFF
--- a/tests/checks/integration/test_elastic.py
+++ b/tests/checks/integration/test_elastic.py
@@ -541,7 +541,7 @@ class TestElastic(AgentCheckTest):
         )
         self.assertServiceCheckOK(
             'elasticsearch.cluster_health',
-            tags=['host:localhost', 'port:9200'] + dummy_tags + server_tags,
+            tags=['host:localhost', 'port:9200'] + dummy_tags,
             count=1
         )
 


### PR DESCRIPTION
`cluster_name` tag was removed from service checks in
https://github.com/DataDog/dd-agent/commit/d4c3d76d4ca20414d219957bbb8edfdf1ca46211