### PR TITLE
[docker/hostname] improve get_hostname for containers

### DIFF
--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -136,7 +136,7 @@ class KubeUtil:
         if not host:
             # if no hostname was provided, use the docker hostname if cert
             # validation is not required, the kubernetes hostname otherwise.
-            docker_hostname = self.docker_util.get_hostname()
+            docker_hostname = self.docker_util.get_hostname(should_resolve=True)
             if self.tls_settings.get('kubelet_verify'):
                 try:
                     k8s_hostname = self.get_node_hostname(docker_hostname)


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

When the agent is containerized it makes sense to use
docker info's Name as the hostname even if it doesn't resolve.
Because otherwise the agent falls back to the container short ID
which is not really helpful.

This PR drops the resolvability check for the name.

### Motivation

Fixing https://github.com/DataDog/docker-dd-agent/issues/139

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.
