### PR TITLE
[kubernetes state] Use a less ambiguous metric name and tags

### DIFF
--- a/tests/checks/mock/test_kubernetes_state.py
+++ b/tests/checks/mock/test_kubernetes_state.py
@@ -67,7 +67,7 @@ class TestKubernetesState(AgentCheckTest):
         self.assertMetric(NAMESPACE + '.node.cpu_allocatable')
         self.assertMetric(NAMESPACE + '.node.memory_allocatable')
         self.assertMetric(NAMESPACE + '.node.pods_allocatable')
-        self.assertMetric(NAMESPACE + '.node.unschedulable')
+        self.assertMetric(NAMESPACE + '.node.status')
         self.assertMetric(NAMESPACE + '.deployment.replicas_available')
         self.assertMetric(NAMESPACE + '.deployment.replicas_unavailable')
         self.assertMetric(NAMESPACE + '.deployment.replicas_desired')

--- a/tests/core/test_kubernetes.py
+++ b/tests/core/test_kubernetes.py
@@ -272,12 +272,12 @@ class TestKubeStateProcessor(unittest.TestCase):
         self.processor.kube_node_spec_unschedulable(msg)
 
         expected = [
-            (NAMESPACE + '.node.unschedulable', 1,
-             ['node:gke-cluster-massi-agent59-default-pool-6087cc76-9cfa', 'status:available']),
-            (NAMESPACE + '.node.unschedulable', 1,
-             ['node:gke-cluster-massi-agent59-default-pool-6087cc76-aah4', 'status:available']),
-            (NAMESPACE + '.node.unschedulable', 1,
-             ['node:gke-cluster-massi-agent59-default-pool-6087cc76-fgnk', 'status:available']),
+            (NAMESPACE + '.node.status', 1,
+             ['node:gke-cluster-massi-agent59-default-pool-6087cc76-9cfa', 'status:schedulable']),
+            (NAMESPACE + '.node.status', 1,
+             ['node:gke-cluster-massi-agent59-default-pool-6087cc76-aah4', 'status:schedulable']),
+            (NAMESPACE + '.node.status', 1,
+             ['node:gke-cluster-massi-agent59-default-pool-6087cc76-fgnk', 'status:schedulable']),
         ]
 
         calls = self.check.gauge.mock_calls

--- a/utils/kubernetes/kube_state_processor.py
+++ b/utils/kubernetes/kube_state_processor.py
@@ -171,8 +171,8 @@ class KubeStateProcessor:
 
     def kube_node_spec_unschedulable(self, message, **kwargs):
         """ Whether a node can schedule new pods. """
-        metric_name = NAMESPACE + '.node.unschedulable'
-        statuses = ('available', 'unavailable')
+        metric_name = NAMESPACE + '.node.status'
+        statuses = ('schedulable', 'unschedulable')
         for metric in message.metric:
             tags = ['{}:{}'.format(label.name, label.value) for label in metric.label]
             status = statuses[int(metric.gauge.value)]  # value can be 0 or 1


### PR DESCRIPTION

### What does this PR do?

This renames a metric name to make it less ambiguous. Otherwise we could end with 
`kubernetes_state.nodes.unschedulable {status:available}` which is quite confusing

