### PR TITLE
Use the env var KUBERNETES_SERVICE_HOST if present

### DIFF
--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -63,7 +63,7 @@ class KubeUtil:
 
         self.kubelet_api_url = '%s://%s:%d' % (self.method, self.host, self.kubelet_port)
         self.cadvisor_url = '%s://%s:%d' % (self.method, self.host, self.cadvisor_port)
-        self.kubernetes_api_url = 'https://%s/api/v1' % self.DEFAULT_MASTER_NAME
+        self.kubernetes_api_url = 'https://%s/api/v1' % (os.environ.get('KUBERNETES_SERVICE_HOST') or self.DEFAULT_MASTER_NAME)
 
         self.metrics_url = urljoin(self.cadvisor_url, KubeUtil.METRICS_PATH)
         self.pods_list_url = urljoin(self.kubelet_api_url, KubeUtil.PODS_LIST_PATH)


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

In the kubernetes check, use the env var KUBERNTES_SERVICE_HOST to specify the API endpoint, if present.

### Motivation

See https://github.com/DataDog/dd-agent/pull/2551#issuecomment-246413595 . When using dd-agent in namespaces such as `kube-system`, the kube-dns service might not be running, so the `kubernetes` host might not be present. 
