### PR TITLE
[kubernetes] Add ability to specify service discovery via kubernetes annotations

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -18,7 +18,6 @@ from utils.dockerutil import DockerUtil, MountException
 from utils.kubeutil import KubeUtil
 from utils.platform import Platform
 from utils.service_discovery.sd_backend import get_sd_backend
-from utils.service_discovery.config_stores import get_config_store
 
 
 EVENT_TYPE = 'docker'
@@ -161,13 +160,7 @@ class DockerDaemon(AgentCheck):
             instance = self.instances[0]
 
             # if service discovery is enabled dockerutil will need a reference to the config store
-            if self._service_discovery:
-                self.docker_util = DockerUtil(
-                    agentConfig=self.agentConfig,
-                    config_store=get_config_store(self.agentConfig)
-                )
-            else:
-                self.docker_util = DockerUtil()
+            self.docker_util = DockerUtil()
             self.docker_client = self.docker_util.client
             self.docker_gateway = DockerUtil.get_gateway()
 
@@ -627,9 +620,9 @@ class DockerDaemon(AgentCheck):
 
     def _get_events(self):
         """Get the list of events."""
-        events, conf_reload_set = self.docker_util.get_events()
-        if conf_reload_set and self._service_discovery:
-            get_sd_backend(self.agentConfig).reload_check_configs = conf_reload_set
+        events, changed_container_ids = self.docker_util.get_events()
+        if changed_container_ids and self._service_discovery:
+            get_sd_backend(self.agentConfig).update_checks(changed_container_ids)
         return events
 
     def _pre_aggregate_events(self, api_events, containers_by_id):

--- a/ci/docker_daemon.rb
+++ b/ci/docker_daemon.rb
@@ -8,6 +8,8 @@ namespace :ci do
   namespace :docker_daemon do |flavor|
     task before_install: ['ci:common:before_install']
 
+    task install: ['ci:common:install']
+
     task before_script: ['ci:common:before_script']
 
     task script: ['ci:common:script'] do

--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -40,7 +40,7 @@ def _get_container_inspect(c_id):
         return None
 
 
-def _get_conf_tpls(image_name, trace_config=False):
+def _get_conf_tpls(image_name, trace_config=False, kube_annotations=None):
     """Return a mocked configuration template from self.mock_templates."""
     return copy.deepcopy(TestServiceDiscovery.mock_templates.get(image_name)[0])
 
@@ -523,6 +523,28 @@ class TestServiceDiscovery(unittest.TestCase):
         for image in invalid_config:
             tpl = self.mock_tpls.get(image)[1]
             self.assertEquals(tpl, config_store.get_check_tpls(image))
+
+    @mock.patch.object(AbstractConfigStore, 'client_read', side_effect=client_read)
+    def test_get_check_tpls_kube(self, mock_client_read):
+        """Test get_check_tpls"""
+        valid_config = ['image_0', 'image_1', 'image_2']
+        invalid_config = ['bad_image_0']
+        config_store = get_config_store(self.auto_conf_agentConfig)
+        for image in valid_config + invalid_config:
+            tpl = self.mock_tpls.get(image)[1]
+            if tpl:
+                self.assertNotEquals(
+                    tpl,
+                    config_store.get_check_tpls('k8s-' + image, auto_conf=True))
+            self.assertEquals(
+                tpl,
+                config_store.get_check_tpls(
+                    'k8s-' + image, auto_conf=True,
+                    kube_annotations=dict(zip(
+                        ['com.datadoghq.sd/check_names',
+                         'com.datadoghq.sd/init_configs',
+                         'com.datadoghq.sd/instances'],
+                        self.mock_tpls[image][0]))))
 
     def test_get_config_id(self):
         """Test get_config_id"""

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -11,7 +11,6 @@ import time
 
 # 3rd party
 from docker import Client, tls
-from docker.errors import NullResource
 
 # project
 from utils.singleton import Singleton
@@ -57,11 +56,6 @@ class DockerUtil:
         # At first run we'll just collect the events from the latest 60 secs
         self._latest_event_collection_ts = int(time.time()) - 60
 
-        if 'config_store' in kwargs:
-            self.config_store = kwargs['config_store']
-        else:
-            self.config_store = None
-
         # Try to detect if we are on ECS
         self._is_ecs = False
         try:
@@ -106,7 +100,7 @@ class DockerUtil:
 
     def get_events(self):
         self.events = []
-        conf_reload_set = set()
+        changed_container_ids = set()
         now = int(time.time())
 
         event_generator = self.client.events(since=self._latest_event_collection_ts,
@@ -120,24 +114,10 @@ class DockerUtil:
                 log.debug('Unable to parse Docker event: %s', event)
                 continue
 
-            if self.config_store and event.get('status') in CONFIG_RELOAD_STATUS:
-                try:
-                    inspect = self.client.inspect_container(event.get('id'))
-                except NullResource:
-                    inspect = {}
-                checks = self._get_checks_from_inspect(inspect)
-                if checks:
-                    conf_reload_set.update(set(checks))
+            if event.get('status') in CONFIG_RELOAD_STATUS:
+                changed_container_ids.add(event.get('id'))
             self.events.append(event)
-        return self.events, conf_reload_set
-
-    def _get_checks_from_inspect(self, inspect):
-        """Get the list of checks applied to a container from the identifier_to_checks cache in the config store.
-        Use the DATADOG_ID label or the image."""
-        identifier = inspect.get('Config', {}).get('Labels', {}).get(DATADOG_ID) or \
-            inspect.get('Config', {}).get('Image')
-
-        return self.config_store.identifier_to_checks[identifier]
+        return self.events, changed_container_ids
 
     @classmethod
     def get_gateway(cls, proc_prefix=""):

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -129,6 +129,16 @@ class AbstractConfigStore(object):
 
         return None
 
+    def get_checks_to_refresh(self, identifier, **kwargs):
+        to_check = set(self.identifier_to_checks[identifier])
+        kube_annotations = kwargs.get('kube_annotations')
+        if kube_annotations:
+            kube_config = self._get_kube_config(identifier, kube_annotations)
+            if kube_config is not None:
+                to_check.update(kube_config[0])
+
+        return to_check
+
     def get_check_tpls(self, identifier, **kwargs):
         """Retrieve template configs for an identifier from the config_store or auto configuration."""
         trace_config = kwargs.get(TRACE_CONFIG, False)

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -20,10 +20,13 @@ log = logging.getLogger(__name__)
 CONFIG_FROM_AUTOCONF = 'auto-configuration'
 CONFIG_FROM_FILE = 'YAML file'
 CONFIG_FROM_TEMPLATE = 'template'
+CONFIG_FROM_KUBE = 'Kubernetes Pod Annotation'
 TRACE_CONFIG = 'trace_config'  # used for tracing config load by service discovery
 CHECK_NAMES = 'check_names'
 INIT_CONFIGS = 'init_configs'
 INSTANCES = 'instances'
+KUBE_ANNOTATIONS = 'kube_annotations'
+KUBE_ANNOTATION_PREFIX = 'com.datadoghq.sd/'
 
 
 class KeyNotFound(Exception):
@@ -95,6 +98,19 @@ class AbstractConfigStore(object):
 
         return identifier_to_checks
 
+    def _get_kube_config(self, identifier, kube_annotations):
+        try:
+            check_names = json.loads(kube_annotations[KUBE_ANNOTATION_PREFIX + CHECK_NAMES])
+            init_config_tpls = json.loads(kube_annotations[KUBE_ANNOTATION_PREFIX + INIT_CONFIGS])
+            instance_tpls = json.loads(kube_annotations[KUBE_ANNOTATION_PREFIX + INSTANCES])
+            return [check_names, init_config_tpls, instance_tpls]
+        except KeyError:
+            return None
+        except json.JSONDecodeError:
+            log.exception('Could not decode the JSON configuration template '
+                          'for the kubernetes pod with ident %s...' % identifier)
+            return None
+
     def _get_auto_config(self, image_name):
         ident = self._get_image_ident(image_name)
         if ident in self.auto_conf_images:
@@ -115,12 +131,22 @@ class AbstractConfigStore(object):
 
     def get_check_tpls(self, identifier, **kwargs):
         """Retrieve template configs for an identifier from the config_store or auto configuration."""
-        templates = []
         trace_config = kwargs.get(TRACE_CONFIG, False)
 
         # this flag is used when no valid configuration store was provided
         # it makes the method skip directly to the auto_conf
         if kwargs.get('auto_conf') is True:
+            # When not using a configuration store on kubernetes, check the pod
+            # annotations for configs before falling back to autoconf.
+            kube_annotations = kwargs.get(KUBE_ANNOTATIONS)
+            if kube_annotations:
+                kube_config = self._get_kube_config(identifier, kube_annotations)
+                if kube_config is not None:
+                    check_names, init_config_tpls, instance_tpls = kube_config
+                    source = CONFIG_FROM_KUBE
+                    return [(source, vs) if trace_config else vs
+                            for vs in zip(check_names, init_config_tpls, instance_tpls)]
+
             # in auto config mode, identifier is the image name
             auto_config = self._get_auto_config(identifier)
             if auto_config is not None:
@@ -147,12 +173,8 @@ class AbstractConfigStore(object):
         # Try to update the identifier_to_checks cache
         self._update_identifier_to_checks(identifier, check_names)
 
-        for idx, c_name in enumerate(check_names):
-            if trace_config:
-                templates.append((source, (c_name, init_config_tpls[idx], instance_tpls[idx])))
-            else:
-                templates.append((c_name, init_config_tpls[idx], instance_tpls[idx]))
-        return templates
+        return [(source, values) if trace_config else values
+                for values in zip(check_names, init_config_tpls, instance_tpls)]
 
     def read_config_from_store(self, identifier):
         """Try to read from the config store, falls back to auto-config in case of failure."""

--- a/utils/service_discovery/abstract_sd_backend.py
+++ b/utils/service_discovery/abstract_sd_backend.py
@@ -22,7 +22,7 @@ class AbstractSDBackend(object):
         self.agentConfig = agentConfig
         # this variable is used to store the name of checks that need to
         # be reloaded at the end of the current collector run.
-        # If a full config reload is required, it is set to True.
+        # If a full config reload is required, it is set to True or a set.
         self.reload_check_configs = False
 
     @classmethod


### PR DESCRIPTION
### What does this PR do?

This change makes the docker service discovery read the kubernetes annotations
to discover how to monitor a pod. This behavior is only triggered when a
service discovery backend isn't set. The 3 annotations looked for are:
 - `com.datadoghq.sd/check_names`
 - `com.datadoghq.sd/init_configs`
 - `com.datadoghq.sd/instances`

The semantics are exactly the same as that of a KV store.

Fixes #2794

### Motivation

#2794 has more motivation. This allows not running a KV store and having multiple versions of monitoring configuration rolled out via standard deployment mechanisms.

### Testing Guidelines

Added a unit test.

### Additional Notes

I don't think there are any integration tests for service discovery, especially on kube. Either way, I'll be running this on my own kube cluster until this is upstreamed.