### PR TITLE
Support elastic 5.0 urls

### DIFF
--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -475,7 +475,7 @@ class ESCheck(AgentCheck):
                 stats_url = "/_nodes/_local/stats"
 
             additional_metrics = self.JVM_METRICS_POST_0_90_10
-        if version >= [0, 90, 10]:
+        elif version >= [0, 90, 10]:
             # ES versions 0.90.10 and above
             health_url = "/_cluster/health?pretty=true"
             nodes_url = "/_nodes?network=true"

--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -462,6 +462,19 @@ class ESCheck(AgentCheck):
 
         pshard_stats_url = "/_stats"
 
+        if version >= [5, 0, 0]:
+            # ES versions 5.0.0 and above
+            health_url = "/_cluster/health?pretty=true"
+            nodes_url = "/_nodes"
+            pending_tasks_url = "/_cluster/pending_tasks?pretty=true"
+
+            # For "external" clusters, we want to collect from all nodes.
+            if cluster_stats:
+                stats_url = "/_nodes/stats"
+            else:
+                stats_url = "/_nodes/_local/stats"
+
+            additional_metrics = self.JVM_METRICS_POST_0_90_10
         if version >= [0, 90, 10]:
             # ES versions 0.90.10 and above
             health_url = "/_cluster/health?pretty=true"


### PR DESCRIPTION
With elasticsearch 5.0, the built in check in datadog fails with:

```
Service Checks: 
[{'check': 'elasticsearch.can_connect',
  'host_name': 'lognode17',
  'id': 1,
  'message': u'Error 400 Client Error: Bad Request when hitting http://localhost:9200/_nodes/_local/stats?all=true',
  'status': 2,
  'tags': ['host:localhost', 'port:9200'],
  'timestamp': 1478000234.845192}]
Service Metadata: 
[{'version': u'[5, 0, 0]'}]
    elastic
    -------
      - instance #0 [ERROR]: '400 Client Error: Bad Request'
        Traceback (most recent call last):
          File "/opt/datadog-agent/agent/checks/__init__.py", line 750, in run
            self.check(copy.deepcopy(instance))
          File "/opt/datadog-agent/agent/checks.d/elastic.py", line 333, in check
            stats_data = self._get_data(stats_url, config)
          File "/opt/datadog-agent/agent/checks.d/elastic.py", line 476, in _get_data
            resp.raise_for_status()
          File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/requests/models.py", line 834, in raise_for_status
            raise HTTPError(http_error_msg, response=self)
        HTTPError: 400 Client Error: Bad Request
        
      - Collected 0 metrics, 0 events & 1 service check
```

This PR fixes the basic urls, without going in-depth for other metrics that 5.0 may provide.