### PR TITLE
[dogstatsd] Add support for configurable histogram percentile names

### DIFF
--- a/config.py
+++ b/config.py
@@ -317,7 +317,6 @@ def get_histogram_percentiles(configstr=None):
 
     return result
 
-
 def clean_dd_url(url):
     url = url.strip()
     if not url.startswith('http'):
@@ -476,6 +475,9 @@ def get_config(parse_args=True, cfg_path=None, options=None):
 
         if config.has_option('Main', 'histogram_percentiles'):
             agentConfig['histogram_percentiles'] = get_histogram_percentiles(config.get('Main', 'histogram_percentiles'))
+
+        if config.has_option('Main', 'histogram_name_format'):
+            agentConfig['histogram_name_format'] = config.get('Main', 'histogram_name_format')
 
         # Disable Watchdog (optionally)
         if config.has_option('Main', 'watchdog'):

--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -503,6 +503,7 @@ def init(config_path=None, use_watchdog=False, use_forwarder=False, args=None):
         formatter=get_formatter(c),
         histogram_aggregates=c.get('histogram_aggregates'),
         histogram_percentiles=c.get('histogram_percentiles'),
+        histogram_name_format=c.get('histogram_name_format'),
         utf8_decoding=c['utf8_decoding']
     )
 

--- a/tests/core/test_histogram.py
+++ b/tests/core/test_histogram.py
@@ -57,6 +57,74 @@ class TestHistogram(unittest.TestCase):
 
         self.assertEquals(value_by_type['40percentile'], 7, value_by_type)
 
+    def test_custom_single_percentile_withCustomName(self):
+        configstr = '0.40'
+        configname = '%s.p%s'
+
+        stats = MetricsAggregator(
+            'myhost',
+            histogram_percentiles=get_histogram_percentiles(configstr),
+            histogram_name_format=configname
+        )
+
+        self.assertEquals(
+            stats.metric_config[Histogram]['percentiles'],
+            [0.40],
+            stats.metric_config[Histogram]
+        )
+        self.assertEquals(
+            stats.metric_config[Histogram]['name_format'],
+            '%s.p%s',
+            stats.metric_config[Histogram]
+        )
+
+        for i in xrange(20):
+            stats.submit_packets('myhistogram:{0}|h'.format(i))
+
+        metrics = stats.flush()
+
+        self.assertEquals(len(metrics), 5, metrics)
+
+        value_by_type = {}
+        for k in metrics:
+            value_by_type[k['metric'][len('myhistogram')+1:]] = k['points'][0][1]
+
+        self.assertEquals(value_by_type['p40'], 7, value_by_type)
+
+    def test_custom_single_percentile_withInvalidCustomName(self):
+        configstr = '0.40'
+        configname = '%s.p%s.%s'
+
+        stats = MetricsAggregator(
+            'myhost',
+            histogram_percentiles=get_histogram_percentiles(configstr),
+            histogram_name_format=configname
+        )
+
+        self.assertEquals(
+            stats.metric_config[Histogram]['percentiles'],
+            [0.40],
+            stats.metric_config[Histogram]
+        )
+        self.assertEquals(
+            stats.metric_config[Histogram]['name_format'],
+            '%s.p%s.%s',
+            stats.metric_config[Histogram]
+        )
+
+        for i in xrange(20):
+            stats.submit_packets('myhistogram:{0}|h'.format(i))
+
+        metrics = stats.flush()
+
+        self.assertEquals(len(metrics), 5, metrics)
+
+        value_by_type = {}
+        for k in metrics:
+            value_by_type[k['metric'][len('myhistogram')+1:]] = k['points'][0][1]
+
+        self.assertEquals(value_by_type['40percentile'], 7, value_by_type)
+
     def test_custom_multiple_percentile(self):
         configstr = '0.4, 0.65, 0.999'
         stats = MetricsAggregator(


### PR DESCRIPTION
### What does this PR do?

This PR makes it possible to customize the histogram percentile names.
### Motivation

If DD dashboards have been built with different metric names for percentiles, this makes it easier to conform to those, rather than updating all the dashboards.
### Additional Notes

If an invalid format is provided, the agent will log a warning (when flushing the metric) and default to the existing name format.
