### PR TITLE
[ceph] Improve health metrics

### DIFF
--- a/checks.d/ceph.py
+++ b/checks.d/ceph.py
@@ -103,44 +103,47 @@ class Ceph(AgentCheck):
         except KeyError:
             self.log.debug('Error retrieving health metrics')
 
-        for osdinfo in raw['osd_pool_stats']:
-            name = osdinfo.get('pool_name')
-            local_tags = tags + ['ceph_pool:%s' % name]
-            ops = 0
-            try:
-                self._publish(osdinfo, self.gauge, ['client_io_rate', 'read_op_per_sec'], local_tags)
-                ops += osdinfo['client_io_rate']['read_op_per_sec']
-            except KeyError:
-                osdinfo['client_io_rate'].update({'read_op_per_sec' : 0})
-                self._publish(osdinfo, self.gauge, ['client_io_rate', 'read_op_per_sec'], local_tags)
+        try:
+            for osdinfo in raw['osd_pool_stats']:
+                name = osdinfo.get('pool_name')
+                local_tags = tags + ['ceph_pool:%s' % name]
+                ops = 0
+                try:
+                    self._publish(osdinfo, self.gauge, ['client_io_rate', 'read_op_per_sec'], local_tags)
+                    ops += osdinfo['client_io_rate']['read_op_per_sec']
+                except KeyError:
+                    osdinfo['client_io_rate'].update({'read_op_per_sec' : 0})
+                    self._publish(osdinfo, self.gauge, ['client_io_rate', 'read_op_per_sec'], local_tags)
 
-            try:
-                self._publish(osdinfo, self.gauge, ['client_io_rate', 'write_op_per_sec'], local_tags)
-                ops += osdinfo['client_io_rate']['write_op_per_sec']
-            except KeyError:
-                osdinfo['client_io_rate'].update({'write_op_per_sec' : 0})
-                self._publish(osdinfo, self.gauge, ['client_io_rate', 'write_op_per_sec'], local_tags)
+                try:
+                    self._publish(osdinfo, self.gauge, ['client_io_rate', 'write_op_per_sec'], local_tags)
+                    ops += osdinfo['client_io_rate']['write_op_per_sec']
+                except KeyError:
+                    osdinfo['client_io_rate'].update({'write_op_per_sec' : 0})
+                    self._publish(osdinfo, self.gauge, ['client_io_rate', 'write_op_per_sec'], local_tags)
 
-            try:
-                osdinfo['client_io_rate']['op_per_sec']
-                self._publish(osdinfo, self.gauge, ['client_io_rate', 'op_per_sec'], local_tags)
-            except KeyError:
-                osdinfo['client_io_rate'].update({'op_per_sec' : ops})
-                self._publish(osdinfo, self.gauge, ['client_io_rate', 'op_per_sec'], local_tags)
+                try:
+                    osdinfo['client_io_rate']['op_per_sec']
+                    self._publish(osdinfo, self.gauge, ['client_io_rate', 'op_per_sec'], local_tags)
+                except KeyError:
+                    osdinfo['client_io_rate'].update({'op_per_sec' : ops})
+                    self._publish(osdinfo, self.gauge, ['client_io_rate', 'op_per_sec'], local_tags)
 
-            try:
-                osdinfo['client_io_rate']['read_bytes_sec']
-                self._publish(osdinfo, self.gauge, ['client_io_rate', 'read_bytes_sec'], local_tags)
-            except KeyError:
-                osdinfo['client_io_rate'].update({'read_bytes_sec' : 0})
-                self._publish(osdinfo, self.gauge, ['client_io_rate', 'read_bytes_sec'], local_tags)
+                try:
+                    osdinfo['client_io_rate']['read_bytes_sec']
+                    self._publish(osdinfo, self.gauge, ['client_io_rate', 'read_bytes_sec'], local_tags)
+                except KeyError:
+                    osdinfo['client_io_rate'].update({'read_bytes_sec' : 0})
+                    self._publish(osdinfo, self.gauge, ['client_io_rate', 'read_bytes_sec'], local_tags)
 
-            try:
-                osdinfo['client_io_rate']['write_bytes_sec']
-                self._publish(osdinfo, self.gauge, ['client_io_rate', 'write_bytes_sec'], local_tags)
-            except KeyError:
-                osdinfo['client_io_rate'].update({'write_bytes_sec' : 0})
-                self._publish(osdinfo, self.gauge, ['client_io_rate', 'write_bytes_sec'], local_tags)
+                try:
+                    osdinfo['client_io_rate']['write_bytes_sec']
+                    self._publish(osdinfo, self.gauge, ['client_io_rate', 'write_bytes_sec'], local_tags)
+                except KeyError:
+                    osdinfo['client_io_rate'].update({'write_bytes_sec' : 0})
+                    self._publish(osdinfo, self.gauge, ['client_io_rate', 'write_bytes_sec'], local_tags)
+        except KeyError:
+            self.log.debug('Error retrieving osd_pool_stats metrics')
 
         try:
             osdstatus = raw['status']['osdmap']['osdmap']

--- a/tests/checks/mock/test_ceph.py
+++ b/tests/checks/mock/test_ceph.py
@@ -59,19 +59,18 @@ class TestCeph(AgentCheckTest):
         }
 
         self.run_check_twice(config, mocks=mocks, force_reload=True)
-        for osd in ['osd2']:
+
+        for osd, pct_used in [('osd1', 94), ('osd2', 95)]:
             expected_tags = ['ceph_fsid:e0efcf84-e8ed-4916-8ce1-9c70242d390a','ceph_mon_state:leader',
                              'ceph_osd:%s' % osd]
 
-            for metric in ['ceph.num_full_osds']:
-                self.assertMetric(metric, count=1, tags=expected_tags)
+            for metric in ['ceph.osd.pct_used']:
+                self.assertMetric(metric, value=pct_used, count=1, tags=expected_tags)
 
-        for osd in ['osd1']:
-            expected_tags = ['ceph_fsid:e0efcf84-e8ed-4916-8ce1-9c70242d390a','ceph_mon_state:leader',
-                             'ceph_osd:%s' % osd]
-
-            for metric in ['ceph.num_near_full_osds']:
-                self.assertMetric(metric, count=1, tags=expected_tags)
+        self.assertMetric('ceph.num_full_osds', value=1, count=1,
+                          tags=['ceph_fsid:e0efcf84-e8ed-4916-8ce1-9c70242d390a', 'ceph_mon_state:leader'])
+        self.assertMetric('ceph.num_near_full_osds', value=1, count=1,
+                          tags=['ceph_fsid:e0efcf84-e8ed-4916-8ce1-9c70242d390a', 'ceph_mon_state:leader'])
 
         for pool in ['rbd', 'scbench']:
             expected_tags = ['ceph_fsid:e0efcf84-e8ed-4916-8ce1-9c70242d390a','ceph_mon_state:leader',
@@ -93,3 +92,8 @@ class TestCeph(AgentCheckTest):
         }
 
         self.run_check_twice(config, mocks=mocks, force_reload=True)
+
+        self.assertMetric('ceph.num_full_osds', value=0, count=1,
+                          tags=['ceph_fsid:7d375c2a-902a-4990-93fd-ce21a296f444', 'ceph_mon_state:leader'])
+        self.assertMetric('ceph.num_near_full_osds', value=0, count=1,
+                          tags=['ceph_fsid:7d375c2a-902a-4990-93fd-ce21a296f444', 'ceph_mon_state:leader'])


### PR DESCRIPTION
### What does this PR do?

* Catch `KeyError` on `osd_pool_stats`
* Improve health metrics: the `ceph.num_full_osds` and `ceph.num_near_full_osds` metrics report values that make more sense and add `ceph.osd.pct_used` metric (see explanation below).

### Motivation

* Check resilience
* Improved usability of the health metrics

### Testing

Updated the existing mock tests, and made them more detailed

### Additional Notes

#### health metrics

Previous behavior: the `ceph.num_near_full_osds` and
`ceph.num_full_osds` would either:
* take the value `0` and be tagged with no `osd` tag if no osd is
reporting health issues
* take a value representing the usage percentage, tagged by `osd`

This doesn't really make sense with respect to the name of the metrics
(`num_*`). To solve this, replace these metrics with the following:
* `ceph.num_near_full_ods` and `ceph.num_full_osds` report the total
number of osds that are respectively near full and full. Not tagged
by osd.
* when some osds report health issues, the check sends a
`ceph.osd.pct_used` metric which reports the usage
percentage, tagged by osd. Unfortunately we can't send `0` values
on this metric when no osd reports health issues since we can't tag by
osd in that case.

This should make these metrics more usable. Also, use `gauge` since
there's no reason to use `count`.
