### PR TITLE
[rabbitmq] Fixed #2905 - add ssl_verify option

### DIFF
--- a/conf.d/rabbitmq.yaml.example
+++ b/conf.d/rabbitmq.yaml.example
@@ -9,6 +9,17 @@ instances:
   - rabbitmq_api_url: http://localhost:15672/api/
     rabbitmq_user: guest
     rabbitmq_pass: guest
+    # The (optional) ssl_verify can be used to tell the check
+    # to skip the verification of the SSL certificate of the
+    # RabbitMQ management web endpoint.
+    # This is mostly useful when checking SSL connections signed with
+    # certificates that are not themselves signed by a public authority.
+    # When false, the check logs a warning in collector.log
+    # Defaults to true; set to false if you want to disable
+    # SSL certificate verification.
+    #
+    # ssl_verify: false
+
     # tag_families: true
     # Use the `nodes` or `nodes_regexes` parameters to specify the nodes you'd like to
     # collect metrics on (up to 100 nodes).


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

[rabbitmq] Fixes #2905 by adding ssl_verify instance config option, which can be used to skip ssl verification for API calls.

### Motivation

We use a vendor app that bundles RabbitMQ using self-signed certificates, and we'd like to monitor it using Datadog.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

I didn't add/change any tests for this, but I'd be willing to add some if I can get some guidance on it.