### PR TITLE
[core] display expected service check count

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -441,7 +441,8 @@ class Collector(object):
             current_check_service_checks = check.get_service_checks()
             if current_check_service_checks:
                 service_checks.extend(current_check_service_checks)
-            service_check_count = len(current_check_service_checks)
+            # -1 because the user doesn't care about the service check for check failure
+            service_check_count = len(current_check_service_checks) - 1
 
             # Update the check status with the correct service_check_count
             check_status.service_check_count = service_check_count


### PR DESCRIPTION
### What does this PR do?

We add one service check per check, to see whether the check is broken
or not. The info command then shows a misleading number service checks.

Let's fix it and not count the additional service check.

### Motivation

Misleading service check count.

### Testing Guidelines
Run info.

### Additional Notes
Backward compatibility issue: unlikely, this only issue would be custom scripts depending on the info output.

