### PR TITLE
[haproxy] Enable collate_status_tags_per_host on new installs

### DIFF
--- a/conf.d/haproxy.yaml.example
+++ b/conf.d/haproxy.yaml.example
@@ -30,8 +30,7 @@ instances:
     # The (optional) `collate_status_tags_per_host` parameter will collate
     # `status` tags for `haproxy.count_per_status` up to one of (`available`, `unavailable`)
     # for each discovered backend.
-    # This only applies if `collect_status_metrics_by_host` is True.
-    # collate_status_tags_per_host: False
+    collate_status_tags_per_host: True
     #
     # The (optional) `count_status_by_service` parameter will instruct the check
     # to tag the status counts it collects by service in addition to by host.


### PR DESCRIPTION

To reduce the number of contexts created
[skip ci]