### PR TITLE
[brocade_vadc] add an integration to support the Brocade vADC/vTM

### DIFF
--- a/checks.d/brocade_vadc.py
+++ b/checks.d/brocade_vadc.py
@@ -1,0 +1,180 @@
+# stdlib
+from collections import namedtuple
+
+# Datadog
+from checks import AgentCheck
+
+# 3p
+import requests
+
+
+class BrocadeVadcCheck(AgentCheck):
+    # See https://www.brocade.com/content/dam/common/documents/content-types/user-guide/brocade-vtm-11.0-restapi.pdf
+    STATS_API = 'api/tm/3.10/status/local_tm/statistics'
+
+    # this is a list of endpoints to recursively query for values
+    METRICS_ENDPOINTS = [
+        'pools',
+        'virtual_servers',
+    ]
+
+    # these are the metrics to collect all 64bit integers.
+    POOL_RATE = [
+        'bytes_in',
+        'bytes_out',
+        'conns_queued',
+        'queue_timeouts',
+    ]
+    POOL_GAUGE = [
+        'max_queue_time',
+        'mean_queue_time',
+        'min_queue_time',
+        'nodes',
+        'session_migrated',
+        'session_migrated',
+        'total_conn',
+    ]
+    VIRTUAL_SERVER_RATE = [
+        'bytes_in',
+        'bytes_out',
+        'cert_status_requests',
+        'cert_status_responses',
+        'connect_timed_out',
+        'connection_errors',
+        'connection_failures',
+        'data_timed_out',
+        'direct_replies',
+        'discard',
+        'gzip',
+        'gzip_bytes_saved',
+        'http_cache_hit_rate',
+        'http_cache_hits',
+        'http_cache_lookups',
+        'http_rewrite_cookie',
+        'http_rewrite_location',
+        'keepalive_timed_out',
+        'max_duration_timed_out',
+        'processing_timed_out',
+        'sip_rejected_requests',
+        'sip_total_calls',
+        'total_dgram',
+        'total_http1_requests',
+        'total_http2_requests',
+        'total_http_requests',
+        'total_requests',
+        'total_tcp_reset',
+        'total_udp_unreachables',
+        'udp_timed_out',
+    ]
+    VIRTUAL_SERVER_GAUGE = [
+        'current_conn',
+        'max_conn',
+    ]
+
+    SERVICE_CHECK_NAME = 'brocade_vadc.can_connect'
+
+    def check(self, instance):
+        config, tags = self._get_config(instance)
+        stats = self._get_vadc_stats(config)
+
+        # iterate over the different metrics endpoints in the stats dict
+        # required because the nesting is different depending on the metric
+        # type collected.
+        for endpoint in BrocadeVadcCheck.METRICS_ENDPOINTS:
+            if endpoint == 'pools':
+                self._get_pool_stats(stats[endpoint], tags)
+            elif endpoint == 'virtual_servers':
+                self._get_virtualserver_stats(stats[endpoint], tags)
+
+    def _get_config(self, instance):
+        required = ['host', 'port', 'username', 'password']
+        for param in required:
+            if not instance.get(param):
+                raise Exception("brocade_vadc instance missing %s. Skipping." % (param))
+
+        host = instance.get('host')
+        port = int(instance.get('port'))
+        username = instance.get('username')
+        password = instance.get('password')
+        verify_ssl = instance.get('verify_ssl')
+        tags = instance.get('tags', [])
+
+        Config = namedtuple('Config', [
+            'host',
+            'port',
+            'username',
+            'password',
+            'verify_ssl',
+        ])
+
+        return Config(host, port, username, password, verify_ssl), tags
+
+    def _get_vadc_stats(self, config):
+        stats = {}
+        service_check_tags = [
+            'brocade_vadc_host:{}'.format(config.host),
+            'brocade_vadc_port:{}'.format(config.port),
+        ]
+
+        try:
+            session = requests.Session()
+            session.auth = (config.username, config.password)
+            url = "https://{}:{}/{}".format(config.host, config.port, self.STATS_API)
+
+            g = session.get(url, verify=config.verify_ssl)
+            g.raise_for_status()
+
+        except Exception:
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
+                               tags=service_check_tags)
+            raise
+
+        for METRICS in self.METRICS_ENDPOINTS:
+            url = "https://{}:{}/{}/{}/".format(config.host, config.port, self.STATS_API, METRICS)
+            # create a temp dict that we use to roll-up into the stats dict created above.
+            tmp = {}
+            try:
+                s = session.get(url, verify=config.verify_ssl)
+                s.raise_for_status()
+            except Exception:
+                self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
+                                   tags=service_check_tags)
+
+            for ref in s.json().get("children"):
+                if ref is None:
+                    continue
+                else:
+                    # we strip the tailing / out of the url format because the href returned from the API
+                    # already includes it.
+                    tmp[ref.get("name")] = session.get("https://{}:{}{}".format(config.host,
+                                                                                config.port,
+                                                                                ref.get("href"))).json()
+
+            # roll-up tmp into stats{}
+            stats[METRICS] = tmp
+
+        self.service_check(self.SERVICE_CHECK_NAME,
+                           AgentCheck.OK,
+                           tags=service_check_tags)
+        return stats
+
+    def _get_pool_stats(self, stats, tags):
+        for pool_name in stats:
+            for name, value in stats[pool_name]['statistics'].items():
+                if name in BrocadeVadcCheck.POOL_GAUGE:
+                    self.gauge('brocade_vadc.pool.{}.{}'.format(pool_name, name),
+                               float(value),
+                               tags=tags)
+                elif name in BrocadeVadcCheck.POOL_RATE:
+                    self.rate('brocade_vadc.pool.{}.{}'.format(pool_name, name),
+                              float(value),
+                              tags=tags)
+
+    def _get_virtualserver_stats(self, stats, tags):
+        for virtual_server in stats:
+            for name, value in stats[virtual_server]['statistics'].items():
+                if name in BrocadeVadcCheck.VIRTUAL_SERVER_GAUGE:
+                    self.gauge('brocade_vadc.virtual_server.{}.{}'.format(virtual_server, name), float(value),
+                               tags=tags)
+                elif name in BrocadeVadcCheck.VIRTUAL_SERVER_RATE:
+                    self.rate('brocade_vadc.virtual_server.{}.{}'.format(virtual_server, name), float(value), tags=tags)

--- a/checks.d/brocade_vadc.py
+++ b/checks.d/brocade_vadc.py
@@ -10,7 +10,7 @@ import requests
 
 class BrocadeVadcCheck(AgentCheck):
     # See https://www.brocade.com/content/dam/common/documents/content-types/user-guide/brocade-vtm-11.0-restapi.pdf
-    STATS_API = 'api/tm/3.10/status/local_tm/statistics'
+    STATS_API = 'api/tm/3.8/status/local_tm/statistics'
 
     # this is a list of endpoints to recursively query for values
     METRICS_ENDPOINTS = [

--- a/conf.d/brocade_vadc.yaml.example
+++ b/conf.d/brocade_vadc.yaml.example
@@ -1,0 +1,20 @@
+init_config:
+
+instances:
+  # Brocade Virtual Application Delivery Controller
+  # statistics gathering. Supporting v11.0 and above..
+  #
+
+  # Host running the recursor.
+  - host: 127.0.0.1
+  # REST API Service port.
+    port: 9070
+  # REST API Authentication Details.
+    username: admin
+    password:
+    verify_ssl: False
+
+  # Optional tags to be applied to every emitted metric.
+    # tags:
+    #   - key:value
+    #   - instance:production

--- a/tests/checks/integration/test_brocade_vadc.py
+++ b/tests/checks/integration/test_brocade_vadc.py
@@ -1,0 +1,193 @@
+# 3p
+from nose.plugins.attrib import attr
+
+# project
+from tests.checks.common import AgentCheckTest
+
+import os
+
+
+@attr(requires='brocade_vadc')
+class TestBrocadeVadcCheck(AgentCheckTest):
+    CHECK_NAME = 'brocade_vadc'
+
+    # this is a list of endpoints to recursively query for values
+    METRICS_ENDPOINTS = [
+        'pools',
+        'virtual_servers',
+    ]
+
+    # these are the metrics to collect all 64bit integers.
+    POOL_RATE = [
+        'bytes_in',
+        'bytes_out',
+        'conns_queued',
+        'queue_timeouts',
+    ]
+    POOL_GAUGE = [
+        'max_queue_time',
+        'mean_queue_time',
+        'min_queue_time',
+        'nodes',
+        'session_migrated',
+        'session_migrated',
+        'total_conn',
+    ]
+    VIRTUAL_SERVER_RATE = [
+        'bytes_in',
+        'bytes_out',
+        'cert_status_requests',
+        'cert_status_responses',
+        'connect_timed_out',
+        'connection_errors',
+        'connection_failures',
+        'data_timed_out',
+        'direct_replies',
+        'discard',
+        'gzip',
+        'gzip_bytes_saved',
+        'http_cache_hit_rate',
+        'http_cache_hits',
+        'http_cache_lookups',
+        'http_rewrite_cookie',
+        'http_rewrite_location',
+        'keepalive_timed_out',
+        'max_duration_timed_out',
+        'processing_timed_out',
+        'sip_rejected_requests',
+        'sip_total_calls',
+        'total_dgram',
+        'total_http1_requests',
+        'total_http2_requests',
+        'total_http_requests',
+        'total_requests',
+        'total_tcp_reset',
+        'total_udp_unreachables',
+        'udp_timed_out',
+    ]
+    VIRTUAL_SERVER_GAUGE = [
+        'current_conn',
+        'max_conn',
+    ]
+
+    METRICS_FORMAT = 'brocade_vadc.{}.{}.{}'
+
+    def __init__(self, *args, **kwargs):
+        AgentCheckTest.__init__(self, *args, **kwargs)
+        self.config = {"instances": [{
+            "host": "127.0.0.1",
+            "port": "9070",
+            "username": "admin",
+            "password": os.getenv('VADC_PASSWORD'),
+            "verify_ssl": False,
+        }]}
+
+    # Really a basic check to see if all metrics are there
+    def test_check(self):
+        self.run_check_twice(self.config)
+
+        # Assert metrics
+        for metric in self.VIRTUAL_SERVER_GAUGE:
+            self.assertMetric(self.METRICS_FORMAT.format("virtual_server",
+                                                         "10.1.1.1",
+                                                         metric),
+                              at_least=0,
+                              tags=[])
+
+        for metric in self.VIRTUAL_SERVER_RATE:
+            self.assertMetric(self.METRICS_FORMAT.format("virtual_server",
+                                                         "10.1.1.1",
+                                                         metric),
+                              at_least=0,
+                              tags=[])
+
+        for pool in ["discard", "pool-1"]:
+            for metric in self.POOL_GAUGE:
+                self.assertMetric(self.METRICS_FORMAT.format("pool",
+                                                             pool,
+                                                             metric),
+                                  at_least=0,
+                                  tags=[])
+
+            for metric in self.POOL_RATE:
+                self.assertMetric(self.METRICS_FORMAT.format("pool",
+                                                             pool,
+                                                             metric),
+                                  at_least=0,
+                                  tags=[])
+
+        service_check_tags = ['brocade_vadc_host:127.0.0.1', 'brocade_vadc_port:9070']
+        self.assertServiceCheckOK('brocade_vadc.can_connect', tags=service_check_tags)
+
+        self.coverage_report()
+
+    def test_tags(self):
+        config = self.config.copy()
+        tags = ['foo:bar']
+        config['instances'][0]['tags'] = ['foo:bar']
+        self.run_check_twice(config)
+
+        # Assert metrics
+        for metric in self.VIRTUAL_SERVER_GAUGE:
+            self.assertMetric(self.METRICS_FORMAT.format("virtual_server",
+                                                         "10.1.1.1",
+                                                         metric),
+                              at_least=0,
+                              tags=tags)
+
+        for metric in self.VIRTUAL_SERVER_RATE:
+            self.assertMetric(self.METRICS_FORMAT.format("virtual_server",
+                                                         "10.1.1.1",
+                                                         metric),
+                              at_least=0,
+                              tags=tags)
+
+        for pool in ["discard", "pool-1"]:
+            for metric in self.POOL_GAUGE:
+                self.assertMetric(self.METRICS_FORMAT.format("pool",
+                                                             pool,
+                                                             metric),
+                                  at_least=0,
+                                  tags=tags)
+
+            for metric in self.POOL_RATE:
+                self.assertMetric(self.METRICS_FORMAT.format("pool",
+                                                             pool,
+                                                             metric),
+                                  at_least=0,
+                                  tags=tags)
+
+        service_check_tags = ['brocade_vadc_host:127.0.0.1', 'brocade_vadc_port:9070']
+        self.assertServiceCheckOK('brocade_vadc.can_connect', tags=service_check_tags)
+
+        self.coverage_report()
+
+    def test_bad_config(self):
+        config = self.config.copy()
+        config['instances'][0]['port'] = 1111
+        service_check_tags = ['brocade_vadc_host:127.0.0.1', 'brocade_vadc_port:1111']
+        self.assertRaises(
+            Exception,
+            lambda: self.run_check(config)
+        )
+        self.assertServiceCheckCritical('brocade_vadc.can_connect', tags=service_check_tags)
+        self.coverage_report()
+
+    def test_bad_password(self):
+        config = self.config.copy()
+        config['instances'][0]['password'] = 'nope'
+        service_check_tags = ['brocade_vadc_host:127.0.0.1', 'brocade_vadc_port:9070']
+        self.assertRaises(
+            Exception,
+            lambda: self.run_check(config)
+        )
+        self.assertServiceCheckCritical('brocade_vadc.can_connect', tags=service_check_tags)
+        self.coverage_report()
+
+    def test_very_bad_config(self):
+        for config in [{}, {"host": "localhost"}, {"port": 1000}, {"host": "localhost", "port": 1000}]:
+            self.assertRaises(
+                Exception,
+                lambda: self.run_check({"instances": [config]})
+            )
+        self.coverage_report()


### PR DESCRIPTION
### What does this PR do?

This adds integration support for the Brocade Virtual Application Delivery controller, previously Virtual Traffic Manager or Stingray (names have changed over time). It uses the REST API to gather statistics for virtual servers and backend pools.

### Motivation

Most SaaS providers will have some form of front end load balancer. Getting decent statistics from these load balancers helps operations and dev teams to understand and identify problems sooner.

### Testing Guidelines

All of the tests have been written for this check. However there are some caveats. 
* The API requires a username and password. The password (for testing) is taken from an environment variable for testing (VADC_PASSWORD). 
* The tests assume that the [Docker](https://github.com/TuxInvader/Docker-Brocade-vTM) version of the VTM is available on localhost. If the Docker image has some virtual servers, pools configured the testing is more valid (as it actually tests the metrics returned etc.

### Additional Notes
* For the tests to pass this will require the Docker image linked above to be running on local host. 
* It will also require a password to be set as an environment variable (this can be changed if you have some default you want me to set).
