### PR TITLE
[HTTP CHECK] Add an Option to mark check as DOWN if a content is found

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -223,15 +223,15 @@ class HTTPCheck(NetworkCheck):
 
             instance_proxy = self.proxies.copy()
 
-            # disable proxy if necessary
-            # if skip_proxy:
-            #     instance_proxy.pop('http')
-            #     instance_proxy.pop('https')
-            # else:
-            #     for url in self.proxies['no'].replace(';', ',').split(","):
-            #         if url in parsed_uri.netloc:
-            #             instance_proxy.pop('http')
-            #             instance_proxy.pop('https')
+            disable proxy if necessary
+            if skip_proxy:
+                instance_proxy.pop('http')
+                instance_proxy.pop('https')
+            else:
+                for url in self.proxies['no'].replace(';', ',').split(","):
+                    if url in parsed_uri.netloc:
+                        instance_proxy.pop('http')
+                        instance_proxy.pop('https')
 
             self.log.debug("Proxies used for %s - %s", addr, instance_proxy)
 

--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -223,7 +223,7 @@ class HTTPCheck(NetworkCheck):
 
             instance_proxy = self.proxies.copy()
 
-            disable proxy if necessary
+            # disable proxy if necessary
             if skip_proxy:
                 instance_proxy.pop('http')
                 instance_proxy.pop('https')

--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -224,14 +224,14 @@ class HTTPCheck(NetworkCheck):
             instance_proxy = self.proxies.copy()
 
             # disable proxy if necessary
-            if skip_proxy:
-                instance_proxy.pop('http')
-                instance_proxy.pop('https')
-            else:
-                for url in self.proxies['no'].replace(';', ',').split(","):
-                    if url in parsed_uri.netloc:
-                        instance_proxy.pop('http')
-                        instance_proxy.pop('https')
+            # if skip_proxy:
+            #     instance_proxy.pop('http')
+            #     instance_proxy.pop('https')
+            # else:
+            #     for url in self.proxies['no'].replace(';', ',').split(","):
+            #         if url in parsed_uri.netloc:
+            #             instance_proxy.pop('http')
+            #             instance_proxy.pop('https')
 
             self.log.debug("Proxies used for %s - %s", addr, instance_proxy)
 

--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -313,18 +313,19 @@ class HTTPCheck(NetworkCheck):
             if content_match:
                 # r.text is the response content decoded by `requests`, of type `unicode`
                 content = r.text if type(content_match) is unicode else r.content
-                if not reverse_content_match and re.search(content_match, content, re.UNICODE):
-                    send_status_up("%s is found in return content" % content_match)
+                if re.search(content_match, content, re.UNICODE):
+                    if reverse_content_match:
+                        send_status_down("%s is found in return content with the reverse_content_match option" % content_match,
+                            'Content "%s" found in response with the reverse_content_match' % content_match)
+                    else:
+                        send_status_up("%s is found in return content" % content_match)
 
-                elif reverse_content_match and not re.search(content_match, content, re.UNICODE):
-                    send_status_up("%s is not found in return content with the reverse_content_match option" % content_match)
-
-                elif reverse_content_match:
-                    send_status_down("%s is found in return content with the reverse_content_match option" % content_match,
-                        'Content "%s" found in response with the reverse_content_match' % content_match)
                 else:
-                    send_status_down("%s is not found in return content" % content_match,
-                        'Content "%s" not found in response.' % content_match)
+                    if reverse_content_match:
+                        send_status_up("%s is not found in return content with the reverse_content_match option" % content_match)
+                    else:
+                        send_status_down("%s is not found in return content" % content_match,
+                            'Content "%s" not found in response.' % content_match)
 
             else:
                 send_status_up("%s is UP" % addr)

--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -196,13 +196,13 @@ class HTTPCheck(NetworkCheck):
             ssl_expire, instance_ca_certs, weakcipher, ignore_ssl_warning, skip_proxy, allow_redirects = self._load_conf(instance)
         start = time.time()
 
-        def sendStatusUp(logMsg):
+        def send_status_up(logMsg):
             self.log.debug(logMsg)
             service_checks.append((
                 self.SC_STATUS, Status.UP, "UP"
             ))
 
-        def sendStatusDown(loginfo, message):
+        def send_status_down(loginfo, message):
             self.log.info(loginfo)
             self.log.debug("Content returned:\n%s" % content)
             if include_content:
@@ -314,20 +314,20 @@ class HTTPCheck(NetworkCheck):
                 # r.text is the response content decoded by `requests`, of type `unicode`
                 content = r.text if type(content_match) is unicode else r.content
                 if not reverse_content_match and re.search(content_match, content, re.UNICODE):
-                    sendStatusUp("%s is found in return content" % content_match)
+                    send_status_up("%s is found in return content" % content_match)
 
                 elif reverse_content_match and not re.search(content_match, content, re.UNICODE):
-                    sendStatusUp("%s is not found in return content with the reverse_content_match option" % content_match)
+                    send_status_up("%s is not found in return content with the reverse_content_match option" % content_match)
 
                 elif reverse_content_match:
-                    sendStatusDown("%s is found in return content with the reverse_content_match option" % content_match,
+                    send_status_down("%s is found in return content with the reverse_content_match option" % content_match,
                         'Content "%s" found in response with the reverse_content_match' % content_match)
                 else:
-                    sendStatusDown("%s is not found in return content" % content_match,
+                    send_status_down("%s is not found in return content" % content_match,
                         'Content "%s" not found in response.' % content_match)
 
             else:
-                sendStatusUp("%s is UP" % addr)
+                send_status_up("%s is UP" % addr)
 
         if ssl_expire and parsed_uri.scheme == "https":
             status, msg = self.check_cert_expiration(instance, timeout, instance_ca_certs)

--- a/conf.d/http_check.yaml.example
+++ b/conf.d/http_check.yaml.example
@@ -29,6 +29,11 @@ instances:
     # content_match: 'In Stock'
     # content_match: '^(Bread|Apples|Very small rocks|Cider|Gravy|Cherries|Mud|Churches|Lead) float(s)? in water'
 
+    # The (optional) reverse_content_match parameter will allow the content_match
+    # to work the other way around. That means that the check will report
+    # as DOWN if the string is DOWN
+    # reverse_content_match: false
+
     # If your service uses basic authentication, you can optionally
     # specify a username and password that will be used in the check.
     #

--- a/conf.d/http_check.yaml.example
+++ b/conf.d/http_check.yaml.example
@@ -31,7 +31,7 @@ instances:
 
     # The (optional) reverse_content_match parameter will allow the content_match
     # to work the other way around. That means that the check will report
-    # as DOWN if the string is DOWN
+    # as DOWN if the string is found.
     # reverse_content_match: false
 
     # If your service uses basic authentication, you can optionally

--- a/tests/checks/integration/test_http_check.py
+++ b/tests/checks/integration/test_http_check.py
@@ -54,7 +54,32 @@ CONFIG = {
         'url': 'https://ja.wikipedia.org/',
         'timeout': 1,
         'check_certificate_expiration': False,
+<<<<<<< f314eb08b7257cf696f8f1bb4d76234f98f6340c
         'content_match': u'メインページ'
+=======
+        'content_match': 'メインページ'
+    }, {
+        'name': 'cnt_mismatch_reverse',
+        'url': 'https://github.com',
+        'timeout': 1,
+        'reverse_content_match': True,
+        'check_certificate_expiration': False,
+        'content_match': 'thereisnosuchword'
+    }, {
+        'name': 'cnt_match_reverse',
+        'url': 'https://github.com',
+        'timeout': 1,
+        'reverse_content_match': True,
+        'check_certificate_expiration': False,
+        'content_match': '(thereisnosuchword|github)'
+    }, {
+        'name': 'cnt_match_unicode_reverse',
+        'url': 'https://ja.wikipedia.org/',
+        'timeout': 1,
+        'reverse_content_match': True,
+        'check_certificate_expiration': False,
+        'content_match': 'メインページ'
+>>>>>>> [HTTP CHECK] Add an Option to mark check as DOWN if a content is found
     }
     ]
 }

--- a/tests/checks/integration/test_http_check.py
+++ b/tests/checks/integration/test_http_check.py
@@ -56,6 +56,12 @@ CONFIG = {
         'check_certificate_expiration': False,
         'content_match': u'メインページ'
     }, {
+        'name': 'cnt_mismatch_unicode',
+        'url': 'https://ja.wikipedia.org/',
+        'timeout': 1,
+        'check_certificate_expiration': False,
+        'content_match': u'メインペーー'
+    }, {
         'name': 'cnt_mismatch_reverse',
         'url': 'https://github.com',
         'timeout': 1,
@@ -69,6 +75,13 @@ CONFIG = {
         'reverse_content_match': True,
         'check_certificate_expiration': False,
         'content_match': '(thereisnosuchword|github)'
+    }, {
+        'name': 'cnt_mismatch_unicode_reverse',
+        'url': 'https://ja.wikipedia.org/',
+        'timeout': 1,
+        'reverse_content_match': True,
+        'check_certificate_expiration': False,
+        'content_match': u'メインペーー'
     }, {
         'name': 'cnt_match_unicode_reverse',
         'url': 'https://ja.wikipedia.org/',
@@ -248,11 +261,19 @@ class HTTPCheckTest(AgentCheckTest):
         self.assertServiceCheckOK("http.can_connect", tags=tags)
         tags = ['url:https://ja.wikipedia.org/', 'instance:cnt_match_unicode']
         self.assertServiceCheckOK("http.can_connect", tags=tags)
+        tags = ['url:https://ja.wikipedia.org/', 'instance:cnt_mismatch_unicode']
+        self.assertServiceCheckCritical("http.can_connect", tags=tags)
+        self.assertServiceCheckOK("http.can_connect", tags=tags, count=0)
         tags = ['url:https://github.com', 'instance:cnt_mismatch_reverse']
         self.assertServiceCheckOK("http.can_connect", tags=tags)
         self.assertServiceCheckCritical("http.can_connect", tags=tags, count=0)
         tags = ['url:https://github.com', 'instance:cnt_match_reverse']
         self.assertServiceCheckCritical("http.can_connect", tags=tags)
+        tags = ['url:https://ja.wikipedia.org/', 'instance:cnt_mismatch_unicode_reverse']
+        self.assertServiceCheckOK("http.can_connect", tags=tags)
+        tags = ['url:https://ja.wikipedia.org/', 'instance:cnt_match_unicode_reverse']
+        self.assertServiceCheckCritical("http.can_connect", tags=tags)
+        self.assertServiceCheckOK("http.can_connect", tags=tags, count=0)
 
         self.coverage_report()
 

--- a/tests/checks/integration/test_http_check.py
+++ b/tests/checks/integration/test_http_check.py
@@ -54,10 +54,7 @@ CONFIG = {
         'url': 'https://ja.wikipedia.org/',
         'timeout': 1,
         'check_certificate_expiration': False,
-<<<<<<< f314eb08b7257cf696f8f1bb4d76234f98f6340c
         'content_match': u'メインページ'
-=======
-        'content_match': 'メインページ'
     }, {
         'name': 'cnt_mismatch_reverse',
         'url': 'https://github.com',
@@ -78,8 +75,7 @@ CONFIG = {
         'timeout': 1,
         'reverse_content_match': True,
         'check_certificate_expiration': False,
-        'content_match': 'メインページ'
->>>>>>> [HTTP CHECK] Add an Option to mark check as DOWN if a content is found
+        'content_match': u'メインページ'
     }
     ]
 }
@@ -252,6 +248,11 @@ class HTTPCheckTest(AgentCheckTest):
         self.assertServiceCheckOK("http.can_connect", tags=tags)
         tags = ['url:https://ja.wikipedia.org/', 'instance:cnt_match_unicode']
         self.assertServiceCheckOK("http.can_connect", tags=tags)
+        tags = ['url:https://github.com', 'instance:cnt_mismatch_reverse']
+        self.assertServiceCheckOK("http.can_connect", tags=tags)
+        self.assertServiceCheckCritical("http.can_connect", tags=tags, count=0)
+        tags = ['url:https://github.com', 'instance:cnt_match_reverse']
+        self.assertServiceCheckCritical("http.can_connect", tags=tags)
 
         self.coverage_report()
 


### PR DESCRIPTION
### What does this PR do?

Adds a feature to the Http_check : allows users to look for a certain content in the URL and shows the check as DOWN if that content is found. 

User will need to set the `reverse_content_match` to `true` in order to do so. 

### Motivation

Several Customer Requests 

### Testing Guidelines

Added some test to the `tests/checks/integration/test_http_check.py` file to test the new feature independantly while checking there was no retro compatibility issue.

Ran the rake ci:run[system] and the behavior was expected

### Additional Notes

Anything else we should know when reviewing?

Option to Enable is reverse_content_match, defaults to False