### PR TITLE
[test][sdk] override fixture dir for SDK.

### DIFF
--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -117,17 +117,20 @@ class Fixtures(object):
         raise Exception('No integration test file in stack')
 
     @staticmethod
-    def directory():
+    def directory(sdk_dir=None):
+        if sdk_dir:
+            return os.path.join(sdk_dir, 'fixtures')
+
         return os.path.join(os.path.dirname(__file__), 'fixtures',
                             Fixtures.integration_name())
 
     @staticmethod
-    def file(file_name):
-        return os.path.join(Fixtures.directory(), file_name)
+    def file(file_name, sdk_dir=None):
+        return os.path.join(Fixtures.directory(sdk_dir), file_name)
 
     @staticmethod
-    def read_file(file_name, string_escape=True):
-        with open(Fixtures.file(file_name)) as f:
+    def read_file(file_name, string_escape=True, sdk_dir=None):
+        with open(Fixtures.file(file_name, sdk_dir)) as f:
             contents = f.read()
             if string_escape:
                 contents = contents.decode('string-escape')


### PR DESCRIPTION
### What does this PR do?

Allows us to override fixtures location. Helpful for the SDK.

### Motivation

Ran into this while porting the `ceph` check to the SDK.

