### PR TITLE
[Spark]  Fix check to enumerate job IDs

### DIFF
--- a/conf.d/spark.yaml.example
+++ b/conf.d/spark.yaml.example
@@ -28,6 +28,10 @@ instances:
     # spark_cluster_mode: spark_standalone_mode
     # spark_cluster_mode: spark_mesos_mode
 
+    # To use an older (versions prior to 2.0) Standalone Spark cluster, 
+    # the 'spark_pre_20_mode' must be set
+    # spark_pre_20_mode: true
+    
     # A Required friendly name for the cluster.
     # cluster_name: MySparkCluster
 

--- a/tests/checks/fixtures/spark/spark_apps_pre20
+++ b/tests/checks/fixtures/spark/spark_apps_pre20
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "PySparkShell",
+    "name": "PySparkShell",
+    "attempts": [
+      {
+        "startTime": "2016-04-12T12:48:17.576GMT",
+        "endTime": "1969-12-31T23:59:59.999GMT",
+        "sparkUser": "",
+        "completed": false
+      }
+    ]
+  }
+]


### PR DESCRIPTION
### What does this PR do?

Spark integration, at least against Spark 1.5, was using the wrong value of 'id'.  It appears there are two values, the generic job id name from 8080/json:

 "activeapps" : [ {
    "starttime" : 1483727736675,
    "id" : "app-20170106103536-0024",
    "name" : "PythonPi",
    "user" : "db",
    "memoryperslave" : 1024,
    "submitdate" : "Fri Jan 06 10:35:36 PST 2017",
    "state" : "RUNNING",
    "duration" : 5357
  } ],

However, when you chase down individual job URL, in this case 4040/api/v1/applications/, you get
[ {
  "id" : "PythonPi",
  "name" : "PythonPi",
  "attempts" : [ {
    "startTime" : "2017-01-06T18:35:34.758GMT",
    "endTime" : "1969-12-31T23:59:59.999GMT",
    "sparkUser" : "",
    "completed" : false
  } ]
} ]

When creating the URLs to retrieve the individual job statistics, the api appears to want the id from the 2nd, not the first.  The code was using the id from the first, and failing.

### Motivation

Customer report.

### Testing Guidelines

### Additional Notes


