### PR TITLE
[tests] do not delete flare fixture

### DIFF
--- a/tests/core/test_flare.py
+++ b/tests/core/test_flare.py
@@ -59,6 +59,11 @@ def mocked_strftime(t):
     return '1'
 
 
+def mocked_os_remove(path):
+    if 'datadog-agent-1.tar.bz2' not in path:
+        os.remove(path)
+
+
 class FakeResponse(object):
     def __init__(self, status_code=200):
         self.status_code = status_code
@@ -73,11 +78,12 @@ class FakeResponse(object):
 
 class FlareTest(unittest.TestCase):
 
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('config.get_version', side_effect=get_mocked_version)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
-    def test_init(self, mock_config, mock_version, mock_tempdir, mock_strftime):
+    def test_init(self, mock_config, mock_version, mock_tempdir, mock_strftime, mock_os_remove):
         f = Flare(case_id=1337)
         conf = mock_config()
         self.assertEqual(f._case_id, 1337)
@@ -85,12 +91,14 @@ class FlareTest(unittest.TestCase):
         self.assertEqual(f._url, 'https://6-6-6-flare.agent.datadoghq.com/support/flare')
         self.assertEqual(f.tar_path, os.path.join(get_mocked_temp(), "datadog-agent-1.tar.bz2"))
 
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
     @mock.patch('utils.flare.requests.post', return_value=FakeResponse())
     @mock.patch('config.get_version', side_effect=get_mocked_version)
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
-    def test_upload_with_case(self, mock_config, mock_tempdir, mock_stfrtime, mock_version, mock_requests):
+    def test_upload_with_case(self, mock_config, mock_tempdir, mock_stfrtime,
+                              mock_version, mock_requests, mock_os_remove):
         f = Flare(case_id=1337)
         f._ask_for_email = lambda: 'test@example.com'
         f._open_tarfile()
@@ -112,12 +120,14 @@ class FlareTest(unittest.TestCase):
         self.assertEqual(kwargs['data']['email'], 'test@example.com')
         assert kwargs['data']['hostname']
 
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
     @mock.patch('utils.flare.requests.post', return_value=FakeResponse())
     @mock.patch('config.get_version', side_effect=get_mocked_version)
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
-    def test_upload_no_case(self, mock_config, mock_tempdir, mock_stfrtime, mock_version, mock_requests):
+    def test_upload_no_case(self, mock_config, mock_tempdir, mock_stfrtime,
+                            mock_version, mock_requests, mock_os_remove):
         f = Flare()
         f._ask_for_email = lambda: 'test@example.com'
         f._open_tarfile()
@@ -139,12 +149,14 @@ class FlareTest(unittest.TestCase):
         self.assertEqual(kwargs['data']['email'], 'test@example.com')
         assert kwargs['data']['hostname']
 
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
     @mock.patch('utils.flare.requests.post', return_value=FakeResponse())
     @mock.patch('config.get_version', side_effect=get_mocked_version)
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config_with_proxy)
-    def test_upload_with_case_proxy(self, mock_config, mock_tempdir, mock_stfrtime, mock_version, mock_requests):
+    def test_upload_with_case_proxy(self, mock_config, mock_tempdir, mock_stfrtime,
+                                    mock_version, mock_requests, mock_os_remove):
         f = Flare(case_id=1337)
         f._ask_for_email = lambda: 'test@example.com'
         f._open_tarfile()
@@ -169,10 +181,11 @@ class FlareTest(unittest.TestCase):
         assert not kwargs['verify']
 
     @attr(requires='core_integration')
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
-    def test_endpoint(self, mock_config, mock_temp, mock_stfrtime):
+    def test_endpoint(self, mock_config, mock_temp, mock_stfrtime, mock_os_remove):
         if os.environ.get('FLARE_BROKEN'):
             raise unittest.case.SkipTest('Flare broken, acknowledged')
         f = Flare()
@@ -185,10 +198,11 @@ class FlareTest(unittest.TestCase):
 
         self.assertEqual(str(cm.exception), "Your request is incorrect: Invalid inputs: 'API key unknown'")
 
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
-    def test_uri_password(self, mock_config, mock_tempdir, mock_strftime):
+    def test_uri_password(self, mock_config, mock_tempdir, mock_strftime, mock_os_remove):
         f = Flare()
         _, credentials_log = f._strip_credentials(
             os.path.join(get_mocked_temp(), mock_cfgs['uri_password']),
@@ -199,10 +213,11 @@ class FlareTest(unittest.TestCase):
             " - this file contains a credential (password in a uri) which has been removed in the collected version"
         )
 
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
-    def test_api_keys_regex(self, mock_config, mock_tempdir, mock_strftime):
+    def test_api_keys_regex(self, mock_config, mock_tempdir, mock_strftime, mock_os_remove):
         f = Flare()
         file_path, _ = f._strip_credentials(
             os.path.join(get_mocked_temp(), 'apikeys.conf'),
@@ -230,11 +245,11 @@ class FlareTest(unittest.TestCase):
             "api_key: **************************aaaaa\n"
         )
 
-
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
-    def test_uri_password_regex(self, mock_config, mock_tempdir, mock_strftime):
+    def test_uri_password_regex(self, mock_config, mock_tempdir, mock_strftime, mock_os_remove):
         f = Flare()
         password_uri_pattern = filter(
             lambda cred_pattern: cred_pattern.label == 'password in a uri',
@@ -253,29 +268,33 @@ class FlareTest(unittest.TestCase):
             password_tests['uri_password_expected']
         )
 
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config_with_proxy)
-    def test_uri_set_proxy(self, mock_config, mock_tempdir, mock_strftime):
+    def test_uri_set_proxy(self, mock_config, mock_tempdir, mock_strftime, mock_os_remove):
         f = Flare()
         request_options = {}
         f.set_proxy(request_options)
         expected = 'http://proxy_user:proxy_pass@proxy.host.com:3128'
         self.assertEqual(expected, request_options['proxies']['https'])
 
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config_with_proxy)
-    def test_uri_no_verify_ssl(self, mock_config, mock_tempdir, mock_strftime):
+    def test_uri_no_verify_ssl(self, mock_config, mock_tempdir, mock_strftime, mock_os_remove):
         f = Flare()
         request_options = {}
         f.set_ssl_validation(request_options)
         self.assertFalse(request_options['verify'])
 
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
-    def test_uri_verify_ssl_default(self, mock_config, mock_tempdir, mock_strftime):
+    def test_uri_verify_ssl_default(self, mock_config, mock_tempdir,
+                                    mock_strftime, mock_os_remove):
         f = Flare()
         request_options = {}
         f.set_ssl_validation(request_options)


### PR DESCRIPTION
This was really annoying when running the tests locally. Now the fixture
is not deleted anymore.