### PR TITLE
Add tests on content_mismatch and fix associated UnicodeDecodeError errors

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -302,9 +302,9 @@ class HTTPCheck(NetworkCheck):
                 else:
                     self.log.info("%s not found in content" % content_match)
                     self.log.debug("Content returned:\n%s" % content)
-                    message = 'Content "%s" not found in response.' % content_match
+                    message = u'Content "%s" not found in response.' % content_match.decode('utf-8', errors='ignore')
                     if include_content:
-                        message += '\nContent: {}'.format(content[:CONTENT_LENGTH])
+                        message += u'\nContent: {}'.format(content[:CONTENT_LENGTH])
                     service_checks.append((
                         self.SC_STATUS,
                         Status.DOWN,

--- a/conf.d/http_check.yaml.example
+++ b/conf.d/http_check.yaml.example
@@ -24,6 +24,9 @@ instances:
     # you will have to escape the following "special" characters with
     # a backslash (\) if you're trying to match them in your content:
     #  . ^ $ * + ? { } [ ] \ | ( )
+
+    # If your content_match includes some unicode characters, make sure to leave the encoding to the
+    # default 'utf-8' format
     #
     # Examples:
     # content_match: 'In Stock'

--- a/tests/checks/integration/test_http_check.py
+++ b/tests/checks/integration/test_http_check.py
@@ -55,6 +55,12 @@ CONFIG = {
         'timeout': 1,
         'check_certificate_expiration': False,
         'content_match': 'メインページ'
+    }, {
+        'name': 'cnt_mismatch_unicode',
+        'url': 'https://ja.wikipedia.org/',
+        'timeout': 1,
+        'check_certificate_expiration': False,
+        'content_match': 'メインペーで'
     }
     ]
 }
@@ -227,6 +233,8 @@ class HTTPCheckTest(AgentCheckTest):
         self.assertServiceCheckOK("http.can_connect", tags=tags)
         tags = ['url:https://ja.wikipedia.org/', 'instance:cnt_match_unicode']
         self.assertServiceCheckOK("http.can_connect", tags=tags)
+        tags = ['url:https://ja.wikipedia.org/', 'instance:cnt_mismatch_unicode']
+        self.assertServiceCheckCritical("http.can_connect", tags=tags)
 
         self.coverage_report()
 


### PR DESCRIPTION
### What does this PR do?

Current tests for the `content_match` feature of the http_check don't include the case of the content_mismatch on a unicode string. 
Adding this test lead to some `UnicodeDecodeError` Errors in the check, so I modified this as well

### Motivation

Cleaning `http_check` tests to then create a new feature of `reverse_content_match` requested by several clients 

### Testing Guidelines

Added a test `CONFIG` and ran `nosetests tests.checks.integration.test_http_check:HTTPCheckTest.test_check`

### Additional Notes

N/A