### PR TITLE
[ci] fix bad citizens detection

### DIFF
--- a/ci/common.rb
+++ b/ci/common.rb
@@ -42,6 +42,7 @@ def travis_pr?
   !ENV['TRAVIS'].nil? && ENV['TRAVIS_EVENT_TYPE'] == 'pull_request'
 end
 
+# Dict converting check.d name to Travis flavor names
 BAD_CITIZENS = {
   'couch' => 'couchdb',
   'disk' => 'system',
@@ -61,7 +62,8 @@ BAD_CITIZENS = {
 
 def translate_to_travis(checks)
   checks.map do |check_name|
-    BAD_CITIZENS.key? check_name ? BAD_CITIZENS[check_name] : check_name
+    check_name = BAD_CITIZENS[check_name] if BAD_CITIZENS.key? check_name
+    check_name
   end
 end
 

--- a/ci/common.rb
+++ b/ci/common.rb
@@ -52,7 +52,6 @@ BAD_CITIZENS = {
   'sysstat' => 'system',
   'elastic' => 'elasticsearch',
   'gearmand' => 'gearman',
-  'mongo' => 'mongodb',
   'mcache' => 'memcache',
   'php_fpm' => 'phpfpm',
   'redisdb' => 'redis',


### PR DESCRIPTION
[ci] fix bad citizens detection

Ternary operation has a high priority in Ruby.
Also add a short comment about the meaning of the bad citizens.