### PR TITLE
[sdk][tests][common] load actual SDK checks (classes/modules) not dd-agent's 

### DIFF
--- a/config.py
+++ b/config.py
@@ -745,7 +745,10 @@ def get_sdk_integrations_path(osname=None):
         if os.environ.get('TRAVIS'):
             path = os.environ['TRAVIS_BUILD_DIR']
         elif os.environ.get('CIRCLECI'):
-            path = os.environ['CIRCLE_PROJECT_REPONAME']
+            path = os.path.join(
+                os.environ['HOME'],
+                os.environ['CIRCLE_PROJECT_REPONAME']
+            )
         elif os.environ.get('APPVEYOR'):
             path = os.environ['APPVEYOR_BUILD_FOLDER']
         else:

--- a/config.py
+++ b/config.py
@@ -740,14 +740,14 @@ def get_checksd_path(osname=None):
 def get_sdk_integrations_path(osname=None):
     if not osname:
         osname = get_os()
-    if osname in ['windows']:
-        raise PathNotFound()
 
     if os.environ.get('INTEGRATIONS_DIR'):
         if os.environ.get('TRAVIS'):
             path = os.environ['TRAVIS_BUILD_DIR']
         elif os.environ.get('CIRCLECI'):
             path = os.environ['CIRCLE_PROJECT_REPONAME']
+        elif os.environ.get('APPVEYOR'):
+            path = os.environ['APPVEYOR_BUILD_FOLDER']
         else:
             cur_path = os.environ['INTEGRATIONS_DIR']
             path = os.path.join(cur_path, '..') # might need tweaking in the future.

--- a/config.py
+++ b/config.py
@@ -740,11 +740,21 @@ def get_checksd_path(osname=None):
 def get_sdk_integrations_path(osname=None):
     if not osname:
         osname = get_os()
-    if osname in ['windows', 'mac']:
+    if osname in ['windows']:
         raise PathNotFound()
 
-    cur_path = os.path.dirname(os.path.realpath(__file__))
-    path = os.path.join(cur_path, '..', SDK_INTEGRATIONS_DIR)
+    if os.environ.get('INTEGRATIONS_DIR'):
+        if os.environ.get('TRAVIS'):
+            path = os.environ['TRAVIS_BUILD_DIR']
+        elif os.environ.get('CIRCLECI'):
+            path = os.environ['CIRCLE_PROJECT_REPONAME']
+        else:
+            cur_path = os.environ['INTEGRATIONS_DIR']
+            path = os.path.join(cur_path, '..') # might need tweaking in the future.
+    else:
+        cur_path = os.path.dirname(os.path.realpath(__file__))
+        path = os.path.join(cur_path, '..', SDK_INTEGRATIONS_DIR)
+
     if os.path.exists(path):
         return path
     raise PathNotFound(path)

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -33,6 +33,10 @@ def _is_sdk():
 def _load_sdk_module(name):
     sdk_path = get_sdk_integrations_path(get_os())
     module_path = os.path.join(sdk_path, name)
+    sdk_module_name = "_{}".format(name)
+    if sdk_module_name in sys.modules:
+        return sys.modules[sdk_module_name]
+
     if sdk_path not in sys.path:
         sys.path.append(sdk_path)
     if module_path not in sys.path:

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -32,10 +32,13 @@ def _is_sdk():
 
 def _load_sdk_module(name):
     sdk_path = get_sdk_integrations_path(get_os())
+    module_path = os.path.join(sdk_path, name)
     if sdk_path not in sys.path:
         sys.path.append(sdk_path)
+    if module_path not in sys.path:
+        sys.path.append(module_path)
 
-    fd, filename, desc = imp.find_module(name, [sdk_path])
+    fd, filename, desc = imp.find_module('check', [module_path])
     module = imp.load_module("_{}".format(name), fd, filename, desc)
     if fd:
         fd.close()
@@ -52,7 +55,6 @@ def get_check_class(name):
         check_module = __import__(name)
     else:
         check_module = _load_sdk_module(name)
-        check_module = __import__("_{}.check".format(name))
 
     check_class = None
     classes = inspect.getmembers(check_module, inspect.isclass)
@@ -80,7 +82,6 @@ def load_class(check_name, class_name):
         check_module = __import__(check_module_name)
     else:
         check_module = _load_sdk_module(check_name)
-        check_module = __import__("_{}.check".format(check_name))
 
     classes = inspect.getmembers(check_module, inspect.isclass)
     for name, clsmember in classes:
@@ -99,7 +100,6 @@ def load_check(name, config, agentConfig):
         check_module = imp.load_module(name, fd, filename, desc)
     else:
         check_module = _load_sdk_module(name) # parent module
-        check_module = __import__("_{}.check".format(name))
 
     check_class = None
     classes = inspect.getmembers(check_module, inspect.isclass)


### PR DESCRIPTION
### What does this PR do?

From the SDK, whenever `load_class` or `load_check` were invoked we were actually loading from the sources in the `dd-agent` repo. The aim of this PR is to ensure that when running from SDK-land (both locally or on the CI environments: Travis, CircleCI) we can guarantee the "common" test logic (shared by `dd-agent` and `integrations-core`, `integrations-extra`) actually loads the corresponding modules/classes. 

### Motivation

We need consistent testing, and preferably having a single source for all testing facilities (at least as long as we have commonalities between `dd-agent` and the SDK repos).  We still have checks/logic that store state (docker, kubernetes, etc) and will remain in `dd-agent` for some time, these checks rely largely on the same testing code. Similarly, `integrations-core` and `integrations-extra` both will use this code, so it's definitely something we probably want to do: keep the testing code in `dd-agent`.

### Testing Guidelines

`dd-agent` remains unaffected, the SDK repos now load the right logic as reflected in https://github.com/DataDog/integrations-core/pull/84.

### Additional Notes

There's one caveat to the way this PR actually handles the importing of modules from the SDK, we actually have to "mangle" the SDK module names a little bit to avoid naming conflicts (one great example would be our `rabbitmq` check, the SDK module is named `rabbitmq` as is the official module we used within our check). I have decided to prepend an underscore '_' to SDK imported modules (so the SDK `rabbitmq` will be imported as `_rabbitmq`), this should be transparent to the user but may play a role when patching/mocking as you can see in the [Openstack SDK PR](https://github.com/DataDog/integrations-core/pull/84). If we have any feedback here, I'd love to hear it.