### PR TITLE
[http_check] Fix content matching for non-ascii characters

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -293,7 +293,8 @@ class HTTPCheck(NetworkCheck):
             # Host is UP
             # Check content matching is set
             if content_match:
-                content = r.content
+                # r.text is the response content decoded by `requests`, of type `unicode`
+                content = r.text if type(content_match) is unicode else r.content
                 if re.search(content_match, content, re.UNICODE):
                     self.log.debug("%s is found in return content" % content_match)
                     service_checks.append((

--- a/tests/checks/integration/test_http_check.py
+++ b/tests/checks/integration/test_http_check.py
@@ -54,7 +54,7 @@ CONFIG = {
         'url': 'https://ja.wikipedia.org/',
         'timeout': 1,
         'check_certificate_expiration': False,
-        'content_match': 'メインページ'
+        'content_match': u'メインページ'
     }
     ]
 }


### PR DESCRIPTION
### What does this PR do?

Fix `content_match` option when non-ascii characters are specified

### Additional Notes

As stated in pyyaml's docs (http://pyyaml.org/wiki/PyYAMLDocumentation#StringconversionPython2only) yaml strings are converted to `unicode` python objects when they contain non-ascii characters. The existing test would use the type `str` for `content_match` instead so it passed but the check actually didn't work  with non-ascii chars in `content_match`

The reason it didn't work is that it'd compare a `unicode` object with the undecoded `content` of the response.

To fix this, change the test to use a `unicode` object instead, and make the check use the response's `text` (i.e. the decoded `content`, see http://docs.python-requests.org/en/master/user/quickstart/#response-content) when `content_match` is a `unicode` object.

See related https://github.com/DataDog/dd-agent/pull/2092