### PR TITLE
Add token auth marathon

### DIFF
--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -28,7 +28,10 @@ class Marathon(AgentCheck):
         'mem',
         'taskRateLimit',
         'tasksRunning',
-        'tasksStaged'
+        'tasksStaged',
+        'tasksHealthy',
+        'tasksUnhealthy'
+
     ]
 
     def check(self, instance):

--- a/conf.d/marathon.yaml.example
+++ b/conf.d/marathon.yaml.example
@@ -6,9 +6,9 @@ instances:
 # url: the API endpoint of your Marathon master
 # - url: https://server:port
 # user: the user for marathon API or ACS token authentication
-# - user: username
+#   user: username
 # password: the password for marathon API or ACS token authentication
-# - password: password
+#   password: password
 # acs_url: the base ACS endpoint url if an ACS token is required to access the marathon API
 # NOTE: The user and password will be used to auth with the acs server if acs_url is provided
-# - acs_url: https://server:port
+#   acs_url: https://server:port

--- a/conf.d/marathon.yaml.example
+++ b/conf.d/marathon.yaml.example
@@ -1,11 +1,14 @@
 init_config:
 # time to wait on a Marathon API request
-  # default_timeout: 5
+# - default_timeout: 5
 
 instances:
 # url: the API endpoint of your Marathon master
-  # - url: "https://server:port"
-  #
-  #   if marathon is protected by basic auth
-  #   user: "username"
-  #   password: "password"
+# - url: https://server:port
+# user: the user for marathon API or ACS token authentication
+# - user: username
+# password: the password for marathon API or ACS token authentication
+# - password: password
+# acs_url: the base ACS endpoint url if an ACS token is required to access the marathon API
+# NOTE: The user and password will be used to auth with the acs server if acs_url is provided
+# - acs_url: https://server:port

--- a/tests/checks/mock/test_marathon.py
+++ b/tests/checks/mock/test_marathon.py
@@ -32,7 +32,7 @@ class MarathonCheckTest(AgentCheckTest):
     CHECK_NAME = 'marathon'
 
     def test_default_configuration(self):
-        def side_effect(url, timeout, auth):
+        def side_effect(url, timeout, auth, acs_url):
             if "v2/apps" in url:
                 return Fixtures.read_json_file("apps.json")
             elif "v2/deployments" in url:
@@ -46,7 +46,7 @@ class MarathonCheckTest(AgentCheckTest):
 
 
     def test_empty_responses(self):
-        def side_effect(url, timeout, auth):
+        def side_effect(url, timeout, auth, acs_url):
             if "v2/apps" in url:
                 return {"apps": []}
             elif "v2/deployments" in url:


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

- Add tasksHealthy and tasksUnhealthy to metrics sent do datadog for all marathon apps
- Add ability to use ACS token to authenticate with the marathon api for marathon running in DC/OS platform 1.8

### Motivation

In order to alert on unhealthy marathon apps, we required the ability to compare unhealthy instances vs healthy instances for an app running in marathon, and alert based on a threshold. This required the tasksHealthy and tasksUnhealthy metrics provided by the marathon api

Marathon running in DC/OS 1.8 requires an ACS token for authentication. Added the ability to optionally configure the base url for the ACS auth endpoint. If configured, the user and password parameters will be used to generate an ACS auth token for the authentication header, and not used for basic auth.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
