### PR TITLE
[marathon] enable deployments monitoring by default

### DIFF
--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -48,6 +48,7 @@ class Marathon(AgentCheck):
         default_timeout = self.init_config.get('default_timeout', self.DEFAULT_TIMEOUT)
         timeout = float(instance.get('timeout', default_timeout))
 
+        # Marathon apps
         response = self.get_json(urljoin(url, "v2/apps"), timeout, auth)
         if response is not None:
             self.gauge('marathon.apps', len(response['apps']), tags=instance_tags)
@@ -57,10 +58,10 @@ class Marathon(AgentCheck):
                     if attr in app:
                         self.gauge('marathon.' + attr, app[attr], tags=tags)
 
-        if instance.get('enable_deployment_metrics', False):
-            response = self.get_json(urljoin(url, "v2/deployments"), timeout, auth)
-            if response is not None:
-                self.gauge('marathon.deployments', len(response), tags=instance_tags)
+        # Number of running/pending deployments
+        response = self.get_json(urljoin(url, "v2/deployments"), timeout, auth)
+        if response is not None:
+            self.gauge('marathon.deployments', len(response), tags=instance_tags)
 
     def get_json(self, url, timeout, auth):
         try:

--- a/conf.d/marathon.yaml.example
+++ b/conf.d/marathon.yaml.example
@@ -9,4 +9,3 @@ instances:
   #   if marathon is protected by basic auth
   #   user: "username"
   #   password: "password"
-  #   enable_deployment_metrics: #Optional. Set to true if you want to receive send deployment related metrics. Adds an extra API call to Marathon.

--- a/tests/checks/mock/test_marathon.py
+++ b/tests/checks/mock/test_marathon.py
@@ -35,34 +35,24 @@ class MarathonCheckTest(AgentCheckTest):
         def side_effect(url, timeout, auth):
             if "v2/apps" in url:
                 return Fixtures.read_json_file("apps.json")
-            else:
-                raise Exception("unknown url:" + url)
-
-        self.run_check(DEFAULT_CONFIG, mocks={"get_json": side_effect})
-        self.assertMetric('marathon.apps', value=1)
-
-        # deployment-related metrics aren't included by default.
-        self.assertTrue('marathon.deployments' not in getMetricNames(self.metrics))
-
-    def test_empty_responses(self):
-        def side_effect(url, timeout, auth):
-            if "v2/apps" in url:
-                return {"apps": []}
-            else:
-                raise Exception("unknown url:" + url)
-
-        self.run_check(DEFAULT_CONFIG, mocks={"get_json": side_effect})
-        self.assertMetric('marathon.apps', value=0)
-
-    def test_enabled_deployment_metrics(self):
-        def side_effect(url, timeout, auth):
-            if "v2/apps" in url:
-                return Fixtures.read_json_file("apps.json")
             elif "v2/deployments" in url:
                 return Fixtures.read_json_file("deployments.json")
             else:
                 raise Exception("unknown url:" + url)
 
-        self.run_check(DEPLOYMENT_METRICS_CONFIG, mocks={"get_json": side_effect})
+        self.run_check(DEFAULT_CONFIG, mocks={"get_json": side_effect})
         self.assertMetric('marathon.apps', value=1)
         self.assertMetric('marathon.deployments', value=1)
+
+
+    def test_empty_responses(self):
+        def side_effect(url, timeout, auth):
+            if "v2/apps" in url:
+                return {"apps": []}
+            elif "v2/deployments" in url:
+                return {"deployments": []}
+            else:
+                raise Exception("unknown url:" + url)
+
+        self.run_check(DEFAULT_CONFIG, mocks={"get_json": side_effect})
+        self.assertMetric('marathon.apps', value=0)


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Deployments monitoring was behind a flag, let's enable it by default instead.

### Motivation

- it's an interesting metric to monitor
- low perf impact (small check, only one more http request)
- the marathon check is usually used in a container, which means enabling this flag requires mounting a custom yaml file for the customer or providing yet another env var for us

### Testing Guidelines

Updated unit tests
