### PR TITLE
[zk] Modified sc_tags in zk.py to include user-specified tags.

### DIFF
--- a/checks.d/zk.py
+++ b/checks.d/zk.py
@@ -129,7 +129,7 @@ class ZookeeperCheck(AgentCheck):
         expected_mode = (instance.get('expected_mode') or '').strip()
         tags = instance.get('tags', [])
         cx_args = (host, port, timeout)
-        sc_tags = ["host:{0}".format(host), "port:{0}".format(port)]
+        sc_tags = ["host:{0}".format(host), "port:{0}".format(port)] + list(set(tags))
         hostname = self.hostname
         report_instance_mode = instance.get("report_instance_mode", True)
 


### PR DESCRIPTION
### What does this PR do?

The manner in which tags are applied to service checks and metric checks depends on 2 separate variables. This change modifies the variable that encapsulates tags relevant to service checks (`sc_tags`). Currently for service checks, this variable applies only the host and port information provided in the instance configuration. This change will allow user-defined tags to similarly be applied to service checks (as is the case with metric checks). 

### Motivation

Several of the core integrations handle tags differently for the purposes of metric checks vs. service checks. It's unclear what motivated the inconsistent handling of tags in these contexts. When users are using tags to template alerts, this presents an unnecessary limitation that impacts the ability to template service check-based alerts.

While this PR addresses this inconsistency in one of these integrations (Zookeeper), there should be an effort to normalize the handling of tags in different contexts across natively-supported integrations. 
