### PR TITLE
Adding Marathon App Id tag capture for Docker Daemon

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -174,6 +174,7 @@ class DockerDaemon(AgentCheck):
             self._disable_net_metrics = False
 
             # Set tagging options
+            self.include_app_id = instance.get("include_marathon_app_id", False)
             self.custom_tags = instance.get("tags", [])
             self.collect_labels_as_tags = instance.get("collect_labels_as_tags", [])
             self.kube_labels = {}
@@ -356,6 +357,19 @@ class DockerDaemon(AgentCheck):
 
         if entity is not None:
             pod_name = None
+
+            if self.include_app_id and ( tag_type is CONTAINER or tag_type is PERFORMANCE ):
+                self.log.debug("We need to capture Marathon Id")
+                cont_id = entity.get("Id")
+                if cont_id is not None:
+                    cont_inspected = self.docker_client.inspect_container(cont_id)
+                    for env_var in cont_inspected['Config']['Env']:
+                        self.log.debug("We have env_var : %s"%env_var)
+                        if 'MARATHON_APP_ID=' in env_var:
+                            app_id = env_var.replace('MARATHON_APP_ID=','')
+                            self.log.debug("We have found the id as %s"%app_id)
+                            tags.append("app_id:%s" % app_id)
+
 
             # Get labels as tags
             labels = entity.get("Labels")


### PR DESCRIPTION
### What does this PR do?

On Mesos/Marathon managed docker daemons, allows tagging container data with app_id tag used by your Marathon integration, allowing to correlated the data in Dashboards

### Motivation

As DevOps integrator, using datadog  we would like to have Marathon and docker data correlation.

Sharing the integration with you, as we believe it maybe of use to others.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Feature gets enabled when instance config in docker_daemon.yaml has the `include_marathon_app_id` set to true
It may not be perfectly within Datadog coding guidelines and feel free to change as required.
Provided as is.
