### PR TITLE
Report CommitLimit and Committed_AS

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -332,7 +332,9 @@ class Collector(object):
                         'memShared': memory.get('physShared'),
                         'memSlab': memory.get('physSlab'),
                         'memPageTables': memory.get('physPageTables'),
-                        'memSwapCached': memory.get('swapCached')
+                        'memSwapCached': memory.get('swapCached'),
+                        'memCommitLimit': memory.get('physCommitLimit'),
+                        'memCommittedAs': memory.get('physCommittedAs')
                     }
                     payload.update(memstats)
 

--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -371,6 +371,8 @@ class Memory(Check):
                 memData['physSlab'] = int(meminfo.get('Slab', 0)) / 1024
                 memData['physPageTables'] = int(meminfo.get('PageTables', 0)) / 1024
                 memData['physUsed'] = memData['physTotal'] - memData['physFree']
+                memData['physCommitLimit'] = int(meminfo.get('CommitLimit', 0)) / 1024
+                memData['physCommittedAs'] = int(meminfo.get('Committed_AS', 0)) / 1024
 
                 if 'MemAvailable' in meminfo:
                     memData['physUsable'] = int(meminfo.get('MemAvailable', 0)) / 1024


### PR DESCRIPTION
### What does this PR do?

Report **CommitLimit** and **Committed_AS** metrics for Unix systems.

### Motivation

The ability to monitor these metrics to prevent an OOM sittuation.

