### PR TITLE
Add missing type

### DIFF
--- a/aggregator.py
+++ b/aggregator.py
@@ -744,6 +744,7 @@ class MetricsBucketAggregator(Aggregator):
         self.last_flush_cutoff_time = 0
         self.metric_type_to_class = {
             'g': BucketGauge,
+            'ct': Count,
             'c': Counter,
             'h': Histogram,
             'ms': Histogram,


### PR DESCRIPTION
### What does this PR do?

This PR adds a missing type of metric. The `Count` metric was already implemented but I was unable to use it due to it being missing from the possible metrics map.

### Motivation

I wanted to be able to count occurrences. `Inc`, `Dec` and `Counter` will only track the rate of occurrence.

### Testing Guidelines

I did not write tests for this PR.

### Additional Notes

As stated above, this started from wanting to submit actual count metrics, rather then rate of occurrences.
I also found https://github.com/DataDog/dd-agent/issues/659 to be helpful.
I submitted an additional PR to the Go client here https://github.com/DataDog/datadog-go/pull/27

