### PR TITLE
removed forced defaults override

### DIFF
--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -57,7 +57,7 @@ api_key:
 
 # use unique hostname for GCE hosts, see http://dtdg.co/1eAynZk
 # when not specified, default: no
-gce_updated_hostname: yes
+# gce_updated_hostname: no
 
 # Set the threshold for accepting points to allow anything
 # within recent_point_threshold seconds (default: 30)

--- a/packaging/datadog-agent/win32/install_files/datadog_win32.conf
+++ b/packaging/datadog-agent/win32/install_files/datadog_win32.conf
@@ -34,7 +34,7 @@ api_key: APIKEYHERE
 
 # use unique hostname for GCE hosts, see http://dtdg.co/1eAynZk
 # when not specified, default: no
-gce_updated_hostname: yes
+# gce_updated_hostname: no
 
 # ========================================================================== #
 # DogStatsd configuration                                                    #


### PR DESCRIPTION
### What does this PR do?

Fixes a set of defaults which can cause a problem if left enabled

### Motivation

This solved our ticket 73779, and made the process of setting custom hostnames easier

