### PR TITLE
[win32] Handle tzname encodings

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -4,6 +4,7 @@
 
 # stdlib
 import collections
+import locale
 import logging
 import pprint
 import socket
@@ -735,7 +736,7 @@ class Collector(object):
             pass
 
         metadata["hostname"] = self.hostname
-        metadata["timezones"] = sanitize_tzname(time.tzname)
+        metadata["timezones"] = self._decode_tzname(time.tzname)
 
         # Add cloud provider aliases
         host_aliases = GCE.get_host_aliases(self.agentConfig)
@@ -782,12 +783,16 @@ class Collector(object):
 
         return output
 
+    @staticmethod
+    def _decode_tzname(tzname):
+        """ On Windows, decodes the timezone from the system-preferred encoding
+        """
+        if Platform.is_windows():
+            try:
+                decoded_tzname = map(lambda tz: tz.decode(locale.getpreferredencoding()), tzname)
+            except Exception:
+                log.exception("Failed decoding timezone with encoding %s", locale.getpreferredencoding())
+                return ('', '')
+            return tuple(decoded_tzname)
 
-def sanitize_tzname(tzname):
-    """ Returns the tzname given, and deals with Japanese encoding issue
-    """
-    if tzname[0] == '\x93\x8c\x8b\x9e (\x95W\x8f\x80\x8e\x9e)':
-        log.debug('tzname from TOKYO detected and converted')
-        return ('JST', 'JST')
-    else:
         return tzname

--- a/tests/core/test_metadata.py
+++ b/tests/core/test_metadata.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+import mock
 import unittest
 
 # project
@@ -65,3 +67,26 @@ class TestMetadata(unittest.TestCase):
         self.assertEquals(service_metadata[0], {'foo': "bar"})
         self.assertEquals(service_metadata[1], {})
         self.assertEquals(service_metadata[2], {'foo': "bar"})
+
+    @mock.patch('utils.platform.Platform.is_windows', return_value=True)
+    def test_decode_tzname(self, mock_platform):
+        # Examples of expected inputs/outputs
+
+        # Korean systems
+        with mock.patch('locale.getpreferredencoding', return_value='cp949'):
+            self.assertEquals(
+                Collector._decode_tzname(('\xb4\xeb\xc7\xd1\xb9\xce\xb1\xb9 \xc7\xa5\xc1\xd8\xbd\xc3', '\xb4\xeb\xc7\xd1\xb9\xce\xb1\xb9 \xc0\xcf\xb1\xa4 \xc0\xfd\xbe\xe0 \xbd\xc3\xb0\xa3')),
+                (u'대한민국 표준시', u'대한민국 일광 절약 시간')
+            )
+        # Japanese systems
+        with mock.patch('locale.getpreferredencoding', return_value='cp932'):
+            self.assertEquals(
+                Collector._decode_tzname(('\x93\x8c\x8b\x9e (\x95W\x8f\x80\x8e\x9e)', '\x93\x8c\x8b\x9e (\x89\xc4\x8e\x9e\x8a\xd4)')),
+                (u'東京 (標準時)', u'東京 (夏時間)')
+            )
+        # if the preferred encoding were to be invalid, return empty timezone
+        with mock.patch('locale.getpreferredencoding', return_value='invalidencoding'):
+            self.assertEquals(
+                Collector._decode_tzname(('\x93\x8c\x8b\x9e (\x95W\x8f\x80\x8e\x9e)', '\x93\x8c\x8b\x9e (\x89\xc4\x8e\x9e\x8a\xd4)')),
+                ('', '')
+            )


### PR DESCRIPTION
### What does this PR do?

Fix encodings of timezone metadata on Windows systems on which `time.tzname` returns non-`ascii` characters. I've been able to confirm on a Korean and on a Japanese system that `locale.getpreferredencoding` returns the correct encoding.

### Motivation
- Non-ascii characters make the emitter crash (at least until #2941)
- the timezone is useless when it's not decoded

### Testing

Added some tests that give example inputs/outputs
This has also been tested successfully on customers' machines.