### PR TITLE
Add support for events collection in all namespaces

### DIFF
--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -413,5 +413,6 @@ class Kubernetes(AgentCheck):
                     'msg_text': msg_body,
                     'source_type_name': EVENT_TYPE,
                     'event_object': 'kubernetes:{}'.format(involved_obj.get('name')),
+                    'tags': [u"kube_namespace:{0}".format(namespace)]
                 }
                 self.event(dd_event)

--- a/conf.d/kubernetes.yaml.example
+++ b/conf.d/kubernetes.yaml.example
@@ -20,6 +20,12 @@ instances:
   # cluster should have this feature enabled. To enable the feature, set the parameter to `true`.
   # collect_events: false
 
+  # collect_events_from_all_namespaces controls wether events collection should be performed
+  # only in one given namespace (by default the `default` namespace) or on all namespaces 
+  # available in the Kubernetes cluster.
+  # This option is only useful is `collect_events` is set to `true`.
+  # collect_events_from_all_namespaces: false
+
   # use_histogram controls whether we send detailed metrics, i.e. one per container. 
   # When false, we send detailed metrics corresponding to individual containers, tagging by container id
   # to keep them unique.

--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -25,6 +25,7 @@ class KubeUtil:
     __metaclass__ = Singleton
 
     DEFAULT_METHOD = 'http'
+    NAMESPACES_LIST_PATH = 'namespaces'
     METRICS_PATH = '/api/v1.3/subcontainers/'
     PODS_LIST_PATH = '/pods/'
     DEFAULT_CADVISOR_PORT = 4194
@@ -65,6 +66,7 @@ class KubeUtil:
         self.cadvisor_url = '%s://%s:%d' % (self.method, self.host, self.cadvisor_port)
         self.kubernetes_api_url = 'https://%s/api/v1' % self.DEFAULT_MASTER_NAME
 
+        self.namespaces_list_url = "%s/%s" % (self.kubernetes_api_url, KubeUtil.NAMESPACES_LIST_PATH)
         self.metrics_url = urljoin(self.cadvisor_url, KubeUtil.METRICS_PATH)
         self.pods_list_url = urljoin(self.kubelet_api_url, KubeUtil.PODS_LIST_PATH)
         self.kube_health_url = urljoin(self.kubelet_api_url, 'healthz')
@@ -115,6 +117,13 @@ class KubeUtil:
             if value is not None:
                 uids.append(value)
         return uids
+
+    def retrieve_namespaces_list(self):
+        """
+        Retrieve the list of namespaces for this cluster querying the kubelet API.
+
+        """
+        return self.retrieve_json_auth(self.namespaces_list_url, self.get_auth_token())
 
     def retrieve_pods_list(self):
         """


### PR DESCRIPTION
Hi,

This PR is a proposition of patch to fix #2838: retrieving events from all namespaces.
It adds a new option `collect_events_from_all_namespaces` for that purpose.
