### PR TITLE
Add cpuacct.usage as docker.cpu.usage to docker_daemon stats.

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -62,6 +62,13 @@ CGROUP_METRICS = [
     },
     {
         "cgroup": "cpuacct",
+        "file": "cpuacct.usage",
+        "metrics": {
+            "usage": ("docker.cpu.usage", RATE),
+        },
+    },
+    {
+        "cgroup": "cpuacct",
         "file": "cpuacct.stat",
         "metrics": {
             "user": ("docker.cpu.user", RATE),
@@ -808,6 +815,8 @@ class DockerDaemon(AgentCheck):
             with open(stat_file, 'r') as fp:
                 if 'blkio' in stat_file:
                     return self._parse_blkio_metrics(fp.read().splitlines())
+                elif 'cpuacct.usage' in stat_file:
+                    return dict({"usage": str(int(fp.read())/10000000)})
                 else:
                     return dict(map(lambda x: x.split(' ', 1), fp.read().splitlines()))
         except IOError:


### PR DESCRIPTION
_Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so._
### What does this PR do?

Adds a new stat 'docker.cpu.usage' which tracks the value in the cgroup accounting file cpuacct.usage for a docker container.  The values are normalized to yield CPU usage a a percentage.
### Motivation

The user and system cpu usage reported in cpuacct.stat is much less accurate than other mechanisms.  Over a short sampling period they can be as much a 30% lower than what /proc or cpuacct.usage reports.  For a long running container, the difference can be an order of magnitude.

In order to get more accurate cpu usage numbers, I have added a new metric 'docker.cpu.usage', which gets the data from cpuacct.usage, converts it to jiffies, and reports it as a rate called docker.cpu.usage.  It is a parallel construction to the existing docker.cpu stats.
### Testing Guidelines

Same as for other docker stats.
An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.
### Additional Notes
