### PR TITLE
[elasticsearch] ES 5.x support

### DIFF
--- a/checks.d/elastic.py
+++ b/checks.d/elastic.py
@@ -397,7 +397,7 @@ class ESCheck(AgentCheck):
         # (URLs and metrics) accordingly
         version = self._get_es_version(config)
 
-        health_url, nodes_url, stats_url, pshard_stats_url, pending_tasks_url, stats_metrics, \
+        health_url, stats_url, pshard_stats_url, pending_tasks_url, stats_metrics, \
             pshard_stats_metrics = self._define_params(version, config.cluster_stats)
 
         # Load stats data.
@@ -410,7 +410,7 @@ class ESCheck(AgentCheck):
             # retreive the cluster name from the data, and append it to the
             # master tag list.
             config.tags.append("cluster_name:{}".format(stats_data['cluster_name']))
-        self._process_stats_data(nodes_url, stats_data, stats_metrics, config)
+        self._process_stats_data(stats_data, stats_metrics, config)
 
         # Load clusterwise data
         if config.pshard_stats:
@@ -465,7 +465,6 @@ class ESCheck(AgentCheck):
         if version >= [0, 90, 10]:
             # ES versions 0.90.10 and above
             health_url = "/_cluster/health?pretty=true"
-            nodes_url = "/_nodes?network=true"
             pending_tasks_url = "/_cluster/pending_tasks?pretty=true"
 
             # For "external" clusters, we want to collect from all nodes.
@@ -477,7 +476,6 @@ class ESCheck(AgentCheck):
             additional_metrics = self.JVM_METRICS_POST_0_90_10
         else:
             health_url = "/_cluster/health?pretty=true"
-            nodes_url = "/_cluster/nodes?network=true"
             pending_tasks_url = None
             if cluster_stats:
                 stats_url = "/_cluster/nodes/stats?all=true"
@@ -537,7 +535,7 @@ class ESCheck(AgentCheck):
 
         pshard_stats_metrics.update(additional_metrics)
 
-        return health_url, nodes_url, stats_url, pshard_stats_url, pending_tasks_url, \
+        return health_url, stats_url, pshard_stats_url, pending_tasks_url, \
             stats_metrics, pshard_stats_metrics
 
     def _get_data(self, url, config, send_sc=True):
@@ -601,7 +599,7 @@ class ESCheck(AgentCheck):
             desc = self.CLUSTER_PENDING_TASKS[metric]
             self._process_metric(node_data, metric, *desc, tags=config.tags)
 
-    def _process_stats_data(self, nodes_url, data, stats_metrics, config):
+    def _process_stats_data(self, data, stats_metrics, config):
         cluster_stats = config.cluster_stats
         for node_data in data['nodes'].itervalues():
             metric_hostname = None


### PR DESCRIPTION
### What does this PR do?

- Add support of ES 5.x (based on #2958, see complete explanation there), the check would fail without these changes.
- Handle RC versions of ES (see #2958)

Also, remove an unused var (`nodes_url`).

### Testing Guidelines

No integration tests on this specific version of ES for now, but I've tested the check against a test ES cluster and it collects metrics w/o errors (haven't looked into which metrics were potentially missing though)

### Additional Notes

Supersedes #2958 and #2980, thanks @ptinsley and @alexef!