### PR TITLE
[config] Fix `_is_affirmative` when passed argument is `None`

### DIFF
--- a/config.py
+++ b/config.py
@@ -222,6 +222,8 @@ def _checksd_path(directory):
 
 
 def _is_affirmative(s):
+    if s is None:
+        return False
     # int or real bool
     if isinstance(s, int):
         return bool(s)


### PR DESCRIPTION
### What does this PR do?

Avoid raising exception when passed argument to `_is_affirmative` is `None`. 

Return `False` in that case instead of raising an exception.

For instance https://github.com/DataDog/dd-agent/pull/3010 introduced a case where the passed argument is `None`, which would make the whole collector fail. **#3010 should not be released without this fix**

### Motivation

Fix stuff

### Testing Guidelines

It works.

Returning `False` doesn't break backwards compatibility because that made the code blow up before.

### Additional Notes

🤖 