### PR TITLE
[flare] ignore whitespace before api_key

### DIFF
--- a/tests/core/fixtures/flare/whitespace_apikeys.conf
+++ b/tests/core/fixtures/flare/whitespace_apikeys.conf
@@ -1,0 +1,1 @@
+    api_key: aaaaaaaaaaaaaaaaaaaaaa ,bbbbbbbbbbbbbbbbbbbbbb, cccccccccccccccccccccc,dddddddddddddddddddddd

--- a/tests/core/test_flare.py
+++ b/tests/core/test_flare.py
@@ -245,6 +245,20 @@ class FlareTest(unittest.TestCase):
             "api_key: **************************aaaaa\n"
         )
 
+        f = Flare()
+        file_path, _ = f._strip_credentials(
+            os.path.join(get_mocked_temp(), 'whitespace_apikeys.conf'),
+            f.MAIN_CREDENTIALS
+        )
+        with open(file_path) as f:
+            contents = f.read()
+
+        self.assertEqual(
+            contents,
+            "api_key: **************************aaaaa, **************************bbbbb,"
+            " **************************ccccc, **************************ddddd\n"
+        )
+
     @mock.patch('os.remove', side_effect=mocked_os_remove)
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -74,7 +74,7 @@ class Flare(object):
     ]
     MAIN_CREDENTIALS = [
         CredentialPattern(
-            re.compile('\s*api_key:( *\w+(\w{5}) ?,?)+$'),
+            re.compile('^\s*api_key:( *\w+(\w{5}) ?,?)+$'),
             lambda matchobj:  'api_key: ' + ', '.join(map(
                 lambda key: '*' * 26 + key[-5:],
                 map(lambda x: x.strip(),

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -74,7 +74,7 @@ class Flare(object):
     ]
     MAIN_CREDENTIALS = [
         CredentialPattern(
-            re.compile('^api_key:( *\w+(\w{5}) ?,?)+$'),
+            re.compile('\s*api_key:( *\w+(\w{5}) ?,?)+$'),
             lambda matchobj:  'api_key: ' + ', '.join(map(
                 lambda key: '*' * 26 + key[-5:],
                 map(lambda x: x.strip(),


### PR DESCRIPTION
### What does this PR do?

Fixes the case when there was whitespace before the `api_key` in datadog.conf causing a pattern match failure.

### Motivation

Support case.