### PR TITLE
[ci] Fix Travis jobs timing out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ env:
     - NOSE_FILTER="not windows"
     - INTEGRATIONS_DIR=$HOME/embedded
     - PIP_CACHE=$HOME/.cache/pip
-    - SKIP_CLEANUP=true
     - VOLATILE_DIR=/tmp
     - DD_CASHER_DIR=/tmp/casher
   matrix:

--- a/ci/apache.rb
+++ b/ci/apache.rb
@@ -73,10 +73,13 @@ namespace :ci do
 
     task before_cache: ['ci:common:before_cache'] do
       # Useless to cache the conf, as it is regenerated every time
-      sh %(rm -f #{apache_rootdir}/conf/httpd.conf)
+      sh %(mkdir -p $VOLATILE_DIR/apache)
+      sh %(mv #{apache_rootdir}/conf/httpd.conf $VOLATILE_DIR/apache/httpd.conf)
     end
 
     task cleanup: ['ci:common:cleanup'] do
+      # We need to move the conf back to apache's dir before stopping
+      sh %(mv $VOLATILE_DIR/apache/httpd.conf #{apache_rootdir}/conf/httpd.conf)
       sh %(#{apache_rootdir}/bin/apachectl stop)
     end
 

--- a/ci/fluentd.rb
+++ b/ci/fluentd.rb
@@ -14,9 +14,8 @@ namespace :ci do
     end
 
     task before_script: ['ci:common:before_script'] do
-      pid = spawn %(fluentd -c $TRAVIS_BUILD_DIR/ci/resources/fluentd/td-agent.conf)
-      Process.detach(pid)
-      sh %(echo #{pid} > $VOLATILE_DIR/fluentd.pid)
+      sh %(fluentd -c $TRAVIS_BUILD_DIR/ci/resources/fluentd/td-agent.conf\
+           -d $VOLATILE_DIR/fluentd.pid)
       # Waiting for fluentd to start
       Wait.for 24_220
     end

--- a/ci/postgres.rb
+++ b/ci/postgres.rb
@@ -51,8 +51,7 @@ namespace :ci do
       # Wait a tiny bit more, for PG to accept connections
       sleep_for 2
       sh %(#{pg_rootdir}/bin/psql\
-           -p 15432 -U $USER\
-           postgres < $TRAVIS_BUILD_DIR/ci/resources/postgres/postgres.sql)
+           -p 15432 postgres < $TRAVIS_BUILD_DIR/ci/resources/postgres/postgres.sql)
       sh %(#{pg_rootdir}/bin/psql\
            -p 15432 -U datadog\
            datadog_test < $TRAVIS_BUILD_DIR/ci/resources/postgres/datadog_test.sql)

--- a/ci/rabbitmq.rb
+++ b/ci/rabbitmq.rb
@@ -32,7 +32,7 @@ namespace :ci do
 
     task before_script: ['ci:common:before_script'] do
       sh %(#{rabbitmq_rootdir}/sbin/rabbitmq-server -detached)
-      Wait.for 5672, 10
+      Wait.for 5672, 15
       sh %(#{rabbitmq_rootdir}/sbin/rabbitmq-plugins enable rabbitmq_management)
       sh %(#{rabbitmq_rootdir}/sbin/rabbitmq-plugins enable rabbitmq_management)
       %w(test1 test5 tralala).each do |q|


### PR DESCRIPTION
Fixes:
- Travis jobs that were timing out by re-enabling the cleanup phase (for some reason some jobs on Travis wouldn't exit unless the processes that are spawned are all killed)
- Postgres setup phase (`psql`'s default user works fine for the first connection, and for some reason the `USER` env var wasn't set correctly on the Travis env)