### PR TITLE
[service discovery] fix single check reload

### DIFF
--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -130,7 +130,11 @@ class AbstractConfigStore(object):
         return None
 
     def get_checks_to_refresh(self, identifier, **kwargs):
-        to_check = set(self.identifier_to_checks[identifier])
+        if identifier in self.identifier_to_checks:
+            to_check = set(self.identifier_to_checks[identifier])
+        else:
+            # auto_conf templates use the canonical image name
+            to_check = set(self.identifier_to_checks[self._get_image_ident(identifier)])
         kube_annotations = kwargs.get('kube_annotations')
         if kube_annotations:
             kube_config = self._get_kube_config(identifier, kube_annotations)

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -53,7 +53,10 @@ class SDDockerBackend(AbstractSDBackend):
             try:
                 inspect = self.docker_client.inspect_container(id_)
             except (NullResource, NotFound):
-                inspect = {}
+                # if the container was removed we can't tell which check is concerned
+                # so we have to reload everything
+                self.reload_check_configs = True
+                return
 
             checks = self._get_checks_from_inspect(inspect)
             conf_reload_set.update(set(checks))


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Fix 2 issues:
- auto_conf templates use the canonical image name (without the repository nor the tag) so individual config reload was failing for them
- containers that were running and are deleted quickly couldn't be inspected so their check wasn't disabled after they were removed
