### PR TITLE
[php_fpm] Include custom tags in service check

### DIFF
--- a/checks.d/php_fpm.py
+++ b/checks.d/php_fpm.py
@@ -103,7 +103,7 @@ class PHPFPMCheck(AgentCheck):
         if ping_reply is None:
             ping_reply = 'pong'
 
-        sc_tags = ["ping_url:{0}".format(ping_url)]
+        sc_tags = ["ping_url:{0}".format(ping_url)] + tags
 
         try:
             # TODO: adding the 'full' parameter gets you per-process detailed

--- a/tests/checks/integration/test_php_fpm.py
+++ b/tests/checks/integration/test_php_fpm.py
@@ -46,7 +46,7 @@ class PHPFPMCheckTest(AgentCheckTest):
         self.assertServiceCheck(
             'php_fpm.can_ping',
             status=AgentCheck.CRITICAL,
-            tags=['ping_url:http://localhost:9001/status'],
+            tags=['ping_url:http://localhost:9001/status', 'expectedbroken'],
             count=1
         )
 
@@ -63,7 +63,7 @@ class PHPFPMCheckTest(AgentCheckTest):
         self.assertServiceCheck(
             'php_fpm.can_ping',
             status=AgentCheck.CRITICAL,
-            tags=['ping_url:http://localhost:42424/ping'],
+            tags=['ping_url:http://localhost:42424/ping', 'expectedbroken'],
             count=1
         )
 
@@ -97,6 +97,6 @@ class PHPFPMCheckTest(AgentCheckTest):
 
         self.assertServiceCheck('php_fpm.can_ping', status=AgentCheck.OK,
                                 count=1,
-                                tags=['ping_url:http://localhost:42424/ping'])
+                                tags=['ping_url:http://localhost:42424/ping', 'cluster:forums'])
 
         self.assertMetric('php_fpm.processes.max_reached', count=1)


### PR DESCRIPTION
### What does this PR do?

Include custom tags in service check

### Motivation

Inside a Docker scheduler, using the `ping_url` is bad, since each restart of the process will assign a new unique port to the process, thus marking the old service as gone, even though its in fact running somewhere else successfully.

Including own tags to the service, a cluster alert can be created to mitigate this issue :)
