### PR TITLE
[Kubernetes] Add state metrics for pods and containers

### DIFF
--- a/tests/checks/mock/test_kubernetes_state.py
+++ b/tests/checks/mock/test_kubernetes_state.py
@@ -60,6 +60,12 @@ class TestKubernetesState(AgentCheckTest):
 
         self.assertServiceCheck(NAMESPACE + '.node.ready', self.check.OK)
         self.assertServiceCheck(NAMESPACE + '.node.out_of_disk', self.check.OK)
+        self.assertServiceCheck(NAMESPACE + '.pod.phase.running', self.check.OK)
+        # TODO: uncomment when any of these are in the test protobuf.bin
+        # self.assertServiceCheck(NAMESPACE + '.pod.phase.pending', self.check.WARNING)
+        # self.assertServiceCheck(NAMESPACE + '.pod.phase.succeeded', self.check.OK)
+        # self.assertServiceCheck(NAMESPACE + '.pod.phase.failed', self.check.CRITICAL)
+        # self.assertServiceCheck(NAMESPACE + '.pod.phase.unknown', self.check.UNKNOWN)
 
         self.assertMetric(NAMESPACE + '.node.cpu_capacity')
         self.assertMetric(NAMESPACE + '.node.memory_capacity')
@@ -68,6 +74,12 @@ class TestKubernetesState(AgentCheckTest):
         self.assertMetric(NAMESPACE + '.node.memory_allocatable')
         self.assertMetric(NAMESPACE + '.node.pods_allocatable')
         self.assertMetric(NAMESPACE + '.node.status')
+        self.assertMetric(NAMESPACE + '.container.cpu_requested')
+        self.assertMetric(NAMESPACE + '.container.memory_requested')
+        # TODO: uncomment when kube-state-metrics 0.4 is released
+        # self.assertMetric(NAMESPACE + '.container.cpu_limit')
+        # self.assertMetric(NAMESPACE + '.container.memory_limit')
+        self.assertMetric(NAMESPACE + '.container.restarts')
         self.assertMetric(NAMESPACE + '.deployment.replicas_available')
         self.assertMetric(NAMESPACE + '.deployment.replicas_unavailable')
         self.assertMetric(NAMESPACE + '.deployment.replicas_desired')


### PR DESCRIPTION
### What does this PR do?

It adds more kubernetes state metrics:
 * Add mem/cpu requests and limits
 * Add container restarts
 * Add pod phase: Pending|Running|Succeeded|Failed|Unknown

It fixes part of #3045

### Motivation

We'd like to know things such as which containers are restarting, which pods are in pending or failed states, container requests/limits, etc.

### Additional Notes

Tests might fail because the prometheus protobuf.bin blob lacks the
resource limits added in https://github.com/kubernetes/kube-state-metrics/pull/49

I can comment those out in the tests or in the code. Or maybe someone can add an updated protobuf dump.
