### PR TITLE
[auto_conf] [elastic] fix elasticsearch autoconf

### DIFF
--- a/conf.d/auto_conf/elastic.yaml
+++ b/conf.d/auto_conf/elastic.yaml
@@ -4,4 +4,4 @@ docker_images:
 init_config:
 
 instances:
-  - url: "http://%%host%%:%%port%%"
+  - url: "http://%%host%%:%%port_0%%"


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Fix elasticsearch auto config when cluster-mode port is exposed.

### Motivation

fix #3128 

### Testing Guidelines

- Run agent in auto_conf mode with the previous version --> ConnectionError.
- Run it again with new settings and the check succeeds.
