### PR TITLE
password cast to string

### DIFF
--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -325,7 +325,7 @@ class MySql(AgentCheck):
         self.mysql_sock = instance.get('sock', '')
         self.defaults_file = instance.get('defaults_file', '')
         user = instance.get('user', '')
-        password = instance.get('pass', '')
+        password = str(instance.get('pass', ''))
         tags = instance.get('tags', [])
         options = instance.get('options', {})
         queries = instance.get('queries', [])


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Password casted to string in mysql.py

### Motivation

Pure number password without  quotes causes an error in pymysql. 


### Additional Notes


If password only contains number, it must be surrounded by quotes, otherwise the pymysql will raise an error. So I cast it to a string to avoid misunderstanding. Or leave it alone to let the user to determine when to use a string? Just my personal opinion.