### PR TITLE
[tests] allow tests to use the additional_checksd parameter

### DIFF
--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -69,7 +69,7 @@ def load_class(check_name, class_name):
 
 def load_check(name, config, agentConfig):
     if not _is_sdk():
-        checksd_path = get_checksd_path(get_os())
+        checksd_path = agentConfig.get('additional_checksd', get_checksd_path(get_os()))
 
         # find (in checksd_path) and load the check module
         fd, filename, desc = imp.find_module(name, [checksd_path])


### PR DESCRIPTION
What does this PR do?

A one-line change that allows tests to optionally access the 'additional_checksd' parameter from the appConfig when using 'load_check()'

Motivation

This is mandatory if you want to have a set of Checks that you will not be submitting back to Datadog. And wish to use the 'additional_checksd' feature to access them. And you also want to be able to reuse Datadog's excellent AgentCheckTest and supporting code.

Testing Guidelines

N/A (it is a part of the test infrastructure)

Additional Notes

None.
It is a one-liner.
It is innocuous if you do not define 'additional_checksd' in your test's appConfig.
But without it, you must resort to dropping your code into a checkout of dd-agent's checks.d.