### PR TITLE
[elasticsearch] Added a couple of tweaks to work with Elasticsearch 5.x and release candidates

### DIFF
--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -586,7 +586,7 @@ class ESCheck(AgentCheck):
                 verify=verify,
                 cert=cert
             )
- 
+
             resp.raise_for_status()
         except Exception as e:
             if send_sc:

--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -397,6 +397,7 @@ class ESCheck(AgentCheck):
         # (URLs and metrics) accordingly
         version = self._get_es_version(config)
 
+
         health_url, nodes_url, stats_url, pshard_stats_url, pending_tasks_url, stats_metrics, \
             pshard_stats_metrics = self._define_params(version, config.cluster_stats)
 
@@ -442,6 +443,9 @@ class ESCheck(AgentCheck):
         """
         try:
             data = self._get_data(config.url, config, send_sc=False)
+            #pre-release versions of elasticearch are suffixed with -rcX etc..
+            #peel that off so that the map below doesn't error out
+            data['version']['number'] = data['version']['number'].split('-')[0]
             version = map(int, data['version']['number'].split('.')[0:3])
         except Exception as e:
             self.warning(
@@ -450,6 +454,7 @@ class ESCheck(AgentCheck):
                 % (config.url, str(e))
             )
             version = [1, 0, 0]
+
 
         self.service_metadata('version', version)
         self.log.debug("Elasticsearch version is %s" % version)
@@ -462,6 +467,8 @@ class ESCheck(AgentCheck):
 
         pshard_stats_url = "/_stats"
 
+        stats_url_all_param = True
+
         if version >= [0, 90, 10]:
             # ES versions 0.90.10 and above
             health_url = "/_cluster/health?pretty=true"
@@ -470,9 +477,9 @@ class ESCheck(AgentCheck):
 
             # For "external" clusters, we want to collect from all nodes.
             if cluster_stats:
-                stats_url = "/_nodes/stats?all=true"
+                stats_url = "/_nodes/stats"
             else:
-                stats_url = "/_nodes/_local/stats?all=true"
+                stats_url = "/_nodes/_local/stats"
 
             additional_metrics = self.JVM_METRICS_POST_0_90_10
         else:
@@ -480,9 +487,9 @@ class ESCheck(AgentCheck):
             nodes_url = "/_cluster/nodes?network=true"
             pending_tasks_url = None
             if cluster_stats:
-                stats_url = "/_cluster/nodes/stats?all=true"
+                stats_url = "/_cluster/nodes/stats"
             else:
-                stats_url = "/_cluster/nodes/_local/stats?all=true"
+                stats_url = "/_cluster/nodes/_local/stats"
 
             additional_metrics = self.JVM_METRICS_PRE_0_90_10
 
@@ -529,11 +536,19 @@ class ESCheck(AgentCheck):
         if version >= [2, 1, 0]:
             stats_metrics.update(self.ADDITIONAL_METRICS_POST_2_1)
 
+        if version >= [5, 0, 0]:
+            stats_url_all_param = False
+
         # Version specific stats metrics about the primary shards
         pshard_stats_metrics = dict(self.PRIMARY_SHARD_METRICS)
 
         if version >= [1, 0, 0]:
             additional_metrics = self.PRIMARY_SHARD_METRICS_POST_1_0
+
+
+        #version 5 errors out if this parameter is set
+        if stats_url_all_param:
+            stats_url += "?all=true"
 
         pshard_stats_metrics.update(additional_metrics)
 
@@ -571,6 +586,7 @@ class ESCheck(AgentCheck):
                 verify=verify,
                 cert=cert
             )
+ 
             resp.raise_for_status()
         except Exception as e:
             if send_sc:


### PR DESCRIPTION
_Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so._
### What does this PR do?

There are two changes in this PR: 
- Allows the elasticsearch plugin to handle pre-release versions of elasticsearch. 5.0.0-rc1 as an example, the plugin expect a purely numeric result. As the status of RC vs GA should not affect the metrics / feature flags in the plugin, I simply truncate the -RCx or anything - and beyond.
- Allows the plugin to work with 5.x versions of elasticsearch, they have changed the behavior of the API endpoint for node statistics in 5.0.0 to return all stats by default and requiring you to filter down if you _don't_ want all the stats. As a result they have removed the flag to ask for all.

Request against 5.x with the all parameter defined:

```
curl http://X.X.X.X:9200/_nodes/_local/stats?all=true
{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"request [/_nodes/_local/stats] contains unrecognized parameter: [all]"}],"type":"illegal_argument_exception","reason":"request [/_nodes/_local/stats] contains unrecognized parameter: [all]"},"status":400}
```

Removing the ?all=true from the url causes the request to complete successfully and return statistics.
### Motivation

We are using ES 5 and I wanted to try and tune performance with Datadog.
### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.
### Additional Notes

Anything else we should know when reviewing?
I'm not experienced in Python, sorry if I did something silly, feel free to rewrite the code as you see fit :)

As for the approach I took of setting a flag for ?all vs overriding the setting of the variable directly. It's currently set in 4 different places based on a couple of different sets of variables. It seemed like the right thing to just append that if by default and let a 5.x version check ask for it to be left off.

Also, sorry if others disagree with the truncation of the -'d portion of the version string, it just seemed like the simplest approach given that it shouldn't have any behavioral impact on interacting with ES which appears to be the entire reason the plugin grabs the version in the first place.
