### PR TITLE
Send all configured tags with process checks.

### DIFF
--- a/checks.d/process.py
+++ b/checks.d/process.py
@@ -374,7 +374,7 @@ class ProcessCheck(AgentCheck):
             if vals:
                 self.rate('system.processes.%s' % mname, sum(vals), tags=tags)
 
-        self._process_service_check(name, len(pids), instance.get('thresholds', None))
+        self._process_service_check(name, len(pids), instance.get('thresholds', None), tags)
 
     def _get_pid_set(self, pid):
         try:
@@ -382,14 +382,15 @@ class ProcessCheck(AgentCheck):
         except psutil.NoSuchProcess:
             return set()
 
-    def _process_service_check(self, name, nb_procs, bounds):
+    def _process_service_check(self, name, nb_procs, bounds, tags):
         """
         Report a service check, for each process in search_string.
         Report as OK if the process is in the warning thresholds
                    CRITICAL             out of the critical thresholds
                    WARNING              out of the warning thresholds
         """
-        tag = ["process:%s" % name]
+        # FIXME 6.x remove the `process:name` tag
+        service_check_tags = tags + ["process:%s" % name]
         status = AgentCheck.OK
         message_str = "PROCS %s: %s processes found for %s"
         status_str = {
@@ -412,6 +413,6 @@ class ProcessCheck(AgentCheck):
         self.service_check(
             "process.up",
             status,
-            tags=tag,
+            tags=service_check_tags,
             message=message_str % (status_str[status], nb_procs, name)
         )

--- a/tests/checks/integration/test_process.py
+++ b/tests/checks/integration/test_process.py
@@ -325,7 +325,8 @@ class ProcessCheckTest(AgentCheckTest):
                     tags=self.generate_expected_tags(stub['config']))
 
             # Assert service checks
-            expected_tags = ['process:{0}'.format(stub['config']['name'])]
+            expected_tags = self.generate_expected_tags(stub['config']) \
+                + ['process:{0}'.format(stub['config']['name'])]
             critical = stub['config'].get('thresholds', {}).get('critical')
             warning = stub['config'].get('thresholds', {}).get('warning')
             procs = len(stub['mocked_processes'])
@@ -376,7 +377,7 @@ class ProcessCheckTest(AgentCheckTest):
                 continue
             self.assertMetric(mname, at_least=1, tags=expected_tags)
 
-        self.assertServiceCheckOK('process.up', count=1, tags=['process:py'])
+        self.assertServiceCheckOK('process.up', count=1, tags=expected_tags + ['process:py'])
 
         self.coverage_report()
 
@@ -466,7 +467,7 @@ class ProcessCheckTest(AgentCheckTest):
                 psutil.PROCFS_PATH = '/proc'
 
         expected_tags = self.generate_expected_tags(config['instances'][0])
-        self.assertServiceCheckOK('process.up', count=1, tags=['process:moved_procfs'])
+        self.assertServiceCheckOK('process.up', count=1, tags=expected_tags + ['process:moved_procfs'])
 
         self.assertMetric('system.processes.number', at_least=1, tags=expected_tags)
         self.assertMetric('system.processes.threads', at_least=1, tags=expected_tags)


### PR DESCRIPTION
Send the tags configured on the `instance` with the process checks. Given the tests around the old behavior I imagine there might be some reason why this isn't the case now, but just in case there isn't I think it would be useful if the checks had the same tags that were configured for the metrics.

This fixes #2974, FYI.
