### PR TITLE
[dev mode] fallback to /tmp to dump pstats

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -225,8 +225,13 @@ class Agent(Daemon):
         self.collector = Collector(self._agentConfig, emitters, systemStats, hostname)
 
         # In developer mode, the number of runs to be included in a single collector profile
-        self.collector_profile_interval = self._agentConfig.get('collector_profile_interval',
-                                                                DEFAULT_COLLECTOR_PROFILE_INTERVAL)
+        try:
+            self.collector_profile_interval = int(
+                self._agentConfig.get('collector_profile_interval', DEFAULT_COLLECTOR_PROFILE_INTERVAL))
+        except ValueError:
+            log.warn('collector_profile_interval is invalid. '
+                     'Using default value instead (%s).' % DEFAULT_COLLECTOR_PROFILE_INTERVAL)
+            self.collector_profile_interval = DEFAULT_COLLECTOR_PROFILE_INTERVAL
 
         # Configure the watchdog.
         self.check_frequency = int(self._agentConfig['check_freq'])


### PR DESCRIPTION
### What does this PR do?

If dumping pstats in the current dir fails, fall back to /tmp.

### Motivation

User noticed that they didn't get the dumps because the agent was trying to write to `/` as the default path is relative and they were probably running it with supervisor.

### Additional Notes

This was just a minor bug as the agent should not run in dev mode in production (it ruins its perf) and usually runs in the foreground from a directory where it has write access.