### PR TITLE
[haproxy] unix socket stats urls

### DIFF
--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -8,10 +8,7 @@ import copy
 import re
 import socket
 import time
-try:
-    import urlparse
-except LoadError:
-    import urllib.parse as urlparse
+import urlparse
 
 # 3rd party
 import requests

--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -6,12 +6,15 @@
 from collections import defaultdict
 import copy
 import re
+import socket
 import time
+try:
+    import urlparse
+except LoadError:
+    import urllib.parse as urlparse
 
 # 3rd party
 import requests
-import requests_unixsocket
-requests_unixsocket.monkeypatch()
 
 # project
 from checks import AgentCheck
@@ -99,8 +102,20 @@ class HAProxy(AgentCheck):
 
     def check(self, instance):
         url = instance.get('url')
-        username = instance.get('username')
-        password = instance.get('password')
+        self.log.debug('Processing HAProxy data for %s' % url)
+
+        parsed_url = urlparse.urlparse(url)
+
+        if parsed_url.scheme == 'unix':
+            data = self._fetch_socket_data(parsed_url.path)
+
+        else:
+            username = instance.get('username')
+            password = instance.get('password')
+            verify = not _is_affirmative(instance.get('disable_ssl_validation', False))
+
+            data = self._fetch_url_data(url, username, password, verify)
+
         collect_aggregates_only = _is_affirmative(
             instance.get('collect_aggregates_only', True)
         )
@@ -129,12 +144,6 @@ class HAProxy(AgentCheck):
 
         custom_tags = instance.get('tags', [])
 
-        verify = not _is_affirmative(instance.get('disable_ssl_validation', False))
-
-        self.log.debug('Processing HAProxy data for %s' % url)
-
-        data = self._fetch_data(url, username, password, verify)
-
         process_events = instance.get('status_check', self.init_config.get('status_check', False))
 
         self._process_data(
@@ -149,19 +158,38 @@ class HAProxy(AgentCheck):
             custom_tags=custom_tags,
         )
 
-    def _fetch_data(self, url, username, password, verify):
-        ''' Hit a given URL and return the parsed json '''
+    def _fetch_url_data(self, url, username, password, verify):
+        ''' Hit a given http url and return the stats lines '''
         # Try to fetch data from the stats URL
 
         auth = (username, password)
         url = "%s%s" % (url, STATS_URL)
 
-        self.log.debug("HAProxy Fetching haproxy search data from: %s" % url)
+        self.log.debug("Fetching haproxy stats from url: %s" % url)
 
-        r = requests.get(url, auth=auth, headers=headers(self.agentConfig), verify=verify, timeout=self.default_integration_http_timeout)
-        r.raise_for_status()
+        response = requests.get(url, auth=auth, headers=headers(self.agentConfig), verify=verify, timeout=self.default_integration_http_timeout)
+        response.raise_for_status()
 
-        return r.content.splitlines()
+        return response.content.splitlines()
+
+    def _fetch_socket_data(self, socket_path):
+        ''' Hit a given stats socket and return the stats lines '''
+
+        self.log.debug("Fetching haproxy stats from socket: %s" % socket_path)
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(socket_path)
+        sock.send("show stat\r\n")
+
+        response = ""
+        output = sock.recv(8192)
+        while output:
+            response += output.decode("ASCII")
+            output = sock.recv(8192)
+
+        sock.close()
+
+        return response.splitlines()
 
     def _process_data(self, data, collect_aggregates_only, process_events, url=None,
                       collect_status_metrics=False, collect_status_metrics_by_host=False,
@@ -430,8 +458,11 @@ class HAProxy(AgentCheck):
         hostname = data['svname']
         service_name = data['pxname']
         back_or_front = data['back_or_front']
-        tags = ["type:%s" % back_or_front, "instance_url:%s" % url]
-        tags.append("service:%s" % service_name)
+        tags = [
+            "type:%s" % back_or_front,
+            "instance_url:%s" % url,
+            "service:%s" % service_name,
+        ]
         tags.extend(custom_tags)
 
         if self._is_service_excl_filtered(service_name, services_incl_filter,

--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -10,6 +10,8 @@ import time
 
 # 3rd party
 import requests
+import requests_unixsocket
+requests_unixsocket.monkeypatch()
 
 # project
 from checks import AgentCheck

--- a/checks.d/haproxy.py
+++ b/checks.d/haproxy.py
@@ -20,6 +20,7 @@ from util import headers
 
 STATS_URL = "/;csv;norefresh"
 EVENT_TYPE = SOURCE_TYPE_NAME = 'haproxy'
+BUFSIZE = 8192
 
 
 class Services(object):
@@ -179,10 +180,10 @@ class HAProxy(AgentCheck):
         sock.send("show stat\r\n")
 
         response = ""
-        output = sock.recv(8192)
+        output = sock.recv(BUFSIZE)
         while output:
             response += output.decode("ASCII")
-            output = sock.recv(8192)
+            output = sock.recv(BUFSIZE)
 
         sock.close()
 

--- a/ci/haproxy.rb
+++ b/ci/haproxy.rb
@@ -44,8 +44,13 @@ namespace :ci do
 
     task before_script: ['ci:common:before_script'] do
       %w(haproxy haproxy-open).each do |name|
+        # Older haproxy doesn't support ENV interpolation
+        config = File.read("#{ENV['TRAVIS_BUILD_DIR']}/ci/resources/haproxy/#{name}.cfg")
+        config.gsub!("$VOLATILE_DIR", ENV["VOLATILE_DIR"])
+        File.write("#{ENV["VOLATILE_DIR"]}/#{name}.cfg", config)
+
         pid = spawn("#{haproxy_rootdir}/haproxy", '-d', '-f',
-                    "#{ENV['TRAVIS_BUILD_DIR']}/ci/resources/haproxy/#{name}.cfg",
+                    "#{ENV["VOLATILE_DIR"]}/#{name}.cfg",
                     out: '/dev/null')
         Process.detach(pid)
         sh %(echo #{pid} > $VOLATILE_DIR/#{name}.pid)

--- a/ci/haproxy.rb
+++ b/ci/haproxy.rb
@@ -46,11 +46,11 @@ namespace :ci do
       %w(haproxy haproxy-open).each do |name|
         # Older haproxy doesn't support ENV interpolation
         config = File.read("#{ENV['TRAVIS_BUILD_DIR']}/ci/resources/haproxy/#{name}.cfg")
-        config.gsub!("$VOLATILE_DIR", ENV["VOLATILE_DIR"])
-        File.write("#{ENV["VOLATILE_DIR"]}/#{name}.cfg", config)
+        config.gsub!('$VOLATILE_DIR', ENV['VOLATILE_DIR'])
+        File.write("#{ENV['VOLATILE_DIR']}/#{name}.cfg", config)
 
         pid = spawn("#{haproxy_rootdir}/haproxy", '-d', '-f',
-                    "#{ENV["VOLATILE_DIR"]}/#{name}.cfg",
+                    "#{ENV['VOLATILE_DIR']}/#{name}.cfg",
                     out: '/dev/null')
         Process.detach(pid)
         sh %(echo #{pid} > $VOLATILE_DIR/#{name}.pid)

--- a/ci/resources/haproxy/haproxy.cfg
+++ b/ci/resources/haproxy/haproxy.cfg
@@ -2,6 +2,7 @@
 global
     log 127.0.0.1 local0
     maxconn 4096
+    stats socket $VOLATILE_DIR/datadog-haproxy-stats.sock
 
 defaults
     log     global

--- a/conf.d/haproxy.yaml.example
+++ b/conf.d/haproxy.yaml.example
@@ -4,10 +4,8 @@ instances:
   - url: http://localhost/admin?stats
     # username: username
     # password: password
-    #
-    # or, with a unix stats or admin socket:
-    #
-    # url: unix:///var/run/haproxy.sock
+  # or, with a unix stats or admin socket:
+  # - url: unix:///var/run/haproxy.sock
     #
     # The (optional) `status_check` paramater will instruct the check to
     # send events on status changes in the backend. This is DEPRECATED in

--- a/conf.d/haproxy.yaml.example
+++ b/conf.d/haproxy.yaml.example
@@ -2,9 +2,12 @@ init_config:
 
 instances:
   - url: http://localhost/admin?stats
-    # url: http+unix://%2fvar%2frun%2fhaproxy.sock/admin?stats
     # username: username
     # password: password
+    #
+    # or, with a unix stats or admin socket:
+    #
+    # url: unix:///var/run/haproxy.sock
     #
     # The (optional) `status_check` paramater will instruct the check to
     # send events on status changes in the backend. This is DEPRECATED in

--- a/conf.d/haproxy.yaml.example
+++ b/conf.d/haproxy.yaml.example
@@ -2,6 +2,7 @@ init_config:
 
 instances:
   - url: http://localhost/admin?stats
+    # url: http+unix://%2fvar%2frun%2fhaproxy.sock/admin?stats
     # username: username
     # password: password
     #

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ pyyaml==3.11
 # note: requests is also used in many checks
 # upgrade with caution
 requests==2.6.2
+requests-unixsocket==0.1.5
 # note: simplejson is used in many checks to inteface APIs
 simplejson==3.6.5
 supervisor==3.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ pyyaml==3.11
 # note: requests is also used in many checks
 # upgrade with caution
 requests==2.6.2
-requests-unixsocket==0.1.5
 # note: simplejson is used in many checks to inteface APIs
 simplejson==3.6.5
 supervisor==3.3.0

--- a/tests/checks/integration/test_haproxy.py
+++ b/tests/checks/integration/test_haproxy.py
@@ -1,6 +1,5 @@
 # stdlib
 import os
-import urllib
 
 # 3p
 from nose.plugins.attrib import attr

--- a/tests/checks/integration/test_haproxy.py
+++ b/tests/checks/integration/test_haproxy.py
@@ -101,7 +101,7 @@ class HaproxyTest(AgentCheckTest):
         self.unixsocket_url = 'http+unix://{0}/stats'.format(urllib.quote(self.unixsocket_path, ''))
         self.config_unixsocket = {
             'instances': [{
-                'url': 'http+unix://{0}/stats'.format(os.environ['VOLATILE_DIR']),
+                'url': self.unixsocket_url,
                 'collect_aggregates_only': False,
             }]
         }

--- a/tests/checks/integration/test_haproxy.py
+++ b/tests/checks/integration/test_haproxy.py
@@ -98,7 +98,7 @@ class HaproxyTest(AgentCheckTest):
             }]
         }
         self.unixsocket_path = os.path.join(os.environ['VOLATILE_DIR'], 'datadog-haproxy-stats.sock')
-        self.unixsocket_url = 'http+unix://{0}/stats'.format(urllib.quote(self.unixsocket_path, ''))
+        self.unixsocket_url = 'unix://{0}'.format(self.unixsocket_path)
         self.config_unixsocket = {
             'instances': [{
                 'url': self.unixsocket_url,


### PR DESCRIPTION
### What does this PR do?

Support unix sockets for haproxy stats collection.

### Motivation

Running a separate stats socket with tight permissions instead of over a tcp port provides greater security.

### Testing Guidelines

Sorry, I have no idea how to get the tests actually working in a local environment. It has been a world of pain. I'm hoping travis does a better job at running them and providing some useful feedback.

I'm on macOS 10.12, using homebrew, ruby 2.3.1, python 2.7.12. `rake` aborts on rubocop errors. So does `rake ci:run`. `rake ci:run[haproxy]` tries to compile haproxy which can't find openssl, even if I supply correct CFLAGS and LDFLAGS to my homebrew'd openssl install as env. Subsequent `rake ci:run[haproxy]` runs don't try to recompile haproxy, they fail with `Errno::ENOENT No such file or directory - /Users/sj26/Projects/dd-agent/embedded/haproxy_1.5.11/haproxy`. And cleanup fails because it can't find an haproxy pid.

I haven't attempted to figure out mocks yet.

### Additional Notes

I realise this introduces a new dependency which requires updating your omnibus, but I'd like to get the code working first before jumping on that dragon.