### PR TITLE
[kafka_consumer] Upgrade `kazoo` dep to `2.2.1`

### DIFF
--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -31,10 +31,6 @@ pysnmp==4.2.5
 # TODO: our checks are not compatible with 3.x
 pymongo==3.2
 
-# checks.d/kafka_consumer.py
-# Requires a compiler because zope.interface is a dep
-kazoo==1.3.1
-
 # checks.d/ssh_check.py
 winrandom-ctypes
 # Require a compiler because pycrypto is a dep

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ httplib2==0.9
 
 # checks.d/kafka_consumer.py
 kafka-python==1.2.5
+kazoo==2.2.1
 
 # checks.d/postgres.py
 pg8000==1.10.1


### PR DESCRIPTION
### What does this PR do?

Upgrade `kazoo` dep to latest `2.2.1`

### Motivation

Customer request: the upgrade fixes a leak handle in Kazoo (see https://github.com/python-zk/kazoo/issues/169)
\+ it's always good to have up-to-date deps

### Testing Guidelines

Tested manually on an Agent running the `kafka_consumer` check. Nothing to report.

### Additional Notes

This moves the req to `requirements.txt` since this version doesn't have a
dependency on `zope.interface` anymore, so it doesn't need a compiler
(see https://github.com/python-zk/kazoo/blob/2.2.1/CHANGES.rst#20b1-2014-04-24)

Related `omnibus-software` PR: https://github.com/DataDog/omnibus-software/pull/84