### PR TITLE
[consul] Remove warning when no whitelist is defined

### DIFF
--- a/checks.d/consul.py
+++ b/checks.d/consul.py
@@ -204,7 +204,7 @@ class ConsulCheck(AgentCheck):
             services = [s for s in services if s in service_whitelist][:self.MAX_SERVICES]
         else:
             if len(services) <= self.MAX_SERVICES:
-                self.warning('Consul service whitelist not defined. Agent will poll for all %d services found' % len(services))
+                self.log.debug('Consul service whitelist not defined. Agent will poll for all %d services found', len(services))
             else:
                 self.warning('Consul service whitelist not defined. Agent will poll for at most %d services' % self.MAX_SERVICES)
                 services = list(islice(services.iterkeys(), 0, self.MAX_SERVICES))


### PR DESCRIPTION
### What does this PR do?

As long as the number of polled services is lower than the limit, let's
just log that no whitelist has been defined. We should only add a
warning when there's an actual issue.

### Motivation

Fixes #2954, removes a spurious warning from the info page of the Agent and from the infra list of the webapp.

### Testing

None for this trivial change, but we have mock and integration tests on this check.
