### PR TITLE
[service discovery] fix fallback IP address extraction

### DIFF
--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -209,7 +209,7 @@ class TestServiceDiscovery(unittest.TestCase):
                 'Networks': {
                     'bridge': {'IPAddress': '172.17.0.2'},
                     'foo': {'IPAddress': '192.168.0.2'}}}},
-             'host', '127.0.0.1'),
+             'host', '172.17.0.2'),
 
             ({'NetworkSettings': {'Networks': {}}}, 'host', None),
             ({'NetworkSettings': {'Networks': {}}}, 'host_bridge', None),
@@ -349,7 +349,7 @@ class TestServiceDiscovery(unittest.TestCase):
                     'Networks': {'bridge': {'IPAddress': '172.17.0.2'}}}
                   },
                  {'host': '%%host%%', 'port': 1337}, ['host'], ['foo', 'bar:baz']),
-                ({'host': '%%host%%', 'port': 1337, 'tags': ['foo', 'bar:baz']}, {'host': '127.0.0.1'}),
+                ({'host': '%%host%%', 'port': 1337, 'tags': ['foo', 'bar:baz']}, {'host': '172.17.0.2'}),
             ),
             (
                 ({'NetworkSettings': {


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

When no key (network name or id) was passed to the `host` variable, we used to skip the `_get_fallback_ip` method and only try using the `Config.NetworkSettings.IPAddress` address (which is empty more often than not now). With this PR, `_get_fallback_ip` applies every time, using the `bridge` network address or the last network (sorted) address.

### Motivation

More and more often `Config.NetworkSettings.IPAddress` is empty, relying on it makes the agent fail in cases where it could infer the config automatically.

### Testing Guidelines

Updated the relevant mocks in unit tests

### Additional Notes

- Fix #2845 
- Also limit the `split('_')` to 1 to avoid splitting the specifier if it has a `_`.