### PR TITLE
[docker_daemon] custom cgroups are per instance only. YAML updates.

### DIFF
--- a/conf.d/docker.yaml.example
+++ b/conf.d/docker.yaml.example
@@ -12,12 +12,6 @@ init_config:
   # Timeout on Docker socket connection. You may have to increase it if you have many containers.
   # socket_timeout: 5
 
-  # Do you use custom cgroups for your containers? Also relevant if using systemd-docker.
-  # Note: enabling this option modifies the way in which we inspect the containers and causes
-  #       some overhead - if you run a high volume of containers we may timeout. Please only
-  #       enable if absolutely necessary.
-  # custom_cgroups: false
-
 instances:
     # URL of the Docker daemon socket to reach the Docker API. HTTP also works.
   - url: "unix://var/run/docker.sock"
@@ -61,12 +55,6 @@ instances:
     #
     # collect_events: true
     #
-    #
-    # Do you use custom cgroups for this particular instance? Overrides the init_config setting.
-    # Note: enabling this option modifies the way in which we inspect the containers and causes
-    #       some overhead - if you run a high volume of containers we may timeout. Please only
-    #       enable if absolutely necessary.
-    # custom_cgroups: false
 
     # Collect disk usage per container with docker.disk.size metric.
     # Warning: This feature is broken in some version of Docker (such as 1.2).

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -45,6 +45,12 @@ instances:
     #
     # collect_container_size: false
 
+    # Do you use custom cgroups for this particular instance?
+    # Note: enabling this option modifies the way in which we inspect the containers and causes
+    #       some overhead - if you run a high volume of containers we may timeout. Please only
+    #       enable if absolutely necessary.
+    # custom_cgroups: false
+
     # Collect images stats
     # Number of available active images and intermediate images as gauges.
     # Defaults to false.


### PR DESCRIPTION
### What does this PR do?

We used to have `custom_cgroups` be a setting that would apply both at the `init_conf` and `instance` levels. This PR makes it only apply per instance. It also updates the documentation.


### Motivation

It's confusing to have it configurable on both levels. Also, there was a small bug. So let's just do this instead.

