### PR TITLE
[mongo] fixing hostname detection when username/password auth are part of the uri

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -441,7 +441,10 @@ class MongoDb(AgentCheck):
     def hostname_for_event(self, clean_server_name, agentConfig):
         """Return a reasonable hostname for a replset membership event to mention."""
         uri = urlsplit(clean_server_name)
-        hostname = uri.netloc.split(':')[0]
+        if '@' in uri.netloc:
+            hostname = uri.netloc.split('@')[1].split(':')[0]
+        else:
+            hostname = uri.netloc.split(':')[0]
         if hostname == 'localhost':
             hostname = self.hostname
         return hostname


### PR DESCRIPTION
### What does this PR do?

When sending MongoDB events back to DataDog, the agent parses the MongoDB connection string URI and attempts to extract the hostname (in the `hostname_for_event` function).

However, if the URI contains username/password auth (`mongodb://username:password@hostname:port`), the existing code will incorrectly extract the username and report that as the hostname.

This PR fixes that and should correctly extract the hostname, whether or not auth is used. It has been tested in production.

### Motivation

I didn't like seeing incorrect **datadog is PRIMARY** messages in my event stream.