### PR TITLE
[Win32] Terminate agent-manager.exe on uninstall/upgrade.

### DIFF
--- a/packaging/datadog-agent/win32/wix/agent.wxs
+++ b/packaging/datadog-agent/win32/wix/agent.wxs
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
     <Product Name="Datadog Agent" Id="*" UpgradeCode="82210ed1-bbe4-4051-aa15-002ea31dde15"
     Language="1033" Codepage="1252" Version="$(var.AgentVersion)" Manufacturer="Datadog Inc.">
         <Package Id="*" Keywords="Installer" Description="Datadog Agent v$(var.AgentVersion)"
@@ -33,6 +33,15 @@
                 <Directory Id="ApplicationProgramsFolder" Name="Datadog"/>
             </Directory>
         </Directory>
+
+        <util:CloseApplication 
+            Id="CloseTrayApp" 
+            CloseMessage="yes" 
+            Target="agent-manager.exe" 
+            ElevatedCloseMessage="yes"
+            TerminateProcess="1"
+            Timeout="1"
+            RebootPrompt="no"/>
 
         <Binary Id="FindReplace" SourceFile="$(var.WixRoot)\FindReplace.exe" />
         <CustomAction
@@ -152,6 +161,8 @@
             <Custom Action="ReplaceAPIKey" Before="StartServices" />
             <Custom Action="ReplaceTags" Before="StartServices" />
             <Custom Action="ReplaceHostname" Before="StartServices" />
+            <Custom Action="WixCloseApplications"
+                After="InstallInitialize"><![CDATA[REMOVE="ALL" OR REINSTALL]]></Custom>
         </InstallExecuteSequence>
 
         <CustomAction Id="LaunchApplication"

--- a/win32/gui.py
+++ b/win32/gui.py
@@ -845,6 +845,10 @@ if __name__ == '__main__':
     if Platform.is_windows():
         # Let's kill any other running instance of our GUI/SystemTray before starting a new one.
         kill_old_process()
+        if len(sys.argv) > 1 and "-stop" in sys.argv:
+            # just return.  The kill_old_process() should have terminated the process,
+            # and now we're done.
+            sys.exit(0)
 
     app = QApplication([])
     if Platform.is_mac():


### PR DESCRIPTION

### What does this PR do?

Modifies the installer so that if agent-manager.exe is running, it is automatically terminated during uninstall and/or upgrade.  This prevents requiring a reboot after upgrade.

### Motivation

Multiple failed installs due to agent-manager.exe running in the background.

### Testing Guidelines

### Additional Notes

Anything else we should know when reviewing?

Modifies install script to terminate agent-manager during uninstall or
upgrade.  Otherwise, agent-manager is running in the background and can't
be upgraded, leading to an unstable install