### PR TITLE
adds proper pagefile memory on windows

### DIFF
--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -114,10 +114,10 @@ class Memory(Check):
         self.gauge('system.mem.usable')
         self.gauge('system.mem.pct_usable')
         #  details about the usage of the pagefile.
-        self.gauge('system.mem.page_total')
-        self.gauge('system.mem.page_used')
-        self.gauge('system.mem.page_free')
-        self.gauge('system.mem.page_pct_free')
+        self.gauge('system.mem.pagefile_total')
+        self.gauge('system.mem.pagefile_used')
+        self.gauge('system.mem.pagefile_free')
+        self.gauge('system.mem.pagefile_pct_free')
 
     def check(self, agentConfig):
         try:
@@ -187,12 +187,14 @@ class Memory(Check):
             pct_usable = float(usable) / total
             self.save_sample('system.mem.pct_usable', pct_usable)
 
-        page = psutil.virtual_memory()
+        # swap_memory pulls from the pagefile data,
+        # rather than from the whole virtual memory data.
+        page = psutil.swap_memory()
         if page.total is not None:
-            self.save_sample('system.mem.page_total', page.total / B2MB)
-            self.save_sample('system.mem.page_used', page.used / B2MB)
-            self.save_sample('system.mem.page_free', page.available / B2MB)
-            self.save_sample('system.mem.page_pct_free', (100 - page.percent) / 100)
+            self.save_sample('system.mem.pagefile_total', page.total / B2MB)
+            self.save_sample('system.mem.pagefile_used', page.used / B2MB)
+            self.save_sample('system.mem.pagefile_free', page.available / B2MB)
+            self.save_sample('system.mem.pagefile_pct_free', (100 - page.percent) / 100)
 
         return self.get_metrics()
 

--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -114,10 +114,10 @@ class Memory(Check):
         self.gauge('system.mem.usable')
         self.gauge('system.mem.pct_usable')
         #  details about the usage of the pagefile.
-        self.gauge('system.mem.pagefile_total')
-        self.gauge('system.mem.pagefile_used')
-        self.gauge('system.mem.pagefile_free')
-        self.gauge('system.mem.pagefile_pct_free')
+        self.gauge('system.mem.pagefile.total')
+        self.gauge('system.mem.pagefile.used')
+        self.gauge('system.mem.pagefile.free')
+        self.gauge('system.mem.pagefile.pct_free')
 
     def check(self, agentConfig):
         try:
@@ -191,10 +191,10 @@ class Memory(Check):
         # rather than from the whole virtual memory data.
         page = psutil.swap_memory()
         if page.total is not None:
-            self.save_sample('system.mem.pagefile_total', page.total / B2MB)
-            self.save_sample('system.mem.pagefile_used', page.used / B2MB)
-            self.save_sample('system.mem.pagefile_free', page.free / B2MB)
-            self.save_sample('system.mem.pagefile_pct_free', (100 - page.percent) / 100)
+            self.save_sample('system.mem.pagefile.total', page.total / B2MB)
+            self.save_sample('system.mem.pagefile.used', page.used / B2MB)
+            self.save_sample('system.mem.pagefile.free', page.free / B2MB)
+            self.save_sample('system.mem.pagefile.pct_free', (100 - page.percent) / 100)
 
         return self.get_metrics()
 

--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -193,7 +193,7 @@ class Memory(Check):
         if page.total is not None:
             self.save_sample('system.mem.pagefile_total', page.total / B2MB)
             self.save_sample('system.mem.pagefile_used', page.used / B2MB)
-            self.save_sample('system.mem.pagefile_free', page.available / B2MB)
+            self.save_sample('system.mem.pagefile_free', page.free / B2MB)
             self.save_sample('system.mem.pagefile_pct_free', (100 - page.percent) / 100)
 
         return self.get_metrics()

--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -191,9 +191,9 @@ class Memory(Check):
         # rather than from the whole virtual memory data.
         page = psutil.swap_memory()
         if page.total is not None:
-            self.save_sample('system.mem.pagefile.total', page.total / B2MB)
-            self.save_sample('system.mem.pagefile.used', page.used / B2MB)
-            self.save_sample('system.mem.pagefile.free', page.free / B2MB)
+            self.save_sample('system.mem.pagefile.total', page.total)
+            self.save_sample('system.mem.pagefile.used', page.used)
+            self.save_sample('system.mem.pagefile.free', page.free)
             self.save_sample('system.mem.pagefile.pct_free', (100 - page.percent) / 100)
 
         return self.get_metrics()


### PR DESCRIPTION
### What does this PR do?

This PR fixes the naming of pagefile memory on windows, it also fixes where we're pulling it from in psutil. Previously, we were reporting the physical memory, rather than the pagefile.