### PR TITLE
[kubernetes] add namespace tag to kubernetes.pods.running

### DIFF
--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -368,25 +368,25 @@ class Kubernetes(AgentCheck):
             "ReplicaSet",
         ]
 
-        controllers_map = defaultdict(lambda: {'count': 0, 'namespace': None})
+        # (create-by, namespace): count
+        controllers_map = defaultdict(int)
         for pod in pods['items']:
             try:
                 created_by = json.loads(pod['metadata']['annotations']['kubernetes.io/created-by'])
                 kind = created_by['reference']['kind']
                 if kind in supported_kinds:
-                    controllers_map[created_by['reference']['name']]['count'] += 1
                     namespace = created_by['reference']['namespace']
-                    controllers_map[created_by['reference']['name']]['namespace'] = namespace
+                    controllers_map[(created_by['reference']['name'], namespace)] += 1
             except (KeyError, ValueError) as e:
                 self.log.debug("Unable to retrieve pod kind for pod %s: %s", pod, e)
                 continue
 
         tags = instance.get('tags', [])
-        for ctrl, values in controllers_map.iteritems():
+        for (ctrl, namespace), pod_count in controllers_map.iteritems():
             _tags = tags[:]  # copy base tags
             _tags.append('kube_replication_controller:{0}'.format(ctrl))
-            _tags.append('kube_namespace:{0}'.format(values['namespace']))
-            self.publish_gauge(self, NAMESPACE + '.pods.running', values['count'], _tags)
+            _tags.append('kube_namespace:{0}'.format(namespace))
+            self.publish_gauge(self, NAMESPACE + '.pods.running', pod_count, _tags)
 
     def _process_events(self, instance, pods_list):
         """

--- a/tests/checks/mock/test_kubernetes.py
+++ b/tests/checks/mock/test_kubernetes.py
@@ -113,10 +113,10 @@ class TestKubernetes(AgentCheckTest):
             (['kube_replication_controller:kube-dns-v8','kube_namespace:kube-system', 'container_name:k8s_healthz.4469a25d_kube-dns-v8-smhcb_kube-system_b80ffab3-3619-11e5-84ce-42010af01c62_241c34d1', 'pod_name:kube-system/kube-dns-v8-smhcb'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
             (['kube_replication_controller:fluentd-cloud-logging-kubernetes-minion','kube_namespace:kube-system', 'container_name:k8s_fluentd-cloud-logging.7721935b_fluentd-cloud-logging-kubernetes-minion-mu4w_kube-system_d0feac1ad02da9e97c4bf67970ece7a1_2c3c0879', 'pod_name:kube-system/fluentd-cloud-logging-kubernetes-minion-mu4w'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
             (['container_name:dd-agent', 'pod_name:no_pod'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
-            (['kube_replication_controller:l7-lb-controller'], [PODS]),
-            (['kube_replication_controller:redis-slave'], [PODS]),
-            (['kube_replication_controller:frontend'], [PODS]),
-            (['kube_replication_controller:heapster-v11'], [PODS]),
+            (['kube_replication_controller:l7-lb-controller', 'kube_namespace:kube-system'], [PODS]),
+            (['kube_replication_controller:redis-slave', 'kube_namespace:default'], [PODS]),
+            (['kube_replication_controller:frontend', 'kube_namespace:default'], [PODS]),
+            (['kube_replication_controller:heapster-v11', 'kube_namespace:kube-system'], [PODS]),
             ([], [LIM, REQ, CAP])  # container from kubernetes api doesn't have a corresponding entry in Cadvisor
         ]
         for m, _type in METRICS:
@@ -161,10 +161,10 @@ class TestKubernetes(AgentCheckTest):
             (['kube_replication_controller:kube-ui-v1','kube_namespace:kube-system', 'pod_name:kube-system/kube-ui-v1-sv2sq'], [MEM, CPU, FS, NET, NET_ERRORS]),
             (['kube_replication_controller:propjoe', 'kube_namespace:default', 'pod_name:default/propjoe-lkc3l'], [MEM, CPU, FS, NET, NET_ERRORS]),
             (['kube_replication_controller:haproxy-6db79c7bbcac01601ac35bcdb18868b3', 'kube_namespace:default', 'pod_name:default/haproxy-6db79c7bbcac01601ac35bcdb18868b3-rr7la'], [MEM, CPU, FS, NET, NET_ERRORS]),
-            (['kube_replication_controller:l7-lb-controller'], [PODS]),
-            (['kube_replication_controller:redis-slave'], [PODS]),
-            (['kube_replication_controller:frontend'], [PODS]),
-            (['kube_replication_controller:heapster-v11'], [PODS]),
+            (['kube_replication_controller:l7-lb-controller', 'kube_namespace:kube-system'], [PODS]),
+            (['kube_replication_controller:redis-slave', 'kube_namespace:default'], [PODS]),
+            (['kube_replication_controller:frontend', 'kube_namespace:default'], [PODS]),
+            (['kube_replication_controller:heapster-v11', 'kube_namespace:kube-system'], [PODS]),
             ([], [LIM, REQ, CAP])  # container from kubernetes api doesn't have a corresponding entry in Cadvisor
         ]
 
@@ -225,7 +225,7 @@ class TestKubernetes(AgentCheckTest):
             (['container_name:k8s_dd-agent.7b520f3f_dd-agent-1rxlh_default_12c7be82-33ca-11e6-ac8f-42010af00003_321fecb4',
               'pod_name:default/dd-agent-1rxlh', 'kube_namespace:default', 'kube_app:dd-agent', 'kube_foo:bar',
               'kube_bar:baz', 'kube_replication_controller:dd-agent'], [LIM, REQ, MEM, CPU, NET, DISK, DISK_USAGE]),
-            (['kube_replication_controller:dd-agent'], [PODS]),
+            (['kube_replication_controller:dd-agent', 'kube_namespace:default'], [PODS]),
             ([], [LIM, REQ, CAP])  # container from kubernetes api doesn't have a corresponding entry in Cadvisor
         ]
 
@@ -272,7 +272,7 @@ class TestKubernetes(AgentCheckTest):
               'kube_bar:baz',
               'kube_replication_controller:dd-agent'], [MEM, CPU, NET, DISK, NET_ERRORS, DISK_USAGE, LIM, REQ]),
             (['pod_name:no_pod'], [MEM, CPU, FS, NET, NET_ERRORS, DISK]),
-            (['kube_replication_controller:dd-agent'], [PODS]),
+            (['kube_replication_controller:dd-agent', 'kube_namespace:default'], [PODS]),
             ([], [LIM, REQ, CAP])  # container from kubernetes api doesn't have a corresponding entry in Cadvisor
         ]
 


### PR DESCRIPTION
_Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so._
### What does this PR do?

Add the `kube_namespace` tag to `kubernetes.pods.running`.
### Motivation

User request, it makes aggregation easier and more useful.
### Testing Guidelines

Relevant tests have been update.
### Additional Notes

We should update the `kube_replication_controller` tag name (must be done carefully as it will break things for users relying on it). It used to be accurate but now pods can be created by daemon sets, jobs, deployments, and replica sets too.
