### PR TITLE
flare: add trace-agent log file

### DIFF
--- a/config.py
+++ b/config.py
@@ -1181,6 +1181,7 @@ def get_logging_config(cfg_path=None):
         logging_config['dogstatsd_log_file'] = '/var/log/datadog/dogstatsd.log'
         logging_config['jmxfetch_log_file'] = '/var/log/datadog/jmxfetch.log'
         logging_config['go-metro_log_file'] = '/var/log/datadog/go-metro.log'
+        logging_config['trace-agent_log_file'] = '/var/log/datadog/trace-agent.log'
         logging_config['log_to_syslog'] = True
 
     config_path = get_config_path(cfg_path, os_name=system_os)

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -252,6 +252,7 @@ class Flare(object):
         self._dogstatsd_log = config.get('{0}dogstatsd_log_file'.format(prefix))
         self._jmxfetch_log = config.get('jmxfetch_log_file')
         self._gometro_log = config.get('go-metro_log_file')
+        self._trace_agent_log = config.get('trace-agent_log_file')
 
     # Add logs to the tarfile
     def _add_logs_tar(self):
@@ -260,6 +261,7 @@ class Flare(object):
         self._add_log_file_tar(self._dogstatsd_log)
         self._add_log_file_tar(self._jmxfetch_log)
         self._add_log_file_tar(self._gometro_log)
+        self._add_log_file_tar(self._trace_agent_log)
         self._add_log_file_tar(
             "{0}/*supervisord.log".format(os.path.dirname(self._collector_log))
         )


### PR DESCRIPTION
Make the `flare` command bundle the `trace-agent.log` file if it exists