### PR TITLE
[service_discovery] Reload config on container change event from dock…

### DIFF
--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -48,6 +48,7 @@ class SDDockerBackend(AbstractSDBackend):
         AbstractSDBackend.__init__(self, agentConfig)
 
     def update_checks(self, changed_containers):
+        self.get_configs()
         conf_reload_set = set()
         for id_ in changed_containers:
             try:


### PR DESCRIPTION
### What does this PR do?

Reloads the configuration on call to `update_checks`

### Motivation

When running a container orchestrator i.e. nomad/kubernetes/etc, new containers (new versions as well as new containers with new images) are deployed onto that host. We found that when datadog starts on a fresh host with no containers, all appears to be good. However, we then found that when new containers were scheduled on the host, no metrics were gathered about these containers from the service discovery plugin, however docker_daemon stats were still flowing. On reloading the datadog-agent service, we found that service discovery was now collecting metrics, again adding new containers, no metrics were sent through for the newly scheduled containers, however old containers were flowing. After digging deeper, a single call to get_configs() on container changes, resolved this issue.

### Testing Guidelines

On old version: Configure service discovery, with no containers on the host, start a container, see that no plugins configured from service discovery are being run (no metrics in dashboard). Add this plugin, and see that the config from service_discovery backend are being reloaded on new containers being started on the host. 
