### PR TITLE
Skip dbname's we can't access

### DIFF
--- a/checks.d/tokumx.py
+++ b/checks.d/tokumx.py
@@ -12,6 +12,7 @@ import bson
 from pymongo import (
     MongoClient,
     ReadPreference,
+    errors,
     uri_parser,
     version as py_version,
 )
@@ -424,7 +425,11 @@ class TokuMX(AgentCheck):
                 db_tags = list(tags)
                 db_tags.append('db:%s' % dbname)
                 db = conn[dbname]
-                stats = db.command('dbstats')
+                try:
+                    stats = db.command('dbstats')
+                except errors.OperationFailure:
+                    self.log.warning("Cannot access dbstats on database %s" % dbname)
+                    continue
                 for m, v in stats.items():
                     if m in ['db', 'ok']:
                         continue


### PR DESCRIPTION
The datadog user may only have access to the databases which the customer
wishes to monitor. Without this patch, a failure to invoke dbstats on _any_
database would raise an exception and prevent monitoring for _all_ databases.
With this patch, databases that cannot be accessed are ignored with a warning.