### PR TITLE
[core] catch EOFError when loading status

### DIFF
--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -248,7 +248,7 @@ class AgentStatus(object):
                 return pickle.load(f)
             finally:
                 f.close()
-        except IOError:
+        except (IOError, EOFError):
             return None
 
     @classmethod


### PR DESCRIPTION
### What does this PR do?

catch EOFError when loading status

### Motivation

It can happen when disk is full.
