### PR TITLE
page memory should be collected through swap_memory()

### DIFF
--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -187,7 +187,7 @@ class Memory(Check):
             pct_usable = float(usable) / total
             self.save_sample('system.mem.pct_usable', pct_usable)
 
-        page = psutil.virtual_memory()
+        page = psutil.swap_memory()
         if page.total is not None:
             self.save_sample('system.mem.page_total', page.total / B2MB)
             self.save_sample('system.mem.page_used', page.used / B2MB)

--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -192,7 +192,7 @@ class Memory(Check):
             self.save_sample('system.mem.page_total', page.total / B2MB)
             self.save_sample('system.mem.page_used', page.used / B2MB)
             self.save_sample('system.mem.page_free', page.free / B2MB)
-            self.save_sample('system.mem.page_pct_free', (100 - page.percent))
+            self.save_sample('system.mem.page_pct_free', 100 - page.percent)
 
         return self.get_metrics()
 

--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -191,8 +191,8 @@ class Memory(Check):
         if page.total is not None:
             self.save_sample('system.mem.page_total', page.total / B2MB)
             self.save_sample('system.mem.page_used', page.used / B2MB)
-            self.save_sample('system.mem.page_free', page.available / B2MB)
-            self.save_sample('system.mem.page_pct_free', (100 - page.percent) / 100)
+            self.save_sample('system.mem.page_free', page.free / B2MB)
+            self.save_sample('system.mem.page_pct_free', (100 - page.percent))
 
         return self.get_metrics()
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

- In order to collect memory swap metrics for windows, we should use sawp_memory() instead. 
- A percentage should be 0 to 100 number.

### Motivation

This can be a bug.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?

