### PR TITLE
[yarn] Add metrics for capacityScheduler

### DIFF
--- a/tests/checks/fixtures/yarn/scheduler_metrics
+++ b/tests/checks/fixtures/yarn/scheduler_metrics
@@ -1,0 +1,76 @@
+{
+   "scheduler" : {
+      "schedulerInfo" : {
+         "type" : "capacityScheduler",
+         "maxCapacity" : 100,
+         "usedCapacity" : 35.012,
+         "capacity" : 100,
+         "queueName" : "root",
+         "queues" : {
+            "queue" : [
+               {
+                  "numPendingApplications" : 0,
+                  "userAMResourceLimit" : {
+                     "memory" : 2587968,
+                     "vCores" : 688
+                  },
+                  "type" : "capacitySchedulerLeafQueueInfo",
+                  "absoluteCapacity" : 52.12,
+                  "userLimitFactor" : 1,
+                  "userLimit" : 100,
+                  "numApplications" : 3,
+                  "users" : {
+                     "user" : [
+                        {
+                           "numPendingApplications" : 0,
+                           "AMResourceUsed" : {
+                              "memory" : 2688,
+                              "vCores" : 3
+                           },
+                           "numActiveApplications" : 3,
+                           "userResourceLimit" : {
+                              "memory" : 5175936,
+                              "vCores" : 1376
+                           },
+                           "username" : "root",
+                           "resourcesUsed" : {
+                              "memory" : 3164800,
+                              "vCores" : 579
+                           }
+                        }
+                     ]
+                  },
+                  "nodeLabels" : [
+                     "*"
+                  ],
+                  "usedAMResource" : {
+                     "memory" : 2688,
+                     "vCores" : 3
+                  },
+                  "hideReservationQueues" : false,
+                  "queueName" : "clientqueue",
+                  "absoluteUsedCapacity" : 31.868685,
+                  "resourcesUsed" : {
+                     "memory" : 3164800,
+                     "vCores" : 579
+                  },
+                  "AMResourceLimit" : {
+                     "vCores" : 688,
+                     "memory" : 2587968
+                  },
+                  "capacity" : 52.12,
+                  "state" : "RUNNING",
+                  "numActiveApplications" : 3,
+                  "preemptionDisabled" : false,
+                  "absoluteMaxCapacity" : 52.12,
+                  "usedCapacity" : 61.14484,
+                  "numContainers" : 75,
+                  "maxCapacity" : 52.12,
+                  "maxApplications" : 5212,
+                  "maxApplicationsPerUser" : 5212
+               }
+            ]
+         }
+      }
+   }
+}

--- a/tests/checks/mock/test_yarn.py
+++ b/tests/checks/mock/test_yarn.py
@@ -17,6 +17,7 @@ RM_ADDRESS = 'http://localhost:8088'
 YARN_CLUSTER_METRICS_URL = urljoin(RM_ADDRESS, '/ws/v1/cluster/metrics')
 YARN_APPS_URL = urljoin(RM_ADDRESS, '/ws/v1/cluster/apps') + '?states=RUNNING'
 YARN_NODES_URL = urljoin(RM_ADDRESS, '/ws/v1/cluster/nodes')
+YARN_SCHEDULER_URL = urljoin(RM_ADDRESS, '/ws/v1/cluster/scheduler')
 
 
 def requests_get_mock(*args, **kwargs):
@@ -44,6 +45,11 @@ def requests_get_mock(*args, **kwargs):
 
     elif args[0] == YARN_NODES_URL:
         with open(Fixtures.file('nodes_metrics'), 'r') as f:
+            body = f.read()
+            return MockResponse(body, 200)
+
+    elif args[0] == YARN_SCHEDULER_URL:
+        with open(Fixtures.file('scheduler_metrics'), 'r') as f:
             body = f.read()
             return MockResponse(body, 200)
 
@@ -128,6 +134,50 @@ class YARNCheck(AgentCheckTest):
         'opt_key:opt_value'
     ]
 
+    YARN_ROOT_QUEUE_METRICS_VALUES = {
+        'yarn.queue.root.max_capacity': 100,
+        'yarn.queue.root.used_capacity': 35.012,
+        'yarn.queue.root.capacity': 100
+    }
+
+    YARN_ROOT_QUEUE_METRICS_TAGS = [
+        'cluster_name:%s' % CLUSTER_NAME,
+        'queue_name:root',
+        'opt_key:opt_value'
+    ]
+
+    YARN_QUEUE_METRICS_VALUES = {
+        'yarn.queue.num_pending_applications': 0,
+        'yarn.queue.user_am_resource_limit.memory': 2587968,
+        'yarn.queue.user_am_resource_limit.vcores': 688,
+        'yarn.queue.absolute_capacity': 52.12,
+        'yarn.queue.user_limit_factor': 1,
+        'yarn.queue.user_limit': 100,
+        'yarn.queue.num_applications': 3,
+        'yarn.queue.used_am_resource.memory': 2688,
+        'yarn.queue.used_am_resource.vcores': 3,
+        'yarn.queue.absolute_used_capacity': 31.868685,
+        'yarn.queue.resources_used.memory': 3164800,
+        'yarn.queue.resources_used.vcores': 579,
+        'yarn.queue.am_resource_limit.vcores': 688,
+        'yarn.queue.am_resource_limit.memory': 2587968,
+        'yarn.queue.capacity': 52.12,
+        'yarn.queue.num_active_applications': 3,
+        'yarn.queue.absolute_max_capacity': 52.12,
+        'yarn.queue.used_capacity': 61.14484,
+        'yarn.queue.num_containers': 75,
+        'yarn.queue.max_capacity': 52.12,
+        'yarn.queue.max_applications': 5212,
+        'yarn.queue.max_applications_per_user': 5212
+    }
+
+    YARN_QUEUE_METRICS_TAGS = [
+        'cluster_name:%s' % CLUSTER_NAME,
+        'queue_name:clientqueue',
+        'opt_key:opt_value'
+    ]
+
+
     @mock.patch('requests.get', side_effect=requests_get_mock)
     def test_check(self, mock_requests):
         config = {
@@ -153,3 +203,15 @@ class YARNCheck(AgentCheckTest):
             self.assertMetric(metric,
                 value=value,
                 tags=self.YARN_NODE_METRICS_TAGS)
+
+        # Check the YARN Root Queue Metrics
+        for metric, value in self.YARN_ROOT_QUEUE_METRICS_VALUES.iteritems():
+            self.assertMetric(metric,
+                value=value,
+                tags=self.YARN_ROOT_QUEUE_METRICS_TAGS)
+
+        # Check the YARN Custom Queue Metrics
+        for metric, value in self.YARN_QUEUE_METRICS_VALUES.iteritems():
+            self.assertMetric(metric,
+                value=value,
+                tags=self.YARN_QUEUE_METRICS_TAGS)


### PR DESCRIPTION
Current yarn Datadog plugin doesn't provide metrics for scheduler endpoint. In this PR we add metrics for capacityScheduler, but also making it extendable for implement fairScheduler metrics.

With capacityScheduler sometimes can be hard to see why a customer cannot submit more applications  (cpu / memory / AM boundaries). To have this metrics can help the teams to understand their usage of their assigned resources.

The fixture and the tests has been added to the already existing yarn plugin tests.

Notes:
* Currently only implementing capacityScheduler
* I've had to make an small change on the function to set the metrics from the response dictionary. So far with the already existing endpoints it was expecting a one-level json. On the response from the capacityScheduler endpoint you get a two-level json per queue.
