### PR TITLE
[kubernetes] support cert auth against apiserver

### DIFF
--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -458,7 +458,7 @@ class Kubernetes(AgentCheck):
             namespaces_endpoint = '{}/namespaces'.format(self.kubeutil.kubernetes_api_url)
             self.log.debug('Kubernetes API endpoint to query namespaces: %s' % namespaces_endpoint)
 
-            namespaces = self.kubeutil.retrieve_json_auth(namespaces_endpoint, self.kubeutil.get_auth_token())
+            namespaces = self.kubeutil.retrieve_json_auth(namespaces_endpoint)
             for namespace in namespaces.get('items', []):
                 name = namespace.get('metadata', {}).get('name', None)
                 if name and self.k8s_namespace_regexp.match(name):
@@ -469,7 +469,7 @@ class Kubernetes(AgentCheck):
         events_endpoint = '{}/events'.format(self.kubeutil.kubernetes_api_url)
         self.log.debug('Kubernetes API endpoint to query events: %s' % events_endpoint)
 
-        events = self.kubeutil.retrieve_json_auth(events_endpoint, self.kubeutil.get_auth_token())
+        events = self.kubeutil.retrieve_json_auth(events_endpoint)
         event_items = events.get('items') or []
         last_read = self.kubeutil.last_event_collection_ts
         most_recent_read = 0

--- a/conf.d/kubernetes.yaml.example
+++ b/conf.d/kubernetes.yaml.example
@@ -13,6 +13,14 @@ instances:
   # method: http
  - port: 4194
 
+  # Authentication against the apiserver
+  # By default the agent authenticates against the apiserver with its service account bearer token.
+  # X509 certificate authentication can also be enabled by providing here the paths to
+  # a client cert/key pair.
+  # The recommended way to expose these files to the agent is by using Kubernetes Secrets.
+  # apiserver_client_crt: /path/to/client.crt
+  # apiserver_client_key: /path/to/client.key
+  #
   # collect_events controls whether the agent should fetch events from the kubernetes API and
   # ingest them in Datadog. To avoid duplicates, only one agent at a time across the entire
   # cluster should have this feature enabled. To enable the feature, set the parameter to `true`.

--- a/conf.d/kubernetes.yaml.example
+++ b/conf.d/kubernetes.yaml.example
@@ -15,7 +15,8 @@ instances:
 
   # Authentication against the apiserver
   # By default the agent authenticates against the apiserver with its service account bearer token.
-  # X509 certificate authentication can also be enabled by providing here the paths to
+  # X509 certificate authentication is also supported.
+  # To enable cert auth in place of bearer token auth, provide here the paths to
   # a client cert/key pair.
   # The recommended way to expose these files to the agent is by using Kubernetes Secrets.
   # apiserver_client_crt: /path/to/client.crt

--- a/tests/checks/mock/test_kubernetes.py
+++ b/tests/checks/mock/test_kubernetes.py
@@ -48,7 +48,7 @@ METRICS = [
 ]
 
 
-def KubeUtil_fake_retrieve_json_auth(url, auth_token, timeout=10):
+def KubeUtil_fake_retrieve_json_auth(url, timeout=10):
     if url.endswith("/namespaces"):
         return json.loads(Fixtures.read_file("namespaces.json", string_escape=False))
     if url.endswith("/events"):
@@ -385,6 +385,19 @@ class TestKubeutil(unittest.TestCase):
         retrieve_pods_list.assert_called_once()
         extract_kube_labels.assert_called_once_with('foo', excluded_keys='bar')
 
+    @mock.patch('utils.kubernetes.kubeutil.KubeUtil.get_auth_token', return_value=None)
+    def test_init_tls_settings(self, get_tkn):
+        self.assertEqual(self.kubeutil._init_tls_settings({}), {})
+        self.assertEqual(self.kubeutil._init_tls_settings({'apiserver_client_crt': 'foo.crt'}), {})
+
+        instance = {'apiserver_client_crt': 'foo.crt', 'apiserver_client_key': 'foo.key'}
+        with mock.patch('utils.kubernetes.kubeutil.os.path.exists', return_value=True):
+            expected_res = {'apiserver_client_cert': ('foo.crt', 'foo.key')}
+            self.assertEqual(self.kubeutil._init_tls_settings(instance), expected_res)
+
+        with mock.patch('utils.kubernetes.kubeutil.os.path.exists', return_value=False):
+            self.assertEqual(self.kubeutil._init_tls_settings(instance), {})
+
     def test_extract_kube_labels(self):
         """
         Test with both 1.1 and 1.2 version payloads
@@ -467,12 +480,27 @@ class TestKubeutil(unittest.TestCase):
 
     @mock.patch('utils.kubernetes.kubeutil.requests')
     def test_retrieve_json_auth(self, r):
-        self.kubeutil.retrieve_json_auth('url', 'foo_tok')
-        r.get.assert_called_once_with('url', verify=False, timeout=10, headers={'Authorization': 'Bearer foo_tok'})
+        instances = [
+            # tls_settings, expected_params
+            ({}, {'verify': False, 'timeout': 10, 'headers': None, 'cert': None}),
+            ({'bearer_token': 'foo_tok'}, {'verify': False, 'timeout': 10, 'headers': {'Authorization': 'Bearer foo_tok'}, 'cert': None}),
+            (
+                {'bearer_token': 'foo_tok', 'apiserver_client_cert': ('foo.crt', 'foo.key')},
+                {'verify': False, 'timeout': 10, 'headers': {'Authorization': 'Bearer foo_tok'}, 'cert': ('foo.crt', 'foo.key')}
+            ),
+        ]
 
+        for tls_settings, expected_params in instances:
+            r.get.reset_mock()
+            self.kubeutil.tls_settings = tls_settings
+            self.kubeutil.retrieve_json_auth('url')
+            r.get.assert_called_once_with('url', **expected_params)
+
+        r.get.reset_mock()
+        self.kubeutil.tls_settings = {'bearer_token': 'foo_tok'}
         self.kubeutil.CA_CRT_PATH = __file__
-        self.kubeutil.retrieve_json_auth('url', 'foo_tok')
-        r.get.assert_called_with('url', verify=__file__, timeout=10, headers={'Authorization': 'Bearer foo_tok'})
+        self.kubeutil.retrieve_json_auth('url')
+        r.get.assert_called_with('url', verify=__file__, timeout=10, headers={'Authorization': 'Bearer foo_tok'}, cert=None)
 
     def test_get_node_info(self):
         with mock.patch('utils.kubernetes.KubeUtil._fetch_host_data') as f:

--- a/tests/checks/mock/test_kubernetes.py
+++ b/tests/checks/mock/test_kubernetes.py
@@ -486,7 +486,7 @@ class TestKubeutil(unittest.TestCase):
             ({'bearer_token': 'foo_tok'}, {'verify': False, 'timeout': 10, 'headers': {'Authorization': 'Bearer foo_tok'}, 'cert': None}),
             (
                 {'bearer_token': 'foo_tok', 'apiserver_client_cert': ('foo.crt', 'foo.key')},
-                {'verify': False, 'timeout': 10, 'headers': {'Authorization': 'Bearer foo_tok'}, 'cert': ('foo.crt', 'foo.key')}
+                {'verify': False, 'timeout': 10, 'headers': None, 'cert': ('foo.crt', 'foo.key')}
             ),
         ]
 

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -188,7 +188,7 @@ class KubeUtil:
         log.debug('ssl validation: {}'.format(verify))
 
         cert = self.tls_settings.get('apiserver_client_cert')
-        bearer_token = self.tls_settings.get('bearer_token')
+        bearer_token = self.tls_settings.get('bearer_token') if not cert else None
         headers = {'Authorization': 'Bearer {}'.format(bearer_token)} if bearer_token else None
 
         r = requests.get(url, timeout=timeout, headers=headers, verify=verify, cert=cert)

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -180,9 +180,12 @@ class KubeUtil:
     def retrieve_json_auth(self, url, timeout=10):
         """
         Kubernetes API requires authentication using a token available in
-        every pod.
+        every pod, or with a client X509 cert/key pair.
+        We authenticate using the service account token by default
+        and replace this behavior with cert authentication if the user provided
+        a cert/key pair in the instance.
 
-        We try to verify ssl certificate if available.
+        We try to verify the server TLS cert if the public cert is available.
         """
         verify = self.CA_CRT_PATH if os.path.exists(self.CA_CRT_PATH) else False
         log.debug('ssl validation: {}'.format(verify))

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -67,6 +67,7 @@ class KubeUtil:
         self.kubelet_api_url = '%s://%s:%d' % (self.method, self.kubelet_host, self.kubelet_port)
         self.cadvisor_url = '%s://%s:%d' % (self.method, self.kubelet_host, self.cadvisor_port)
         self.kubernetes_api_url = 'https://%s/api/v1' % (os.environ.get('KUBERNETES_SERVICE_HOST') or self.DEFAULT_MASTER_NAME)
+        self.tls_settings = self._init_tls_settings(instance)
 
         self.metrics_url = urljoin(self.cadvisor_url, KubeUtil.METRICS_PATH)
         self.machine_info_url = urljoin(self.cadvisor_url, KubeUtil.MACHINE_INFO_PATH)
@@ -76,6 +77,23 @@ class KubeUtil:
         # keep track of the latest k8s event we collected and posted
         # default value is 0 but TTL for k8s events is one hour anyways
         self.last_event_collection_ts = 0
+
+    def _init_tls_settings(self, instance):
+        """
+        Initialize TLS settings for connection to apiserver and kubelet.
+        """
+        tls_settings = {}
+
+        client_crt = instance.get('apiserver_client_crt')
+        client_key = instance.get('apiserver_client_key')
+        if client_crt and client_key and os.path.exists(client_crt) and os.path.exists(client_key):
+            tls_settings['apiserver_client_cert'] = (client_crt, client_key)
+
+        token = self.get_auth_token()
+        if token:
+            tls_settings['bearer_token']
+
+        return tls_settings
 
     def get_kube_labels(self, excluded_keys=None):
         pods = self.retrieve_pods_list()
@@ -159,7 +177,7 @@ class KubeUtil:
         pods_list['items'] = filtered_pods
         return pods_list
 
-    def retrieve_json_auth(self, url, auth_token, timeout=10):
+    def retrieve_json_auth(self, url, timeout=10):
         """
         Kubernetes API requires authentication using a token available in
         every pod.
@@ -168,8 +186,12 @@ class KubeUtil:
         """
         verify = self.CA_CRT_PATH if os.path.exists(self.CA_CRT_PATH) else False
         log.debug('ssl validation: {}'.format(verify))
-        headers = {'Authorization': 'Bearer {}'.format(auth_token)}
-        r = requests.get(url, timeout=timeout, headers=headers, verify=verify)
+
+        cert = self.tls_settings.get('apiserver_client_cert')
+        bearer_token = self.tls_settings.get('bearer_token')
+        headers = {'Authorization': 'Bearer {}'.format(bearer_token)} if bearer_token else None
+
+        r = requests.get(url, timeout=timeout, headers=headers, verify=verify, cert=cert)
         r.raise_for_status()
         return r.json()
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### What does this PR do?

Authentication against the apiserver was limited to bearer token. This PR adds support for X509 cert auth.

### Motivation

#3142 adds the feature for authenticating against kubelet, apiserver deserves some love too.
Also, it was requested by existing users ( 👋 @netvisao )

### Testing Guidelines

Tests were updated accordingly.
