### PR TITLE
[kubernetes_state] added note for RHEL users

### DIFF
--- a/conf.d/kubernetes_state.yaml.example
+++ b/conf.d/kubernetes_state.yaml.example
@@ -5,4 +5,8 @@ init_config:
 
 instances:
   # To enable Kube State metrics you must specify the url exposing the API
+  #
+  # Note for RHEL users: due to compatibility issues, the check does not make use of
+  # the CPP extension to process Protocol buffer messages coming from the api. Depending
+  # on the metrics volume, the check may run very slowly.
   - kube_state_url: http://example.com:8080/metrics

--- a/conf.d/kubernetes_state.yaml.example
+++ b/conf.d/kubernetes_state.yaml.example
@@ -6,7 +6,7 @@ init_config:
 instances:
   # To enable Kube State metrics you must specify the url exposing the API
   #
-  # Note for RHEL users: due to compatibility issues, the check does not make use of
+  # Note for RHEL and SUSE users: due to compatibility issues, the check does not make use of
   # the CPP extension to process Protocol buffer messages coming from the api. Depending
   # on the metrics volume, the check may run very slowly.
   - kube_state_url: http://example.com:8080/metrics


### PR DESCRIPTION
### What does this PR do?

Add a note for RHEL users about Protobuf client performances