### PR TITLE
[DataDog/dd-agent][kafka] Update incorrect kafka.yaml.example bean names

### DIFF
--- a/conf.d/kafka.yaml.example
+++ b/conf.d/kafka.yaml.example
@@ -310,14 +310,14 @@ init_config:
             alias: kafka.request.handler.avg.idle.pct.rate
     - include:
         domain: 'kafka.server'
-        bean: 'kafka.server:type=ProducerRequestPurgatory,name=PurgatorySize'
+        bean: 'kafka.server:delayedOperation=Produce,name=PurgatorySize,type=DelayedOperationPurgatory'
         attribute:
           Value:
             metric_type: gauge
             alias: kafka.request.producer_request_purgatory.size
     - include:
         domain: 'kafka.server'
-        bean: 'kafka.server:type=FetchRequestPurgatory,name=PurgatorySize'
+        bean: 'kafka.server:delayedOperation=Fetch,name=PurgatorySize,type=DelayedOperationPurgatory'
         attribute:
           Value:
             metric_type: gauge
@@ -349,14 +349,14 @@ init_config:
             alias: kafka.replication.isr_expands.rate
     - include:
         domain: 'kafka.controller'
-        bean: 'kafka.controller:type=ControllerStats,name=LeaderElectionRateAndTimeMs'
+        bean: 'kafka.controller:name=LeaderElectionRateAndTimeMs,type=ControllerStats'
         attribute:
           Count:
             metric_type: rate
             alias: kafka.replication.leader_elections.rate
     - include:
         domain: 'kafka.controller'
-        bean: 'kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec'
+        bean: 'kafka.controller:name=UncleanLeaderElectionsPerSec,type=ControllerStats'
         attribute:
           Count:
             metric_type: rate


### PR DESCRIPTION
### What does this PR do?

This PR updates four of the bean names listed in the kafka.yaml.example file to accurately reflect changes that have been made to Kafka.

Updated:
```
kafka.server:type=ProducerRequestPurgatory,name=PurgatorySize
kafka.server:type=FetchRequestPurgatory,name=PurgatorySize
kafka.controller:type=ControllerStats,name=LeaderElectionRateAndTimeMs
kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec
```
To:
```
kafka.server:delayedOperation=Produce,name=PurgatorySize,type=DelayedOperationPurgatory
kafka.server:delayedOperation=Fetch,name=PurgatorySize,type=DelayedOperationPurgatory
kafka.controller:name=LeaderElectionRateAndTimeMs,type=ControllerStats
kafka.controller:name=UncleanLeaderElectionsPerSec,type=ControllerStat
```

### Motivation
A more accurate example file, and requests: https://trello.com/c/V80dk24K/2051-update-kafka-yaml-default-bean-names

### Additional Notes
Please see the reference here:
https://issues.apache.org/jira/browse/KAFKA-3480

