### PR TITLE
[CI][Kong] if cassandra isn't there, kong env is broken

### DIFF
--- a/ci/resources/kong/setup_uuid.sh
+++ b/ci/resources/kong/setup_uuid.sh
@@ -4,9 +4,11 @@ set -e
 
 
 pushd $INTEGRATIONS_DIR
-mkdir $UUID_DIR
+mkdir -p $UUID_DIR
 
-curl https://www.kernel.org/pub/linux/utils/util-linux/v2.27/util-linux-2.27.tar.gz | tar xz
+rsync rsync://rsync.kernel.org/pub/linux/utils/util-linux/v2.27/util-linux-2.27.tar.gz util-linux-2.27.tar.gz
+tar xzf util-linux-2.27.tar.gz
+
 echo $TRAVIS_PYTHON_VERSION
 pushd util-linux-2.27
 ./configure \


### PR DESCRIPTION
### What does this PR do?

Takes care of having a working Cassandra

### Motivation

don't ask, don't tell

### Notes

Had to update Cassandra version, the old archive was giving a 404
I'm using rsync instead of curl to grab `utils-linux` b/c the curl shipped with Travis is quite old and doesn't support recent SSL implementations