### PR TITLE
[kafka] Bump kafka-python to 1.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ pyro4==4.35 # required by adodbapi
 httplib2==0.9
 
 # checks.d/kafka_consumer.py
-kafka-python==1.2.5
+kafka-python==1.3.1
 kazoo==2.2.1
 
 # checks.d/postgres.py


### PR DESCRIPTION
Another take on #2863 because I deleted the original branch

What does this PR do?

Bumps kafka-python 1.3.1.

Motivation

There's a number of bug fixes and issues since the 1.2.5 release. Similar to #2709, if you're bumping the version in the newest release of the agent, might as well bump it up to 1.3 series.