### PR TITLE
[psutil] Upgrade to 4.4.1

### DIFF
--- a/checks.d/disk.py
+++ b/checks.d/disk.py
@@ -118,21 +118,10 @@ class Disk(AgentCheck):
             tags = [part.fstype] if self._tag_by_filesystem else []
             device_name = part.mountpoint if self._use_mount else part.device
 
-            # Note: psutil (0.3.0 to at least 3.1.1) calculates in_use as (used / total)
-            #       The problem here is that total includes reserved space the user
-            #       doesn't have access to. This causes psutil to calculate a misleadng
-            #       percentage for in_use; a lower percentage than df shows.
-
-            # Calculate in_use w/o reserved space; consistent w/ df's Use% metric.
-            pmets = self._collect_part_metrics(part, disk_usage)
-            used = 'system.disk.used'
-            free = 'system.disk.free'
-            pmets['system.disk.in_use'] = pmets[used] / (pmets[used] + pmets[free])
-
             # legacy check names c: vs psutil name C:\\
             if Platform.is_win32():
                 device_name = device_name.strip('\\').lower()
-            for metric_name, metric_value in pmets.iteritems():
+            for metric_name, metric_value in self._collect_part_metrics(part, disk_usage).iteritems():
                 self.gauge(metric_name, metric_value,
                            tags=tags, device_name=device_name)
         # And finally, latency metrics, a legacy gift from the old Windows Check

--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -201,65 +201,20 @@ class Cpu(Check):
     def __init__(self, logger):
         Check.__init__(self, logger)
 
-        # Sampler(s)
-        self.wmi_sampler = WMISampler(
-            logger,
-            "Win32_PerfRawData_PerfOS_Processor",
-            ["Name", "PercentInterruptTime"]
-        )
-
         self.counter('system.cpu.user')
         self.counter('system.cpu.idle')
-        self.gauge('system.cpu.interrupt')
         self.counter('system.cpu.system')
+        self.counter('system.cpu.interrupt')
 
     def check(self, agentConfig):
-        try:
-            self.wmi_sampler.sample()
-        except TimeoutException:
-            self.logger.warning(
-                u"Timeout while querying Win32_PerfRawData_PerfOS_Processor WMI class."
-                u" CPU metrics will be returned at next iteration."
-            )
-            return []
-
-        if not (len(self.wmi_sampler)):
-            self.logger.warning('Missing Win32_PerfRawData_PerfOS_Processor WMI class.'
-                             ' No CPU metrics will be returned')
-            return []
-
-        cpu_interrupt = self._average_metric(self.wmi_sampler, 'PercentInterruptTime')
-        if cpu_interrupt is not None:
-            self.save_sample('system.cpu.interrupt', cpu_interrupt)
-
         cpu_percent = psutil.cpu_times()
 
         self.save_sample('system.cpu.user', 100 * cpu_percent.user / psutil.cpu_count())
         self.save_sample('system.cpu.idle', 100 * cpu_percent.idle / psutil.cpu_count())
         self.save_sample('system.cpu.system', 100 * cpu_percent.system / psutil.cpu_count())
+        self.save_sample('system.cpu.interrupt', 100 * cpu_percent.interrupt / psutil.cpu_count())
 
         return self.get_metrics()
-
-    def _average_metric(self, sampler, wmi_prop):
-        ''' Sum all of the values of a metric from a WMI class object, excluding
-            the value for "_Total"
-        '''
-        val = 0
-        counter = 0
-        for wmi_object in sampler:
-            if wmi_object['Name'] == '_Total':
-                # Skip the _Total value
-                continue
-
-            wmi_prop_value = wmi_object.get(wmi_prop)
-            if wmi_prop_value is not None:
-                counter += 1
-                val += float(wmi_prop_value)
-
-        if counter > 0:
-            return val / counter
-
-        return val
 
 
 class Network(Check):

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -18,7 +18,7 @@ pycurl==7.19.5.1
 # checks.d/gunicorn.py
 # checks.d/btrfs.py
 # checks.d/system_core.py
-psutil==3.3.0
+psutil==4.4.1
 
 # checks.d/snmp.py
 # Require a compiler because pycrypto is a dep


### PR DESCRIPTION
### What does this PR do?

Upgrades psutil to the latest version (`4.4.1`), and related changes on `dd-agent` (see details in commit messages):
- [disk] Use `in_use` percentage provided by psutil
- [win32][system] Use `psutil` to sample `cpu.interrupt`: tested on my local windows VM: `psutil` and `WMI` send the same values for `cpu.interrupt`

### Motivation

The upgrade was requested by a customer so that we ship a version that includes this fix: https://github.com/giampaolo/psutil/issues/761
More generally it's good to keep an up-to-date version.

### Testing Guidelines

Went through the changelog of `psutil` and through the occurences of `psutil` in `dd-agent` to find things that could be affected. Not sure I've spotted everything but I'll closely monitor the deploy of the updated Agent on our staging infrastructure (especially for the `gunicorn` check that could potentially be affected).

### Additional Notes

Related PR on `omnibus-software`: https://github.com/DataDog/omnibus-software/pull/82
`psutil` changelog: https://github.com/giampaolo/psutil/blob/master/HISTORY.rst