### PR TITLE
remove graph.png and set color to white for background of agent statu…

### DIFF
--- a/win32/status.html
+++ b/win32/status.html
@@ -71,7 +71,7 @@
       color: #333;
       font-family: 'Open Sans', 'Lucida Sans','Lucida Sans Unicode',Arial, sans-serif;
       height: 100%;
-      background: #f2f2f2 url("/graph.png") repeat;
+      background: #ffffff;
       letter-spacing: 1px;
       text-rendering: optimizeLegibility;
     }


### PR DESCRIPTION
### What does this PR do?

If an image named `graph.png` is in C:\ it will be used as the background for the agent status page. This PR removes the image in the background.

### Motivation

Customer emailed support reporting this as a bug.