### PR TITLE
[init scripts] Add APPLICATION_DEFAULTS to init scripts

### DIFF
--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -197,6 +197,15 @@ configcheck() {
     exit $?
 }
 
+# Source /etc/default/datadog-agent environment values
+#  NOTE: The purpose of /etc/default/XX files is to provide extra overrides or startup options on top of whatever
+#         configuration the daemon already has. It provides a hook for configuration management systems like Puppet or Chef,
+#         or for any 12 factor system, to pass environment specific variables directly to custom Checks and Emitters.
+#         It means you don't have to fiddle with the conf.d files. And that it is easier to interact
+#         with libraries like boto that can receive input via env-vars
+APPLICATION_DEFAULTS=/etc/default/datadog-agent
+[[ -f "${APPLICATION_DEFAULTS}" ]] && source "${APPLICATION_DEFAULTS}"
+
 
 case "$1" in
     start)

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -35,6 +35,15 @@ if [ ! -x $AGENTPATH ]; then
     exit 0
 fi
 
+# Source the /etc/default/datadog-agent environment values
+#  NOTE: The purpose of /etc/default/XX files is to provide extra overrides or startup options on top of whatever
+#         configuration the daemon already has. It provides a hook for configuration management systems like Puppet or Chef,
+#         or for any 12 factor system, to pass environment specific variables directly to custom Checks and Emitters.
+#         It means you don't have to fiddle with the conf.d files. And that it is easier to interact
+#         with libraries like boto that can recieve input via env-vars
+APPLICATION_DEFAULTS=/etc/default/datadog-agent
+[[ -f "${APPLICATION_DEFAULTS}" ]] && source "${APPLICATION_DEFAULTS}"
+
 check_status() {
 
     QUERY="all"


### PR DESCRIPTION
### What does this PR do?

Adds sourcing of /etc/defaults/datadog-agent to the two init scripts (debian & centos)
### Motivation

The purpose of /etc/default/XX files is to provide extra overrides or startup options on top of whatever configuration the daemon already has. It provides a hook for configuration management systems like Puppet or Chef, or for any 12 factor system, to pass environment specific variables directly to custom Checks and Emitters. It means you don't have to fiddle with the conf.d files. And more important, that it is easier for custom Checks and Emitters to interact with libraries like boto that can receive input via env-vars.
### Testing Guidelines

N/A. Although I did verify that the bash is correctly implemented and runs as expected
### Additional Notes

N/A
