### PR TITLE
[core][subprocess output] Do not set close_fds=True

### DIFF
--- a/checks.d/varnish.py
+++ b/checks.d/varnish.py
@@ -107,7 +107,8 @@ class Varnish(AgentCheck):
 
     def _get_version_info(self, varnishstat_path):
         # Get the varnish version from varnishstat
-        output, error, _ = get_subprocess_output([varnishstat_path, "-V"], self.log)
+        output, error, _ = get_subprocess_output([varnishstat_path, "-V"], self.log,
+            raise_on_empty_output=False)
 
         # Assumptions regarding varnish's version
         use_xml = True

--- a/utils/subprocess_output.py
+++ b/utils/subprocess_output.py
@@ -9,16 +9,13 @@ import logging
 import subprocess
 import tempfile
 
-# project
-from utils.platform import Platform
-
 log = logging.getLogger(__name__)
 
 class SubprocessOutputEmptyError(Exception):
     pass
 
 # FIXME: python 2.7 has a far better way to do this
-def get_subprocess_output(command, log, shell=False, stdin=None, output_expected=True):
+def get_subprocess_output(command, log, raise_on_empty_output=True):
     """
     Run the given subprocess command and return it's output. Raise an Exception
     if an error occurs.
@@ -28,23 +25,18 @@ def get_subprocess_output(command, log, shell=False, stdin=None, output_expected
     # docs warn that the data read is buffered in memory. They suggest not to
     # use subprocess.PIPE if the data size is large or unlimited.
     with nested(tempfile.TemporaryFile(), tempfile.TemporaryFile()) as (stdout_f, stderr_f):
-        proc = subprocess.Popen(command,
-                                close_fds=not Platform.is_windows(),  # only set to True when on Unix, for WIN compatibility
-                                shell=shell,
-                                stdin=stdin,
-                                stdout=stdout_f,
-                                stderr=stderr_f)
+
+        proc = subprocess.Popen(command, stdout=stdout_f, stderr=stderr_f)
         proc.wait()
         stderr_f.seek(0)
         err = stderr_f.read()
         if err:
-            log.debug("Error while running {0} : {1}".format(" ".join(command),
-                                                             err))
+            log.debug("Error while running {0} : {1}".format(" ".join(command), err))
 
         stdout_f.seek(0)
         output = stdout_f.read()
 
-    if output_expected and output is None:
+    if not output and raise_on_empty_output:
         raise SubprocessOutputEmptyError("get_subprocess_output expected output but had none.")
 
     return (output, err, proc.returncode)


### PR DESCRIPTION
### What does this PR do?
Do not set close_fds=True

This was introduced by
https://github.com/DataDog/dd-agent/commit/24cf7823c254925ab061baf6aff712678a4c793f

But it’s not needed anymore and as a result the collector is looping
over thousand of file descriptors, trying to close all file descriptors between 3 and the max number of open files descriptors (most of the
time it cannot) and use a lot of CPU to do so.

See: https://github.com/python/cpython/blob/2.7/Lib/subprocess.py#L1185-L1197 for implementation

This commit change that
and revert to the default `close_fds=False`

Also I’m removing a bunch of options that are not used anywhere.

### Motivation
Thanks a lot to @ross for pointing that out.
