### PR TITLE
[Apache] service check could hang entire collector process if the connection to the apache status URL hangs.

### DIFF
--- a/conf.d/apache.yaml.example
+++ b/conf.d/apache.yaml.example
@@ -12,3 +12,13 @@ instances:
     # Defaults to false, set to true if you want to disable SSL certificate validation.
     #
     # disable_ssl_validation: false
+
+    # The (optional) connect_timeout will override the default value, and fail
+    # the check if the time to establish the (TCP) connection exceeds the
+    # connect_timeout value (in seconds)
+    # connect_timeout: 5
+    
+    # The (optional) receive_timeout will override the default value, and fail
+    # the check if the time to receive the server status from the Apache server
+    # exceeds the receive_timeout value (in seconds)
+    # receive_timeout: 15


### PR DESCRIPTION

### What does this PR do?

Adds a timeout for connecting to the Apache status server, and fails the service check if the connection can't be established or the status isn't supplied in a timely manner.

### Motivation

Customer report that a hung Apache caused the dd-agent to hang as well.  Therefore, not only did it not report the Apache failure but prevented other metrics from being reported too.

### Testing Guidelines


### Additional Notes

Anything else we should know when reviewing?

If the apache process is hung, then the service check will hang
indefinitely, too.  With this change, the service check will time out,
and (correctly) report that the service is down.