### PR TITLE
[mongo] Use db.current_op instead of manually querying

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -430,12 +430,6 @@ class MongoDb(AgentCheck):
         else:
             return 'UNKNOWN'
 
-    def get_version(self, client):
-        """
-        Return MongoDB version.
-        """
-        return tuple(map(int, client.server_info()['version'].split('.')))
-
     def _report_replica_set_state(self, state, clean_server_name, replset_name, agentConfig):
         """
         Report the member's replica set state
@@ -737,11 +731,7 @@ class MongoDb(AgentCheck):
         if status['ok'] == 0:
             raise Exception(status['errmsg'].__str__())
 
-        if self.get_version(cli) >= (3, 2, 0):
-            ops = admindb.command('currentOp', True)
-        else:
-            ops = db['$cmd.sys.inprog'].find_one()
-
+        ops = db.current_op()
         status['fsyncLocked'] = 1 if ops.get('fsyncLock') else 0
 
         status['stats'] = db.command('dbstats')


### PR DESCRIPTION
### What does this PR do?

MongoDB 3.2 introduced a new find command, which standard query
operations in pymongo will use if it's available. That command doesn't
support the legacy `$cmd.sys.inprog` pseudo-collection, which is
replaced by a `currentOp` command.

Fortunately there's a built-in API to handle this. Use it.

### Motivation

Based on https://github.com/DataDog/dd-agent/commit/f6b074248f463552a0f640b95f6ba5246ea7d61d#commitcomment-19773690, this is currently broken under newer versions of MongoDB.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
