### PR TITLE
Updating Kubernetes check to handle multiple namespaces fix #2838

### DIFF
--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -33,6 +33,7 @@ DEFAULT_ENABLED_RATES = [
     'network.??_bytes',
     'cpu.*.total']
 DEFAULT_COLLECT_EVENTS = False
+DEFAULT_NAMESPACES = ['default']
 
 NET_ERRORS = ['rx_errors', 'tx_errors', 'rx_dropped', 'tx_dropped']
 
@@ -89,6 +90,15 @@ class Kubernetes(AgentCheck):
         self.kubeutil = KubeUtil(instance=inst)
         if not self.kubeutil.host:
             raise Exception('Unable to retrieve Docker hostname and host parameter is not set')
+
+        self.k8s_namespace_regexp = None
+        if inst:
+            regexp = inst.get('namespace_name_regexp', None)
+            if regexp:
+                try:
+                    self.k8s_namespace_regexp = re.compile(regexp)
+                except re.error as e:
+                    self.log.warning('Invalid regexp for "namespace_name_regexp" in configuration (ignoring regexp): %s' % str(e))
 
     def _perform_kubelet_checks(self, url):
         service_check_base = NAMESPACE + '.kubelet.check'
@@ -423,16 +433,38 @@ class Kubernetes(AgentCheck):
         node_ip, node_name = self.kubeutil.get_node_info()
         self.log.debug('Processing events on {} [{}]'.format(node_name, node_ip))
 
-        k8s_namespace = instance.get('namespace', 'default')
-        events_endpoint = '{}/namespaces/{}/events'.format(self.kubeutil.kubernetes_api_url, k8s_namespace)
+        k8s_namespaces = instance.get('namespaces', DEFAULT_NAMESPACES)
+        if not isinstance(k8s_namespaces, list):
+            self.log.warning('Configuration key "namespaces" is not a list: fallback to the default value')
+            k8s_namespaces = DEFAULT_NAMESPACES
+
+        # handle old config value
+        if 'namespace' in instance and instance.get('namespace') not in (None, 'default'):
+            self.log.warning('''The 'namespace' parameter is deprecated and will stop being supported starting '''
+                             '''from 5.12. Please use 'namespaces' and/or 'namespace_name_regexp' instead.''')
+            k8s_namespaces.append(instance.get('namespace'))
+
+        if self.k8s_namespace_regexp:
+            namespaces_endpoint = '{}/namespaces'.format(self.kubeutil.kubernetes_api_url)
+            self.log.debug('Kubernetes API endpoint to query namespaces: %s' % namespaces_endpoint)
+
+            namespaces = self.kubeutil.retrieve_json_auth(namespaces_endpoint, self.kubeutil.get_auth_token())
+            for namespace in namespaces.get('items', []):
+                name = namespace.get('metadata', {}).get('name', None)
+                if name and self.k8s_namespace_regexp.match(name):
+                    k8s_namespaces.append(name)
+
+        k8s_namespaces = set(k8s_namespaces)
+
+        events_endpoint = '{}/events'.format(self.kubeutil.kubernetes_api_url)
         self.log.debug('Kubernetes API endpoint to query events: %s' % events_endpoint)
 
         events = self.kubeutil.retrieve_json_auth(events_endpoint, self.kubeutil.get_auth_token())
         event_items = events.get('items') or []
-        last_read = self.kubeutil.last_event_collection_ts[k8s_namespace]
+        last_read = self.kubeutil.last_event_collection_ts
         most_recent_read = 0
 
-        self.log.debug('Found {} events, filtering out using timestamp: {}'.format(len(event_items), last_read))
+        self.log.debug('Found {} events, filtering out using timestamp: {} and namespaces: {}'.format(len(event_items), last_read, k8s_namespaces))
 
         for event in event_items:
             # skip if the event is too old
@@ -441,6 +473,10 @@ class Kubernetes(AgentCheck):
                 continue
 
             involved_obj = event.get('involvedObject', {})
+
+            # filter events by white listed namespaces (empty namespace belong to the 'default' one)
+            if involved_obj.get('namespace', 'default') not in k8s_namespaces:
+                continue
 
             tags = self.kubeutil.extract_event_tags(event)
 
@@ -467,5 +503,5 @@ class Kubernetes(AgentCheck):
             self.event(dd_event)
 
         if most_recent_read > 0:
-            self.kubeutil.last_event_collection_ts[k8s_namespace] = most_recent_read
-            self.log.debug('_last_event_collection_ts is now {}'.format(most_recent_read))
+            self.kubeutil.last_event_collection_ts = most_recent_read
+            self.log.debug('last_event_collection_ts is now {}'.format(most_recent_read))

--- a/conf.d/kubernetes.yaml.example
+++ b/conf.d/kubernetes.yaml.example
@@ -22,10 +22,18 @@ instances:
   # collect_events: false
   #
   #
-  # The namespace for which events should be collected.
-  # If not modified, the default namespace will be used.
+  # The namespaces for which events should be collected.
+  # If not modified, the 'default' namespace will be used.
   #
-  # namespace: default
+  # namespaces:
+  #  - default
+
+  # The regexp used to select namespaces for which events should be collected.
+  # The matched namespaces will be added to the "namespaces" list.
+  # If empty, regexp selection will be ignored.
+  #
+  # namespace_name_regexp:
+
 
   # use_histogram controls whether we send detailed metrics, i.e. one per container.
   # When false, we send detailed metrics corresponding to individual containers, tagging by container id

--- a/tests/checks/fixtures/kubernetes/events.json
+++ b/tests/checks/fixtures/kubernetes/events.json
@@ -527,6 +527,33 @@
       "lastTimestamp": "2016-05-27T16:37:13Z",
       "count": 1,
       "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "dd-agent-a769.148751928c4f601b",
+        "namespace": "test-namespace-1",
+        "selfLink": "/api/v1/namespaces/test-namespace-1/events/dd-agent-a769.148751928c4f601b",
+        "uid": "b3aff766-ab6f-11e6-819b-42010a84006e",
+        "resourceVersion": "2432",
+        "creationTimestamp": "2016-11-15T20:11:32Z"
+      },
+      "involvedObject": {
+        "kind": "DaemonSet",
+        "namespace": "test-namespace-1",
+        "name": "dd-agent-a769",
+        "uid": "8469b0d3-a769-11e6-b048-42010a84006e",
+        "apiVersion": "extensions",
+        "resourceVersion": "2835032"
+      },
+      "reason": "SuccessfulDelete",
+      "message": "Deleted pod: dd-agent-a769-zbdic",
+      "source": {
+        "component": "daemon-set"
+      },
+      "firstTimestamp": "2016-11-15T20:11:32Z",
+      "lastTimestamp": "2016-11-15T20:11:32Z",
+      "count": 1,
+      "type": "Normal"
     }
   ]
 }

--- a/tests/checks/fixtures/kubernetes/namespaces.json
+++ b/tests/checks/fixtures/kubernetes/namespaces.json
@@ -1,0 +1,87 @@
+{
+  "kind": "NamespaceList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/namespaces",
+    "resourceVersion": "2841873"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "default",
+        "selfLink": "/api/v1/namespaces/default",
+        "uid": "7f1a0d0c-65f3-11e6-b5c9-42010a840043",
+        "resourceVersion": "6",
+        "creationTimestamp": "2016-08-19T09:58:36Z"
+      },
+      "spec": {
+        "finalizers": [
+          "kubernetes"
+        ]
+      },
+      "status": {
+        "phase": "Active"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kube-system",
+        "selfLink": "/api/v1/namespaces/kube-system",
+        "uid": "7f239026-65f3-11e6-b5c9-42010a840043",
+        "resourceVersion": "46",
+        "creationTimestamp": "2016-08-19T09:58:36Z",
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"kind\":\"Namespace\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"kube-system\",\"creationTimestamp\":null},\"spec\":{},\"status\":{}}"
+        }
+      },
+      "spec": {
+        "finalizers": [
+          "kubernetes"
+        ]
+      },
+      "status": {
+        "phase": "Active"
+      }
+    },
+    {
+      "metadata": {
+        "name": "test-namespace-1",
+        "selfLink": "/api/v1/namespaces/test-namespace-1",
+        "uid": "473b5f59-a769-11e6-b048-42010a84006e",
+        "resourceVersion": "2152956",
+        "creationTimestamp": "2016-11-10T17:15:28Z",
+        "labels": {
+          "name": "test-namespace-1"
+        }
+      },
+      "spec": {
+        "finalizers": [
+          "kubernetes"
+        ]
+      },
+      "status": {
+        "phase": "Active"
+      }
+    },
+    {
+      "metadata": {
+        "name": "test-namespace-2",
+        "selfLink": "/api/v1/namespaces/test-namespace-2",
+        "uid": "d4973ec1-a769-11e6-b048-42010a84006e",
+        "resourceVersion": "2153046",
+        "creationTimestamp": "2016-11-10T17:19:26Z",
+        "labels": {
+          "name": "test-namespace-2"
+        }
+      },
+      "spec": {
+        "finalizers": [
+          "kubernetes"
+        ]
+      },
+      "status": {
+        "phase": "Active"
+      }
+    }
+  ]
+}

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -74,7 +74,7 @@ class KubeUtil:
 
         # keep track of the latest k8s event we collected and posted
         # default value is 0 but TTL for k8s events is one hour anyways
-        self.last_event_collection_ts = defaultdict(int)
+        self.last_event_collection_ts = 0
 
     def get_kube_labels(self, excluded_keys=None):
         pods = self.retrieve_pods_list()


### PR DESCRIPTION
### What does this PR do?

This PR allows the agent to collect events from multiple Kubernetes namespaces by using a list of names and/or a regexp.

Two new configuration keys are added:
'namespaces': a list of names
'namespace_name_regexp': a regexp to match any namespace

### Additional Notes

The old configuration value 'namespace' is still handled by the agent: if present it is added to the 'namespaces' list.