### PR TITLE
[tcp_check] Set instance tags in response_time metric

### DIFF
--- a/checks.d/tcp_check.py
+++ b/checks.d/tcp_check.py
@@ -25,6 +25,7 @@ class TCPCheck(NetworkCheck):
         port = instance.get('port', None)
         timeout = float(instance.get('timeout', 10))
         response_time = instance.get('collect_response_time', False)
+        custom_tags = instance.get('tags', [])
         socket_type = None
         try:
             port = int(port)
@@ -54,10 +55,10 @@ class TCPCheck(NetworkCheck):
             except Exception:
                 raise BadConfException("URL: %s is not a correct IPv4, IPv6 or hostname" % addr)
 
-        return addr, port, socket_type, timeout, response_time
+        return addr, port, custom_tags, socket_type, timeout, response_time
 
     def _check(self, instance):
-        addr, port, socket_type, timeout, response_time = self._load_conf(instance)
+        addr, port, custom_tags, socket_type, timeout, response_time = self._load_conf(instance)
         start = time.time()
         try:
             self.log.debug("Connecting to %s %s" % (addr, port))
@@ -94,7 +95,7 @@ class TCPCheck(NetworkCheck):
             return Status.DOWN, "%s. Connection failed after %s ms" % (str(e), length)
 
         if response_time:
-            self.gauge('network.tcp.response_time', time.time() - start, tags=['url:%s:%s' % (instance.get('host', None), port)])
+            self.gauge('network.tcp.response_time', time.time() - start, tags=['url:%s:%s' % (instance.get('host', None), port)] + custom_tags)
 
         self.log.debug("%s:%s is UP" % (addr, port))
         return Status.UP, "UP"

--- a/tests/checks/integration/test_tcp_check.py
+++ b/tests/checks/integration/test_tcp_check.py
@@ -20,12 +20,14 @@ CONFIG = {
         'host': '126.0.0.1',
         'port': 65530,
         'timeout': 1,
-        'name': 'DownService2'
+        'name': 'DownService2',
+        'tags': ['test1']
     }, {
         'host': 'datadoghq.com',
         'port': 80,
         'timeout': 1,
-        'name': 'UpService'
+        'name': 'UpService',
+        'tags': ['test2']
     }]
 }
 
@@ -55,9 +57,6 @@ class TCPCheckTest(AgentCheckTest):
                                 getattr(self.check, attribute)))
 
     def test_event_deprecation(self):
-        """
-        Deprecate events usage for service checks.
-        """
         # Run the check
         self.run_check(CONFIG)
 
@@ -73,9 +72,6 @@ class TCPCheckTest(AgentCheckTest):
         )
 
     def test_check(self):
-        """
-        Check coverage.
-        """
         # Run the check
         self.run_check(CONFIG)
 
@@ -85,10 +81,10 @@ class TCPCheckTest(AgentCheckTest):
         expected_tags = ["instance:DownService", "target_host:127.0.0.1", "port:65530"]
         self.assertServiceCheckCritical("tcp.can_connect", tags=expected_tags)
 
-        expected_tags = ["instance:DownService2", "target_host:126.0.0.1", "port:65530"]
+        expected_tags = ["instance:DownService2", "target_host:126.0.0.1", "port:65530", "test1"]
         self.assertServiceCheckCritical("tcp.can_connect", tags=expected_tags)
 
-        expected_tags = ["instance:UpService", "target_host:datadoghq.com", "port:80"]
+        expected_tags = ["instance:UpService", "target_host:datadoghq.com", "port:80", "test2"]
         self.assertServiceCheckOK("tcp.can_connect", tags=expected_tags)
 
         self.coverage_report()


### PR DESCRIPTION
Before this commit, adding instance tags in the tcp_check configuration
only applied the tags to the (deprecated) service_check but not the
response_time metric sent to datadog.
With this improvement, the custom instance tags are also applied to the
response_time metric, as I would expect.
