### PR TITLE
[docker] Use proper tag when filtering pause containers

### DIFF
--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -33,7 +33,7 @@ DEFAULT_VERSION = 'auto'
 CHECK_NAME = 'docker_daemon'
 CONFIG_RELOAD_STATUS = ['start', 'die', 'stop', 'kill']  # used to trigger service discovery
 
-DEFAULT_CONTAINER_EXCLUDE = ["container_image:gcr.io/google_containers/pause.*"]
+DEFAULT_CONTAINER_EXCLUDE = ["docker_image:gcr.io/google_containers/pause.*"]
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION

### What does this PR do?
This fixes a bug that was caused by the wrong tag being used.
The bug was resulting in the feature not working (pause containers were not ignored) and 
this warning being shown:
```
Warning: container_image isn't a supported tag
```

### Motivation
Inspiration

### Testing Guidelines

Tested on kubernetes 1.4.5