### PR TITLE
[mysql] Allow basic replication info to be available without performance_schema available

### DIFF
--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -529,7 +529,12 @@ class MySql(AgentCheck):
         if _is_affirmative(options.get('replication', False)):
             # Get replica stats
             results.update(self._get_replica_stats(db))
-            results.update(self._get_slave_status(db))
+            performance_schema_enabled = self._get_variable_enabled(results, 'performance_schema')
+            if _is_affirmative(options.get('extra_performance_metrics', False)) and \
+                self._version_compatible(db, host, "5.6.0") and \
+                performance_schema_enabled:
+                results.update(self._get_slave_status(db))
+
             metrics.update(REPLICA_VARS)
 
             # get slave running form global status page

--- a/checks.d/mysql.py
+++ b/checks.d/mysql.py
@@ -530,9 +530,10 @@ class MySql(AgentCheck):
             # Get replica stats
             results.update(self._get_replica_stats(db))
             performance_schema_enabled = self._get_variable_enabled(results, 'performance_schema')
+
             if _is_affirmative(options.get('extra_performance_metrics', False)) and \
-                self._version_compatible(db, host, "5.6.0") and \
-                performance_schema_enabled:
+                    self._version_compatible(db, host, "5.6.0") and \
+                    performance_schema_enabled:
                 results.update(self._get_slave_status(db))
 
             metrics.update(REPLICA_VARS)


### PR DESCRIPTION

*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

This change removes an arbitrary requirement for mysql >=5.6 if trying to view basic replication status

### Motivation

We have MySQL 5.1.x, which does not have performance_schema. I wanted to monitor basic replication data, and I saw that this data was coming from SLOW SLAVE STATUS and not the performance_schema database.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
