### PR TITLE
[proc] fix to search by pid.

### DIFF
--- a/checks.d/process.py
+++ b/checks.d/process.py
@@ -325,7 +325,9 @@ class ProcessCheck(AgentCheck):
                 ignore_ad=ignore_ad
             )
         elif pid is not None:
-            pids = [psutil.Process(pid)]
+            # we use Process(pid) as a means to search, if pid not found
+            # psutil.NoSuchProcess is raised.
+            pids = set([psutil.Process(pid).pid])
         else:
             raise ValueError('The "search_string" or "pid" options are required for process identification')
 


### PR DESCRIPTION
### What does this PR do?

While testing for #2119, I found a few problems. `pids` should be a set as that's what is expected by `get_process_state()`. It also expects a set of integers, not `psutil.Process`es. This short PR addresses the two.

### Motivation
Found the bug while testing for the feature.

