### PR TITLE
Upgrade docker-py version to 1.10.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ pyvmomi==6.0.0
 snakebite==1.3.11
 
 # utils/platform.py
-docker-py==1.8.1
+docker-py==1.10.6
 
 # checks.d/dns_check.py
 dnspython==1.12.0


### PR DESCRIPTION
### What does this PR do?

Bump version of the docker lib

### Motivation

Use a more recent version of docker. This is needed to match the version in the integration-core repo. We need 1.10.+ to use docker-compose in version 2. This should not impact anything for the dd-agent code.

ref: https://github.com/DataDog/omnibus-software/pull/97