### PR TITLE
[dns_check] support monitoring the performance of NXDOMAIN queries

### DIFF
--- a/checks.d/dns_check.py
+++ b/checks.d/dns_check.py
@@ -67,8 +67,17 @@ class DNSCheck(NetworkCheck):
 
         try:
             self.log.debug('Querying "{0}" record for hostname "{1}"...'.format(record_type, hostname))
-            answer = resolver.query(hostname, rdtype=record_type)
-            assert(answer.rrset.items[0].to_text())
+            if record_type == "NXDOMAIN":
+                try:
+                    resolver.query(hostname)
+                except dns.resolver.NXDOMAIN:
+                    pass
+                else:
+                    raise AssertionError("Expected an NXDOMAIN, got a result.")
+            else:
+                answer = resolver.query(hostname, rdtype=record_type)
+                assert(answer.rrset.items[0].to_text())
+
             end_time = time.time()
 
         except dns.exception.Timeout:

--- a/conf.d/dns_check.yaml.example
+++ b/conf.d/dns_check.yaml.example
@@ -18,6 +18,15 @@ instances:
       #   - tag:one
       #   - tag:two
 
-    - hostname: nxdomain.example.org
-      nameserver: 127.0.0.1
-      record_type: NXDOMAIN
+    # If you use NXDOMAIN as the `record_type`, an NXDOMAIN result is expected from the query,
+    # and the check instance will report response time data.
+    # In many DNS systems, NXDOMAIN results are uncached. Further a query for a unqualified domain
+    # name that one expects to return an NXDOMAIN result can result in many dns queries, depending
+    # on the resolver's configured search domain.
+    # For these reasons, these queries are good candidates to monitor the worst-case performance of a DNS lookup.
+    # See https://github.com/DataDog/dd-agent/pull/2849 for more details.
+
+    # - name: nxdomain_example
+    #   hostname: nxdomain.example.org
+    #   nameserver: 127.0.0.1
+    #   record_type: NXDOMAIN

--- a/conf.d/dns_check.yaml.example
+++ b/conf.d/dns_check.yaml.example
@@ -17,3 +17,7 @@ instances:
       # tags:
       #   - tag:one
       #   - tag:two
+
+    - hostname: nxdomain.example.org
+      nameserver: 127.0.0.1
+      record_type: NXDOMAIN

--- a/tests/checks/integration/test_dns_check.py
+++ b/tests/checks/integration/test_dns_check.py
@@ -25,6 +25,15 @@ CONFIG_SUCCESS = {
     }]
 }
 
+CONFIG_SUCCESS_NXDOMAIN = {
+    'instances': [{
+        'name': 'nxdomain',
+        'hostname': 'www.example.org',
+        'nameserver': '127.0.0.1',
+        'record_type': 'NXDOMAIN'
+    }]
+}
+
 CONFIG_DEFAULT_TIMEOUT = {
     'init_config': {
         'default_timeout': 0.1
@@ -60,6 +69,11 @@ CONFIG_INVALID = [
         'name': 'invalid_rcrd_type',
         'hostname': 'www.example.org',
         'record_type': 'FOO'}]}, UnknownRdatatype),
+    # valid domain when NXDOMAIN is expected
+    ({'instances': [{
+        'name': 'valid_domain_for_nxdomain_type',
+        'hostname': 'example.com',
+        'record_type': 'NXDOMAIN'}]}, AssertionError),
 ]
 
 SERVICE_CHECK_NAME = 'dns.can_resolve'
@@ -86,6 +100,9 @@ def success_query_mock(d_name, rdtype):
         return MockDNSAnswer('127.0.0.1')
     elif rdtype == 'CNAME':
         return MockDNSAnswer('alias.example.org')
+
+def nxdomain_query_mock(d_name):
+    raise NXDOMAIN
 
 
 @attr(requires='system')
@@ -121,6 +138,15 @@ class DNSCheckTest(AgentCheckTest):
         self.assertServiceCheckOK(SERVICE_CHECK_NAME, tags=tags)
         tags = ['instance:cname', 'resolved_hostname:www.example.org', 'nameserver:127.0.0.1', 'record_type:CNAME']
         self.assertServiceCheckOK(SERVICE_CHECK_NAME, tags=tags)
+        self.coverage_report()
+
+    @mock.patch.object(Resolver, 'query', side_effect=nxdomain_query_mock)
+    def test_success_nxdomain(self, mocked_query):
+        self.run_check(CONFIG_SUCCESS_NXDOMAIN)
+        # Overrides self.service_checks attribute when values are available
+        self.service_checks = self.wait_for_async('get_service_checks', 'service_checks', 1)
+        self.assertServiceCheckOK(SERVICE_CHECK_NAME,
+                                tags=['instance:nxdomain', 'nameserver:127.0.0.1', 'resolved_hostname:www.example.org', 'record_type:NXDOMAIN'])
         self.coverage_report()
 
     @mock.patch.object(Resolver, 'query', side_effect=Timeout())


### PR DESCRIPTION
### What does this PR do?

Adds support to `dns_check` for a new `record_type`: `NXDOMAIN`. If specified, an NXDOMAIN result is required from the query to return "success", and response time data is reported.
### Motivation

In many DNS systems, NXDOMAIN results are uncached. Further, a query for a unqualified domain name that one expects to return an NXDOMAIN result can result in many dns queries, depending on the resolver's configured search domain. For these reasons, queries that are expected to return NXDOMAIN are a good candidate for simulating the worst-case performance of a DNS lookup on any given instance. The worst-case performance of a DNS lookup is something we'd like to monitor, and this change provides a way to do so with Datadog.
### Testing Guidelines

Tests have been added for two cases:
- Confirming that a check instance configured with `record_type: NXDOMAIN` generates metrics in the case of an `NXDOMAIN` response.
- Confirming that a check instance configured with `record_type: NXDOMAIN` returns a critical check value in the event of a non-`NXDOMAIN` response.
