### PR TITLE
[Windows] Remove system network check.  Network check was added as

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -214,7 +214,6 @@ class Collector(object):
             'io': w32.IO(log),
             'proc': w32.Processes(log),
             'memory': w32.Memory(log),
-            'network': w32.Network(log),
             'cpu': w32.Cpu(log),
             'system': w32.System(log)
         }
@@ -294,7 +293,7 @@ class Collector(object):
         # Run the system checks. Checks will depend on the OS
         if Platform.is_windows():
             # Win32 system checks
-            for check_name in ['memory', 'cpu', 'network', 'io', 'proc', 'system']:
+            for check_name in ['memory', 'cpu', 'io', 'proc', 'system']:
                 try:
                     metrics.extend(self._win32_system_checks[check_name].check(self.agentConfig))
                 except Exception:

--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -216,51 +216,6 @@ class Cpu(Check):
 
         return self.get_metrics()
 
-
-class Network(Check):
-    def __init__(self, logger):
-        Check.__init__(self, logger)
-
-        # Sampler(s)
-        self.wmi_sampler = WMISampler(
-            logger,
-            "Win32_PerfRawData_Tcpip_NetworkInterface",
-            ["Name", "BytesReceivedPerSec", "BytesSentPerSec"]
-        )
-
-        self.gauge('system.net.bytes_rcvd')
-        self.gauge('system.net.bytes_sent')
-
-    def check(self, agentConfig):
-        try:
-            self.wmi_sampler.sample()
-        except TimeoutException:
-            self.logger.warning(
-                u"Timeout while querying Win32_PerfRawData_Tcpip_NetworkInterface WMI class."
-                u" Network metrics will be returned at next iteration."
-            )
-            return []
-
-        if not (len(self.wmi_sampler)):
-            self.logger.warning('Missing Win32_PerfRawData_Tcpip_NetworkInterface WMI class.'
-                             ' No network metrics will be returned')
-            return []
-
-        for iface in self.wmi_sampler:
-            name = iface.get('Name')
-            bytes_received_per_sec = iface.get('BytesReceivedPerSec')
-            bytes_sent_per_sec = iface.get('BytesSentPerSec')
-
-            name = self.normalize_device_name(name)
-            if bytes_received_per_sec is not None:
-                self.save_sample('system.net.bytes_rcvd', bytes_received_per_sec,
-                                 device_name=name)
-            if bytes_sent_per_sec is not None:
-                self.save_sample('system.net.bytes_sent', bytes_sent_per_sec,
-                                 device_name=name)
-        return self.get_metrics()
-
-
 class IO(Check):
     def __init__(self, logger):
         Check.__init__(self, logger)


### PR DESCRIPTION
checks.d/network. This check is redundant, and causing confusing returns
as the same metric is being reported from two different places.

*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Removes the Network check from the system checks.

### Motivation

While debugging/testing a separate code change, found that two different checks were reporting the same metric, and this was causing confusing data.

