### PR TITLE
Kubernetes: Add CPU and memory capacity reporting

### DIFF
--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -50,6 +50,28 @@ FUNC_MAP = {
 
 EVENT_TYPE = 'kubernetes'
 
+# Suffixes per
+# https://github.com/kubernetes/kubernetes/blob/8fd414537b5143ab039cb910590237cabf4af783/pkg/api/resource/suffix.go#L108
+FACTORS = {
+    'n': float(1)/(1000*1000*1000),
+    'u': float(1)/(1000*1000),
+    'm': float(1)/1000,
+    'k': 1000,
+    'M': 1000*1000,
+    'G': 1000*1000*1000,
+    'T': 1000*1000*1000*1000,
+    'P': 1000*1000*1000*1000*1000,
+    'E': 1000*1000*1000*1000*1000*1000,
+    'Ki': 1024,
+    'Mi': 1024*1024,
+    'Gi': 1024*1024*1024,
+    'Ti': 1024*1024*1024*1024,
+    'Pi': 1024*1024*1024*1024*1024,
+    'Ei': 1024*1024*1024*1024*1024*1024,
+}
+
+QUANTITY_EXP = re.compile(r'[-+]?\d+[\.]?\d*[numkMGTPE]?i?')
+
 
 class Kubernetes(AgentCheck):
     """ Collect metrics and events from kubelet """
@@ -249,6 +271,16 @@ class Kubernetes(AgentCheck):
         return tags
 
     def _update_metrics(self, instance, pods_list):
+        def parse_quantity(s):
+            number = ''
+            unit = ''
+            for c in s:
+                if c.isdigit() or c == '.':
+                    number += c
+                else:
+                    unit += c
+            return float(number) * FACTORS.get(unit, 1)
+
         metrics = self.kubeutil.retrieve_metrics()
 
         excluded_labels = instance.get('excluded_labels')
@@ -289,12 +321,10 @@ class Kubernetes(AgentCheck):
                 c_name = container.get('name')
                 _tags = container_tags.get(name2id.get(c_name), [])
 
-                prog = re.compile(r'[-+]?\d+[\.]?\d*')
-
                 # limits
                 try:
                     for limit, value_str in container['resources']['limits'].iteritems():
-                        values = [float(s) for s in prog.findall(value_str)]
+                        values = [parse_quantity(s) for s in QUANTITY_EXP.findall(value_str)]
                         if len(values) != 1:
                             self.log.warning("Error parsing limits value string: %s", value_str)
                             continue
@@ -306,7 +336,7 @@ class Kubernetes(AgentCheck):
                 # requests
                 try:
                     for request, value_str in container['resources']['requests'].iteritems():
-                        values = [float(s) for s in prog.findall(value_str)]
+                        values = [parse_quantity(s) for s in QUANTITY_EXP.findall(value_str)]
                         if len(values) != 1:
                             self.log.warning("Error parsing requests value string: %s", value_str)
                             continue

--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -349,20 +349,7 @@ class Kubernetes(AgentCheck):
         self._update_node(instance)
 
     def _update_node(self, instance):
-        # These vars and fetch stuff should live in kubeuitl:
-        from utils.http import retrieve_json
-        from urlparse import urljoin
-
-        self.log.info('Hostname: %s' % self.kubeutil.host)
-        self.log.info('Metrics URL: %s' % self.kubeutil.metrics_url)
-        self.log.info('Pod list URL: %s' % self.kubeutil.pods_list_url)
-
-        MACHINE_INFO_PATH = '/api/v1.3/machine/'
-        machine_info_url = urljoin(
-            '%s://%s:%d' % (self.kubeutil.method, self.kubeutil.host, self.kubeutil.cadvisor_port), MACHINE_INFO_PATH)
-        self.log.info('Machine info URL: %s' % machine_info_url)
-        machine_info = retrieve_json(machine_info_url)
-
+        machine_info = self.kubeutil.retrieve_machine_info()
         num_cores = machine_info.get('num_cores', 0)
         memory_capacity = machine_info.get('memory_capacity', 0)
 

--- a/utils/kubeutil.py
+++ b/utils/kubeutil.py
@@ -25,6 +25,7 @@ class KubeUtil:
     __metaclass__ = Singleton
 
     DEFAULT_METHOD = 'http'
+    MACHINE_INFO_PATH = '/api/v1.3/machine/'
     METRICS_PATH = '/api/v1.3/subcontainers/'
     PODS_LIST_PATH = '/pods/'
     DEFAULT_CADVISOR_PORT = 4194
@@ -66,6 +67,7 @@ class KubeUtil:
         self.kubernetes_api_url = 'https://%s/api/v1' % (os.environ.get('KUBERNETES_SERVICE_HOST') or self.DEFAULT_MASTER_NAME)
 
         self.metrics_url = urljoin(self.cadvisor_url, KubeUtil.METRICS_PATH)
+        self.machine_info_url = urljoin(self.cadvisor_url, KubeUtil.MACHINE_INFO_PATH)
         self.pods_list_url = urljoin(self.kubelet_api_url, KubeUtil.PODS_LIST_PATH)
         self.kube_health_url = urljoin(self.kubelet_api_url, 'healthz')
 
@@ -123,6 +125,12 @@ class KubeUtil:
         TODO: the list of pods could be cached with some policy to be decided.
         """
         return retrieve_json(self.pods_list_url)
+
+    def retrieve_machine_info(self):
+        """
+        Retrieve machine info from Cadvisor.
+        """
+        return retrieve_json(self.machine_info_url)
 
     def retrieve_metrics(self):
         """


### PR DESCRIPTION
### What does this PR do?

Add CPU and memory capacity reporting to the Kubernetes check.

This is a rebase of #2766 with a part of the code moved to KubeUtil.

### Motivation

Monitoring of cluster resources from a scheduling/allocation perspective is important. E.g. over-allocation of CPU resources to deployments may cause pod scheduling failures even if actual CPU usage in the cluster is low. We want to get ahead of these errors by monitoring capacity data in DataDog.
