### PR TITLE
[marathon] catch can't connect instead of failing on nodata found

### DIFF
--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -80,6 +80,12 @@ class Marathon(AgentCheck):
                 tags = ["url:{0}".format(url)])
             raise Exception("Got %s when hitting %s" % (r.status_code, url))
 
+        except requests.exceptions.ConnectionError:
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL,
+                message='%s Connection Refused.' % (url),
+                tags = ["url:{0}".format(url)])
+            raise Exception("Connection refused when hitting %s" % url)
+
         else:
             self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK,
                 tags = ["url:{0}".format(url)]


### PR DESCRIPTION
### What does this PR do?

If you use marathon.can_connect to check for marathon service availability and health, it won't fail if the check can't connect (if marathon is down) 

### Motivation

The check should raise a critical event if marathon can't connect. Otherwise if marathon is down you may only get an alert if you have enabled "Alert on no data" which can be a high timeframe as well.

### Additional Notes

I'm not a python dev by anymeans, but perhaps other "can_connect" alerts should be updated to send critical alert on "Can't connect" rather than rely on no data found.
