### PR TITLE
[service discovery] pass missing config_store reference to dockerutil

### DIFF
--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -61,6 +61,7 @@ class DockerUtil:
             self.config_store = kwargs['config_store']
         else:
             self.config_store = None
+            log.warning('No config store configured. Configuration reload will not work.')
 
         # Try to detect if we are on ECS
         self._is_ecs = False

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -21,10 +21,6 @@ class SDDockerBackend(AbstractSDBackend):
     """Docker-based service discovery"""
 
     def __init__(self, agentConfig):
-        self.docker_client = DockerUtil().client
-        if Platform.is_k8s():
-            self.kubeutil = KubeUtil()
-
         try:
             self.config_store = get_config_store(agentConfig=agentConfig)
         except Exception as e:
@@ -32,6 +28,10 @@ class SDDockerBackend(AbstractSDBackend):
                       'Auto-config only will be used. %s' % str(e))
             agentConfig['sd_config_backend'] = None
             self.config_store = get_config_store(agentConfig=agentConfig)
+
+        self.docker_client = DockerUtil(config_store=self.config_store).client
+        if Platform.is_k8s():
+            self.kubeutil = KubeUtil()
 
         self.VAR_MAPPING = {
             'host': self._get_host_address,


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

dockerutil needs a reference to config_store to enable config reload. In some cases this reference was missing. This PR fixes that.
