### PR TITLE
Update on tag_by_filesystem section of disk.yaml.default

### DIFF
--- a/conf.d/disk.yaml.default
+++ b/conf.d/disk.yaml.default
@@ -24,7 +24,7 @@ instances:
     # excluded_disk_re: /dev/sde.*
     #
     # The (optional) tag_by_filesystem parameter will instruct the check to
-    # tag all disks with their filesystem (for ex: filesystem:nfs)
+    # tag all disks with their filesystem (for ex: nfs)
     # tag_by_filesystem: no
     #
     # The (optional) excluded_mountpoint_re parameter will instruct the check to


### PR DESCRIPTION

### What does this PR do?

Makes a small change in `disk.yaml.default`.

### Motivation

A client is using the disk integration's `tag_by_filesystem` option and expecting tags like `#filesystem:nfs` as the example states in disk.yaml.default. 

Tags are being generated without the `filesystem:` prefix.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?

