### PR TITLE
[ci] Fix Travis test skipping

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,6 @@ gem 'colorize'
 gem 'httparty'
 gem 'rake'
 gem 'rubocop', '~>0.38.0'
+
+# Upper versions are incompatible with ruby version on Travis (1.9.3)
+gem 'public_suffix', '~>1.4.0'

--- a/ci/common.rb
+++ b/ci/common.rb
@@ -66,12 +66,14 @@ def translate_to_travis(checks)
 end
 
 # rubocop:disable Metrics/AbcSize
-# [15.39/15]....
+# rubocop:disable Metrics/MethodLength
 def can_skip?
   return false, [] unless travis_pr?
 
   modified_checks = []
-  git_output = `git diff-tree --no-commit-id --name-only -r #{ENV['TRAVIS_COMMIT']} #{ENV['TRAVIS_BRANCH']}`
+  puts "Comparing #{ENV['TRAVIS_PULL_REQUEST_SHA']} with #{ENV['TRAVIS_BRANCH']}"
+  git_output = `git diff --name-only #{ENV['TRAVIS_BRANCH']}...#{ENV['TRAVIS_PULL_REQUEST_SHA']}`
+  puts "Git diff: \n#{git_output}"
   git_output.each_line do |filename|
     filename.strip!
     if filename.start_with? 'checks.d'
@@ -88,6 +90,7 @@ def can_skip?
   [true, translate_to_travis(modified_checks)]
 end
 # rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/MethodLength
 
 # helper class to wait for TCP/HTTP services to boot
 class Wait


### PR DESCRIPTION
And add some debug logging.

Using `TRAVIS_COMMIT` on the `git diff` command sometimes fail because
git can't find the object reference for some reason (see https://travis-ci.org/DataDog/dd-agent/jobs/173291117#L240-L242 for instance). Instead use the
latest commit of the PR branch and use a difference comparison to only
take into account the changes brought by the PR branch since the latest
common commit with the base branch.

Also, pin the version of a gem dependency since later versions are
incompatible with the provided ruby on Travis (1.9.3).
