### PR TITLE
[docker] Fix pid retrieval

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -806,6 +806,17 @@ class DockerDaemon(AgentCheck):
                 metrics['io_write'] += int(line.split()[2])
         return metrics
 
+    def _is_container_cgroup(self, line, selinux_policy):
+        if line[1] not in ('cpu,cpuacct', 'cpuacct,cpu', 'cpuacct') or line[2] == '/docker-daemon':
+            return False
+        if 'docker' in line[2]: # general case
+            return True
+        if 'docker' in selinux_policy: # selinux
+            return True
+        if line[2].startswith('/') and re.match(CONTAINER_ID_RE, line[2][1:]): # kubernetes
+            return True
+        return False
+
     # proc files
     def _crawl_container_pids(self, container_dict):
         """Crawl `/proc` to find container PIDs and add them to `containers_by_id`."""
@@ -846,8 +857,7 @@ class DockerDaemon(AgentCheck):
 
             try:
                 for line in content:
-                    if line[1] in ('cpu,cpuacct', 'cpuacct,cpu', 'cpuacct') and \
-                            ('docker' in line[2] or 'docker' in selinux_policy):
+                    if self._is_container_cgroup(line, selinux_policy):
                         cpuacct = line[2]
                         break
                 else:


### PR DESCRIPTION
### What does this PR do?

On kubernetes a cgroup file will look like
```
root@dd-agent-nightly-rc-jnexb:/host/proc/17916# cat cgroup
10:net_prio:/5e5f675ab3dbd1353837e46d158a6401abe0673324568b204a3a183ea6a
42772
9:perf_event:/5e5f675ab3dbd1353837e46d158a6401abe0673324568b204a3a183ea6
a42772
8:blkio:/5e5f675ab3dbd1353837e46d158a6401abe0673324568b204a3a183ea6a4277
2
7:net_cls:/5e5f675ab3dbd1353837e46d158a6401abe0673324568b204a3a183ea6a42
772

freezer:/5e5f675ab3dbd1353837e46d158a6401abe0673324568b204a3a183ea6a4277
2
5:devices:/5e5f675ab3dbd1353837e46d158a6401abe0673324568b204a3a183ea6a42
772
4:memory:/5e5f675ab3dbd1353837e46d158a6401abe0673324568b204a3a183ea6a427
72
3:cpuacct:/5e5f675ab3dbd1353837e46d158a6401abe0673324568b204a3a183ea6a42
772
2:cpu:/5e5f675ab3dbd1353837e46d158a6401abe0673324568b204a3a183ea6a42772
1:cpuset:/5e5f675ab3dbd1353837e46d158a6401abe0673324568b204a3a183ea6a427
72
```

Which was previously ignored. The refactored logic will take that
format in consideration

### Motivation
Without this PR the docker daemon check was failing with
```python
   Traceback (most recent call last):
          File "/opt/datadog-agent/agent/checks/__init__.py", line 771, in run
            self.check(copy.deepcopy(instance))
          File "/opt/datadog-agent/agent/checks.d/docker_daemon.py", line 263, in check
            self._report_performance_metrics(containers_by_id)
          File "/opt/datadog-agent/agent/checks.d/docker_daemon.py", line 534, in _report_performance_metrics
            self._report_cgroup_metrics(container, tags)
          File "/opt/datadog-agent/agent/checks.d/docker_daemon.py", line 552, in _report_cgroup_metrics
            stat_file = self._get_cgroup_from_proc(cgroup["cgroup"], container['_pid'], cgroup['file'])
        KeyError: '_pid'
```

### Testing Guidelines
Tested on k8s 1.2, will test on 1.3 as well