### PR TITLE
[service_discovery][jmx] trying to pick-up JMX changes with SD.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ embedded/*
 dump.rdb
 tests/core/fixtures/flare/dd*
 .python-version
+.ropeproject
+.bundle
+tags

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,6 @@ Style/Documentation:
 # Configuration parameters: Methods.
 Style/SingleLineBlockParams:
   Enabled: false
+
+BlockLength:
+  Max: 110

--- a/config.py
+++ b/config.py
@@ -42,6 +42,9 @@ MAC_CONFIG_PATH = '/opt/datadog-agent/etc'
 DEFAULT_CHECK_FREQUENCY = 15   # seconds
 LOGGING_MAX_BYTES = 10 * 1024 * 1024
 SDK_INTEGRATIONS_DIR = 'integrations'
+SD_PIPE_NAME = "dd-service_discovery"
+SD_PIPE_UNIX_PATH = '/opt/datadog-agent/run'
+SD_PIPE_WIN_PATH = "\\\\.\\pipe\\{pipename}"
 
 log = logging.getLogger(__name__)
 
@@ -743,6 +746,16 @@ def get_sdk_integrations_path(osname=None):
     if os.path.exists(path):
         return path
     raise PathNotFound(path)
+
+def get_jmx_pipe_path():
+    if Platform.is_windows():
+        pipe_path = SD_PIPE_WIN_PATH
+    else:
+        pipe_path = SD_PIPE_UNIX_PATH
+        if not os.path.isdir(pipe_path):
+            pipe_path = '/tmp'
+
+    return pipe_path
 
 
 def get_auto_confd_path(osname=None):

--- a/config.py
+++ b/config.py
@@ -1,3 +1,4 @@
+# (C) Datadog, Inc. 2010-2016
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
@@ -1121,8 +1122,8 @@ def generate_jmx_configs(agentConfig, hostname, checknames=None):
                 # generated["{}_{}".format(check_name, idx)] = yaml
                 generated["{}_{}".format(check_name, 0)] = yaml
                 log.debug("YAML generated: %s", yaml)
-            except Exception as e:
-                log.exception("Unable to generate YAML config for %s: %s", check_name, e)
+            except Exception:
+                log.exception("Unable to generate YAML config for %s", check_name)
 
     return generated
 

--- a/config.py
+++ b/config.py
@@ -887,6 +887,7 @@ def _service_disco_configs(agentConfig):
             service_disco_configs = sd_backend.get_configs()
         except Exception:
             log.exception("Loading service discovery configurations failed.")
+            return {}
     else:
         service_disco_configs = {}
 

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -123,6 +123,9 @@ gce_updated_hostname: yes
 # and modify its value.
 # sd_template_dir: /datadog/check_configs
 #
+# JMX Service Disocvery
+# sd_jmx_enable: no
+#
 # ========================================================================== #
 # Other                                                                      #
 # ========================================================================== #

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -123,7 +123,7 @@ gce_updated_hostname: yes
 # and modify its value.
 # sd_template_dir: /datadog/check_configs
 #
-# JMX Service Disocvery
+# Enable JMX checks for service disocvery
 # sd_jmx_enable: no
 #
 # ========================================================================== #

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -25,6 +25,7 @@ from config import (
     DEFAULT_CHECK_FREQUENCY,
     get_confd_path,
     get_config,
+    get_jmx_pipe_path,
     get_logging_config,
     PathNotFound,
     _is_affirmative
@@ -277,6 +278,9 @@ class JMXFetch(object):
                 subprocess_args.insert(len(subprocess_args) - 1, path_to_exit_file)
 
             if self.service_discovery:
+                pipe_path = get_jmx_pipe_path()
+                subprocess_args.insert(4, '--tmp_directory')
+                subprocess_args.insert(5, pipe_path)
                 subprocess_args.insert(4, '--sd_standby')
 
             if jmx_checks:

--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -7,7 +7,7 @@ import unittest
 from nose.plugins.attrib import attr
 
 # project
-from config import generate_jmx_configs  # noqa
+from config import generate_jmx_configs
 from utils.service_discovery.config_stores import get_config_store
 from utils.service_discovery.consul_config_store import ConsulStore
 from utils.service_discovery.etcd_config_store import EtcdStore

--- a/util.py
+++ b/util.py
@@ -124,6 +124,37 @@ def check_yaml(conf_path):
         else:
             return check_config
 
+def config_to_yaml(config):
+    '''
+    Convert a config dict to YAML
+    '''
+    assert 'init_config' in config, "No 'init_config' section found"
+    assert 'instances' in config, "No 'instances' section found"
+
+    valid_instances = True
+    if config['instances'] is None or not isinstance(config['instances'], list):
+        valid_instances = False
+    else:
+        yaml_output = yaml.safe_dump(config, default_flow_style=False)
+
+    if not valid_instances:
+        raise Exception('You need to have at least one instance defined in your config.')
+
+    return yaml_output
+
+def dump_yaml(path, config):
+    '''
+    Dump config dict to YAML file in path
+    '''
+    try:
+        yaml = config_to_yaml(config)
+    except Exception as e:
+        log.exception("Unable to convert config to YAML: %s", e)
+    else:
+        with open(path, 'w+') as f:
+            f.write(yaml)
+
+
 class Watchdog(object):
     """
     Simple signal-based watchdog. Restarts the process when:

--- a/util.py
+++ b/util.py
@@ -142,18 +142,6 @@ def config_to_yaml(config):
 
     return yaml_output
 
-def dump_yaml(path, config):
-    '''
-    Dump config dict to YAML file in path
-    '''
-    try:
-        yaml = config_to_yaml(config)
-    except Exception as e:
-        log.exception("Unable to convert config to YAML: %s", e)
-    else:
-        with open(path, 'w+') as f:
-            f.write(yaml)
-
 
 class Watchdog(object):
     """

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -114,12 +114,14 @@ class AbstractConfigStore(object):
             return None
 
     def _get_auto_config(self, image_name):
+        from jmxfetch import JMX_CHECKS
+
         ident = self._get_image_ident(image_name)
         if ident in self.auto_conf_images:
             check_name = self.auto_conf_images[ident]
 
             # get the check class to verify it matches
-            check = get_check_class(self.agentConfig, check_name)
+            check = get_check_class(self.agentConfig, check_name) if check_name not in JMX_CHECKS else True
             if check is None:
                 log.info("Could not find an auto configuration template for %s."
                          " Leaving it unconfigured." % image_name)

--- a/utils/service_discovery/config.py
+++ b/utils/service_discovery/config.py
@@ -11,7 +11,6 @@ from utils.service_discovery.config_stores import extract_sd_config, SD_CONFIG_B
 
 log = logging.getLogger(__name__)
 
-
 def extract_agent_config(config):
     # get merged into the real agentConfig
     agentConfig = {}

--- a/utils/service_discovery/config_stores.py
+++ b/utils/service_discovery/config_stores.py
@@ -41,6 +41,9 @@ def extract_sd_config(config):
     if config.has_option('Main', 'sd_backend_port'):
         sd_config['sd_backend_port'] = config.get(
             'Main', 'sd_backend_port')
+    if config.has_option('Main', 'sd_jmx_enable'):
+        sd_config['sd_jmx_enable'] = config.get(
+            'Main', 'sd_jmx_enable')
     return sd_config
 
 


### PR DESCRIPTION
### What does this PR do?
Enables service discovery for JMX integrations. 

Once a service discovery index config is detected, we parse the config from JSON (as stored in etcd/consul) to YAML and the relayed over to JMXfetch over a named pipe `dd-service_discovery` that lives in `/tmp` by default.

If multiple changes are detected, these are all submitted to JMXfetch by a single write operation to avoid race conditions. The pipe should take care of locking from the reading and writing ends, and by dropping all relevant configs in a single write operation we can guarantee all configs will be read on the JMXfetch in a single iteration and thus help avoid having multiple versions of the same config in the pipe at any given time.

### Motivation

Enabling Service Discovery for JMXfetch integrations.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Related PR: https://github.com/DataDog/jmxfetch/pull/113
