### PR TITLE
[yarn] Add configurable application tags

### DIFF
--- a/checks.d/yarn.py
+++ b/checks.d/yarn.py
@@ -143,6 +143,13 @@ class YarnCheck(AgentCheck):
     '''
     Extract statistics from YARN's ResourceManger REST API
     '''
+    _ALLOWED_APPLICATION_TAGS = [
+        'applicationTags',
+        'applicationType',
+        'name',
+        'queue',
+        'user'
+    ]
 
     def check(self, instance):
 
@@ -154,8 +161,15 @@ class YarnCheck(AgentCheck):
             self.log.error('application_tags is incorrect: %s is not a dictionary', app_tags)
             app_tags = {}
 
+        filtered_app_tags = {}
+        for dd_prefix, yarn_key in app_tags.iteritems():
+            if yarn_key in self._ALLOWED_APPLICATION_TAGS:
+                filtered_app_tags[dd_prefix] = yarn_key
+        app_tags = filtered_app_tags
+
         # Collected by default
         app_tags['app_name'] = 'name'
+
 
         # Get additional tags from the conf file
         tags = instance.get('tags', [])
@@ -201,7 +215,7 @@ class YarnCheck(AgentCheck):
         )
 
         if (metrics_json and metrics_json['apps'] is not None and
-            metrics_json['apps']['app'] is not None):
+                metrics_json['apps']['app'] is not None):
 
             for app_json in metrics_json['apps']['app']:
 
@@ -225,7 +239,7 @@ class YarnCheck(AgentCheck):
         metrics_json = self._rest_request_to_json(rm_address, YARN_NODES_PATH)
 
         if (metrics_json and metrics_json['nodes'] is not None and
-            metrics_json['nodes']['node'] is not None):
+                metrics_json['nodes']['node'] is not None):
 
             for node_json in metrics_json['nodes']['node']:
                 node_id = node_json['id']

--- a/checks.d/yarn.py
+++ b/checks.d/yarn.py
@@ -148,6 +148,7 @@ class YarnCheck(AgentCheck):
 
         # Get properties from conf file
         rm_address = instance.get('resourcemanager_uri', DEFAULT_RM_URI)
+        app_tags = instance.get('application_tags', [])
 
         # Get additional tags from the conf file
         tags = instance.get('tags', [])
@@ -166,7 +167,7 @@ class YarnCheck(AgentCheck):
 
         # Get metrics from the Resource Manager
         self._yarn_cluster_metrics(rm_address, tags)
-        self._yarn_app_metrics(rm_address, tags)
+        self._yarn_app_metrics(rm_address, app_tags, tags)
         self._yarn_node_metrics(rm_address, tags)
 
     def _yarn_cluster_metrics(self, rm_address, addl_tags):
@@ -182,7 +183,7 @@ class YarnCheck(AgentCheck):
             if yarn_metrics is not None:
                 self._set_yarn_metrics_from_json(addl_tags, yarn_metrics, YARN_CLUSTER_METRICS)
 
-    def _yarn_app_metrics(self, rm_address, addl_tags):
+    def _yarn_app_metrics(self, rm_address, app_tags, addl_tags):
         '''
         Get metrics for running applications
         '''
@@ -196,9 +197,19 @@ class YarnCheck(AgentCheck):
 
                     for app_json in metrics_json['apps']['app']:
 
-                        app_name = app_json['name']
+                        tags = []
 
-                        tags = ['app_name:%s' % str(app_name)]
+                        for tag in app_tags:
+                            try:
+                                key, value = tag.split(':')
+                                tags.append("{tag}:{value}".format(
+                                    tag=value, value=str(app_json[key])
+                                ))
+                            except ValueError:
+                                self.log.error("Invalid value %s for application_tag", tag)
+                            except KeyError:
+                                self.log.warning("Application tag %s not found, so it will be ignored", key)
+
                         tags.extend(addl_tags)
 
                         self._set_yarn_metrics_from_json(tags, app_json, YARN_APP_METRICS)

--- a/conf.d/yarn.yaml.example
+++ b/conf.d/yarn.yaml.example
@@ -17,6 +17,15 @@ instances:
     # A Required friendly name for the cluster.
     # cluster_name: MyYarnCluster
 
+    # Values from running applications response that will be applied as datadog tags, set as app_key:datadog_tag
+    # You can find the whole list keys on yarn api reference - application response body:
+    # https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API
+    # Example:
+    #   - queue:app_queue
+    #   - user:app_user
+     application_tags:
+       - name:app_name
+
     # Optional tags to be applied to every emitted metric.
     # tags:
     #   - key:value

--- a/conf.d/yarn.yaml.example
+++ b/conf.d/yarn.yaml.example
@@ -19,17 +19,16 @@ instances:
 
     # Optional tags to be applied to every emitted metric.
     # tags:
-    #   - key:value
-    #   - instance:production
+    #   - "key:value"
+    #   - "instance:production"
 
     # Optional tags retrieved from the application data to be applied to the
     # application metrics.
     # application_tags:
-    #   # tag_prefix: yarn_key
-    #   - app_queue: queue
+    # # tag_prefix: yarn_key
+    #   app_queue: queue
     # This will add a tag 'app_queue:name_of_the_queue' to the app metrics,
-    # app_queue being the tag_prefix and queue the actual YARN key. Whole list
-    # of keys on yarn api reference:
-    # https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API
+    # app_queue being the tag_prefix and queue the actual YARN key.
+    # Allowed yarn keys: applicationType, applicationTags, name, queue, user
     # By default, the application name is collected with the prefix app_name.
 

--- a/conf.d/yarn.yaml.example
+++ b/conf.d/yarn.yaml.example
@@ -3,7 +3,7 @@ init_config:
 instances:
   # The YARN check retrieves metrics from YARNS's ResourceManager. This
   # check must be run from the Master Node and the ResourceManager URI must
-  # be specified below. The ResourceManager URI is composed of the 
+  # be specified below. The ResourceManager URI is composed of the
   # ResourceManager's hostname and port.
   #
   # The ResourceManager hostname can be found in the yarn-site.xml conf file
@@ -17,16 +17,19 @@ instances:
     # A Required friendly name for the cluster.
     # cluster_name: MyYarnCluster
 
-    # Values from running applications response that will be applied as datadog tags, set as app_key:datadog_tag
-    # You can find the whole list keys on yarn api reference - application response body:
-    # https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API
-    # Example:
-    #   - queue:app_queue
-    #   - user:app_user
-     application_tags:
-       - name:app_name
-
     # Optional tags to be applied to every emitted metric.
     # tags:
     #   - key:value
     #   - instance:production
+
+    # Optional tags retrieved from the application data to be applied to the
+    # application metrics.
+    # application_tags:
+    #   # tag_prefix: yarn_key
+    #   - app_queue: queue
+    # This will add a tag 'app_queue:name_of_the_queue' to the app metrics,
+    # app_queue being the tag_prefix and queue the actual YARN key. Whole list
+    # of keys on yarn api reference:
+    # https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/ResourceManagerRest.html#Cluster_Applications_API
+    # By default, the application name is collected with the prefix app_name.
+

--- a/tests/checks/mock/test_yarn.py
+++ b/tests/checks/mock/test_yarn.py
@@ -58,7 +58,8 @@ class YARNCheck(AgentCheckTest):
             'opt_key:opt_value'
         ],
         'application_tags': {
-            'app_id': 'id'
+            'app_id': 'id',
+            'app_queue': 'queue'
         }
     }
 
@@ -108,7 +109,7 @@ class YARNCheck(AgentCheckTest):
     YARN_APP_METRICS_TAGS = [
         'cluster_name:%s' % CLUSTER_NAME,
         'app_name:word count',
-        'app_id:application_1326815542473_0001',
+        'app_queue:default',
         'opt_key:opt_value'
     ]
 

--- a/tests/checks/mock/test_yarn.py
+++ b/tests/checks/mock/test_yarn.py
@@ -53,7 +53,14 @@ class YARNCheck(AgentCheckTest):
 
     YARN_CONFIG = {
         'resourcemanager_uri': 'http://localhost:8088',
-        'cluster_name': CLUSTER_NAME
+        'cluster_name': CLUSTER_NAME,
+        'tags': [
+            'opt_key:opt_value'
+        ],
+        'application_tags': [
+            'id:app_id',
+            'name:app_name'
+        ]
     }
 
     YARN_CLUSTER_METRICS_VALUES = {
@@ -82,7 +89,10 @@ class YARNCheck(AgentCheckTest):
         'yarn.metrics.rebooted_nodes': 0,
     }
 
-    YARN_CLUSTER_METRICS_TAGS = ['cluster_name:%s' % CLUSTER_NAME]
+    YARN_CLUSTER_METRICS_TAGS = [
+        'cluster_name:%s' % CLUSTER_NAME,
+        'opt_key:opt_value'
+    ]
 
     YARN_APP_METRICS_VALUES = {
         'yarn.apps.progress': 100,
@@ -98,7 +108,9 @@ class YARNCheck(AgentCheckTest):
 
     YARN_APP_METRICS_TAGS = [
         'cluster_name:%s' % CLUSTER_NAME,
-        'app_name:word count'
+        'app_name:word count',
+        'app_id:application_1326815542473_0001',
+        'opt_key:opt_value'
     ]
 
     YARN_NODE_METRICS_VALUES = {
@@ -112,7 +124,8 @@ class YARNCheck(AgentCheckTest):
 
     YARN_NODE_METRICS_TAGS = [
         'cluster_name:%s' % CLUSTER_NAME,
-        'node_id:h2:1235'
+        'node_id:h2:1235',
+        'opt_key:opt_value'
     ]
 
     @mock.patch('requests.get', side_effect=requests_get_mock)

--- a/tests/checks/mock/test_yarn.py
+++ b/tests/checks/mock/test_yarn.py
@@ -57,10 +57,9 @@ class YARNCheck(AgentCheckTest):
         'tags': [
             'opt_key:opt_value'
         ],
-        'application_tags': [
-            'id:app_id',
-            'name:app_name'
-        ]
+        'application_tags': {
+            'app_id': 'id'
+        }
     }
 
     YARN_CLUSTER_METRICS_VALUES = {


### PR DESCRIPTION
Rebased https://github.com/DataDog/dd-agent/pull/2489 (and fixed typo).

Added application tags in the configuration file,
allowing set extra tags for app metrics like queue,
user, etc.

Also, added the tags functionality merged in
https://github.com/DataDog/dd-agent/pull/2473
on tests