### PR TITLE
Adding a check for filebeat

### DIFF
--- a/checks.d/filebeat.py
+++ b/checks.d/filebeat.py
@@ -1,0 +1,51 @@
+# (C) Datadog, Inc. 2010-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+import json
+import os
+
+# project
+from checks import AgentCheck
+
+
+class FilebeatCheck(AgentCheck):
+
+    def check(self, instance):
+        registry_file_path = instance.get('registry_file_path')
+        if registry_file_path is None:
+            raise Exception('An absolute path to a filebeat registry path must be specified')
+
+        registry_contents = self._parse_registry_file(registry_file_path)
+
+        for item in registry_contents.itervalues():
+            self._process_registry_item(item)
+
+    def _parse_registry_file(self, registry_file_path):
+        try:
+            with open(registry_file_path) as registry_file:
+                return json.load(registry_file)
+        except IOError:
+            self.log.warn('No filebeat registry file found at %s' % (registry_file_path, ))
+            return {}
+
+    def _process_registry_item(self, item):
+        source = item['source']
+        offset = item['offset']
+
+        try:
+            stats = os.stat(source)
+
+            if self._is_same_file(stats, item['FileStateOS']):
+                unprocessed_bytes = stats.st_size - offset
+
+                self.gauge('filebeat.registry.unprocessed_bytes', unprocessed_bytes,
+                           tags=["source:{0}".format(source)])
+            else:
+                self.log.debug("Filebeat source %s appears to have changed" % (source, ))
+        except OSError:
+            self.log.debug("Unable to get stats on filebeat source %s" % (source, ))
+
+    def _is_same_file(self, stats, file_state_os):
+        return stats.st_dev == file_state_os['device'] and stats.st_ino == file_state_os['inode']

--- a/conf.d/filebeat.yaml.example
+++ b/conf.d/filebeat.yaml.example
@@ -1,0 +1,7 @@
+init_config:
+
+instances:
+  # The absolute path to the registry file used by filebeat
+  # See https://www.elastic.co/guide/en/beats/filebeat/current/migration-registry-file.html
+
+  - registry_file_path: /var/lib/filebeat/registry

--- a/tests/checks/fixtures/filebeat/happy_path_registry.json
+++ b/tests/checks/fixtures/filebeat/happy_path_registry.json
@@ -1,0 +1,18 @@
+{
+    "/test_dd_agent/var/log/nginx/access.log": {
+        "source": "/test_dd_agent/var/log/nginx/access.log",
+        "offset": 391747,
+        "FileStateOS": {
+            "inode": 277025,
+            "device": 51713
+        }
+    },
+    "/test_dd_agent/var/log/syslog": {
+        "source": "/test_dd_agent/var/log/syslog",
+        "offset": 1024917,
+        "FileStateOS": {
+            "inode": 152172,
+            "device": 51713
+        }
+    }
+}

--- a/tests/checks/fixtures/filebeat/missing_source_file_registry.json
+++ b/tests/checks/fixtures/filebeat/missing_source_file_registry.json
@@ -1,0 +1,10 @@
+{
+    "/i/sure/dont/exist.log": {
+        "source": "/i/sure/dont/exist.log",
+        "offset": 391747,
+        "FileStateOS": {
+            "inode": 277025,
+            "device": 51713
+        }
+    }
+}

--- a/tests/checks/fixtures/filebeat/single_source_registry.json
+++ b/tests/checks/fixtures/filebeat/single_source_registry.json
@@ -1,0 +1,10 @@
+{
+    "/test_dd_agent/var/log/syslog": {
+        "source": "/test_dd_agent/var/log/syslog",
+        "offset": 1024917,
+        "FileStateOS": {
+            "inode": 152172,
+            "device": 51713
+        }
+    }
+}

--- a/tests/checks/mock/test_filebeat.py
+++ b/tests/checks/mock/test_filebeat.py
@@ -1,0 +1,85 @@
+# stdlib
+from collections import namedtuple
+import os
+
+# 3p
+from mock import patch
+
+# project
+from tests.checks.common import AgentCheckTest, Fixtures
+
+mocked_file_stats = namedtuple('mocked_file_stats', ['st_size', 'st_ino', 'st_dev'])
+
+
+# allows mocking `os.stat` only for certain paths; for all others it will call
+# the actual function - needed as a number of test helpers do make calls to it
+def with_mocked_os_stat(mocked_paths_and_stats):
+    vanilla_os_stat = os.stat
+
+    def internal_mock(path):
+        if path in mocked_paths_and_stats:
+            return mocked_paths_and_stats[path]
+        return vanilla_os_stat(path)
+
+    def external_wrapper(function):
+        # silly, but this _must_ start with `test_` for nose to pick it up as a
+        # test when used below
+        def test_wrapper(*args, **kwargs):
+            with patch.object(os, 'stat') as patched_os_stat:
+                patched_os_stat.side_effect = internal_mock
+                return function(*args, **kwargs)
+        return test_wrapper
+
+    return external_wrapper
+
+
+class TestCheckFilebeat(AgentCheckTest):
+    CHECK_NAME = 'filebeat'
+
+    def _build_config(self, name):
+        return {
+            'init_config': None,
+            'instances': [
+                {
+                    'registry_file_path': Fixtures.file(name + '_registry.json')
+                }
+            ]
+        }
+
+    @with_mocked_os_stat({'/test_dd_agent/var/log/nginx/access.log': mocked_file_stats(394154, 277025, 51713),
+                          '/test_dd_agent/var/log/syslog': mocked_file_stats(1024917, 152172, 51713)})
+    def test_happy_path(self):
+        self.run_check(self._build_config('happy_path'))
+
+        self.assertMetric('filebeat.registry.unprocessed_bytes', value=2407, tags=['source:/test_dd_agent/var/log/nginx/access.log'])
+        self.assertMetric('filebeat.registry.unprocessed_bytes', value=0, tags=['source:/test_dd_agent/var/log/syslog'])
+
+    def test_bad_config(self):
+        bad_config = {
+            'init_config': None,
+            'instances': [{}]
+        }
+
+        self.assertRaises(
+            Exception,
+            lambda: self.run_check(bad_config)
+        )
+
+    def test_missing_registry_file(self):
+        # tests that it simply silently ignores it
+        self.run_check(self._build_config('i_dont_exist'))
+        self.assertMetric('filebeat.registry.unprocessed_bytes', count=0)
+
+    def test_missing_source_file(self):
+        self.run_check(self._build_config('missing_source_file'))
+        self.assertMetric('filebeat.registry.unprocessed_bytes', count=0)
+
+    @with_mocked_os_stat({'/test_dd_agent/var/log/syslog': mocked_file_stats(1024917, 152171, 51713)})
+    def test_source_file_inode_has_changed(self):
+        self.run_check(self._build_config('single_source'))
+        self.assertMetric('filebeat.registry.unprocessed_bytes', count=0)
+
+    @with_mocked_os_stat({'/test_dd_agent/var/log/syslog': mocked_file_stats(1024917, 152172, 51714)})
+    def test_source_file_device_has_changed(self):
+        self.run_check(self._build_config('single_source'))
+        self.assertMetric('filebeat.registry.unprocessed_bytes', count=0)


### PR DESCRIPTION
### What does this PR do?

Adds a check for filebeat

### Motivation

Filebeat (https://github.com/elastic/beats) is a deamon tailing and processing
log files, for example to send them to Logstash.

It maintains a _registry file_, in which it keeps track of which log files it's
currently tailing, and up to what point it has processed them.

This patch adds an agent check that leverages that registry file to gauge
filebat's progress; more specifically, it pushes how many bytes are currently
left to process for filebeat.

This metric would be useful for example to create a monitor alerting when
filebeat falls too far behind.

### Testing

A Testcase is provided here: tests/checks/mock/test_filebeat.py
It contains 6 tests, which provide 100% code coverage on the new check.