### PR TITLE
[ceph] Fix check failure when health detail contains non-osd info

### DIFF
--- a/tests/checks/fixtures/ceph/ceph_10.2.2_mon_health.json
+++ b/tests/checks/fixtures/ceph/ceph_10.2.2_mon_health.json
@@ -1,0 +1,420 @@
+{
+    "df_detail": {
+        "pools": [
+            {
+                "id": 0,
+                "name": "rbd",
+                "stats": {
+                    "bytes_used": 0,
+                    "dirty": 0,
+                    "kb_used": 0,
+                    "max_avail": 7665373184,
+                    "objects": 0,
+                    "quota_bytes": 0,
+                    "quota_objects": 0,
+                    "raw_bytes_used": 0,
+                    "rd": 0,
+                    "rd_bytes": 0,
+                    "wr": 0,
+                    "wr_bytes": 0
+                }
+            },
+            {
+                "id": 1,
+                "name": "cephfs_data",
+                "stats": {
+                    "bytes_used": 0,
+                    "dirty": 0,
+                    "kb_used": 0,
+                    "max_avail": 7665373184,
+                    "objects": 0,
+                    "quota_bytes": 0,
+                    "quota_objects": 0,
+                    "raw_bytes_used": 0,
+                    "rd": 0,
+                    "rd_bytes": 0,
+                    "wr": 0,
+                    "wr_bytes": 0
+                }
+            },
+            {
+                "id": 2,
+                "name": "cephfs_metadata",
+                "stats": {
+                    "bytes_used": 2068,
+                    "dirty": 20,
+                    "kb_used": 3,
+                    "max_avail": 7665373184,
+                    "objects": 20,
+                    "quota_bytes": 0,
+                    "quota_objects": 0,
+                    "raw_bytes_used": 2068,
+                    "rd": 0,
+                    "rd_bytes": 0,
+                    "wr": 41,
+                    "wr_bytes": 7168
+                }
+            },
+            {
+                "id": 3,
+                "name": ".rgw.root",
+                "stats": {
+                    "bytes_used": 1636,
+                    "dirty": 4,
+                    "kb_used": 2,
+                    "max_avail": 7665373184,
+                    "objects": 4,
+                    "quota_bytes": 0,
+                    "quota_objects": 0,
+                    "raw_bytes_used": 1636,
+                    "rd": 0,
+                    "rd_bytes": 0,
+                    "wr": 4,
+                    "wr_bytes": 5120
+                }
+            },
+            {
+                "id": 4,
+                "name": "default.rgw.control",
+                "stats": {
+                    "bytes_used": 0,
+                    "dirty": 8,
+                    "kb_used": 0,
+                    "max_avail": 7665373184,
+                    "objects": 8,
+                    "quota_bytes": 0,
+                    "quota_objects": 0,
+                    "raw_bytes_used": 0,
+                    "rd": 0,
+                    "rd_bytes": 0,
+                    "wr": 0,
+                    "wr_bytes": 0
+                }
+            },
+            {
+                "id": 5,
+                "name": "default.rgw.data.root",
+                "stats": {
+                    "bytes_used": 0,
+                    "dirty": 0,
+                    "kb_used": 0,
+                    "max_avail": 7665373184,
+                    "objects": 0,
+                    "quota_bytes": 0,
+                    "quota_objects": 0,
+                    "raw_bytes_used": 0,
+                    "rd": 0,
+                    "rd_bytes": 0,
+                    "wr": 0,
+                    "wr_bytes": 0
+                }
+            },
+            {
+                "id": 6,
+                "name": "default.rgw.gc",
+                "stats": {
+                    "bytes_used": 0,
+                    "dirty": 32,
+                    "kb_used": 0,
+                    "max_avail": 7665373184,
+                    "objects": 32,
+                    "quota_bytes": 0,
+                    "quota_objects": 0,
+                    "raw_bytes_used": 0,
+                    "rd": 192,
+                    "rd_bytes": 163840,
+                    "wr": 128,
+                    "wr_bytes": 0
+                }
+            },
+            {
+                "id": 7,
+                "name": "default.rgw.log",
+                "stats": {
+                    "bytes_used": 0,
+                    "dirty": 127,
+                    "kb_used": 0,
+                    "max_avail": 7665373184,
+                    "objects": 127,
+                    "quota_bytes": 0,
+                    "quota_objects": 0,
+                    "raw_bytes_used": 0,
+                    "rd": 3810,
+                    "rd_bytes": 3771392,
+                    "wr": 2540,
+                    "wr_bytes": 0
+                }
+            },
+            {
+                "id": 8,
+                "name": "default.rgw.users.uid",
+                "stats": {
+                    "bytes_used": 0,
+                    "dirty": 0,
+                    "kb_used": 0,
+                    "max_avail": 7665373184,
+                    "objects": 0,
+                    "quota_bytes": 0,
+                    "quota_objects": 0,
+                    "raw_bytes_used": 0,
+                    "rd": 0,
+                    "rd_bytes": 0,
+                    "wr": 0,
+                    "wr_bytes": 0
+                }
+            }
+        ],
+        "stats": {
+            "total_avail_bytes": 7665373184,
+            "total_bytes": 42241163264,
+            "total_objects": 191,
+            "total_used_bytes": 32798216192
+        }
+    },
+    "health_detail": {
+        "detail": [
+            "mon.vagrant-ubuntu-trusty-64 low disk space -- 18% avail"
+        ],
+        "health": {
+            "health_services": [
+                {
+                    "mons": [
+                        {
+                            "avail_percent": 18,
+                            "health": "HEALTH_WARN",
+                            "health_detail": "low disk space",
+                            "kb_avail": 7485952,
+                            "kb_total": 41251136,
+                            "kb_used": 32029272,
+                            "last_updated": "2016-09-16 09:24:37.116671",
+                            "name": "vagrant-ubuntu-trusty-64",
+                            "store_stats": {
+                                "bytes_log": 912,
+                                "bytes_misc": 11813961,
+                                "bytes_sst": 0,
+                                "bytes_total": 11814873,
+                                "last_updated": "0.000000"
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "overall_status": "HEALTH_WARN",
+        "summary": [
+            {
+                "severity": "HEALTH_WARN",
+                "summary": "mon.vagrant-ubuntu-trusty-64 low disk space"
+            }
+        ],
+        "timechecks": {
+            "epoch": 3,
+            "round": 0,
+            "round_status": "finished"
+        }
+    },
+    "mon_status": {
+        "election_epoch": 3,
+        "extra_probe_peers": [],
+        "monmap": {
+            "created": "2016-09-15 17:01:16.908541",
+            "epoch": 1,
+            "fsid": "7d375c2a-902a-4990-93fd-ce21a296f444",
+            "modified": "2016-09-15 17:01:16.908541",
+            "mons": [
+                {
+                    "addr": "192.168.39.10:6789/0",
+                    "name": "vagrant-ubuntu-trusty-64",
+                    "rank": 0
+                }
+            ]
+        },
+        "name": "vagrant-ubuntu-trusty-64",
+        "outside_quorum": [],
+        "quorum": [
+            0
+        ],
+        "rank": 0,
+        "state": "leader",
+        "sync_provider": []
+    },
+    "osd_perf": {
+        "osd_perf_infos": [
+            {
+                "id": 0,
+                "perf_stats": {
+                    "apply_latency_ms": 2,
+                    "commit_latency_ms": 0
+                }
+            }
+        ]
+    },
+    "osd_pool_stats": [
+        {
+            "client_io_rate": {},
+            "pool_id": 0,
+            "pool_name": "rbd",
+            "recovery": {},
+            "recovery_rate": {}
+        },
+        {
+            "client_io_rate": {},
+            "pool_id": 1,
+            "pool_name": "cephfs_data",
+            "recovery": {},
+            "recovery_rate": {}
+        },
+        {
+            "client_io_rate": {},
+            "pool_id": 2,
+            "pool_name": "cephfs_metadata",
+            "recovery": {},
+            "recovery_rate": {}
+        },
+        {
+            "client_io_rate": {},
+            "pool_id": 3,
+            "pool_name": ".rgw.root",
+            "recovery": {},
+            "recovery_rate": {}
+        },
+        {
+            "client_io_rate": {},
+            "pool_id": 4,
+            "pool_name": "default.rgw.control",
+            "recovery": {},
+            "recovery_rate": {}
+        },
+        {
+            "client_io_rate": {},
+            "pool_id": 5,
+            "pool_name": "default.rgw.data.root",
+            "recovery": {},
+            "recovery_rate": {}
+        },
+        {
+            "client_io_rate": {},
+            "pool_id": 6,
+            "pool_name": "default.rgw.gc",
+            "recovery": {},
+            "recovery_rate": {}
+        },
+        {
+            "client_io_rate": {},
+            "pool_id": 7,
+            "pool_name": "default.rgw.log",
+            "recovery": {},
+            "recovery_rate": {}
+        },
+        {
+            "client_io_rate": {},
+            "pool_id": 8,
+            "pool_name": "default.rgw.users.uid",
+            "recovery": {},
+            "recovery_rate": {}
+        }
+    ],
+    "status": {
+        "election_epoch": 3,
+        "fsid": "7d375c2a-902a-4990-93fd-ce21a296f444",
+        "fsmap": {
+            "by_rank": [
+                {
+                    "filesystem_id": 1,
+                    "name": "0",
+                    "rank": 0,
+                    "status": "up:active"
+                }
+            ],
+            "epoch": 5,
+            "id": 1,
+            "in": 1,
+            "max": 1,
+            "up": 1
+        },
+        "health": {
+            "detail": [],
+            "health": {
+                "health_services": [
+                    {
+                        "mons": [
+                            {
+                                "avail_percent": 18,
+                                "health": "HEALTH_WARN",
+                                "health_detail": "low disk space",
+                                "kb_avail": 7485952,
+                                "kb_total": 41251136,
+                                "kb_used": 32029272,
+                                "last_updated": "2016-09-16 09:24:37.116671",
+                                "name": "vagrant-ubuntu-trusty-64",
+                                "store_stats": {
+                                    "bytes_log": 912,
+                                    "bytes_misc": 11813961,
+                                    "bytes_sst": 0,
+                                    "bytes_total": 11814873,
+                                    "last_updated": "0.000000"
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "overall_status": "HEALTH_WARN",
+            "summary": [
+                {
+                    "severity": "HEALTH_WARN",
+                    "summary": "mon.vagrant-ubuntu-trusty-64 low disk space"
+                }
+            ],
+            "timechecks": {
+                "epoch": 3,
+                "round": 0,
+                "round_status": "finished"
+            }
+        },
+        "monmap": {
+            "created": "2016-09-15 17:01:16.908541",
+            "epoch": 1,
+            "fsid": "7d375c2a-902a-4990-93fd-ce21a296f444",
+            "modified": "2016-09-15 17:01:16.908541",
+            "mons": [
+                {
+                    "addr": "192.168.39.10:6789/0",
+                    "name": "vagrant-ubuntu-trusty-64",
+                    "rank": 0
+                }
+            ]
+        },
+        "osdmap": {
+            "osdmap": {
+                "epoch": 19,
+                "full": false,
+                "nearfull": false,
+                "num_in_osds": 1,
+                "num_osds": 1,
+                "num_remapped_pgs": 0,
+                "num_up_osds": 1
+            }
+        },
+        "pgmap": {
+            "bytes_avail": 7665373184,
+            "bytes_total": 42241163264,
+            "bytes_used": 32798216192,
+            "data_bytes": 3704,
+            "num_pgs": 128,
+            "pgs_by_state": [
+                {
+                    "count": 128,
+                    "state_name": "active+clean"
+                }
+            ],
+            "version": 1009
+        },
+        "quorum": [
+            0
+        ],
+        "quorum_names": [
+            "vagrant-ubuntu-trusty-64"
+        ]
+    }
+}

--- a/tests/checks/mock/test_ceph.py
+++ b/tests/checks/mock/test_ceph.py
@@ -79,3 +79,17 @@ class TestCeph(AgentCheckTest):
             expected_metrics = ['ceph.read_op_per_sec', 'ceph.write_op_per_sec', 'ceph.op_per_sec']
             for metric in expected_metrics:
                 self.assertMetric(metric, count=1, tags=expected_tags)
+
+    def test_osd_status_metrics_non_osd_health(self):
+        """
+        The `detail` key of `health detail` can contain info on the health of non-osd units:
+        shouldn't make the check fail
+        """
+        mocks = {
+            '_collect_raw': lambda x,y: json.loads(Fixtures.read_file('ceph_10.2.2_mon_health.json')),
+        }
+        config = {
+            'instances': [{'host': 'foo'}]
+        }
+
+        self.run_check_twice(config, mocks=mocks, force_reload=True)


### PR DESCRIPTION
### What does this PR do?

Avoid check failure when the `detail` key of `health detail` contains info on non-osd components. The bug was introduced in https://github.com/DataDog/dd-agent/pull/2805

### Motivation

Improve check resilience.

### Testing

PR includes a test case that reproduces the issue.

### Additional Notes

The `detail` key of `health detail` can contain info on the health of
non-osd units, for example:

```
mon.vagrant-ubuntu-trusty-64 low disk space -- 18% avail
```

In that case the check would previously fail with an IndexError because
the regex we use wouldn't match this string.

Ignore the entry instead.

cc @vagelim 