### PR TITLE
[CI][Apache] store pidfile in the volatile dir

### DIFF
--- a/ci/resources/apache/httpd.conf
+++ b/ci/resources/apache/httpd.conf
@@ -1,4 +1,5 @@
 ServerRoot "%APACHE_ROOTDIR%"
+PidFile "%VOLATILE_DIR%/apache.pid"
 Listen 8080
 
 LoadModule authn_file_module modules/mod_authn_file.so


### PR DESCRIPTION
### What does this PR do?

Apache won't start if we have a dangling pidfile


