### PR TITLE
[service_discovery] Get tags from docker, provides ability to drill i…

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -945,3 +945,4 @@ class DockerDaemon(AgentCheck):
                 self.warning("Cannot parse %s content: %s" % (path, str(e)))
                 continue
         return container_dict
+

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -19,6 +19,37 @@ from utils.service_discovery.config_stores import get_config_store
 DATADOG_ID = 'com.datadoghq.sd.check.id'
 log = logging.getLogger(__name__)
 
+DEFAULT_CONTAINER_TAGS = [
+    "docker_image",
+    "image_name",
+    "image_tag",
+]
+
+DEFAULT_PERFORMANCE_TAGS = [
+    "container_name",
+    "docker_image",
+    "image_name",
+    "image_tag",
+]
+
+DEFAULT_IMAGE_TAGS = [
+    'image_name',
+    'image_tag'
+]
+
+
+TAG_EXTRACTORS = {
+    "docker_image": lambda c: [c["Image"]],
+    "image_name": lambda c: DockerUtil.image_tag_extractor(c, 0),
+    "image_tag": lambda c: DockerUtil.image_tag_extractor(c, 1),
+    "container_command": lambda c: [c["Command"]],
+    "container_name": DockerUtil.container_name_extractor,
+    "container_id": lambda c: [c["Id"]],
+}
+
+CONTAINER = "container"
+PERFORMANCE = "performance"
+IMAGE = "image"
 
 class _SDDockerBackendConfigFetchState(object):
     def __init__(self, inspect_fn, kube_pods=None):
@@ -87,6 +118,12 @@ class SDDockerBackend(AbstractSDBackend):
             'host': self._get_host_address,
             'port': self._get_port,
             'tags': self._get_additional_tags,
+        }
+
+        self.tag_names = {
+            CONTAINER: DEFAULT_CONTAINER_TAGS,
+            PERFORMANCE: DEFAULT_PERFORMANCE_TAGS,
+            IMAGE: DEFAULT_IMAGE_TAGS
         }
 
         AbstractSDBackend.__init__(self, agentConfig)
@@ -234,7 +271,17 @@ class SDDockerBackend(AbstractSDBackend):
 
     def get_tags(self, state, c_id):
         """Extract useful tags from docker or platform APIs. These are collected by default."""
+        c_id = c_inspect.get('Id', '')
+        entity = self.docker_client.containers(filters={'id': c_id})[0]
         tags = []
+        for tag_type in self.tag_names:
+            tag_names = self.tag_names[tag_type]
+            for tag_name in tag_names:
+                tag_value = self._extract_tag_value(entity, tag_name)
+                if tag_value is not None:
+                    for t in tag_value:
+                        tags.append('%s:%s' % (tag_name, str(t).strip()))
+
         if Platform.is_k8s():
             pod_metadata = state.get_kube_config(c_id, 'metadata')
 
@@ -256,6 +303,23 @@ class SDDockerBackend(AbstractSDBackend):
             tags.append('kube_namespace:%s' % pod_metadata.get('namespace'))
 
         return tags
+
+    def _extract_tag_value(self, entity, tag_name):
+        """Extra tag information from the API result (containers or images).
+        Cache extracted tags inside the entity object.
+        """
+        if tag_name not in TAG_EXTRACTORS:
+            self.warning("{0} isn't a supported tag".format(tag_name))
+            return
+
+        # Check for already extracted tags
+        if "_tag_values" not in entity:
+            entity["_tag_values"] = {}
+
+        if tag_name not in entity["_tag_values"]:
+            entity["_tag_values"][tag_name] = TAG_EXTRACTORS[tag_name](entity)
+
+        return entity["_tag_values"][tag_name]
 
     def _get_additional_tags(self, state, c_id, *args):
         tags = []


### PR DESCRIPTION
### What does this PR do?

Provides the ability to pull tags from the container level, using the same API that the docker_daemon check uses
### Motivation

When using container schedulers other than kubernetes, the lack of ability to drill into issues at a container level when utilizing the service discovery plugin was frustrating. In order to provide a better insight for my development team, we added the ability to gather tags from docker. This allows us to specify a specific container/type of container/image/etc instead of only on the host level. When running N containers of the same type on the same host, it was difficult to get insight into what was happening. 
### Testing Guidelines

Use service discovery with docker, see tags being set for the container.
