### PR TITLE
[packaging] fixes source install for sdk

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -389,25 +389,31 @@ tar -xz -C "$DD_HOME/agent" --strip-components 1 -f "$DD_HOME/agent.tar.gz"
 rm -f "$DD_HOME/agent.tar.gz"
 print_done
 
-print_console "* Downloading integrations from GitHub"
-mkdir -p "$DD_HOME/integrations"
-$DOWNLOADER "$DD_HOME/integrations.tar.gz" "https://api.github.com/repos/DataDog/integrations-core/tarball"
-print_done
+AGENT_VERSION_ARRAY=(${AGENT_VERSION//./ })
+AGENT_MAJOR_VERSION=${AGENT_VERSION_ARRAY[0]}
+AGENT_MINOR_VERSION=${AGENT_VERSION_ARRAY[1]}
+# Only install the integrations from the integrations-core if it's version 5.11 or above.
+if [[ (("$AGENT_MAJOR_VERSION" = "5")) && (("$AGENT_MINOR_VERSION" > "11")) ]]; then
+  print_console "* Downloading integrations from GitHub"
+  mkdir -p "$DD_HOME/integrations"
+  $DOWNLOADER "$DD_HOME/integrations.tar.gz" "https://api.github.com/repos/DataDog/integrations-core/tarball/$AGENT_VERSION"
+  print_done
 
-print_console "* Uncompressing tarball"
-tar -xz -C "$DD_HOME/integrations" --strip-components 1 -f "$DD_HOME/integrations.tar.gz"
-rm -f "$DD_HOME/integrations.tar.gz"
-print_done
+  print_console "* Uncompressing tarball"
+  tar -xz -C "$DD_HOME/integrations" --strip-components 1 -f "$DD_HOME/integrations.tar.gz"
+  rm -f "$DD_HOME/integrations.tar.gz"
+  print_done
 
-print_console "* Trying to install integration requirements"
-for INT_DIR in "$DD_HOME/integrations/*"; do
-  if [ -d $INT_DIR ]; then
-    if [-f "$INT_DIR/requirements.txt" ]; then
-      "$DD_HOME/agent/utils/pip-allow-failures.sh" "$INT_DIR/requirements.txt"
+  print_console "* Trying to install integration requirements"
+  for INT_DIR in "$DD_HOME/integrations/*"; do
+    if [ -d $INT_DIR ]; then
+      if [-f "$INT_DIR/requirements.txt" ]; then
+        "$DD_HOME/agent/utils/pip-allow-failures.sh" "$INT_DIR/requirements.txt"
+      fi
     fi
-  fi
-done
-print_done
+  done
+  print_done
+fi
 
 print_console "* Trying to install optional requirements"
 $DOWNLOADER "$DD_HOME/requirements-opt.txt" "$BASE_GITHUB_URL/requirements-opt.txt"

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -389,6 +389,26 @@ tar -xz -C "$DD_HOME/agent" --strip-components 1 -f "$DD_HOME/agent.tar.gz"
 rm -f "$DD_HOME/agent.tar.gz"
 print_done
 
+print_console "* Downloading integrations from GitHub"
+mkdir -p "$DD_HOME/integrations"
+$DOWNLOADER "$DD_HOME/integrations.tar.gz" "https://api.github.com/repos/DataDog/integrations-core/tarball"
+print_done
+
+print_console "* Uncompressing tarball"
+tar -xz -C "$DD_HOME/integrations" --strip-components 1 -f "$DD_HOME/integrations.tar.gz"
+rm -f "$DD_HOME/integrations.tar.gz"
+print_done
+
+print_console "* Trying to install integration requirements"
+for INT_DIR in "$DD_HOME/integrations/*"; do
+  if [ -d $INT_DIR ]; then
+    if [-f "$INT_DIR/requirements.txt" ]; then
+      "$DD_HOME/agent/utils/pip-allow-failures.sh" "$INT_DIR/requirements.txt"
+    fi
+  fi
+done
+print_done
+
 print_console "* Trying to install optional requirements"
 $DOWNLOADER "$DD_HOME/requirements-opt.txt" "$BASE_GITHUB_URL/requirements-opt.txt"
 "$DD_HOME/agent/utils/pip-allow-failures.sh" "$DD_HOME/requirements-opt.txt"

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -389,11 +389,12 @@ tar -xz -C "$DD_HOME/agent" --strip-components 1 -f "$DD_HOME/agent.tar.gz"
 rm -f "$DD_HOME/agent.tar.gz"
 print_done
 
-AGENT_VERSION_ARRAY=(${AGENT_VERSION//./ })
-AGENT_MAJOR_VERSION=${AGENT_VERSION_ARRAY[0]}
-AGENT_MINOR_VERSION=${AGENT_VERSION_ARRAY[1]}
-# Only install the integrations from the integrations-core if it's version 5.11 or above.
-if [[ (("$AGENT_MAJOR_VERSION" = "5")) && (("$AGENT_MINOR_VERSION" > "11")) ]]; then
+IFS='.' read AGENT_MAJOR_VERSION AGENT_MINOR_VERSION AGENT_BUGFIX_VERSION<<VERSION
+$AGENT_VERSION
+VERSION
+
+# Only install the integrations from the integrations-core if it's version 5.12 or above.
+if [ "$AGENT_MAJOR_VERSION" -eq "5" -a "$AGENT_MINOR_VERSION" -gt "11" ]; then
   print_console "* Downloading integrations from GitHub"
   mkdir -p "$DD_HOME/integrations"
   $DOWNLOADER "$DD_HOME/integrations.tar.gz" "https://api.github.com/repos/DataDog/integrations-core/tarball/$AGENT_VERSION"


### PR DESCRIPTION
This fixes the source install after https://github.com/DataDog/dd-agent/pull/3114 is merged.

I tested the new logic on dash, bash and zsh.