### PR TITLE
[Kafka] Document specifying multiple Kafka / ZK nodes

### DIFF
--- a/conf.d/kafka_consumer.yaml.example
+++ b/conf.d/kafka_consumer.yaml.example
@@ -11,3 +11,15 @@ instances:
   #   consumer_groups:
   #     my_consumer:
   #       my_topic: [0, 1, 4, 12]
+  
+  # Production example with redundant hosts:
+  # In a production environment, it's often useful to specify multiple
+  # Kafka / Zookeper nodes for a single check instance. This way you
+  # only generate a single check process, but if one host goes down,
+  # KafkaClient / KazooClient will try contacting the next host.
+  # Details: https://github.com/DataDog/dd-agent/issues/2943
+  #
+  # - kafka_connect_str: 
+  #   - <kafka_host1:port>
+  #   - <kafka_host2:port>
+  #   zk_connect_str: <zk_host1:port>,<zk_host2:port>


### PR DESCRIPTION
### What does this PR do?

Documents how to specify multiple Kafka/ZK nodes. 

### Motivation

In a production environment, it's often useful to specify multiple Kafka / Zookeper nodes for a single check instance. This way you only generate a single check process, but if one host goes down, KafkaClient / KazooClient will try contacting the next host. Generating multiple check processes is a bad solution because then you're doing redundant reads against Kafka (not a big deal) and Zookeeper (can be a bottleneck).

### Testing Guidelines

Modify config to see if it works.

Fixes #2943