### PR TITLE
Add in support for /etc/default/datadog-agent and set nicelevel from it

### DIFF
--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -42,6 +42,7 @@ DD_OPT_PROC_REGEX="dogstatsd|jmxfetch|go-metro"
 # Source function library.
 . /etc/rc.d/init.d/functions
 
+[ -r /etc/default/datadog-agent ] && . /etc/default/datadog-agent
 
 check_status() {
     # run checks to determine if the service is running or use generic status
@@ -135,6 +136,10 @@ start() {
         echo -n $'\n'"Invalid check configuration. Please run sudo /etc/init.d/datadog-agent configtest for more details."
         echo -n $'\n'"Resuming starting process."$'\n'
     fi
+
+    # NICELEVEL, if set, comes from /etc/default/datadog-agent.
+    # daemon will honor it, so we should export it.
+    export NICELEVEL
 
     # no need to test for status before daemon,
     # the daemon function does the right thing

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -30,6 +30,8 @@ COLLECTOR_PIDFILE="/opt/datadog-agent/run/dd-agent.pid"
 SYSTEM_PATH=/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:$PATH
 DD_OPT_PROC_REGEX="dogstatsd|jmxfetch|go-metro"
 
+[ -r /etc/default/datadog-agent ] && . /etc/default/datadog-agent
+
 if [ ! -x $AGENTPATH ]; then
     echo "$AGENTPATH not found. Exiting."
     exit 0
@@ -133,7 +135,7 @@ case "$1" in
 
 
         log_daemon_msg "Starting $DESC (using supervisord)" "$NAME"
-        PATH=$SYSTEM_PATH start-stop-daemon --start --quiet --oknodo --exec $SUPERVISORD_PATH -- -c $SUPERVISOR_FILE --pidfile $SUPERVISOR_PIDFILE
+        PATH=$SYSTEM_PATH start-stop-daemon --start ${NICELEVEL:+"--nicelevel $NICELEVEL"} --quiet --oknodo --exec $SUPERVISORD_PATH -- -c $SUPERVISOR_FILE --pidfile $SUPERVISOR_PIDFILE
         if [ $? -ne 0 ]; then
             log_end_msg 1
         fi


### PR DESCRIPTION
### What does this PR do?

This adds support for `/etc/default/datadog-agent` into the debian and centos init scripts.
It then uses the `NICELEVEL` if set.

In debian, start-stop-daemon has a `--nicelevel` argument.

In centos, daemon does not, but seems to honor the NICELEVEL environmental variable

### Motivation

In my environment, we run sshd at a high priority to aid in access during host issues. This higher priority is inherited by apt, and by the init script. Thus accidentally causing datadog-agent to run at high priority

We're finding that when datadog-agent runs at a high priority, gohai ends up causing some CPU locks.  I referenced this in https://github.com/DataDog/dd-agent/issues/3085 This is workaround.

### Additional Notes

I don't know how to add this to the systemd configs. Though they won't have the same inheritance issue I'm running into.
