### PR TITLE
Exclude shutdown-script and google-container-manifest metadata.

### DIFF
--- a/utils/cloud_metadata.py
+++ b/utils/cloud_metadata.py
@@ -19,8 +19,8 @@ class GCE(object):
     TIMEOUT = 0.3 # second
     SOURCE_TYPE_NAME = 'google cloud platform'
     metadata = None
-    EXCLUDED_ATTRIBUTES = ["kube-env", "startup-script", "sshKeys", "user-data",
-    "cli-cert", "ipsec-cert", "ssl-cert"]
+    EXCLUDED_ATTRIBUTES = ["kube-env", "startup-script", "shutdown-script", "sshKeys", "user-data",
+    "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest"]
 
 
     @staticmethod

--- a/utils/cloud_metadata.py
+++ b/utils/cloud_metadata.py
@@ -19,7 +19,7 @@ class GCE(object):
     TIMEOUT = 0.3 # second
     SOURCE_TYPE_NAME = 'google cloud platform'
     metadata = None
-    EXCLUDED_ATTRIBUTES = ["kube-env", "startup-script", "shutdown-script", "sshKeys", "user-data",
+    EXCLUDED_ATTRIBUTES = ["kube-env", "startup-script", "shutdown-script", "configure-sh", "sshKeys", "user-data",
     "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest"]
 
 


### PR DESCRIPTION
### What does this PR do?

Adds `shutdown-script`, `configure-sh`, and `google-container-manifest` to the list of excluded GCE metadata keys.

### Motivation

The `google-container-manifest` metadata likely contains sensitive info, and is a kubernetes config file so it doesn't make any sense to use as a datadog tag in any case. It's similar to what can be stored in the `user-data` key (which is already excluded) but is specifically used for configuring the older container-vm images on GCE. The `configure-sh` metadata is a big kubernetes bash script that should also be excluded.

Excluding `shutdown-script` is equivalent to the current exclusion for `startup-script`.
