### PR TITLE
[kubernetes] add some tags to events

### DIFF
--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -378,6 +378,8 @@ class Kubernetes(AgentCheck):
 
             involved_obj = event.get('involvedObject', {})
 
+            tags = self.kubeutil.extract_event_tags(event)
+
             # compute the most recently seen event, without relying on items order
             if event_ts > most_recent_read:
                 most_recent_read = event_ts
@@ -396,6 +398,7 @@ class Kubernetes(AgentCheck):
                 'msg_text': msg_body,
                 'source_type_name': EVENT_TYPE,
                 'event_object': 'kubernetes:{}'.format(involved_obj.get('name')),
+                'tags': tags,
             }
             self.event(dd_event)
 

--- a/conf.d/kubernetes.yaml.example
+++ b/conf.d/kubernetes.yaml.example
@@ -18,9 +18,16 @@ instances:
   # collect_events controls whether the agent should fetch events from the kubernetes API and
   # ingest them in Datadog. To avoid duplicates, only one agent at a time across the entire
   # cluster should have this feature enabled. To enable the feature, set the parameter to `true`.
+  #
   # collect_events: false
+  #
+  #
+  # The namespace for which events should be collected.
+  # If not modified, the default namespace will be used.
+  #
+  # namespace: default
 
-  # use_histogram controls whether we send detailed metrics, i.e. one per container. 
+  # use_histogram controls whether we send detailed metrics, i.e. one per container.
   # When false, we send detailed metrics corresponding to individual containers, tagging by container id
   # to keep them unique.
   # When true, we aggregate data based on container image.

--- a/tests/checks/mock/test_kubernetes.py
+++ b/tests/checks/mock/test_kubernetes.py
@@ -430,3 +430,17 @@ class TestKubeutil(unittest.TestCase):
         self.assertFalse(Platform.is_k8s())
         os.environ['KUBERNETES_PORT'] = '999'
         self.assertTrue(Platform.is_k8s())
+
+    def test_extract_event_tags(self):
+        events = json.loads(Fixtures.read_file("events.json", string_escape=False))['items']
+        for ev in events:
+            tags = KubeUtil().extract_event_tags(ev)
+            # there should be 4 tags except for some events where source.host is missing
+            self.assertTrue(len(tags) >= 3)
+
+            tag_names = [tag.split(':')[0] for tag in tags]
+            self.assertIn('reason', tag_names)
+            self.assertIn('namespace', tag_names)
+            self.assertIn('object_type', tag_names)
+            if len(tags) == 4:
+                self.assertIn('node_name', tag_names)

--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -195,6 +195,23 @@ class KubeUtil:
                 self._node_name = spec.get('nodeName', '')
                 break
 
+    def extract_event_tags(self, event):
+        """
+        Return a list of tags extracted from an event object
+        """
+        tags = []
+
+        if 'reason' in event:
+            tags.append('reason:%s' % event.get('reason', '').lower())
+        if 'namespace' in event.get('metadata', {}):
+            tags.append('namespace:%s' % event['metadata']['namespace'])
+        if 'host' in event.get('source', {}):
+            tags.append('node_name:%s' % event['source']['host'])
+        if 'kind' in event.get('involvedObject', {}):
+            tags.append('object_type:%s' % event['involvedObject'].get('kind', '').lower())
+
+        return tags
+
     @classmethod
     def get_auth_token(cls):
         """


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

- add a few tags to k8s events
- also expose the `namespace` parameter in the check configuration file

### Motivation

Events are more useful with context.
The namespace parameter is interesting and deserves to be explicitly exposed.

### Testing Guidelines

Added a unit test for `KubeUtil.extract_event_tags`.
