### PR TITLE
[service discovery] cache templates and reduce # of kv store calls

### DIFF
--- a/config.py
+++ b/config.py
@@ -1094,7 +1094,7 @@ def load_check(agentConfig, hostname, checkname):
 
             # try to load the check and return the result
             load_success, load_failure = load_check_from_places(check_config, check_name, checks_places, agentConfig)
-            return load_success.values()[0] or load_failure
+            return load_success.values()[0] if load_success else load_failure
 
     return None
 

--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -557,8 +557,8 @@ class TestServiceDiscovery(unittest.TestCase):
                 clear_singletons(self.auto_conf_agentConfig)
 
     @mock.patch.object(AbstractConfigStore, '_issue_read', side_effect=issue_read)
-    def test_read_config_from_store(self, issue_read):
-        """Test read_config_from_store"""
+    def test_retrieve_config_tpl(self, issue_read):
+        """Test retrieve_config_tpl"""
         valid_idents = [('nginx', 'nginx'), ('nginx:latest', 'nginx:latest'),
                         ('custom-nginx', 'custom-nginx'), ('custom-nginx:latest', 'custom-nginx'),
                         ('repo/custom-nginx:latest', 'custom-nginx'),
@@ -566,8 +566,8 @@ class TestServiceDiscovery(unittest.TestCase):
         invalid_idents = ['foo']
         config_store = get_config_store(self.auto_conf_agentConfig)
         for ident, expected_key in valid_idents:
-            tpl = config_store.read_config_from_store(ident)
+            tpl = config_store.retrieve_config_tpl(ident)
             # source is added after reading from the store
-            self.assertEquals(tpl, ('template',) + self.mock_tpls.get(expected_key))
+            self.assertEquals(tpl, self.mock_tpls.get(expected_key))
         for ident in invalid_idents:
-            self.assertEquals(config_store.read_config_from_store(ident), [])
+            self.assertEquals(config_store.retrieve_config_tpl(ident), [])

--- a/utils/checkfiles.py
+++ b/utils/checkfiles.py
@@ -75,11 +75,11 @@ def get_auto_conf(agentConfig, check_name):
     return auto_conf
 
 
-def get_auto_conf_images(agentConfig):
+def get_auto_conf_images(agentConfig, full_tpl=True):
     """Walk through the auto_config folder and build a dict of auto-configurable images."""
     from config import PathNotFound, get_auto_confd_path
     auto_conf_images = {
-        # image_name: check_name
+        # image_name: check_name or [check_name, init_tpl, instance_tpl]
     }
 
     try:
@@ -100,5 +100,10 @@ def get_auto_conf_images(agentConfig):
         # extract the supported image list
         images = auto_conf.get('docker_images', [])
         for image in images:
-            auto_conf_images[image] = check_name
+            if full_tpl:
+                init_tpl = auto_conf.get('init_config', None)
+                instance_tpl = auto_conf.get('instances', [])
+                auto_conf_images[image] = [check_name, init_tpl, instance_tpl]
+            else:
+                auto_conf_images[image] = check_name
     return auto_conf_images

--- a/utils/configcheck.py
+++ b/utils/configcheck.py
@@ -94,10 +94,10 @@ def print_templates(agentConfig):
         except Exception as ex:
             print("Failed to extract configuration templates from the backend:\n%s" % str(ex))
 
-        for img, tpl in templates.iteritems():
+        for ident, tpl in templates.iteritems():
             print(
-                "- Image %s:\n\tcheck names: %s\n\tinit_configs: %s\n\tinstances: %s" % (
-                    img,
+                "- Identifier %s:\n\tcheck names: %s\n\tinit_configs: %s\n\tinstances: %s" % (
+                    ident,
                     tpl.get('check_names'),
                     tpl.get('init_configs'),
                     tpl.get('instances'),

--- a/utils/service_discovery/consul_config_store.py
+++ b/utils/service_discovery/consul_config_store.py
@@ -51,7 +51,7 @@ class ConsulStore(AbstractConfigStore):
         if kwargs.get('watch', False):
             return res[0]
         elif kwargs.get('all', False):
-            # we use it in _populate_identifier_to_checks
+            # we use it in _populate_identifier_to_tpls
             return [(child.get('Key'), child.get('Value')) for child in res[1]]
         else:
             if res[1] is not None:

--- a/utils/service_discovery/etcd_config_store.py
+++ b/utils/service_discovery/etcd_config_store.py
@@ -49,7 +49,7 @@ class EtcdStore(AbstractConfigStore):
                 modified_indices = (res.modifiedIndex, ) + tuple(leaf.modifiedIndex for leaf in res.leaves)
                 return max(modified_indices)
             elif kwargs.get('all', False):
-                # we use it in _populate_identifier_to_checks
+                # we use it in _populate_identifier_to_tpls
                 return [(child.key, child.value) for child in res.children]
             else:
                 return res.value


### PR DESCRIPTION
### What does this PR do?

Cache config templates to reduce the # of calls to the config store.
### Motivation

I was benchmarking service discovery against a node with 500 containers and noticed the high volumes of reads. It's not blocking or anything but we can do better.
### Testing Guidelines

Updated the relevant unit tests.
