### PR TITLE
Allow SSL connects to pgbouncer

### DIFF
--- a/checks.d/pgbouncer.py
+++ b/checks.d/pgbouncer.py
@@ -165,6 +165,10 @@ class PgBouncer(AgentCheck):
                 pg.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
             self.log.debug('pgbouncer status: %s' % AgentCheck.OK)
 
+        # re-raise the ChceckExcpetions raised by _get_connect_kwargs()
+        except CheckException:
+            raise
+
         except Exception:
             message = u'Cannot establish connection to pgbouncer://%s:%s/%s' % (host, port, self.DB_NAME)
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,

--- a/checks.d/pgbouncer.py
+++ b/checks.d/pgbouncer.py
@@ -187,7 +187,6 @@ class PgBouncer(AgentCheck):
 
         if database_url:
             key = database_url
-
         else:
             key = '%s:%s' % (host, port)
 

--- a/checks.d/pgbouncer.py
+++ b/checks.d/pgbouncer.py
@@ -137,7 +137,7 @@ class PgBouncer(AgentCheck):
             raise CheckException(
                 "Please specify a user to connect to PgBouncer as.")
 
-        if host.lower() in ('localhost', '127.0.0.1') and password == '':
+        if host in ('localhost', '127.0.0.1') and password == '':
             return {  # Use ident method
                 'dsn': "user={} dbname={}".format(user, self.DB_NAME)
             }

--- a/checks.d/pgbouncer.py
+++ b/checks.d/pgbouncer.py
@@ -124,7 +124,6 @@ class PgBouncer(AgentCheck):
         """
         Get the params to pass to psycopg2.connect() based on passed-in vals
         from yaml settings file
-
         """
         if database_url:
             return {'dsn': database_url}

--- a/checks.d/pgbouncer.py
+++ b/checks.d/pgbouncer.py
@@ -165,7 +165,7 @@ class PgBouncer(AgentCheck):
                 pg.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
             self.log.debug('pgbouncer status: %s' % AgentCheck.OK)
 
-        # re-raise the ChceckExcpetions raised by _get_connect_kwargs()
+        # re-raise the ChceckExceptions raised by _get_connect_kwargs()
         except CheckException:
             raise
 

--- a/conf.d/pgbouncer.yaml.example
+++ b/conf.d/pgbouncer.yaml.example
@@ -8,3 +8,8 @@ instances:
 #     tags:
 #       - optional_tag1
 #       - optional_tag2
+#
+#   - database_url: postgresql://user:pass@host:5432/dbname?sslmode=require
+#     tags:
+#       - optional_tag3
+#       - optional_tag4


### PR DESCRIPTION
### What does this PR do?
Rather than reconstructing the postgres connection string from its constituent parts (username, password, host, port), pass through connection strings authored by the user to psycopg2. This lets us use all of psycopg2's features, including SSL encryption.

### Motivation

pgbouncer v1.7 added SSL support, which is currently missing from the pgbouncer check.
