### PR TITLE
[postgresql]: fixes the tag name to be uniformly postgresql

### DIFF
--- a/checks.d/postgres.py
+++ b/checks.d/postgres.py
@@ -216,7 +216,7 @@ SELECT schemaname, count(*) FROM
     }
 
     REPLICATION_METRICS_9_2 = {
-        'abs(pg_xlog_location_diff(pg_last_xlog_receive_location(), pg_last_xlog_replay_location())) AS replication_delay_bytes': ('postgres.replication_delay_bytes', GAUGE)
+        'abs(pg_xlog_location_diff(pg_last_xlog_receive_location(), pg_last_xlog_replay_location())) AS replication_delay_bytes': ('postgresql.replication_delay_bytes', GAUGE)
     }
 
     REPLICATION_METRICS = {


### PR DESCRIPTION
_Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so._
### What does this PR do?

Changes the tag associated with the metric "replication_delay_bytes" to postgresql from postgres.

A brief description of the change being made with this pull request.
When we receive replication metrics, we get one metric under each of two tags - postgres and postgresql.  This pull fixes the metric "replication_delay_bytes" to be under postgresql so that all metrics show up under one label.
### Motivation

What inspired you to submit this pull request?
I just setup replication monitoring and noticed we're getting data under two tags, would be nice if all events were under one.
### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.
### Additional Notes

Anything else we should know when reviewing?

Currently, when using the postgresql integration, you get events under
two tags, postgres and postgresql.  Under the postgres tag, you see a metric
"replication_delay_bytes", where all other metrics are under postgresql.

This pull fixes this so that all postgresql metrics for replication
monitoring are under one tag - postgresql.
