### PR TITLE
[activemq] updated default jmx configuration

### DIFF
--- a/conf.d/activemq.yaml.example
+++ b/conf.d/activemq.yaml.example
@@ -20,54 +20,109 @@ instances:
 init_config:
   conf:
     - include:
-        Type: Queue
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*,destinationType=Topic,destinationName=.*'
         attribute:
           AverageEnqueueTime:
             alias: activemq.queue.avg_enqueue_time
             metric_type: gauge
+    - include:
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*,destinationType=Topic,destinationName=.*'
+        attribute:
           ConsumerCount:
             alias: activemq.queue.consumer_count
             metric_type: gauge
+    - include:
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*,destinationType=Topic,destinationName=.*'
+        attribute:
           ProducerCount:
             alias: activemq.queue.producer_count
             metric_type: gauge
+    - include:
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*,destinationType=Topic,destinationName=.*'
+        attribute:
           MaxEnqueueTime:
             alias: activemq.queue.max_enqueue_time
             metric_type: gauge
+    - include:
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*,destinationType=Topic,destinationName=.*'
+        attribute:
           MinEnqueueTime:
             alias: activemq.queue.min_enqueue_time
             metric_type: gauge
+    - include:
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*,destinationType=Topic,destinationName=.*'
+        attribute:
           MemoryPercentUsage:
             alias: activemq.queue.memory_pct
             metric_type: gauge
+    - include:
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*,destinationType=Topic,destinationName=.*'
+        attribute:
           QueueSize:
             alias: activemq.queue.size
             metric_type: gauge
+    - include:
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*,destinationType=Topic,destinationName=.*'
+        attribute:
           DequeueCount:
             alias: activemq.queue.dequeue_count
             metric_type: counter
+    - include:
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*,destinationType=Topic,destinationName=.*'
+        attribute:
           DispatchCount:
             alias: activemq.queue.dispatch_count
             metric_type: counter
+    - include:
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*,destinationType=Topic,destinationName=.*'
+        attribute:
           EnqueueCount:
             alias: activemq.queue.enqueue_count
             metric_type: counter
+    - include:
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*,destinationType=Topic,destinationName=.*'
+        attribute:
           ExpiredCount:
             alias: activemq.queue.expired_count
             metric_type: counter
+    - include:
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*,destinationType=Topic,destinationName=.*'
+        attribute:
           InFlightCount:
             alias: activemq.queue.in_flight_count
             metric_type: counter
 
     - include:
-        Type: Broker
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*'
         attribute:
           StorePercentUsage:
             alias: activemq.broker.store_pct
             metric_type: gauge
+    - include:
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*'
+        attribute:
           TempPercentUsage:
             alias: activemq.broker.temp_pct
             metric_type: gauge
+    - include:
+        domain: 'org.apache.activemq'
+        bean_regex: 'org\.apache\.activemq:type=Broker,brokerName=.*'
+        attribute:
           MemoryPercentUsage:
             alias: activemq.broker.memory_pct
             metric_type: gauge
+


### PR DESCRIPTION
### What does this PR do?

Update JMX metrics collection for ActiveMQ, up to version 5.15

### Motivation

Old configuration did not work with version > 5.14

