### PR TITLE
[forwarder] refactor transaction flush scheduling

### DIFF
--- a/ddagent.py
+++ b/ddagent.py
@@ -283,8 +283,6 @@ class AgentTransaction(Transaction):
         else:
             self._trManager.tr_success(self)
 
-        self._trManager.flush_next()
-
 
 class MetricTransaction(AgentTransaction):
     _type = "metrics"


### PR DESCRIPTION
### What does this PR do?

This introduces a schedule function which schedules the transaction
flushes (instead of `flush_next`).
The main change: there is only one tornado timeout waiting instead of
multiple previously. (because every `flush_next` which wasn't flushing a
transaction was creating a timeout)

The workflow now: (with one endpoint)
1 - schedule is called, it starts the first transaction flush, then
"sleeps" (tornado timeout) for 0.5s.
2a - the first transaction completes before the 0.5s, calls
`tr_something`, which at the end runs `_should_schedule`, which returns
False (because of the 0.5s throttling) 2b - the first transaction
doesn't complete before the 0.5s.
3a - `schedule` is called and starts a new transaction flush. Then it
"sleeps".
3b - `schedule` is called, transaction is still running, nothing
happens. It goes back to sleep.
4b - transaction completes, `should_schedule` returns True and a
schedule is started.

With multiple endpoints, `schedule` starts up to 5 transaction flushes
concurrently (while still respecting the throttling delay).

Main improvement: flush is limited to 15s by default (i.e. if it takes
more than 15s, nothing more is flushed, it just waits for the current
flushes to end).
### Motivation

Broken multiple endpoints (because of the non-limitation of the flush, a flush can take multiple minutes, meaning that new data is not processed).
