### PR TITLE
[mongo] add metric with number of databases

### DIFF
--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -829,7 +829,7 @@ class MongoDb(AgentCheck):
             pass
 
         dbnames = cli.database_names()
-        GAUGE(self, 'mongodb.dbs', len(dbnames), tags=tags)
+        self.gauge('mongodb.dbs', len(dbnames), tags=tags)
 
         for db_n in dbnames:
             db_aux = cli[db_n]

--- a/checks.d/mongo.py
+++ b/checks.d/mongo.py
@@ -829,6 +829,8 @@ class MongoDb(AgentCheck):
             pass
 
         dbnames = cli.database_names()
+        GAUGE(self, 'mongodb.dbs', len(dbnames), tags=tags)
+
         for db_n in dbnames:
             db_aux = cli[db_n]
             dbstats[db_n] = {'stats': db_aux.command('dbstats')}


### PR DESCRIPTION
We want to see number of mongodb databases because our databases can grow dynamically. I was thinking about this code. The best solution which I see it's usage of GAUGE link to AgentCheck.gauge function with static metric's name.
Please correct me if I am wrong
Would like to see this metric in the oficial repository
Thanks