### PR TITLE
[kubernetes] Only use kube annotations for sd once per pod

### DIFF
--- a/config.py
+++ b/config.py
@@ -1038,16 +1038,11 @@ def load_check_directory(agentConfig, hostname):
         if check_name in initialized_checks or check_name in init_failed_checks:
             continue
 
-        # if TRACE_CONFIG is set, service_disco_check_config looks like:
-        # (config_src, (sd_init_config, sd_instances)) instead of
-        # (sd_init_config, sd_instances)
+        sd_init_config, sd_instances = service_disco_check_config[1]
         if agentConfig.get(TRACE_CONFIG):
-            sd_init_config, sd_instances = service_disco_check_config[1]
             configs_and_sources[check_name] = (
                 service_disco_check_config[0],
                 {'init_config': sd_init_config, 'instances': sd_instances})
-        else:
-            sd_init_config, sd_instances = service_disco_check_config
 
         check_config = {'init_config': sd_init_config, 'instances': sd_instances}
 
@@ -1065,8 +1060,7 @@ def load_check_directory(agentConfig, hostname):
         return configs_and_sources
 
     return {'initialized_checks': initialized_checks.values(),
-            'init_failed_checks': init_failed_checks,
-            }
+            'init_failed_checks': init_failed_checks}
 
 
 def load_check(agentConfig, hostname, checkname):
@@ -1089,7 +1083,7 @@ def load_check(agentConfig, hostname, checkname):
     # the check was not found, try with service discovery
     for check_name, service_disco_check_config in _service_disco_configs(agentConfig).iteritems():
         if check_name == checkname:
-            sd_init_config, sd_instances = service_disco_check_config
+            sd_init_config, sd_instances = service_disco_check_config[1]
             check_config = {'init_config': sd_init_config, 'instances': sd_instances}
 
             # try to load the check and return the result

--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -42,14 +42,14 @@ def _get_container_inspect(c_id):
 
 def _get_conf_tpls(image_name, kube_annotations=None, kube_pod_name=None, kube_container_name=None):
     """Return a mocked configuration template from self.mock_templates."""
-    return [(x, image_name + ':0', y) for x, y in
+    return [(x, y) for x, y in
             copy.deepcopy(TestServiceDiscovery.mock_templates.get(image_name)[0])]
 
 
 def _get_check_tpls(image_name, **kwargs):
     if image_name in TestServiceDiscovery.mock_templates:
         result = copy.deepcopy(TestServiceDiscovery.mock_templates.get(image_name)[0][0])
-        return [(result[0], image_name + ':0', result[1][0:3])]
+        return [(result[0], result[1][0:3])]
     elif image_name in TestServiceDiscovery.bad_mock_templates:
         try:
             return [copy.deepcopy(TestServiceDiscovery.bad_mock_templates.get(image_name))]
@@ -112,13 +112,13 @@ class TestServiceDiscovery(unittest.TestCase):
         # image_name: ([(source, (check_name, init_tpl, instance_tpl, variables))], (expected_config_template))
         'image_0': (
             [('template', ('check_0', {}, {'host': '%%host%%'}, ['host']))],
-            ('template', 'image_0:0', ('check_0', {}, {'host': '127.0.0.1'}))),
+            ('template', ('check_0', {}, {'host': '127.0.0.1'}))),
         'image_1': (
             [('template', ('check_1', {}, {'port': '%%port%%'}, ['port']))],
-            ('template', 'image_1:0', ('check_1', {}, {'port': '1337'}))),
+            ('template', ('check_1', {}, {'port': '1337'}))),
         'image_2': (
             [('template', ('check_2', {}, {'host': '%%host%%', 'port': '%%port%%'}, ['host', 'port']))],
-            ('template', 'image_2:0', ('check_2', {}, {'host': '127.0.0.1', 'port': '1337'}))),
+            ('template', ('check_2', {}, {'host': '127.0.0.1', 'port': '1337'}))),
     }
 
     # raw templates coming straight from the config store
@@ -126,13 +126,13 @@ class TestServiceDiscovery(unittest.TestCase):
         # image_name: ('[check_name]', '[init_tpl]', '[instance_tpl]', expected_python_tpl_list)
         'image_0': (
             ('["check_0"]', '[{}]', '[{"host": "%%host%%"}]'),
-            [('template', 'image_0:0', ('check_0', {}, {"host": "%%host%%"}))]),
+            [('template', ('check_0', {}, {"host": "%%host%%"}))]),
         'image_1': (
             ('["check_1"]', '[{}]', '[{"port": "%%port%%"}]'),
-            [('template', 'image_1:0', ('check_1', {}, {"port": "%%port%%"}))]),
+            [('template', ('check_1', {}, {"port": "%%port%%"}))]),
         'image_2': (
             ('["check_2"]', '[{}]', '[{"host": "%%host%%", "port": "%%port%%"}]'),
-            [('template', 'image_2:0', ('check_2', {}, {"host": "%%host%%", "port": "%%port%%"}))]),
+            [('template', ('check_2', {}, {"host": "%%host%%", "port": "%%port%%"}))]),
         'bad_image_0': ((['invalid template']), []),
         'bad_image_1': (('invalid template'), []),
         'bad_image_2': (None, []),
@@ -278,7 +278,6 @@ class TestServiceDiscovery(unittest.TestCase):
             for image in self.mock_templates.keys():
                 template = sd_backend._get_config_templates(image)
                 expected_template = self.mock_templates.get(image)[0]
-                expected_template = [(t[0], image + ':0', t[1]) for t in expected_template]
                 self.assertEquals(template, expected_template)
             # error cases
             for image in self.bad_mock_templates.keys():
@@ -535,7 +534,7 @@ class TestServiceDiscovery(unittest.TestCase):
         config_store = get_config_store(self.auto_conf_agentConfig)
         for image in valid_config + invalid_config:
             tpl = self.mock_tpls.get(image)[1]
-            tpl = [(CONFIG_FROM_KUBE, t[1], t[2]) for t in tpl]
+            tpl = [(CONFIG_FROM_KUBE, t[1]) for t in tpl]
             if tpl:
                 self.assertNotEquals(
                     tpl,

--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -40,7 +40,7 @@ def _get_container_inspect(c_id):
         return None
 
 
-def _get_conf_tpls(image_name, kube_annotations=None, kube_pod_name=None):
+def _get_conf_tpls(image_name, kube_annotations=None, kube_pod_name=None, kube_container_name=None):
     """Return a mocked configuration template from self.mock_templates."""
     return [(x, image_name + ':0', y) for x, y in
             copy.deepcopy(TestServiceDiscovery.mock_templates.get(image_name)[0])]
@@ -545,10 +545,11 @@ class TestServiceDiscovery(unittest.TestCase):
                 config_store.get_check_tpls(
                     'k8s-' + image, auto_conf=True,
                     kube_pod_name=image,
+                    kube_container_name='foo',
                     kube_annotations=dict(zip(
-                        ['com.datadoghq.sd/check_names',
-                         'com.datadoghq.sd/init_configs',
-                         'com.datadoghq.sd/instances'],
+                        ['sd.datadoghq.com/foo/check_names',
+                         'sd.datadoghq.com/foo/init_configs',
+                         'sd.datadoghq.com/foo/instances'],
                         self.mock_tpls[image][0]))))
 
     def test_get_config_id(self):

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -158,14 +158,14 @@ class AbstractConfigStore(object):
                 if kube_config is not None:
                     check_names, init_config_tpls, instance_tpls = kube_config
                     source = CONFIG_FROM_KUBE
-                    return [(source, '{}:{}'.format(kube_pod_name, i), vs)
+                    return [(source, vs)
                             for i, vs in enumerate(zip(check_names, init_config_tpls, instance_tpls))]
 
             # in auto config mode, identifier is the image name
             auto_config = self._get_auto_config(identifier)
             if auto_config is not None:
                 source = CONFIG_FROM_AUTOCONF
-                return [(source, identifier, auto_config)]
+                return [(source, auto_config)]
             else:
                 log.debug('No auto config was found for image %s, leaving it alone.' % identifier)
                 return []
@@ -185,7 +185,7 @@ class AbstractConfigStore(object):
         # Try to update the identifier_to_checks cache
         self._update_identifier_to_checks(identifier, check_names)
 
-        return [(source, '{}:{}'.format(identifier, i), values)
+        return [(source, values)
                 for i, values in enumerate(zip(check_names, init_config_tpls, instance_tpls))]
 
     def read_config_from_store(self, identifier):

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -26,7 +26,6 @@ CHECK_NAMES = 'check_names'
 INIT_CONFIGS = 'init_configs'
 INSTANCES = 'instances'
 KUBE_ANNOTATIONS = 'kube_annotations'
-KUBE_POD_NAME = 'kube_pod_name'
 KUBE_CONTAINER_NAME = 'kube_container_name'
 KUBE_ANNOTATION_PREFIX = 'sd.datadoghq.com'
 
@@ -151,7 +150,6 @@ class AbstractConfigStore(object):
             # When not using a configuration store on kubernetes, check the pod
             # annotations for configs before falling back to autoconf.
             kube_annotations = kwargs.get(KUBE_ANNOTATIONS)
-            kube_pod_name = kwargs.get(KUBE_POD_NAME)
             kube_container_name = kwargs.get(KUBE_CONTAINER_NAME)
             if kube_annotations:
                 kube_config = self._get_kube_config(identifier, kube_annotations, kube_container_name)

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -159,7 +159,7 @@ class AbstractConfigStore(object):
                     check_names, init_config_tpls, instance_tpls = kube_config
                     source = CONFIG_FROM_KUBE
                     return [(source, vs)
-                            for i, vs in enumerate(zip(check_names, init_config_tpls, instance_tpls))]
+                            for vs in zip(check_names, init_config_tpls, instance_tpls)]
 
             # in auto config mode, identifier is the image name
             auto_config = self._get_auto_config(identifier)
@@ -186,7 +186,7 @@ class AbstractConfigStore(object):
         self._update_identifier_to_checks(identifier, check_names)
 
         return [(source, values)
-                for i, values in enumerate(zip(check_names, init_config_tpls, instance_tpls))]
+                for values in zip(check_names, init_config_tpls, instance_tpls)]
 
     def read_config_from_store(self, identifier):
         """Try to read from the config store, falls back to auto-config in case of failure."""

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -27,7 +27,7 @@ INIT_CONFIGS = 'init_configs'
 INSTANCES = 'instances'
 KUBE_ANNOTATIONS = 'kube_annotations'
 KUBE_CONTAINER_NAME = 'kube_container_name'
-KUBE_ANNOTATION_PREFIX = 'sd.datadoghq.com'
+KUBE_ANNOTATION_PREFIX = 'service-discovery.datadoghq.com'
 
 
 class KeyNotFound(Exception):
@@ -101,7 +101,7 @@ class AbstractConfigStore(object):
 
     def _get_kube_config(self, identifier, kube_annotations, kube_container_name):
         try:
-            prefix = '{}/{}/'.format(KUBE_ANNOTATION_PREFIX, kube_container_name)
+            prefix = '{}/{}.'.format(KUBE_ANNOTATION_PREFIX, kube_container_name)
             check_names = json.loads(kube_annotations[prefix + CHECK_NAMES])
             init_config_tpls = json.loads(kube_annotations[prefix + INIT_CONFIGS])
             instance_tpls = json.loads(kube_annotations[prefix + INSTANCES])

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -288,7 +288,6 @@ class SDDockerBackend(AbstractSDBackend):
         if Platform.is_k8s():
             kube_metadata = self._get_kube_config(inspect.get('Id'), 'metadata') or {}
             platform_kwargs = {
-                'kube_pod_name': kube_metadata.get('name'),
                 'kube_container_name': self._get_kube_container_name(inspect.get('Id')),
                 'kube_annotations': kube_metadata.get('annotations'),
             }

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -17,10 +17,54 @@ from utils.service_discovery.abstract_sd_backend import AbstractSDBackend
 from utils.service_discovery.config_stores import get_config_store
 
 DATADOG_ID = 'com.datadoghq.sd.check.id'
-K8S_ANNOTATION_CHECK_NAMES = 'com.datadoghq.sd/check_names'
-K8S_ANNOTATION_INIT_CONFIGS = 'com.datadoghq.sd/init_configs'
-K8S_ANNOTATION_INSTANCES = 'com.datadoghq.sd/instances'
 log = logging.getLogger(__name__)
+
+
+class _SDDockerBackendConfigFetchState(object):
+    def __init__(self, inspect_fn, kube_pods=None):
+        self.inspect_cache = {}
+
+        self.inspect_fn = inspect_fn
+        self.kube_pods = kube_pods
+
+    def inspect_container(self, c_id):
+        if c_id in self.inspect_cache:
+            return self.inspect_cache[c_id]
+
+        try:
+            self.inspect_cache[c_id] = inspect = self.inspect_fn(c_id)
+        except (NullResource, NotFound):
+            self.inspect_cache[c_id] = inspect = {}
+
+        return inspect
+
+    def get_kube_container_status(self, c_id):
+        for pod in self.kube_pods:
+            c_statuses = pod.get('status', {}).get('containerStatuses', [])
+            for status in c_statuses:
+                if c_id == status.get('containerID', '').split('//')[-1]:
+                    return status
+        return {}
+
+    def get_kube_container_name(self, c_id):
+        return self.get_kube_container_status(c_id).get('name')
+
+    def get_kube_container_spec(self, c_id):
+        c_name = self.get_kube_container_name(c_id)
+        containers = self.get_kube_config(c_id, 'spec').get('containers', [])
+        for co in containers:
+            if co.get('name') == c_name:
+                return co
+        return None
+
+    def get_kube_config(self, c_id, key):
+        """Get a part of a pod config from the kubernetes API"""
+        for pod in self.kube_pods:
+            c_statuses = pod.get('status', {}).get('containerStatuses', [])
+            for status in c_statuses:
+                if c_id == status.get('containerID', '').split('//')[-1]:
+                    return pod.get(key, {})
+        return {}
 
 
 class SDDockerBackend(AbstractSDBackend):
@@ -47,38 +91,42 @@ class SDDockerBackend(AbstractSDBackend):
 
         AbstractSDBackend.__init__(self, agentConfig)
 
-    def update_checks(self, changed_containers):
-        conf_reload_set = set()
-        for id_ in changed_containers:
-            try:
-                inspect = self.docker_client.inspect_container(id_)
-            except (NullResource, NotFound):
-                inspect = {}
+    def _make_fetch_state(self):
+        return _SDDockerBackendConfigFetchState(
+            self.docker_client.inspect_container,
+            self.kubeutil.retrieve_pods_list().get('items', []) if Platform.is_k8s() else None)
 
-            checks = self._get_checks_from_inspect(inspect)
+    def update_checks(self, changed_containers):
+        state = self._make_fetch_state()
+
+        conf_reload_set = set()
+        for c_id in changed_containers:
+            checks = self._get_checks_to_refresh(state, c_id)
             conf_reload_set.update(set(checks))
 
         if conf_reload_set:
             self.reload_check_configs = conf_reload_set
 
-    def _get_checks_from_inspect(self, inspect):
+    def _get_checks_to_refresh(self, state, c_id):
         """Get the list of checks applied to a container from the identifier_to_checks cache in the config store.
         Use the DATADOG_ID label or the image."""
+        inspect = state.inspect_container(c_id)
         identifier = inspect.get('Config', {}).get('Labels', {}).get(DATADOG_ID) or \
             inspect.get('Config', {}).get('Image')
 
         platform_kwargs = {}
         if Platform.is_k8s():
-            kube_metadata = self._get_kube_config(inspect.get('Id'), 'metadata') or {}
+            kube_metadata = state.get_kube_config(c_id, 'metadata') or {}
             platform_kwargs = {
                 'kube_annotations': kube_metadata.get('annotations'),
-                'kube_container_name': self._get_kube_container_name(inspect.get('Id')),
+                'kube_container_name': state.get_kube_container_name(c_id),
             }
 
         return self.config_store.get_checks_to_refresh(identifier, **platform_kwargs)
 
-    def _get_host_address(self, c_inspect, tpl_var):
+    def _get_host_address(self, state, c_id, tpl_var):
         """Extract the container IP from a docker inspect object, or the kubelet API."""
+        c_inspect = state.inspect_container(c_id)
         c_id, c_img = c_inspect.get('Id', ''), c_inspect.get('Config', {}).get('Image', '')
 
         networks = c_inspect.get('NetworkSettings', {}).get('Networks') or {}
@@ -102,17 +150,9 @@ class SDDockerBackend(AbstractSDBackend):
             # kubernetes case
             log.debug("Couldn't find the IP address for container %s (%s), "
                       "using the kubernetes way." % (c_id[:12], c_img))
-            pod_list = self.kubeutil.retrieve_pods_list().get('items', [])
-            for pod in pod_list:
-                pod_ip = pod.get('status', {}).get('podIP')
-                if pod_ip is None:
-                    continue
-                else:
-                    c_statuses = pod.get('status', {}).get('containerStatuses', [])
-                    for status in c_statuses:
-                        # compare the container id with those of containers in the current pod
-                        if c_id == status.get('containerID', '').split('//')[-1]:
-                            return pod_ip
+            pod_ip = state.get_kube_config(c_id, 'status').get('podIP')
+            if pod_ip:
+                return pod_ip
 
         log.error("No IP address was found for container %s (%s)" % (c_id[:12], c_img))
         return None
@@ -145,9 +185,9 @@ class SDDockerBackend(AbstractSDBackend):
             log.warning("Trying with the last (sorted) network: '%s'." % last_key)
             return ip_dict[last_key]
 
-    def _get_port(self, container_inspect, tpl_var):
+    def _get_port(self, state, c_id, tpl_var):
         """Extract a port from a container_inspect or the k8s API given a template variable."""
-        c_id = container_inspect.get('Id', '')
+        container_inspect = state.inspect_container(c_id)
 
         try:
             ports = map(lambda x: x.split('/')[0], container_inspect['NetworkSettings']['Ports'].keys())
@@ -159,17 +199,10 @@ class SDDockerBackend(AbstractSDBackend):
             if not ports and Platform.is_k8s():
                 log.debug("Didn't find the port for container %s (%s), trying the kubernetes way." %
                           (c_id[:12], container_inspect.get('Config', {}).get('Image', '')))
-                co_statuses = self._get_kube_config(c_id, 'status').get('containerStatuses', [])
-                c_name = None
-                for co in co_statuses:
-                    if co.get('containerID', '').split('//')[-1] == c_id:
-                        c_name = co.get('name')
-                        break
-                containers = self._get_kube_config(c_id, 'spec').get('containers', [])
-                for co in containers:
-                    if co.get('name') == c_name:
-                        ports = map(lambda x: str(x.get('containerPort')), co.get('ports', []))
-        ports = sorted(ports, key=lambda x: int(x))
+                spec = state.get_kube_container_spec(c_id)
+                if spec:
+                    ports = [str(x.get('containerPort')) for x in spec.get('ports', [])]
+        ports = sorted(ports, key=int)
         return self._extract_port_from_list(ports, tpl_var)
 
     def _extract_port_from_list(self, ports, tpl_var):
@@ -192,15 +225,15 @@ class SDDockerBackend(AbstractSDBackend):
             log.error("Port index is out of range. Using the last element instead.")
         return ports[-1]
 
-    def get_tags(self, c_inspect):
+    def get_tags(self, state, c_id):
         """Extract useful tags from docker or platform APIs. These are collected by default."""
         tags = []
         if Platform.is_k8s():
-            pod_metadata = self._get_kube_config(c_inspect.get('Id'), 'metadata')
+            pod_metadata = state.get_kube_config(c_id, 'metadata')
 
             if pod_metadata is None:
                 log.warning("Failed to fetch pod metadata for container %s."
-                            " Kubernetes tags may be missing." % c_inspect.get('Id', '')[:12])
+                            " Kubernetes tags may be missing." % c_id[:12])
                 return []
             # get labels
             kube_labels = pod_metadata.get('labels', {})
@@ -217,39 +250,23 @@ class SDDockerBackend(AbstractSDBackend):
 
         return tags
 
-    def _get_additional_tags(self, container_inspect, *args):
+    def _get_additional_tags(self, state, c_id, *args):
         tags = []
         if Platform.is_k8s():
-            pod_metadata = self._get_kube_config(container_inspect.get('Id'), 'metadata')
-            pod_spec = self._get_kube_config(container_inspect.get('Id'), 'spec')
+            pod_metadata = state.get_kube_config(c_id, 'metadata')
+            pod_spec = state.get_kube_config(c_id, 'spec')
             if pod_metadata is None or pod_spec is None:
                 log.warning("Failed to fetch pod metadata or pod spec for container %s."
-                            " Additional Kubernetes tags may be missing." % container_inspect.get('Id', '')[:12])
+                            " Additional Kubernetes tags may be missing." % c_id[:12])
                 return []
             tags.append('node_name:%s' % pod_spec.get('nodeName'))
             tags.append('pod_name:%s' % pod_metadata.get('name'))
         return tags
 
-    def _get_kube_container_name(self, c_id):
-        pods = self.kubeutil.retrieve_pods_list().get('items', [])
-        for pod in pods:
-            c_statuses = pod.get('status', {}).get('containerStatuses', [])
-            for status in c_statuses:
-                if c_id == status.get('containerID', '').split('//')[-1]:
-                    return status.get('name')
-
-    def _get_kube_config(self, c_id, key):
-        """Get a part of a pod config from the kubernetes API"""
-        pods = self.kubeutil.retrieve_pods_list().get('items', [])
-        for pod in pods:
-            c_statuses = pod.get('status', {}).get('containerStatuses', [])
-            for status in c_statuses:
-                if c_id == status.get('containerID', '').split('//')[-1]:
-                    return pod.get(key, {})
-
     def get_configs(self):
         """Get the config for all docker containers running on the host."""
         configs = {}
+        state = self._make_fetch_state()
         containers = [(
             container.get('Image'),
             container.get('Id'), container.get('Labels')
@@ -259,7 +276,7 @@ class SDDockerBackend(AbstractSDBackend):
             try:
                 # value of the DATADOG_ID tag or the image name if the label is missing
                 identifier = self.get_config_id(image, labels)
-                check_configs = self._get_check_configs(cid, identifier) or []
+                check_configs = self._get_check_configs(state, cid, identifier) or []
                 for conf in check_configs:
                     source, (check_name, init_config, instance) = conf
 
@@ -281,14 +298,13 @@ class SDDockerBackend(AbstractSDBackend):
         """Look for a DATADOG_ID label, return its value or the image name if missing"""
         return labels.get(DATADOG_ID) or image
 
-    def _get_check_configs(self, c_id, identifier):
+    def _get_check_configs(self, state, c_id, identifier):
         """Retrieve configuration templates and fill them with data pulled from docker and tags."""
-        inspect = self.docker_client.inspect_container(c_id)
         platform_kwargs = {}
         if Platform.is_k8s():
-            kube_metadata = self._get_kube_config(inspect.get('Id'), 'metadata') or {}
+            kube_metadata = state.get_kube_config(c_id, 'metadata') or {}
             platform_kwargs = {
-                'kube_container_name': self._get_kube_container_name(inspect.get('Id')),
+                'kube_container_name': state.get_kube_container_name(c_id),
                 'kube_annotations': kube_metadata.get('annotations'),
             }
         config_templates = self._get_config_templates(identifier, **platform_kwargs)
@@ -298,13 +314,13 @@ class SDDockerBackend(AbstractSDBackend):
             return None
 
         check_configs = []
-        tags = self.get_tags(inspect)
+        tags = self.get_tags(state, c_id)
         for config_tpl in config_templates:
             source, config_tpl = config_tpl
             check_name, init_config_tpl, instance_tpl, variables = config_tpl
 
             # insert tags in instance_tpl and process values for template variables
-            instance_tpl, var_values = self._fill_tpl(inspect, instance_tpl, variables, tags)
+            instance_tpl, var_values = self._fill_tpl(state, c_id, instance_tpl, variables, tags)
 
             tpl = self._render_template(init_config_tpl or {}, instance_tpl or {}, var_values)
             if tpl and len(tpl) == 2:
@@ -351,11 +367,11 @@ class SDDockerBackend(AbstractSDBackend):
 
         return templates
 
-    def _fill_tpl(self, inspect, instance_tpl, variables, tags=None):
+    def _fill_tpl(self, state, c_id, instance_tpl, variables, tags=None):
         """Add container tags to instance templates and build a
            dict from template variable names and their values."""
         var_values = {}
-        c_id, c_image = inspect.get('Id', ''), inspect.get('Config', {}).get('Image', '')
+        c_image = state.inspect_container(c_id).get('Config', {}).get('Image', '')
 
         # add default tags to the instance
         if tags:
@@ -367,7 +383,7 @@ class SDDockerBackend(AbstractSDBackend):
             # variables can be suffixed with an index in case several values are found
             if var.split('_')[0] in self.VAR_MAPPING:
                 try:
-                    res = self.VAR_MAPPING[var.split('_')[0]](inspect, var)
+                    res = self.VAR_MAPPING[var.split('_')[0]](state, c_id, var)
                     if res is None:
                         raise ValueError("Invalid value for variable %s." % var)
                     var_values[var] = res


### PR DESCRIPTION
### What does this PR do?

Currently the kube annotations are used for service discovery once per docker container. This causes "duplicate" checks to be instantiated if you have sidecar containers in your kubernetes pod.

This PR changes the annotations to annotate a specific container to monitor (by name).
### Motivation

Seeing dup checks in my cluster :X.
### Testing Guidelines

Unit tests. I will also be deploying this to my internal cluster and monitoring.
### Additional Notes

The various tuples flying around between config & backend are getting a bit old. AFAICT there are 4 distinct sets:
- Config->Backend: `[(source, (check_name, init_config, instance_tpl))]`
- `_get_config_templates` -> `_get_check_configs`: `[(source, (check_name, init_config, instance_tpl, variables))]`
- `_get_check_configs` -> `get_configs`: `[(source, (check_name, init_config, instance))]`

It's getting a bit weird. I removed `trace_configs` as a variation because that was getting to be a bit too much. I think there was also a bug where some code didn't handle this case.
