### PR TITLE
[Core] Do not requeue all responses

### DIFF
--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -763,7 +763,7 @@ class ForwarderStatus(AgentStatus):
     NAME = 'Forwarder'
 
     def __init__(self, queue_length=0, queue_size=0, flush_count=0, transactions_received=0,
-                 transactions_flushed=0, too_big_count=0):
+                 transactions_flushed=0, transactions_rejected=0):
         AgentStatus.__init__(self)
         self.queue_length = queue_length
         self.queue_size = queue_size
@@ -772,7 +772,7 @@ class ForwarderStatus(AgentStatus):
         self.transactions_flushed = transactions_flushed
         self.hidden_username = None
         self.hidden_password = None
-        self.too_big_count = too_big_count
+        self.transactions_rejected = transactions_rejected
 
     def body_lines(self):
         lines = [
@@ -781,7 +781,7 @@ class ForwarderStatus(AgentStatus):
             "Flush Count: %s" % self.flush_count,
             "Transactions received: %s" % self.transactions_received,
             "Transactions flushed: %s" % self.transactions_flushed,
-            "Transactions rejected: %s" % self.too_big_count,
+            "Transactions rejected: %s" % self.transactions_rejected,
             ""
         ]
 
@@ -796,7 +796,7 @@ class ForwarderStatus(AgentStatus):
             'flush_count': self.flush_count,
             'queue_length': self.queue_length,
             'queue_size': self.queue_size,
-            'too_big_count': self.too_big_count,
+            'transactions_rejected': self.transactions_rejected,
             'transactions_received': self.transactions_received,
             'transactions_flushed': self.transactions_flushed
         })

--- a/ddagent.py
+++ b/ddagent.py
@@ -86,6 +86,9 @@ MAX_WAIT_FOR_REPLAY = timedelta(seconds=90)
 # Maximum queue size in bytes (when this is reached, old messages are dropped)
 MAX_QUEUE_SIZE = 30 * 1024 * 1024  # 30MB
 
+# Some responses should be rejected, rather than replayed. This list will be rejected.
+RESPONSES_TO_REJECT = [413, 400]
+
 THROTTLING_DELAY = timedelta(microseconds=1000000 / 2)  # 2 msg/second
 
 
@@ -273,7 +276,7 @@ class AgentTransaction(Transaction):
     def on_response(self, response):
         if response.error:
             log.error("Response: %s" % response)
-            if response.code in [413, 400]:
+            if response.code in RESPONSES_TO_REJECT:
                 self._trManager.tr_error_reject_request(self)
             else:
                 self._trManager.tr_error(self)

--- a/ddagent.py
+++ b/ddagent.py
@@ -273,8 +273,8 @@ class AgentTransaction(Transaction):
     def on_response(self, response):
         if response.error:
             log.error("Response: %s" % response)
-            if response.code == 413:
-                self._trManager.tr_error_too_big(self)
+            if response.code in [413, 400]:
+                self._trManager.tr_error_reject_request(self)
             else:
                 self._trManager.tr_error(self)
         else:

--- a/transaction.py
+++ b/transaction.py
@@ -90,7 +90,7 @@ class TransactionManager(object):
         self._transactions_received = 0
         self._transactions_flushed = 0
 
-        self._too_big_count = 0
+        self._transactions_rejected = 0
 
         # Global counter to assign a number to each transaction: we may have an issue
         #  if this overlaps
@@ -192,7 +192,7 @@ class TransactionManager(object):
             flush_count=self._flush_count,
             transactions_received=self._transactions_received,
             transactions_flushed=self._transactions_flushed,
-            too_big_count=self._too_big_count).persist()
+            transactions_rejected=self._transactions_rejected).persist()
 
     def flush_next(self):
 
@@ -262,7 +262,7 @@ class TransactionManager(object):
 
             self._trs_to_flush = new_trs_to_flush
 
-    def tr_error_too_big(self, tr):
+    def tr_error_reject_request(self, tr):
         self._running_flushes -= 1
         self._finished_flushes += 1
         tr.inc_error_count()
@@ -275,14 +275,14 @@ class TransactionManager(object):
         self._total_size -= tr.get_size()
         self._transactions_flushed += 1
         self.print_queue_stats()
-        self._too_big_count += 1
+        self._transactions_rejected += 1
         ForwarderStatus(
             queue_length=self._total_count,
             queue_size=self._total_size,
             flush_count=self._flush_count,
             transactions_received=self._transactions_received,
             transactions_flushed=self._transactions_flushed,
-            too_big_count=self._too_big_count).persist()
+            transactions_rejected=self._transactions_rejected).persist()
 
     def tr_success(self, tr):
         self._running_flushes -= 1

--- a/win32/status.html
+++ b/win32/status.html
@@ -244,7 +244,7 @@
             <dt>Queue length</dt>       <dd>{{ forwarder['queue_length'] }}</dd>
             <dt>Transactions received</dt> <dd>{{ forwarder['transactions_received'] }}</dd>
             <dt>Transactions flushed</dt> <dd>{{ forwarder['transactions_flushed'] }}</dd>
-            <dt>Transactions rejected</dt>       <dd>{{ forwarder['too_big_count'] }}</dd>
+            <dt>Transactions rejected</dt>       <dd>{{ forwarder['transactions_rejected'] }}</dd>
           </dl>
 
           <!-- Dogstatsd -->


### PR DESCRIPTION
### What does this PR do?

Not all requests should be replayed. We already do not replay requests that are too large (#2418), this extends the logic to 400 responses and makes the list of bad response types into a constant (`RESPONSES_TO_REJECT`), so that it can easily be added to or pruned.

### Motivation

It was causing some issues in certain setups that these were being requeued. Also, it's wasteful to requeue responses that we know will be rejected. And, it's confusing to pollute the logs with re-rejections of validly rejected requests.

### Additional Questions
Rather than having a blacklist of responses, we might want to have a whitelist of responses: Only requeue responses that were rejected for network errors or server errors.