### PR TITLE
[flare] ignore whitespace before proxy credentials

### DIFF
--- a/tests/core/fixtures/flare/proxy.conf
+++ b/tests/core/fixtures/flare/proxy.conf
@@ -1,0 +1,2 @@
+proxy_user: user
+proxy_password: password

--- a/tests/core/fixtures/flare/whitespace_proxy.conf
+++ b/tests/core/fixtures/flare/whitespace_proxy.conf
@@ -1,0 +1,2 @@
+  proxy_user: user
+     proxy_password: password

--- a/tests/core/test_flare.py
+++ b/tests/core/test_flare.py
@@ -263,7 +263,6 @@ class FlareTest(unittest.TestCase):
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
-
     def test_proxy_user_pass_regex(self, mock_config, mock_tempdir, mock_strftime, mock_os_remove):
         f = Flare()
         file_path, _ = f._strip_credentials(
@@ -283,7 +282,6 @@ class FlareTest(unittest.TestCase):
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
-
     def test_whitespace_proxy_user_pass_regex(self, mock_config, mock_tempdir, mock_strftime, mock_os_remove):
         f = Flare()
         file_path, _ = f._strip_credentials(
@@ -303,7 +301,6 @@ class FlareTest(unittest.TestCase):
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
-
     def test_uri_password_regex(self, mock_config, mock_tempdir, mock_strftime, mock_os_remove):
         f = Flare()
         password_uri_pattern = filter(

--- a/tests/core/test_flare.py
+++ b/tests/core/test_flare.py
@@ -263,6 +263,47 @@ class FlareTest(unittest.TestCase):
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
+
+    def test_proxy_user_pass_regex(self, mock_config, mock_tempdir, mock_strftime, mock_os_remove):
+        f = Flare()
+        file_path, _ = f._strip_credentials(
+            os.path.join(get_mocked_temp(), 'proxy.conf'),
+            f.MAIN_CREDENTIALS
+        )
+        with open(file_path) as f:
+            contents = f.read()
+
+        self.assertEqual(
+            contents,
+            "proxy_user: ********\n"
+            "proxy_password: ********\n"
+        )
+
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
+    @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
+    @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
+    @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
+
+    def test_whitespace_proxy_user_pass_regex(self, mock_config, mock_tempdir, mock_strftime, mock_os_remove):
+        f = Flare()
+        file_path, _ = f._strip_credentials(
+            os.path.join(get_mocked_temp(), 'whitespace_proxy.conf'),
+            f.MAIN_CREDENTIALS
+        )
+        with open(file_path) as f:
+            contents = f.read()
+
+        self.assertEqual(
+            contents,
+            "proxy_user: ********\n"
+            "proxy_password: ********\n"
+        )
+
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
+    @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
+    @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
+    @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
+
     def test_uri_password_regex(self, mock_config, mock_tempdir, mock_strftime, mock_os_remove):
         f = Flare()
         password_uri_pattern = filter(

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -84,7 +84,7 @@ class Flare(object):
             'api_key'
         ),
         CredentialPattern(
-            re.compile('^(proxy_user|proxy_password): *.+'),
+            re.compile('^\s*(proxy_user|proxy_password): *.+'),
             r'\1: ********',
             'proxy credentials'
         ),


### PR DESCRIPTION
### What does this PR do?

Fixes the case when there was whitespace before proxy user/pass causing our regex match to fail.

### Motivation

Raised in support ticket.

### Testing Guidelines

Added unit test for cases with and without whitespace.