### PR TITLE
Export http_host tag with PHP-FPM metrics

### DIFF
--- a/checks.d/php_fpm.py
+++ b/checks.d/php_fpm.py
@@ -104,6 +104,8 @@ class PHPFPMCheck(AgentCheck):
             ping_reply = 'pong'
 
         sc_tags = ["ping_url:{0}".format(ping_url)]
+        if http_host is not None:
+            sc_tags += ["http_host:{0}".format(http_host)]
 
         try:
             # TODO: adding the 'full' parameter gets you per-process detailed

--- a/checks.d/php_fpm.py
+++ b/checks.d/php_fpm.py
@@ -83,6 +83,8 @@ class PHPFPMCheck(AgentCheck):
 
         pool_name = data.get('pool', 'default')
         metric_tags = tags + ["pool:{0}".format(pool_name)]
+        if http_host is not None:
+            metric_tags += ["http_host:{0}".format(http_host)]
 
         for key, mname in self.GAUGES.iteritems():
             if key not in data:


### PR DESCRIPTION
### What does this PR do?

This PR builds upon https://github.com/DataDog/dd-agent/pull/2779.

It exports the newly added `http_host` option as a tag for both the PHP-FPM
service check and the metric data.

### Motivation

The author's use case in the original PR was for a single site behind a load
balancer that may be exposed by _only_ a distinct host URL that wasn't
`localhost`.

My current use case differs slightly.  I have a host with multiple vhosts, each
with its own FPM pool defined.  The FPM status page for each vhost listens on
http://localhost/php-fpm-status.  The newly added `http_host` option allows me
to define multiple instances that each talk to a different vhost/pool by way of
the host header whilst hitting the same `ping_url`.

The current integration allows you to group checks based on `ping_url`.  In my
circumstance, this is value identical for every pool.  This means that if just
one of the pool checks fails, the check hits its critical threshold without any
indication to the operator as to _which_ pool or instance failed.  Allowing the
option to group by the `http_host` tag allows the operator to identify the
source of the problem easily.

The first commit exposes this tag via the service check.

The second commit exposes this tag with the metric data also.  I have made this
amendment for consistency such that an operator can query on this tag for
relevant metrics in future.

### Testing Guidelines

I have tested this as a custom service check however have not executed your
test harness.

### Additional Notes

I am unsure as to the conditional statements and am willing to amend if
necessary.

I felt it better omit the tag rather than supply one with a null value.  I am
unsure what preferred practice is.

I am also aware that the `pool` tag is already exported with the metrics.
Whilst an operator can potentially discern the right pool exhibiting a problem
by way of the `pool` tag, I felt it wise to include the extra tag for the
following reasons:

 * The `pool` tag is not always populated.  This tag is gathered from the
   response that the FPM extended status page returns.  If the request to the
   status page fails (an error condition I am facing now), the tag is exported
   with no value.
 * Adding the extra `http_host` tag allows for easier metric queries later that
   are consistent between the service check data and metric data.

Additionally, I am unsure if the Datadog UI will require any amendments because
of this change.  The PHP-FPM integration page appears to lock down the
'grouping' clauses to `host` and `ping_url` with no option for adjustment.
