### PR TITLE
[sqlserver] remove warning message leaking password strings

### DIFF
--- a/checks.d/sqlserver.py
+++ b/checks.d/sqlserver.py
@@ -329,7 +329,6 @@ class SQLServer(AgentCheck):
         except Exception as e:
             cx = "%s - %s" % (host, database)
             message = "Unable to connect to SQL Server for instance %s." % cx
-            self.log.warning("%s Exception: %s", message, e)
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
                                tags=service_check_tags, message=message)
 


### PR DESCRIPTION
### What does this PR do?

Remove a `log.warning` call outputting a string containing connection password in case of errors. The log operation was redundant anyways since the exception is correctly and safely propagated.
