### PR TITLE
[ci][rabbitmq] Increase wait timeout

### DIFF
--- a/ci/rabbitmq.rb
+++ b/ci/rabbitmq.rb
@@ -32,7 +32,7 @@ namespace :ci do
 
     task before_script: ['ci:common:before_script'] do
       sh %(#{rabbitmq_rootdir}/sbin/rabbitmq-server -detached)
-      Wait.for 5672, 15
+      Wait.for 5672, 60
       sh %(#{rabbitmq_rootdir}/sbin/rabbitmq-plugins enable rabbitmq_management)
       sh %(#{rabbitmq_rootdir}/sbin/rabbitmq-plugins enable rabbitmq_management)
       %w(test1 test5 tralala).each do |q|


### PR DESCRIPTION
Rabbitmq can take a long time to start up on the Travis environment
(can take from 1sec to more than 30sec from what I've found), and
unfortunately I went through rabbitmq's logs and haven't found any
obvious explanation for that.

Let's just increase the timeout instead of having the test fail every
other build.