### PR TITLE
[kubernetes_state] fixed init param names

### DIFF
--- a/checks.d/kubernetes_state.py
+++ b/checks.d/kubernetes_state.py
@@ -14,8 +14,8 @@ class KubernetesState(AgentCheck):
 
     [0] https://github.com/kubernetes/kube-state-metrics
     """
-    def __init__(self, name, init_config, agent_config, instances=None):
-        super(KubernetesState, self).__init__(name, init_config, agent_config, instances)
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        super(KubernetesState, self).__init__(name, init_config, agentConfig, instances)
         self.kube_state_processor = KubeStateProcessor(self)
 
     def check(self, instance):


### PR DESCRIPTION
### What does this PR do?

some code call the constructor using keywords, fixed the name of the params, got completely unnoticed in the tests
