### PR TITLE
allow override of kubelet host with KUBERNETES_KUBELET_HOST env var

### DIFF
--- a/conf.d/kubernetes.yaml.example
+++ b/conf.d/kubernetes.yaml.example
@@ -3,7 +3,8 @@ init_config:
 instances:
   # The kubernetes check retrieves metrics from cadvisor running under kubelet.
   # By default we will assume we're running under docker and will use the address
-  # of the default router to reach the cadvisor api.
+  # of the default router to reach the cadvisor api unless the environment variable
+  # KUBERNETES_KUBELET_HOST is found.
   #
   # To override, e.g. in the case of a standalone cadvisor instance, use the following:
   #

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -57,14 +57,15 @@ class KubeUtil:
 
         self.method = instance.get('method', KubeUtil.DEFAULT_METHOD)
         self.host = instance.get("host") or self.docker_util.get_hostname()
+        self.kubelet_host = os.environ.get('KUBERNETES_KUBELET_HOST') or self.host
         self._node_ip = self._node_name = None  # lazy evaluation
         self.host_name = os.environ.get('HOSTNAME')
 
         self.cadvisor_port = instance.get('port', KubeUtil.DEFAULT_CADVISOR_PORT)
         self.kubelet_port = instance.get('kubelet_port', KubeUtil.DEFAULT_KUBELET_PORT)
 
-        self.kubelet_api_url = '%s://%s:%d' % (self.method, self.host, self.kubelet_port)
-        self.cadvisor_url = '%s://%s:%d' % (self.method, self.host, self.cadvisor_port)
+        self.kubelet_api_url = '%s://%s:%d' % (self.method, self.kubelet_host, self.kubelet_port)
+        self.cadvisor_url = '%s://%s:%d' % (self.method, self.kubelet_host, self.cadvisor_port)
         self.kubernetes_api_url = 'https://%s/api/v1' % (os.environ.get('KUBERNETES_SERVICE_HOST') or self.DEFAULT_MASTER_NAME)
 
         self.metrics_url = urljoin(self.cadvisor_url, KubeUtil.METRICS_PATH)


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

dd-agent assumes that the kubelet API is available at the default gateway of the container. This PR allows overriding of the kubelet host if the KUBERNETES_KUBELET_HOST environment variable is found. As an example, the kubernetes downward API in 1.4+ can be used to specify the node name:

```
          - name: KUBERNETES_KUBELET_HOST
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
```

### Motivation

There are implementations of kubernetes where the kubelet API is not available at the default gateway. An example of this would be when Calico is used: projectcalico/calico-containers#1099

What inspired you to submit this pull request?

We're testing Calico with kubernetes and a docker-dd-agent daemonset does not function properly. 

### Additional Notes

I can cut a PR to update docs in DataDog/docker-dd-agent if this gets merged.

Anything else we should know when reviewing?

- this addresses kubernetes environments where the kubelet api is
  not reachable at the default gateway
- addresses projectcalico/calico-containers#1099