### PR TITLE
[packaging] Update pyro4 dep to 4.36

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ uptime==3.0.1
 
 # checks.d/sqlserver.py
 adodbapi==2.6.0.7
-pyro4==4.35 # required by adodbapi
+pyro4==4.36 # required by adodbapi
 
 # checks.d/riak.py
 httplib2==0.9


### PR DESCRIPTION
To stay in sync with omnibus-software (`pyro4` was bumped in https://github.com/DataDog/omnibus-software/pull/81)
