### PR TITLE
[etcd] Report errors connecting to etcd endpoint

### DIFF
--- a/checks.d/etcd.py
+++ b/checks.d/etcd.py
@@ -3,6 +3,8 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+import sys
+
 # 3rd party
 import requests
 
@@ -171,6 +173,11 @@ class Etcd(AgentCheck):
             # If there's a timeout
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
                                message="Timeout when hitting %s" % url,
+                               tags=["url:{0}".format(url)])
+            raise
+        except:
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
+                               message="Error hitting %s. Error: %s" % (url, sys.exc_info()[1]),
                                tags=["url:{0}".format(url)])
             raise
 

--- a/checks.d/etcd.py
+++ b/checks.d/etcd.py
@@ -3,8 +3,6 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-import sys
-
 # 3rd party
 import requests
 

--- a/checks.d/etcd.py
+++ b/checks.d/etcd.py
@@ -175,9 +175,9 @@ class Etcd(AgentCheck):
                                message="Timeout when hitting %s" % url,
                                tags=["url:{0}".format(url)])
             raise
-        except:
+        except Exception as e:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
-                               message="Error hitting %s. Error: %s" % (url, sys.exc_info()[1]),
+                               message="Error hitting %s. Error: %s" % (url, e.message),
                                tags=["url:{0}".format(url)])
             raise
 

--- a/tests/checks/integration/test_etcd.py
+++ b/tests/checks/integration/test_etcd.py
@@ -114,3 +114,13 @@ class CheckEtcdTest(AgentCheckTest):
                                         tags=['url:http://localhost:4001/test/v2/stats/self'])
 
         self.coverage_report()
+
+    def test_closed_port(self):
+        self.assertRaises(Exception,
+                          lambda: self.run_check({"instances": [{"url": "http://localhost:9999"}]}))
+
+        self.assertServiceCheckCritical(self.check.SERVICE_CHECK_NAME,
+                                        count=1,
+                                        tags=['url:http://localhost:9999/v2/stats/self'])
+
+        self.coverage_report()

--- a/tests/checks/integration/test_etcd.py
+++ b/tests/checks/integration/test_etcd.py
@@ -48,7 +48,6 @@ class CheckEtcdTest(AgentCheckTest):
                                   tags=['url:http://localhost:4001'])
         self.coverage_report()
 
-
     # FIXME: not really an integration test, should be pretty easy
     # to spin up a cluster to test that.
     def test_followers(self):
@@ -116,6 +115,7 @@ class CheckEtcdTest(AgentCheckTest):
         self.coverage_report()
 
     def test_closed_port(self):
+        # We expect port 9999 to be closed - there should not be a process listening there.
         self.assertRaises(Exception,
                           lambda: self.run_check({"instances": [{"url": "http://localhost:9999"}]}))
 


### PR DESCRIPTION
This PR makes the `etcd` check send a `CRITICAL` status if it encouters _any_ errors
when talking to etcd.

### Motivation

When creating some forced failure scenarios in our infrastructure, but stopping `etcd` processes,
I noticed that the agent was not reporting the 'Connection refused' error to Datadog.
