### PR TITLE
[psutil] Only set `psutil.PROCFS_PATH` once in the collector

### DIFF
--- a/checks.d/btrfs.py
+++ b/checks.d/btrfs.py
@@ -15,7 +15,6 @@ import psutil
 
 # project
 from checks import AgentCheck
-from utils.platform import Platform
 
 MIXED = "mixed"
 DATA = "data"
@@ -120,10 +119,6 @@ class BTRFS(AgentCheck):
     def check(self, instance):
         btrfs_devices = {}
         excluded_devices = instance.get('excluded_devices', [])
-
-        if Platform.is_linux():
-            procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
-            psutil.PROCFS_PATH = procfs_path
 
         for p in psutil.disk_partitions():
             if (p.fstype == 'btrfs' and p.device not in btrfs_devices

--- a/checks.d/disk.py
+++ b/checks.d/disk.py
@@ -43,9 +43,6 @@ class Disk(AgentCheck):
         # Windows and Mac will always have psutil
         # (we have packaged for both of them)
         if self._psutil():
-            if Platform.is_linux():
-                procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
-                psutil.PROCFS_PATH = procfs_path
             self.collect_metrics_psutil()
         else:
             # FIXME: implement all_partitions (df -a)

--- a/checks.d/gunicorn.py
+++ b/checks.d/gunicorn.py
@@ -15,7 +15,6 @@ import psutil
 
 # project
 from checks import AgentCheck
-from util import Platform
 
 
 class GUnicornCheck(AgentCheck):
@@ -37,10 +36,6 @@ class GUnicornCheck(AgentCheck):
     def check(self, instance):
         """ Collect metrics for the given gunicorn instance. """
         self.log.debug("Running instance: %s", instance)
-
-        if Platform.is_linux():
-            procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
-            psutil.PROCFS_PATH = procfs_path
 
         # Validate the config.
         if not instance or self.PROC_NAME not in instance:

--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -20,7 +20,6 @@ except ImportError:
 # project
 from config import _is_affirmative
 from checks import AgentCheck
-from util import Platform
 
 GAUGE = "gauge"
 RATE = "rate"
@@ -289,11 +288,6 @@ class MySql(AgentCheck):
         return {"pymysql": pymysql.__version__}
 
     def check(self, instance):
-
-        if Platform.is_linux() and PSUTIL_AVAILABLE:
-            procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
-            psutil.PROCFS_PATH = procfs_path
-
         host, port, user, password, mysql_sock, defaults_file, tags, options, queries, ssl, connect_timeout = \
             self._get_config(instance)
 

--- a/checks.d/process.py
+++ b/checks.d/process.py
@@ -76,12 +76,16 @@ class ProcessCheck(AgentCheck):
             )
         )
 
+        self._conflicting_procfs = False
+        self._deprecated_init_procfs = False
         if Platform.is_linux():
             procfs_path = init_config.get('procfs_path')
-            if not procfs_path:
-                procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
-
-            psutil.PROCFS_PATH = procfs_path
+            if procfs_path:
+                if 'procfs_path' in agentConfig and procfs_path != agentConfig.get('procfs_path').rstrip('/'):
+                    self._conflicting_procfs = True
+                else:
+                    self._deprecated_init_procfs = True
+                    psutil.PROCFS_PATH = procfs_path
 
         # Process cache, indexed by instance
         self.process_cache = defaultdict(dict)
@@ -304,6 +308,13 @@ class ProcessCheck(AgentCheck):
         ignore_ad = _is_affirmative(instance.get('ignore_denied_access', True))
         pid = instance.get('pid')
         pid_file = instance.get('pid_file', None)
+
+        if self._conflicting_procfs:
+            self.warning('The `procfs_path` defined in `process.yaml` is different from the one defined in '
+                         '`datadog.conf`. This is currently not supported by the Agent')
+        elif self._deprecated_init_procfs:
+            self.warning('DEPRECATION NOTICE: Specifying `procfs_path` in `process.yaml` is deprecated. '
+                         'Please specify it in `datadog.conf` instead')
 
         if not isinstance(search_string, list) and pid is None and pid_file is None:
             raise ValueError('"search_string" or "pid" or "pid_file" parameter is required')

--- a/checks.d/process.py
+++ b/checks.d/process.py
@@ -311,7 +311,8 @@ class ProcessCheck(AgentCheck):
 
         if self._conflicting_procfs:
             self.warning('The `procfs_path` defined in `process.yaml` is different from the one defined in '
-                         '`datadog.conf`. This is currently not supported by the Agent')
+                         '`datadog.conf`. This is currently not supported by the Agent. Defaulting to the '
+                         'value defined in `datadog.conf`: {}'.format(psutil.PROCFS_PATH))
         elif self._deprecated_init_procfs:
             self.warning('DEPRECATION NOTICE: Specifying `procfs_path` in `process.yaml` is deprecated. '
                          'Please specify it in `datadog.conf` instead')

--- a/checks.d/system_core.py
+++ b/checks.d/system_core.py
@@ -7,17 +7,11 @@ import psutil
 
 # project
 from checks import AgentCheck
-from utils.platform import Platform
 
 
 class SystemCore(AgentCheck):
 
     def check(self, instance):
-
-        if Platform.is_linux():
-            procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
-            psutil.PROCFS_PATH = procfs_path
-
         cpu_times = psutil.cpu_times(percpu=True)
         self.gauge("system.core.count", len(cpu_times))
 

--- a/checks.d/system_swap.py
+++ b/checks.d/system_swap.py
@@ -7,17 +7,11 @@ import psutil
 
 # project
 from checks import AgentCheck
-from utils.platform import Platform
 
 
 class SystemSwap(AgentCheck):
 
     def check(self, instance):
-
-        if Platform.is_linux():
-            procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
-            psutil.PROCFS_PATH = procfs_path
-
         swap_mem = psutil.swap_memory()
         self.rate('system.swap.swapped_in', swap_mem.sin)
         self.rate('system.swap.swapped_out', swap_mem.sout)

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -343,10 +343,6 @@ class AgentCheck(object):
             histogram_percentiles=agentConfig.get('histogram_percentiles')
         )
 
-        if Platform.is_linux() and psutil is not None:
-            procfs_path = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
-            psutil.PROCFS_PATH = procfs_path
-
         self.events = []
         self.service_checks = []
         self.instances = instances or []

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -12,6 +12,11 @@ import sys
 import time
 
 # 3p
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
 import simplejson as json
 
 # project
@@ -189,6 +194,10 @@ class Collector(object):
         self.hostname_metadata_cache = None
         self.initialized_checks_d = []
         self.init_failed_checks_d = {}
+
+        if Platform.is_linux() and psutil is not None:
+            procfs_path = agentConfig.get('procfs_path', '/proc').rstrip('/')
+            psutil.PROCFS_PATH = procfs_path
 
         # Unix System Checks
         self._unix_system_checks = {

--- a/conf.d/process.yaml.example
+++ b/conf.d/process.yaml.example
@@ -5,6 +5,7 @@ init_config:
   # pid_cache_duration: 120
   #
   # used to override the default procfs path, e.g. for docker containers with the outside fs mounted at /host/proc
+  # DEPRECATED: please specify `procfs_path` globally in `datadog.conf` instead
   # procfs_path: /proc
 
 instances:


### PR DESCRIPTION
### What does this PR do?

Fixes the `procfs_path` customization in the `process` check.  Previously the `procfs_path` specified in `process.yaml` wouldn't be taken into account because `psutil.PROCFS_PATH` would get overwritten in the `__init__` method of other checks (in particular the `disk` check since it runs by default)

Also, since `PROCFS_PATH` is a global setting of the `psutil` lib it makes sense to set it once for the whole collector and only allow its customization from `datadog.conf`, so let's deprecate the setting in `process.yaml`.

### Additional Notes

🐮 