### PR TITLE
[http_check] SSL certificate strptime fix

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -4,7 +4,7 @@
 
 # stdlib
 from datetime import datetime
-import _strptime
+import _strptime # noqa
 import os.path
 from os import environ
 import re

--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -4,6 +4,7 @@
 
 # stdlib
 from datetime import datetime
+import _strptime
 import os.path
 from os import environ
 import re


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Fixes an issue with the http_check module where using a HTTPS URL would fail to parse the 'notAfter' date due to improper import of _strptime

### Motivation

I have 30 endpoints all using https that I needed to monitor and was disappointed to find out that there was a blocking error when trying to monitor them. I'm new to doing pull requests and contributing on github, but I'm interested in helping out where I can!

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

I'm not sure this is the best fix, but I was able to fix the issue on Ubuntu 14.04 with this fix. I'm open to discussing this further.

Fix an issue in the http_check module when a HTTPS URL was used. The certificate check was failing due to a bad reference to a _strptime function on the datetime module

Fixes #2902