### PR TITLE
pkg: add trace-agent to supervisor

### DIFF
--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -37,7 +37,9 @@ SUPERVISOR_CONF="/etc/dd-agent/supervisor.conf"
 SUPERVISOR_SOCK="/opt/datadog-agent/run/datadog-supervisor.sock"
 SUPERVISOR_PIDFILE="/opt/datadog-agent/run/datadog-supervisord.pid"
 COLLECTOR_PIDFILE="/opt/datadog-agent/run/dd-agent.pid"
-DD_OPT_PROC_REGEX="dogstatsd|jmxfetch|go-metro"
+
+# Captures processes in the supervisord group that are 'optional' i.e. not essential for the agent to run
+DD_OPT_PROC_REGEX="dogstatsd|jmxfetch|go-metro|trace-agent"
 
 # Source function library.
 . /etc/rc.d/init.d/functions
@@ -61,16 +63,16 @@ check_status() {
 
         s=`$SUPERVISORCTL_PATH -c $SUPERVISOR_CONF status`
 
-        # number of RUNNING supervisord programs (ignoring dogstatsd, jmxfetch and go-metro)
+        # Number of RUNNING supervisord programs (ignoring optional procs captured by $DD_OPT_PROC_REGEX)
         p=`echo "$s" | grep -Ev $DD_OPT_PROC_REGEX | grep -c RUNNING`
 
-        # Number of non-failed OPTIONAL supervisord programs (dogstatsd, jmxfetch and go-metro)
+        # Number of non-failed OPTIONAL supervisord programs
         p_o=`echo "$s" | grep -E $DD_OPT_PROC_REGEX | grep -cv FATAL`
 :
-        # number of expected running supervisord programs (ignoring dogstatsd and jmxfetch)
+        # Number of expected running supervisord programs (ignoring optional procs)
         c=`grep -Ev $DD_OPT_PROC_REGEX $SUPERVISOR_CONF | grep -c '\[program:'`
 
-        # Number of expected optional supervisord programs (dogstatsd, jmxfetch and go-metro)
+        # Number of expected optional supervisord programs
         c_o=`grep -E $DD_OPT_PROC_REGEX $SUPERVISOR_CONF | grep -c '\[program:'`
 
         if [ "$p" -ne "$c" ]; then

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -28,7 +28,9 @@ SUPERVISORCTL_PATH="/opt/datadog-agent/bin/supervisorctl"
 SUPERVISORD_PATH="/opt/datadog-agent/bin/supervisord"
 COLLECTOR_PIDFILE="/opt/datadog-agent/run/dd-agent.pid"
 SYSTEM_PATH=/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:$PATH
-DD_OPT_PROC_REGEX="dogstatsd|jmxfetch|go-metro"
+
+# Captures processes in the supervisord group that are 'optional' i.e. not essential for the agent to run
+DD_OPT_PROC_REGEX="dogstatsd|jmxfetch|go-metro|trace-agent"
 
 if [ ! -x $AGENTPATH ]; then
     echo "$AGENTPATH not found. Exiting."
@@ -57,23 +59,23 @@ check_status() {
 
         supervisor_processes=$($SUPERVISORCTL_PATH -c $SUPERVISOR_FILE status)
 
-        # Number of RUNNING supervisord programs (ignoring dogstatsd, jmxfetch and go-metro)
+        # Number of RUNNING supervisord programs (ignoring optional procs captured by $DD_OPT_PROC_REGEX)
         datadog_supervisor_processes=$(echo "$supervisor_processes" |
                                        grep -Ev $DD_OPT_PROC_REGEX |
                                        grep $NAME |
                                        grep -c RUNNING)
 
-        # Number of non-failed OPTIONAL supervisord programs (dogstatsd, jmxfetch and go-metro)
+        # Number of non-failed OPTIONAL supervisord programs
         datadog_supervisor_opt_processes=$(echo "$supervisor_processes" |
                                        grep -E $DD_OPT_PROC_REGEX |
                                        grep $NAME |
                                        grep -cv FATAL)
 
-        # Number of expected running supervisord programs (ignoring dogstatsd, jmxfetch and go-metro)
+        # Number of expected running supervisord programs (ignoring optional procs)
         supervisor_config_programs=$(grep -Ev $DD_OPT_PROC_REGEX $SUPERVISOR_FILE |
                                      grep -c '\[program:')
 
-        # Number of expected optional supervisord programs (dogstatsd, jmxfetch and go-metro)
+        # Number of expected optional supervisord programs
         supervisor_config_opt_programs=$(grep -E $DD_OPT_PROC_REGEX $SUPERVISOR_FILE |
                                      grep -c '\[program:')
 

--- a/packaging/supervisor.conf
+++ b/packaging/supervisor.conf
@@ -67,5 +67,14 @@ startsecs=2
 startretries=2
 user=dd-agent
 
+[program:trace-agent]
+command=/opt/datadog-agent/bin/trace-agent
+stdout_logfile=NONE
+stderr_logfile=NONE
+startsecs=5
+startretries=3
+priority=998
+user=dd-agent
+
 [group:datadog-agent]
-programs=forwarder,collector,dogstatsd,jmxfetch,go-metro
+programs=forwarder,collector,dogstatsd,jmxfetch,go-metro,trace-agent

--- a/packaging/suse/datadog-agent.init
+++ b/packaging/suse/datadog-agent.init
@@ -28,7 +28,9 @@ SUPERVISORCTL_PATH="/opt/datadog-agent/bin/supervisorctl"
 SUPERVISORD_PATH="/opt/datadog-agent/bin/supervisord"
 COLLECTOR_PIDFILE="/opt/datadog-agent/run/dd-agent.pid"
 SYSTEM_PATH=/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:$PATH
-DD_OPT_PROC_REGEX="dogstatsd|jmxfetch|go-metro"
+
+# Captures processes in the supervisord group that are 'optional' i.e. not essential for the agent to run
+DD_OPT_PROC_REGEX="dogstatsd|jmxfetch|go-metro|trace-agent"
 
 if [ ! -x $AGENTPATH ]; then
     echo "$AGENTPATH not found. Exiting."
@@ -298,23 +300,23 @@ check_status() {
 
         supervisor_processes=$($SUPERVISORCTL_PATH -c $SUPERVISOR_FILE status)
 
-        # Number of RUNNING supervisord programs (ignoring dogstatsd, jmxfetch and go-metro)
+        # Number of RUNNING supervisord programs (ignoring optional procs captured by $DD_OPT_PROC_REGEX)
         datadog_supervisor_processes=$(echo "$supervisor_processes" |
                                        grep -Ev $DD_OPT_PROC_REGEX |
                                        grep $NAME |
                                        grep -c RUNNING)
 
-        # Number of non-failed OPTIONAL supervisord programs (dogstatsd, jmxfetch and go-metro)
+        # Number of non-failed OPTIONAL supervisord programs
         datadog_supervisor_opt_processes=$(echo "$supervisor_processes" |
                                        grep -E $DD_OPT_PROC_REGEX |
                                        grep $NAME |
                                        grep -cv FATAL)
 
-        # Number of expected running supervisord programs (ignoring dogstatsd, jmxfetch and go-metro)
+        # Number of expected running supervisord programs (ignoring optional procs)
         supervisor_config_programs=$(grep -Ev $DD_OPT_PROC_REGEX $SUPERVISOR_FILE |
                                      grep -c '\[program:')
 
-        # Number of expected optional supervisord programs (dogstatsd, jmxfetch and go-metro)
+        # Number of expected optional supervisord programs
         supervisor_config_opt_programs=$(grep -E $DD_OPT_PROC_REGEX $SUPERVISOR_FILE |
                                      grep -c '\[program:')
 


### PR DESCRIPTION
In a future release, the `datadog-agent` package will bundle the [datadog-trace-agent](https://github.com/DataDog/datadog-trace-agent)

This change will add a process definition for the trace-agent to the bundled supervisor config. It will also add this proc to the `datadog-agent` process group so that existing install methods will start it up along with existing processes.

Should be merged after https://github.com/DataDog/dd-agent-omnibus/pull/107