### PR TITLE
[service_discovery][jmx] enabling for JMX-based integrations (GRPC)

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -140,9 +140,12 @@ class Agent(Daemon):
         # restart jmx
         if jmx_checks:
             jmx_state = self.supervisor_proxy.supervisor.getProcessInfo(JMX_SUPERVISOR_ENTRY)
+            log.debug("Current JMX check state: %s", jmx_state['statename'])
             if jmx_state['statename'] in ['STOPPED', 'EXITED', 'FATAL']:
+                log.debug("Starting JMX...")
                 self.supervisor_proxy.supervisor.startProcess(JMX_SUPERVISOR_ENTRY)
 
+            log.debug("Signaling JMX load-up...")
             self.supervisor_proxy.supervisor.signalProcess(JMX_SUPERVISOR_ENTRY, 'USR1') # send SIGUSR1 to process
 
         # Logging

--- a/agent.py
+++ b/agent.py
@@ -163,7 +163,7 @@ class Agent(Daemon):
                 except Exception as e:
                     log.exception("unable to submit YAML via RPC: %s", e)
                 else:
-                    if res.applied:
+                    if res.success:
                         log.info("JMX SD Config submitted via RPC for %s successfully.", name)
                     else:
                         log.info("JMX SD Config submitted via RPC for %s failed. \

--- a/config.py
+++ b/config.py
@@ -1,4 +1,3 @@
-# (C) Datadog, Inc. 2010-2016
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
@@ -1108,6 +1107,7 @@ def load_check(agentConfig, hostname, checkname):
 def generate_jmx_configs(agentConfig, hostname, checknames=None):
     """Similar logic to load_check_directory for JMX checks"""
     from jmxfetch import JMX_CHECKS
+
     if not checknames:
         checknames = JMX_CHECKS
     agentConfig['checksd_hostname'] = hostname
@@ -1116,12 +1116,14 @@ def generate_jmx_configs(agentConfig, hostname, checknames=None):
     generated = []
     for check_name, service_disco_check_config in _service_disco_configs(agentConfig).iteritems():
         if check_name in checknames and check_name in JMX_CHECKS:
+            log.info('Generating JMX config for: %s' % check_name)
             sd_init_config, sd_instances = service_disco_check_config
             check_config = {'init_config': sd_init_config, 'instances': sd_instances}
 
             # try to load the check and return the result
             # TODO Jaime: make this an RPC call...
             temp_file = os.path.join('/tmp',JMX_SD_CONF_TEMPLATE.format(check_name))
+            log.info('Dumping config %s to: %s' % (check_config, temp_file))
             dump_yaml(temp_file, check_config)
             generated.append(check_name)
 

--- a/config.py
+++ b/config.py
@@ -41,7 +41,6 @@ MAC_CONFIG_PATH = '/opt/datadog-agent/etc'
 DEFAULT_CHECK_FREQUENCY = 15   # seconds
 LOGGING_MAX_BYTES = 10 * 1024 * 1024
 SDK_INTEGRATIONS_DIR = 'integrations'
-SERVICE_DISCOVERY_PREFIX = 'SD-'
 
 log = logging.getLogger(__name__)
 
@@ -1117,7 +1116,7 @@ def generate_jmx_configs(agentConfig, hostname, checknames=None):
     generated = {}
     for check_name, service_disco_check_config in _service_disco_configs(agentConfig).iteritems():
         if check_name in checknames and check_name in JMX_CHECKS:
-            log.info('Generating JMX config for: %s' % check_name)
+            log.debug('Generating JMX config for: %s' % check_name)
             sd_init_config, sd_instances = service_disco_check_config
             check_config = {'init_config': sd_init_config, 'instances': sd_instances}
 

--- a/config.py
+++ b/config.py
@@ -377,7 +377,6 @@ def get_config(parse_args=True, cfg_path=None, options=None):
         if options is not None and options.profile:
             agentConfig['developer_mode'] = True
 
-        #
         # Core config
         #ap
         if not config.has_option('Main', 'api_key'):
@@ -1117,9 +1116,13 @@ def generate_jmx_configs(agentConfig, hostname, checknames=None):
     for check_name, service_disco_check_config in _service_disco_configs(agentConfig).iteritems():
         if check_name in checknames and check_name in JMX_CHECKS:
             log.debug('Generating JMX config for: %s' % check_name)
+
+            # Why is sd_init_config a dict and sd_instances a list of dicts?
             sd_init_config, sd_instances = service_disco_check_config
-            for idx, init_config in enumerate(sd_init_config):
-                check_config = {'init_config': init_config, 'instances': sd_instances[idx]}
+            for idx, instance in enumerate(sd_instances):
+                check_config = {}
+                check_config.update(sd_init_config)
+                check_config.update(instance)
 
                 try:
                     yaml = config_to_yaml(check_config)

--- a/config.py
+++ b/config.py
@@ -1118,13 +1118,14 @@ def generate_jmx_configs(agentConfig, hostname, checknames=None):
         if check_name in checknames and check_name in JMX_CHECKS:
             log.debug('Generating JMX config for: %s' % check_name)
             sd_init_config, sd_instances = service_disco_check_config
-            check_config = {'init_config': sd_init_config, 'instances': sd_instances}
+            for idx, init_config in enumerate(sd_init_config):
+                check_config = {'init_config': init_config, 'instances': sd_instances[idx]}
 
-            try:
-                yaml = config_to_yaml(check_config)
-                generated[check_name] = yaml
-            except Exception as e:
-                log.exception("Unable to generate YAML config for %s: %s", check_name, e)
+                try:
+                    yaml = config_to_yaml(check_config)
+                    generated["{}_{}".format(check_name, idx)] = yaml
+                except Exception as e:
+                    log.exception("Unable to generate YAML config for %s: %s", check_name, e)
 
     return generated
 

--- a/config.py
+++ b/config.py
@@ -41,6 +41,7 @@ MAC_CONFIG_PATH = '/opt/datadog-agent/etc'
 DEFAULT_CHECK_FREQUENCY = 15   # seconds
 LOGGING_MAX_BYTES = 10 * 1024 * 1024
 SDK_INTEGRATIONS_DIR = 'integrations'
+SERVICE_DISCOVERY_PREFIX = 'SD-'
 
 log = logging.getLogger(__name__)
 

--- a/config.py
+++ b/config.py
@@ -35,7 +35,6 @@ from utils.subprocess_output import (
 )
 
 # CONSTANTS
-from jmxfetch import JMX_CHECKS
 AGENT_VERSION = "5.10.0"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
@@ -1000,6 +999,7 @@ def load_check_directory(agentConfig, hostname):
     initialize. Only checks that have a configuration
     file in conf.d will be returned. '''
     from checks import AGENT_METRICS_CHECK_NAME
+    from jmxfetch import JMX_CHECKS
 
     initialized_checks = {}
     init_failed_checks = {}
@@ -1076,6 +1076,8 @@ def load_check_directory(agentConfig, hostname):
 
 def load_check(agentConfig, hostname, checkname):
     """Same logic as load_check_directory except it loads one specific check"""
+    from jmxfetch import JMX_CHECKS
+
     agentConfig['checksd_hostname'] = hostname
     osname = get_os()
     checks_places = get_checks_places(osname, agentConfig)
@@ -1103,8 +1105,11 @@ def load_check(agentConfig, hostname, checkname):
 
     return None
 
-def generate_jmx_configs(agentConfig, hostname, checknames=JMX_CHECKS):
+def generate_jmx_configs(agentConfig, hostname, checknames=None):
     """Similar logic to load_check_directory for JMX checks"""
+    from jmxfetch import JMX_CHECKS
+    if not checknames:
+        checknames = JMX_CHECKS
     agentConfig['checksd_hostname'] = hostname
 
     # the check was not found, try with service discovery

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -123,6 +123,9 @@ gce_updated_hostname: yes
 # and modify its value.
 # sd_template_dir: /datadog/check_configs
 #
+# JMX Service Disocvery
+# sd_jmx_enable: no
+#
 # ========================================================================== #
 # Other                                                                      #
 # ========================================================================== #

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -93,6 +93,10 @@ class JMXFetch(object):
         log.debug("Caught sigterm. Stopping subprocess.")
         self.jmx_process.terminate()
 
+    def _handle_sigreload(self, signum, frame):
+        # Terminate jmx process on SIGTERM signal
+        log.debug("Caught sigusr. Prompting reload...")
+
     def register_signal_handlers(self):
         """
         Enable SIGTERM and SIGINT handlers
@@ -103,6 +107,9 @@ class JMXFetch(object):
 
             # Handle Keyboard Interrupt
             signal.signal(signal.SIGINT, self._handle_sigterm)
+
+            # Handle Config reload...
+            signal.signal(signal.SIGUSR1, self._handle_sigreload)
 
         except ValueError:
             log.exception("Unable to register signal handlers.")

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -27,11 +27,13 @@ from config import (
     get_config,
     get_logging_config,
     PathNotFound,
+    _is_affirmative
 )
 from util import yLoader
 from utils.jmx import JMX_FETCH_JAR_NAME, JMXFiles
 from utils.platform import Platform
 from utils.subprocess_output import subprocess
+from utils.service_discovery.config import SD_DEFAULT_RPC_WAIT
 
 log = logging.getLogger('jmxfetch')
 
@@ -46,6 +48,7 @@ JAVA_LOGGING_LEVEL = {
 }
 
 _JVM_DEFAULT_MAX_MEMORY_ALLOCATION = " -Xmx200m"
+_JVM_DEFAULT_SD_MAX_MEMORY_ALLOCATION = " -Xmx512m"
 _JVM_DEFAULT_INITIAL_MEMORY_ALLOCATION = " -Xms50m"
 JMXFETCH_MAIN_CLASS = "org.datadog.jmxfetch.App"
 JMX_CHECKS = [
@@ -81,6 +84,7 @@ class JMXFetch(object):
         self.agentConfig = agentConfig
         self.logging_config = get_logging_config()
         self.check_frequency = DEFAULT_CHECK_FREQUENCY
+        self.service_discovery = _is_affirmative(self.agentConfig.get('sd_jmx_enable', False))
 
         self.jmx_process = None
         self.jmx_checks = None
@@ -155,7 +159,7 @@ class JMXFetch(object):
                 except Exception:
                     log.exception("Error while writing JMX status file")
 
-            if len(self.jmx_checks) > 0:
+            if len(self.jmx_checks) > 0 or self.service_discovery:
                 return self._start(self.java_bin_path, self.java_options, self.jmx_checks,
                                    command, reporter, self.tools_jar_path, self.custom_jar_paths, redirect_std_streams)
             else:
@@ -280,13 +284,18 @@ class JMXFetch(object):
                 subprocess_args.insert(len(subprocess_args) - 1, '--exit_file_location')
                 subprocess_args.insert(len(subprocess_args) - 1, path_to_exit_file)
 
-            subprocess_args.insert(4, '--check')
-            for check in jmx_checks:
-                subprocess_args.insert(5, check)
+            if self.service_discovery:
+                subprocess_args.insert(4, '--rpc_wait')
+                subprocess_args.insert(5, str(SD_DEFAULT_RPC_WAIT))
+
+            if jmx_checks:
+                subprocess_args.insert(4, '--check')
+                for check in jmx_checks:
+                    subprocess_args.insert(5, check)
 
             # Specify a maximum memory allocation pool for the JVM
             if "Xmx" not in java_run_opts and "XX:MaxHeapSize" not in java_run_opts:
-                java_run_opts += _JVM_DEFAULT_MAX_MEMORY_ALLOCATION
+                java_run_opts += _JVM_DEFAULT_SD_MAX_MEMORY_ALLOCATION if self.service_discovery else _JVM_DEFAULT_MAX_MEMORY_ALLOCATION
             # Specify the initial memory allocation pool for the JVM
             if "Xms" not in java_run_opts and "XX:InitialHeapSize" not in java_run_opts:
                 java_run_opts += _JVM_DEFAULT_INITIAL_MEMORY_ALLOCATION

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ simplejson==3.6.5
 supervisor==3.3.0
 tornado==3.2.2
 uptime==3.0.1
+grpcio==1.0.0
 
 ###########################################################
 # These modules are for checks. But they are

--- a/rpc/proto/service_discovery.proto
+++ b/rpc/proto/service_discovery.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.datadog.jmxfetch";
+option java_outer_classname = "ServiceDiscoveryProto";
+
+package servicediscovery;
+
+// Interface exported by the server.
+service ServiceDiscovery {
+  // A simple RPC.
+  //
+  // Obtains the feature at a given position.
+  //
+  // A feature with an empty name is returned if there's no feature at the given
+  // position.
+  rpc SetConfig(SDConfig) returns (SDConfigApplied) {}
+
+}
+
+message SDConfigApplied {
+  bool applied = 1;
+}
+
+message SDConfig {
+  string name = 1;
+  string config = 2;
+}

--- a/rpc/proto/service_discovery.proto
+++ b/rpc/proto/service_discovery.proto
@@ -8,18 +8,19 @@ package servicediscovery;
 
 // Interface exported by the server.
 service ServiceDiscovery {
+
   // A simple RPC.
   //
-  // Obtains the feature at a given position.
+  // Attempts to set a YAML service discovery configuration.
   //
-  // A feature with an empty name is returned if there's no feature at the given
-  // position.
-  rpc SetConfig(SDConfig) returns (SDConfigApplied) {}
+  // A confirmation message is returned with the status of the
+  // operation.
+  rpc SetConfig(SDConfig) returns (Confirmation) {}
 
 }
 
-message SDConfigApplied {
-  bool applied = 1;
+message Confirmation {
+  bool success = 1;
 }
 
 message SDConfig {

--- a/util.py
+++ b/util.py
@@ -124,23 +124,35 @@ def check_yaml(conf_path):
         else:
             return check_config
 
+def config_to_yaml(config):
+    '''
+    Convert a config dict to YAML
+    '''
+    assert 'init_config' in config, "No 'init_config' section found"
+    assert 'instances' in config, "No 'instances' section found"
+
+    valid_instances = True
+    if config['instances'] is None or not isinstance(config['instances'], list):
+        valid_instances = False
+    else:
+        yaml_output = yaml.dump(config, default_flow_style=False)
+
+    if not valid_instances:
+        raise Exception('You need to have at least one instance defined in your config.')
+
+    return yaml_output
+
 def dump_yaml(path, config):
     '''
     Dump config dict to YAML file in path
     '''
-    with open(path, 'w+') as f:
-        assert 'init_config' in config, "No 'init_config' section found"
-        assert 'instances' in config, "No 'instances' section found"
-
-        valid_instances = True
-        if config['instances'] is None or not isinstance(config['instances'], list):
-            valid_instances = False
-        else:
-            yaml_output = yaml.dump(config, default_flow_style=False)
-            f.write(yaml_output)
-
-        if not valid_instances:
-            raise Exception('You need to have at least one instance defined in your config.')
+    try:
+        yaml = config_to_yaml(config)
+    except Exception as e:
+        log.exception("Unable to convert config to YAML: %s", e)
+    else:
+        with open(path, 'w+') as f:
+            f.write(yaml)
 
 
 class Watchdog(object):

--- a/util.py
+++ b/util.py
@@ -128,7 +128,7 @@ def dump_yaml(path, config):
     '''
     Dump config dict to YAML file in path
     '''
-    with open(path) as f:
+    with open(path, 'w+') as f:
         assert 'init_config' in config, "No 'init_config' section found"
         assert 'instances' in config, "No 'instances' section found"
 

--- a/util.py
+++ b/util.py
@@ -124,6 +124,25 @@ def check_yaml(conf_path):
         else:
             return check_config
 
+def dump_yaml(path, config):
+    '''
+    Dump config dict to YAML file in path
+    '''
+    with open(path) as f:
+        assert 'init_config' in config, "No 'init_config' section found"
+        assert 'instances' in config, "No 'instances' section found"
+
+        valid_instances = True
+        if config['instances'] is None or not isinstance(config['instances'], list):
+            valid_instances = False
+        else:
+            yaml_output = yaml.dump(config, default_flow_style=False)
+            f.write(yaml_output)
+
+        if not valid_instances:
+            raise Exception('You need to have at least one instance defined in your config.')
+
+
 class Watchdog(object):
     """
     Simple signal-based watchdog. Restarts the process when:

--- a/util.py
+++ b/util.py
@@ -135,7 +135,7 @@ def config_to_yaml(config):
     if config['instances'] is None or not isinstance(config['instances'], list):
         valid_instances = False
     else:
-        yaml_output = yaml.dump(config, default_flow_style=False)
+        yaml_output = yaml.safe_dump(config, default_flow_style=False)
 
     if not valid_instances:
         raise Exception('You need to have at least one instance defined in your config.')

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -275,7 +275,7 @@ class AbstractConfigStore(object):
         # Initialize the config index reference
         if self.previous_config_index is None:
             self.previous_config_index = config_index
-            return False
+            return True
         # Config has been modified since last crawl
         # in this case a full config reload is triggered and the identifier_to_checks cache is rebuilt
         if config_index != self.previous_config_index:

--- a/utils/service_discovery/config.py
+++ b/utils/service_discovery/config.py
@@ -11,6 +11,7 @@ from utils.service_discovery.config_stores import extract_sd_config, SD_CONFIG_B
 
 log = logging.getLogger(__name__)
 
+SD_DEFAULT_RPC_WAIT = 5
 
 def extract_agent_config(config):
     # get merged into the real agentConfig

--- a/utils/service_discovery/config_stores.py
+++ b/utils/service_discovery/config_stores.py
@@ -41,6 +41,9 @@ def extract_sd_config(config):
     if config.has_option('Main', 'sd_backend_port'):
         sd_config['sd_backend_port'] = config.get(
             'Main', 'sd_backend_port')
+    if config.has_option('Main', 'sd_jmx_enable'):
+        sd_config['sd_jmx_enable'] = config.get(
+            'Main', 'sd_jmx_enable')
     return sd_config
 
 


### PR DESCRIPTION
### What does this PR do?

This PR introduces an RPC client to enable the submission of JMX configurations (in YAML format) to JMXfetch, thus enabling service discovery for JMX-based integrations (jmxfetch). The changes introduce a dependency with [grpc.io](http://www.grpc.io/). The PR might require some polishing, but is functional at this time.
### Motivation

There was a fairly obvious void in the functionalities for service discovery with regard to JMX-based integrations. This PR attempts to address that issue.
### Testing Guidelines

Manual, at the moment.
### Additional Notes

Note that the RPC client code is generate at build time in omnibus, so this may cause some issues in terms of linting, etc... due to unfound modules.

https://github.com/DataDog/omnibus-software/pull/79
https://github.com/DataDog/dd-agent-omnibus/pull/96
https://github.com/DataDog/jmxfetch/pull/109
https://github.com/DataDog/docker-dd-agent/pull/135
