### PR TITLE
[couchbase] Modified service_check_tags in couchbase.py to include user-spec…

### DIFF
--- a/checks.d/couchbase.py
+++ b/checks.d/couchbase.py
@@ -172,7 +172,12 @@ class Couchbase(AgentCheck):
         url = '%s%s' % (server, COUCHBASE_STATS_PATH)
 
         # Fetch initial stats and capture a service check based on response.
-        service_check_tags = ['instance:%s' % server]
+        service_check_tags = instance.get('tags', [])
+        if service_check_tags is None:
+            service_check_tags = []
+        else:
+            service_check_tags = list(set(service_check_tags))
+        service_check_tags.append('instance:%s' % server)
         try:
             overall_stats = self._get_stats(url, instance)
             # No overall stats? bail out now


### PR DESCRIPTION
### What does this PR do?

The manner in which tags are applied to service checks and metric checks depends on 2 separate variables. This change modifies the variable that encapsulates tags relevant to service checks (`service_check_tags`). Currently for service checks, this variable applies only the host and port information provided in the instance configuration. This change will allow user-defined tags to similarly be applied to service checks (as is the case with metric checks).

### Motivation

Several of the core integrations handle tags differently for the purposes of metric checks vs. service checks. It's unclear what motivated the inconsistent handling of tags in these contexts. When users are using tags to template alerts, this presents an unnecessary limitation that impacts the ability to template service check-based alerts.

While this PR addresses this inconsistency in one of these integrations (Couchbase), there should be an effort to normalize the handling of tags in different contexts across natively-supported integrations.