### PR TITLE
[docker_deamon] docker healthcheck as service checks.

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -242,7 +242,8 @@ class DockerDaemon(AgentCheck):
 
         # Report docker healthcheck SC's where available
         if health_service_checks:
-            self._send_container_healthcheck_sc(containers_by_id)
+            health_scs_whitelist = set(instance.get('health_service_check_whitelist', []))
+            self._send_container_healthcheck_sc(containers_by_id, health_scs_whitelist)
 
     def _count_and_weigh_images(self):
         try:
@@ -477,8 +478,12 @@ class DockerDaemon(AgentCheck):
                     self, 'docker.container.size_rootfs', container['SizeRootFs'],
                     tags=tags)
 
-    def _send_container_healthcheck_sc(self, containers_by_id):
+    def _send_container_healthcheck_sc(self, containers_by_id, whitelist):
+        """Send health service checks for containers. Whitelist should preferably be a set."""
         for container in containers_by_id.itervalues():
+            if container.get('Image') not in whitelist:
+                continue
+
             health = container.get('health', {})
             tags = self._get_tags(container, CONTAINER)
             status = AgentCheck.UNKNOWN

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -57,7 +57,11 @@ instances:
     #       Container Healthchecks are available starting with docker 1.12, enabling with older
     #       versions will result in an UNKNOWN state for the service check.
     #
+    # You should whitelist the container images you wish to submit health service checks for.
+    # Example: ["tomcat", "nginx", "etcd"]
+    #
     # health_service_checks: false
+    # health_service_check_whitelist: []
 
     # Collect images stats
     # Number of available active images and intermediate images as gauges.

--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -47,9 +47,17 @@ instances:
 
     # Do you use custom cgroups for this particular instance?
     # Note: enabling this option modifies the way in which we inspect the containers and causes
-    #       some overhead - if you run a high volume of containers we may timeout. Please only
-    #       enable if absolutely necessary.
+    #       some overhead - if you run a high volume of containers we may timeout.
+    #
     # custom_cgroups: false
+
+    # Report docker container healthcheck events as service checks
+    # Note: enabling this option modifies the way in which we inspect the containers and causes
+    #       some overhead - if you run a high volume of containers we may timeout.
+    #       Container Healthchecks are available starting with docker 1.12, enabling with older
+    #       versions will result in an UNKNOWN state for the service check.
+    #
+    # health_service_checks: false
 
     # Collect images stats
     # Number of available active images and intermediate images as gauges.

--- a/tests/checks/integration/test_docker_daemon.py
+++ b/tests/checks/integration/test_docker_daemon.py
@@ -529,10 +529,28 @@ class TestCheckDockerDaemon(AgentCheckTest):
             },
             ],
         }
+
         DockerUtil().set_docker_settings(config['init_config'], config['instances'][0])
 
         self.run_check(config, force_reload=True)
         self.assertEqual(len(self.events), 2)
+
+    def test_healthcheck(self):
+        config = {
+            "init_config": {},
+            "instances": [{
+                "url": "unix://var/run/docker.sock",
+                "collect_images_stats": True,
+                "health_service_checks": True,
+            },
+            ],
+        }
+
+        DockerUtil().set_docker_settings(config['init_config'], config['instances'][0])
+
+        self.run_check(config, force_reload=True)
+        self.assertServiceCheck('docker.container_health', at_least=2)
+
 
     def test_container_size(self):
         expected_metrics = [


### PR DESCRIPTION
### What does this PR do?

This PR allows us to send service checks according to the healthcheck reported by docker for containers. This is a new feature introduced with Docker `1.12`, and not all containers will implement it. Currently we will send an `UNKNOWN` status in that case. Maybe we should only submit the service check when available.

Because grabbing the health status requires inspecting the containers, and that's a potentially expensive call, for now this feature will be hid behind a feature flag `health_service_checks`.

Also added a simple test. More work could be done on this front.
### Motivation

Provides yet another point of view regarding a container's health, as intended by the container's maintainers. 

I have also noticed a couple CI/tooling issues - we can sneak them in here. Or address them in a separate PR which probably makes more sense. One of the issues affects contributors as there's a problem with the old `setuptools` and `rake setup_env`.
