### PR TITLE
Setup auto config for kube-state-metrics

### DIFF
--- a/conf.d/auto_conf/kubernetes_state.yaml
+++ b/conf.d/auto_conf/kubernetes_state.yaml
@@ -1,0 +1,7 @@
+docker_images:
+  - kube-state-metrics
+
+init_config:
+instances:
+  # To enable Kube State metrics you must specify the url exposing the API
+  - kube_state_url: http://%%host%%:%%port%%/metrics


### PR DESCRIPTION
### What does this PR do?

Add automatic configuration for the kubernetes_state integration.

### Motivation

Leading up to 5.10.x we've added a new kube-state-metrics integration.  Since one deploys kube-state-metrics as a pod/service on their kubernetes cluster the IP/PORT/etc needed in the kubernetes_state.yaml file will likely be as dynamic as any other service deployed on kubernetes. This seems like the most reasonable way to deploy/configure the integration such that it's picked up, configured and enabled automatically if a user has kube-state-metrics deployed.

### Testing Guidelines

Deploy dd-agent to a k8s cluster with kube-state-metrics deployed. Confim the kubernetes_state integration is picked up automatically by service discovery/auto_conf.

