### PR TITLE
Fixes IndexError from killing agent when no process table returned

### DIFF
--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -560,11 +560,11 @@ class Processes(Check):
         try:
             output, _, _ = get_subprocess_output(['ps', ps_arg], self.logger)
             processLines = output.splitlines()  # Also removes a trailing empty line
+
+            del processLines[0]  # Removes the headers
         except StandardError:
             self.logger.exception('getProcesses')
             return False
-
-        del processLines[0]  # Removes the headers
 
         processes = []
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

The pull request moves the removal of the process table header into the try block above to prevent an IndexError from crashing the process. The general standard error will catch the IndexError and not require an additional error class

### Motivation

We had a system that filled its disk so the output of the process table returned was empty and cause the process to fail. Other errors are caught when running the `ps` command so I figured why not catch this one at the same time if `ps` command succeeds but nothing is returned.

### Testing Guidelines

I looked at the testing but I couldn't any tests that test this file. If I could get a pointer of where to look then I'd be happy to try to add in a test.

### Additional Notes

Error from the logs:

```
2016-11-23 01:08:05 UTC | ERROR | dd.collector | checks.collector(logger.py:23) | Uncaught exception while running run
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/utils/logger.py", line 20, in wrapper
    result = func(*args, **kwargs)
  File "/opt/datadog-agent/agent/checks/collector.py", line 349, in run
    processes = sys_checks['processes'].check(self.agentConfig)
  File "/opt/datadog-agent/agent/checks/system/unix.py", line 557, in check
    del processLines[0]  # Removes the headers
IndexError: list assignment index out of range
2016-11-23 01:08:05 UTC | ERROR | dd.collector | collector(agent.py:428) | Uncaught error running the Agent
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/agent.py", line 424, in <module>
    sys.exit(main())
  File "/opt/datadog-agent/agent/agent.py", line 367, in main
    agent.start(foreground=True)
  File "/opt/datadog-agent/agent/daemon.py", line 175, in start
    self.run()
  File "/opt/datadog-agent/agent/agent.py", line 198, in run
    configs_reloaded=self.reload_configs_flag)
  File "/opt/datadog-agent/agent/utils/logger.py", line 20, in wrapper
    result = func(*args, **kwargs)
  File "/opt/datadog-agent/agent/checks/collector.py", line 349, in run
    processes = sys_checks['processes'].check(self.agentConfig)
  File "/opt/datadog-agent/agent/checks/system/unix.py", line 557, in check
    del processLines[0]  # Removes the headers
IndexError: list assignment index out of range
```