### PR TITLE
[check_marathon] Add marathon disable_ssl_validation and group support

### DIFF
--- a/checks.d/marathon.py
+++ b/checks.d/marathon.py
@@ -53,9 +53,9 @@ class Marathon(AgentCheck):
 
         # Marathon apps
         if group is None:
-          marathon_path = urljoin(url, "v2/apps")
+            marathon_path = urljoin(url, "v2/apps")
         else:
-          marathon_path = urljoin(url, "v2/groups/{}".format(group))
+            marathon_path = urljoin(url, "v2/groups/{}".format(group))
         response = self.get_json(marathon_path, timeout, auth, ssl_verify)
         if response is not None:
             self.gauge('marathon.apps', len(response['apps']), tags=instance_tags)

--- a/conf.d/marathon.yaml.example
+++ b/conf.d/marathon.yaml.example
@@ -9,3 +9,9 @@ instances:
   #   if marathon is protected by basic auth
   #   user: "username"
   #   password: "password"
+  #
+  #   to disable ssl validation
+  #   disable_ssl_validation: true
+  #
+  #   to get metrics from just one application group:
+  #   group: product

--- a/tests/checks/mock/test_marathon.py
+++ b/tests/checks/mock/test_marathon.py
@@ -32,7 +32,7 @@ class MarathonCheckTest(AgentCheckTest):
     CHECK_NAME = 'marathon'
 
     def test_default_configuration(self):
-        def side_effect(url, timeout, auth):
+        def side_effect(url, timeout, auth, verify):
             if "v2/apps" in url:
                 return Fixtures.read_json_file("apps.json")
             elif "v2/deployments" in url:
@@ -46,7 +46,7 @@ class MarathonCheckTest(AgentCheckTest):
 
 
     def test_empty_responses(self):
-        def side_effect(url, timeout, auth):
+        def side_effect(url, timeout, auth, verify):
             if "v2/apps" in url:
                 return {"apps": []}
             elif "v2/deployments" in url:


### PR DESCRIPTION
### What does this PR do?

Add support to marathon for:
  disable_ssl_validation: to bypass bad or self-signed certs
  group: to get a subset of apps running in marathon (https://mesosphere.github.io/marathon/docs/application-groups.html)

### Motivation

Optional features to support different usecases

### Testing Guidelines

Tests already exist for check_marathon

### Additional Notes

none that I know of
