### PR TITLE
[mesos_slave] Connect to master with same protocol as slave

### DIFF
--- a/checks.d/mesos_slave.py
+++ b/checks.d/mesos_slave.py
@@ -143,12 +143,15 @@ class MesosSlave(AgentCheck):
 
     def _get_constant_attributes(self, url, timeout, master_port, verify):
         state_metrics = None
+        parsed_url = urlparse(url)
         if self.cluster_name is None:
             state_metrics = self._get_state(url, timeout, verify)
             if state_metrics is not None:
                 self.version = map(int, state_metrics['version'].split('.'))
                 master_state = self._get_state(
-                    'http://{0}:{1}'.format(state_metrics['master_hostname'], master_port),
+                    '{0}://{1}:{2}'.format(parsed_url.scheme,
+                                           state_metrics['master_hostname'],
+                                           master_port),
                     timeout,
                     verify
                 )


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Fixes a bug in the mesos-slave.py check. This check queries both the localhost and the master node. The bug is that even if you specify SSL for communicating with the localhost (slave), the master is always queried with plain HTTP. This is definitely a bug because it is impossible to configure a mesos cluster where master and slave are using different protocols.

### Motivation

I've got SSL enabled on my mesos cluster and this check just plain doesn't work with SSL enabled.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?

This work is a follow-on to Zendesk ticket: 62968