### PR TITLE
prevent bad service disco configs from crashing dd-agent

### DIFF
--- a/config.py
+++ b/config.py
@@ -882,6 +882,7 @@ def _file_configs_paths(osname, agentConfig):
 def _service_disco_configs(agentConfig):
     """ Retrieve all the service disco configs and return their conf dicts
     """
+    service_disco_configs = {}
     if agentConfig.get('service_discovery') and agentConfig.get('service_discovery_backend') in SD_BACKENDS:
         try:
             log.info("Fetching service discovery check configurations.")
@@ -890,8 +891,6 @@ def _service_disco_configs(agentConfig):
         except Exception:
             log.exception("Loading service discovery configurations failed.")
             return {}
-    else:
-        service_disco_configs = {}
 
     return service_disco_configs
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

In the event that service discovery configs cannot be properly parsed, rather than crashing, return empty dict and continue.

### Motivation

```
UnboundLocalError: local variable 'service_disco_configs' referenced before assignment
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/agent.py", line 493, in <module>
    sys.exit(main())
  File "/opt/datadog-agent/agent/agent.py", line 473, in main
    sd_configcheck(agentConfig)
  File "/opt/datadog-agent/agent/utils/configcheck.py", line 52, in sd_configcheck
    configs = load_check_directory(agentConfig, get_hostname(agentConfig))
  File "/opt/datadog-agent/agent/config.py", line 1036, in load_check_directory
    for check_name, service_disco_check_config in _service_disco_configs(agentConfig).iteritems():
  File "/opt/datadog-agent/agent/config.py", line 879, in _service_disco_configs
    return service_disco_configs
UnboundLocalError: local variable 'service_disco_configs' referenced before assignment
```

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
