### PR TITLE
Fix incorrect time conversion for Kubernetes events

### DIFF
--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -11,6 +11,7 @@ from fnmatch import fnmatch
 import numbers
 import re
 import time
+import calendar
 
 # 3rd party
 import requests
@@ -371,7 +372,7 @@ class Kubernetes(AgentCheck):
 
         for event in event_items:
             # skip if the event is too old
-            event_ts = int(time.mktime(time.strptime(event.get('lastTimestamp'), '%Y-%m-%dT%H:%M:%SZ')))
+            event_ts = calendar.timegm(time.strptime(event.get('lastTimestamp'), '%Y-%m-%dT%H:%M:%SZ'))
             if event_ts <= last_read:
                 continue
 


### PR DESCRIPTION
This a pull request proposal for issue #2872.

We simply replace time.mktime by calendar.gmtime which takes as input struct time in UTC like the ones used in Kubernetes events.