### PR TITLE
[mongodb] Add metrics for fsyncLocked-ness, replset votes and vote fraction

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -72,6 +72,7 @@ class MongoDb(AgentCheck):
         "cursors.totalOpen": GAUGE,
         "extra_info.heap_usage_bytes": RATE,
         "extra_info.page_faults": RATE,
+        "fsyncLocked": GAUGE,
         "globalLock.activeClients.readers": GAUGE,
         "globalLock.activeClients.total": GAUGE,
         "globalLock.activeClients.writers": GAUGE,
@@ -727,6 +728,9 @@ class MongoDb(AgentCheck):
 
         if status['ok'] == 0:
             raise Exception(status['errmsg'].__str__())
+
+        ops = db['$cmd.sys.inprog'].find_one()
+        status['fsyncLocked'] = 1 if ops.get('fsyncLock') else 0
 
         status['stats'] = db.command('dbstats')
         dbstats = {}

--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -157,6 +157,8 @@ class MongoDb(AgentCheck):
         "replSet.health": GAUGE,
         "replSet.replicationLag": GAUGE,
         "replSet.state": GAUGE,
+        "replSet.votes": GAUGE,
+        "replSet.voteFraction": GAUGE,
         "stats.avgObjSize": GAUGE,
         "stats.collections": GAUGE,
         "stats.dataSize": GAUGE,
@@ -793,6 +795,16 @@ class MongoDb(AgentCheck):
                     data['health'] = current['health']
 
                 data['state'] = replSet['myState']
+
+                if current is not None:
+                    total = 0.0
+                    cfg = cli['local']['system.replset'].find_one()
+                    for member in cfg.get('members'):
+                        total += member.get('votes', 1)
+                        if member['_id'] == current['_id']:
+                            data['votes'] = member.get('votes', 1)
+                    data['voteFraction'] = data['votes'] / total
+
                 status['replSet'] = data
 
                 # Submit events

--- a/ci/common.rb
+++ b/ci/common.rb
@@ -51,6 +51,7 @@ BAD_CITIZENS = {
   'sysstat' => 'system',
   'elastic' => 'elasticsearch',
   'gearmand' => 'gearman',
+  'mongo' => 'mongodb',
   'mcache' => 'memcache',
   'php_fpm' => 'phpfpm',
   'redisdb' => 'redis',


### PR DESCRIPTION
Supersedes https://github.com/DataDog/dd-agent/pull/2952. Thanks @ebroder 🙇 

**Additional changes**
* Move MongoDB `fsyncLock` metric test to the `AgentCheckTest` class suite.