### PR TITLE
[collector][emitter] Ignore all non-unicode-decodable characters

### DIFF
--- a/emitter.py
+++ b/emitter.py
@@ -29,34 +29,47 @@ control_chars = ''.join(map(unichr, range(0, 32) + range(127, 160)))
 control_char_re = re.compile('[%s]' % re.escape(control_chars))
 
 
-def remove_control_chars(s):
+def remove_control_chars(s, log):
     if isinstance(s, str):
         sanitized = control_char_re.sub('', s)
     elif isinstance(s, unicode):
         sanitized = ''.join(['' if unicodedata.category(c) in ['Cc','Cf'] else c
                             for c in u'{}'.format(s)])
-
+    if sanitized != s:
+        log.warning('Removed control chars from string: ' + s)
     return sanitized
 
-def remove_control_chars_from(item, log=None):
+def remove_undecodable_chars(s, log):
+    sanitized = s
+    if isinstance(s, str):
+        try:
+            s.decode('utf8')
+        except UnicodeDecodeError:
+            sanitized = s.decode('utf8', errors='ignore')
+            log.warning(u'Removed undecodable chars from string: ' + s.decode('utf8', errors='replace'))
+    return sanitized
+
+def sanitize_payload(item, log, sanitize_func):
     if isinstance(item, dict):
         newdict = {}
         for k, v in item.iteritems():
-            newval = remove_control_chars_from(v, log)
-            newkey = remove_control_chars(k)
+            newval = sanitize_payload(v, log, sanitize_func)
+            newkey = sanitize_func(k, log)
             newdict[newkey] = newval
         return newdict
     if isinstance(item, list):
         newlist = []
         for listitem in item:
-            newlist.append(remove_control_chars_from(listitem, log))
+            newlist.append(sanitize_payload(listitem, log, sanitize_func))
         return newlist
+    if isinstance(item, tuple):
+        newlist = []
+        for listitem in item:
+            newlist.append(sanitize_payload(listitem, log, sanitize_func))
+        return tuple(newlist)
     if isinstance(item, basestring):
-        newstr = remove_control_chars(item)
-        if item != newstr:
-            if log is not None:
-                log.warning('changed string: ' + newstr)
-            return newstr
+        return sanitize_func(item, log)
+
     return item
 
 def http_emitter(message, log, agentConfig, endpoint):
@@ -70,8 +83,13 @@ def http_emitter(message, log, agentConfig, endpoint):
         try:
             payload = json.dumps(message)
         except UnicodeDecodeError:
-            newmessage = remove_control_chars_from(message, log)
-            payload = json.dumps(newmessage)
+            newmessage = sanitize_payload(message, log, remove_control_chars)
+            try:
+                payload = json.dumps(newmessage)
+            except UnicodeDecodeError:
+                log.info('Removing undecodable characters from payload')
+                newmessage = sanitize_payload(newmessage, log, remove_undecodable_chars)
+                payload = json.dumps(newmessage)
     except UnicodeDecodeError as ude:
         log.error('http_emitter: Unable to convert message to json %s', ude)
         # early return as we can't actually process the message

--- a/tests/core/test_emitter.py
+++ b/tests/core/test_emitter.py
@@ -1,10 +1,14 @@
 # -*- coding: utf-8 -*-
 # 3p
+from mock import Mock
 import unittest
 
 # project
-from emitter import remove_control_chars
-from emitter import remove_control_chars_from
+from emitter import (
+    remove_control_chars,
+    remove_undecodable_chars,
+    sanitize_payload,
+)
 
 
 class TestEmitter(unittest.TestCase):
@@ -16,27 +20,47 @@ class TestEmitter(unittest.TestCase):
             (u'_e{2,19}:t4|♬ †øU †øU ¥ºu T0µ ♪', u'_e{2,19}:t4|♬ †øU †øU ¥ºu T0µ ♪')
         ]
 
+        log = Mock()
         for bad, good in messages:
-            self.assertTrue(remove_control_chars(bad) == good, (bad,good))
+            self.assertTrue(remove_control_chars(bad, log) == good, (bad,good))
 
-    def test_remove_control_chars_from(self):
+    def test_remove_control_chars_from_payload(self):
         bad_messages = [
-            ({"processes":[1234,[[u'☢cd≤Ω≈ç√∫˜µ≤\r\n', 0, 2.2,12,34,'compiz\r\n',1]]]},
-             {"processes":[1234,[[u'☢cd≤Ω≈ç√∫˜µ≤', 0, 2.2,12,34,'compiz',1]]]})
+            (
+                {"processes":[1234,[[u'☢cd≤Ω≈ç√∫˜µ≤\r\n', 0, 2.2,12,34,'compiz\r\n',1]]]},
+                {"processes":[1234,[[u'☢cd≤Ω≈ç√∫˜µ≤', 0, 2.2,12,34,'compiz',1]]]}
+            ),
+            (
+                (u'☢cd≤Ω≈ç√∫˜µ≤\r', ),
+                (u'☢cd≤Ω≈ç√∫˜µ≤', )
+            )
         ]
         good_messages = [
             {"processes":[1234,[[u'db🖫', 0, 2.2,12,34,u'☢compiz☢',1]]]}
         ]
 
+        log = Mock()
+
         def is_converted_same(msg):
-            new_msg = remove_control_chars_from(msg, None)
+            new_msg = sanitize_payload(msg, log, remove_control_chars)
             if str(new_msg) == str(msg):
                 return True
             return False
 
         for bad, good in bad_messages:
             self.assertFalse(is_converted_same(bad))
-            self.assertTrue(remove_control_chars_from(bad, None) == good)
+            self.assertTrue(sanitize_payload(bad, log, remove_control_chars) == good)
 
         for msg in good_messages:
             self.assertTrue(is_converted_same(msg))
+
+    def test_remove_undecodable_characters(self):
+        messages = [
+            ('\xc3\xa9 \xe9 \xc3\xa7', u'é  ç', True),
+            (u'_e{2,19}:t4|♬ †øU †øU ¥ºu T0µ ♪', u'_e{2,19}:t4|♬ †øU †øU ¥ºu T0µ ♪', False), # left unchanged
+        ]
+
+        for bad, good, log_called in messages:
+            log = Mock()
+            self.assertEqual(good, remove_undecodable_chars(bad, log))
+            self.assertEqual(log_called, log.warning.called)


### PR DESCRIPTION
### What does this PR do?

On Japanese and Korean versions of Windows, We've seen cases where
the json encoding would fail on a UnicodeDecodeError because of
non-utf8-decodable characters in strings, which causes the whole emitter to fail.

This fixes the issue by making another pass on the
whole payload to remove all the non-decodable characters and log the
affected strings.

### Testing Guidelines

Added a mock test on the function that removes non-decodable chars.
