### PR TITLE
[install_script][yum] Enable all the repos when installing `datadog-agent`

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -131,7 +131,7 @@ if [ $OS = "RedHat" ]; then
             $sudo_cmd yum -y remove datadog-agent-base
         fi
     fi
-    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install datadog-agent
+    $sudo_cmd yum -y --disablerepo='*' --enablerepo='datadog' install datadog-agent || $sudo_cmd yum -y install datadog-agent
 elif [ $OS = "Debian" ]; then
     printf "\033[34m\n* Installing apt-transport-https\n\033[0m\n"
     $sudo_cmd apt-get update || printf "\033[31m'apt-get update' failed, the script will not install the latest version of apt-transport-https.\033[0m\n"


### PR DESCRIPTION
### What does this PR do?

Fixes the install script when the `initscripts` package is not installed.

### Testing Guidelines

Tested the resulting install script on CentOS 5/6/7

### Additional Notes

The yum package of `datadog-agent` has a dependency on `initscripts`.
If we disable all the repos when installing `datadog-agent` _and_ if
`initscripts` is not installed `yum` won't be able to find the dep,
and the install will fail.

To fix this we fall back to installing the agent with all the repos enabled when
the install without them fails.