### PR TITLE
[disk] used not initailized variable self._excluded_disk_re

### DIFF
--- a/checks.d/disk.py
+++ b/checks.d/disk.py
@@ -58,6 +58,8 @@ class Disk(AgentCheck):
     def _load_conf(self, instance):
         self._excluded_filesystems = instance.get('excluded_filesystems', [])
         self._excluded_disks = instance.get('excluded_disks', [])
+        self._excluded_disk_re = re.compile(
+            instance.get('excluded_disk_re', '^$'))
         self._excluded_mountpoint_re = re.compile(
             instance.get('excluded_mountpoint_re', '^$'))
         self._tag_by_filesystem = _is_affirmative(


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

[disk] used **not** initialized variable self._excluded_disk_re

### Motivation

I used datadog-agent, so fix this bug

