### PR TITLE
[postgres] Fix unix socket connection with psycopg2

### DIFF
--- a/checks.d/postgres.py
+++ b/checks.d/postgres.py
@@ -25,7 +25,11 @@ MAX_CUSTOM_RESULTS = 100
 TABLE_COUNT_LIMIT = 200
 
 def psycopg2_connect(*args, **kwargs):
-    del kwargs['ssl']
+    if 'ssl' in kwargs:
+        del kwargs['ssl']
+    if 'unix_sock' in kwargs:
+        kwargs['host'] = kwargs['unix_sock']
+        del kwargs['unix_sock']
     return psycopg2.connect(*args, **kwargs)
 
 
@@ -605,7 +609,7 @@ SELECT s.schemaname,
                 elif host.startswith('/'):
                     # If the hostname starts with /, it's probably a path
                     # to a UNIX socket. This is similar behaviour to psql
-                    connection = pg.connect(unix_sock=host, user=user,
+                    connection = connect_fct(unix_sock=host, user=user,
                         password=password, database=dbname)
                 else:
                     connection = connect_fct(host=host, user=user, password=password,

--- a/conf.d/postgres.yaml.example
+++ b/conf.d/postgres.yaml.example
@@ -13,6 +13,7 @@ instances:
 #      - optional_tag2
 
 # Connect using a UNIX socket (host must begin with a /)
+# If `use_psycopg2` is enabled, use the directory of the UNIX socket (ex: `/run/postgresql/`)
 #  - host: /run/postgresql/.s.PGSQL.5433
 #    dbname: db_name
 
@@ -24,7 +25,7 @@ instances:
 #      - my_table
 #      - my_other_table
 #
-# By default all schemas are included. To track relations from specific schemas only, 
+# By default all schemas are included. To track relations from specific schemas only,
 # use the following syntax:
 #
 #    relations:
@@ -37,10 +38,10 @@ instances:
 
 # Custom metrics
 # Below are some examples of commonly used metrics, which are implemented as custom metrics.
-# Uncomment them if you want to use them as is, or use as an example for creating your own custom metrics. 
+# Uncomment them if you want to use them as is, or use as an example for creating your own custom metrics.
 # The format for describing custome metrics is identical with the one used for common metrics in postgres.py
-# Be extra careful with ensuring proper custom metrics description format. If your custom metric does not work 
-# after an agent restart, look for errors in the output of "/etc/init.d/datadog-agent info" command, as well as 
+# Be extra careful with ensuring proper custom metrics description format. If your custom metric does not work
+# after an agent restart, look for errors in the output of "/etc/init.d/datadog-agent info" command, as well as
 # /var/log/datadog/collector.log file.
 #
 #    custom_metrics:


### PR DESCRIPTION
### What does this PR do?

Fix the postgres check to make it handle `psycopg2` nicely with the support of UNIX sockets

### Motivation

Fixing the postgres check that I completely broke by merging #2734

### Testing Guidelines

Ran the updated check on a local postgres DB, with and without a UNIX socket as `host`, and with `use_psycopg2` enabled and disabled

### Additional notes

:confounded: