### PR TITLE
[mongo] Add metrics for fsyncLocked-ness, replset votes and vote fraction

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -72,6 +72,7 @@ class MongoDb(AgentCheck):
         "cursors.totalOpen": GAUGE,
         "extra_info.heap_usage_bytes": RATE,
         "extra_info.page_faults": RATE,
+        "fsyncLocked": GAUGE,
         "globalLock.activeClients.readers": GAUGE,
         "globalLock.activeClients.total": GAUGE,
         "globalLock.activeClients.writers": GAUGE,
@@ -727,6 +728,9 @@ class MongoDb(AgentCheck):
 
         if status['ok'] == 0:
             raise Exception(status['errmsg'].__str__())
+
+        ops = db['$cmd.sys.inprog'].find_one()
+        status['fsyncLocked'] = 1 if ops.get('fsyncLock') else 0
 
         status['stats'] = db.command('dbstats')
         dbstats = {}

--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -157,6 +157,8 @@ class MongoDb(AgentCheck):
         "replSet.health": GAUGE,
         "replSet.replicationLag": GAUGE,
         "replSet.state": GAUGE,
+        "replSet.votes": GAUGE,
+        "replSet.voteFraction": GAUGE,
         "stats.avgObjSize": GAUGE,
         "stats.collections": GAUGE,
         "stats.dataSize": GAUGE,
@@ -793,6 +795,16 @@ class MongoDb(AgentCheck):
                     data['health'] = current['health']
 
                 data['state'] = replSet['myState']
+
+                if current is not None:
+                    total = 0.0
+                    cfg = cli['local']['system.replset'].find_one()
+                    for member in cfg.get('members'):
+                        total += member.get('votes', 1)
+                        if member['_id'] == current['_id']:
+                            data['votes'] = member.get('votes', 1)
+                    data['voteFraction'] = data['votes'] / total
+
                 status['replSet'] = data
 
                 # Submit events


### PR DESCRIPTION
### What does this PR do?

This introduces 3 new metrics:
 - fsyncLocked: which is 1 if the mongod is fsynclocked and 0 if not
 - replSet.votes: which is the number of votes assigned to a node (on 2.6 or newer this will always be 0 or 1)
 - replSet.voteFraction: the fraction of votes in the replset assigned to this node

### Motivation

These metrics are part of our monitoring for mongo node health. We alert on nodes being fsyncLocked for an extended period of time (since it usually indicates forgotten maintenance), and on voteFraction-grouped-by-AZ being > 0.5, since that indicates that loss of an AZ would break quorum.