### PR TITLE
[Mongodb] Check was sending password in the clear if the password inc…

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -628,7 +628,14 @@ class MongoDb(AgentCheck):
         db_name = parsed.get('database')
         additional_metrics = instance.get('additional_metrics', [])
 
-        clean_server_name = server.replace(password, "*" * 5) if password else server
+        # IF the password contains a URL encoded character (for example '/'), then the
+        # raw server string will have %2F, but the password string will have the '/'.
+        # Therefore, the string replace (below) won't work, because it won't have an
+        # exact match.  Convert the password *back* to URL encoded, so the string
+        # replace works properly.
+        encoded_password = urllib.quote_plus(password) if password else None
+
+        clean_server_name = server.replace(encoded_password, "*" * 5) if encoded_password else server
 
         if ssl_params:
             username_uri = u"{}@".format(urllib.quote(username))

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -67,7 +67,7 @@ class Flare(object):
             'password'
         ),
         CredentialPattern(
-            re.compile('(.*\ [A-Za-z0-9]+)\:\/\/([A-Za-z0-9]+)\:(.+)\@'),
+            re.compile('(.*\ [A-Za-z0-9]+)\:\/\/([A-Za-z0-9_]+)\:(.+)\@'),
             r'\1://\2:********@',
             'password in a uri'
         ),


### PR DESCRIPTION
### What does this PR do?

PR fixes two problems which resulted in passwords being sent in the clear.
Problem 1 was that passwords are URL decoded for supplying to mongo, but the replace string didn't account for that.

Problem 2 was that the regular expression for replacing passwords in a URI looks for username:password@host....  If the username had a "_" in it, the regex wouldn't match and the password would be left.

### Motivation

Customer report.


…ludes

a character that needs to be URL encoded (i.e. '/').  Account for
passwords that include URL encoded chars

Also allow "_" to be a username in the regular expression matching
username/password in a URI.  Otherwise, a username with a "_" will not
match, and the password will be sent in the clear