### PR TITLE
[Service Discovery][jmx] is_jmx flag in auto_conf

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -59,7 +59,6 @@ from utils.service_discovery.config_stores import get_config_store
 from utils.service_discovery.sd_backend import get_sd_backend
 
 # Constants
-from jmxfetch import JMX_CHECKS
 PID_NAME = "dd-agent"
 PID_DIR = None
 WATCHDOG_MULTIPLIER = 10
@@ -137,8 +136,7 @@ class Agent(Daemon):
                 jmx_sd_configs = generate_jmx_configs(self._agentConfig, hostname)
         else:
             new_checksd = copy(self._checksd)
-            auto_conf_is_jmx_checks = get_jmx_checks()
-            all_jmx_checks = JMX_CHECKS + auto_conf_is_jmx_checks
+            all_jmx_checks = get_jmx_checks(auto_conf=True)
             jmx_checks = [check for check in checks_to_reload if check in all_jmx_checks]
             py_checks = set(checks_to_reload) - set(jmx_checks)
             self.refresh_specific_checks(hostname, new_checksd, py_checks)

--- a/agent.py
+++ b/agent.py
@@ -39,11 +39,12 @@ from config import (
     generate_jmx_configs,
     _is_affirmative,
     SD_PIPE_NAME
-
 )
 from daemon import AgentSupervisor, Daemon
 from emitter import http_emitter
 from utils.platform import Platform
+from jmxfetch import get_jmx_checks
+
 
 # utils
 from util import Watchdog
@@ -136,8 +137,9 @@ class Agent(Daemon):
                 jmx_sd_configs = generate_jmx_configs(self._agentConfig, hostname)
         else:
             new_checksd = copy(self._checksd)
-
-            jmx_checks = [check for check in checks_to_reload if check in JMX_CHECKS]
+            auto_conf_is_jmx_checks = get_jmx_checks()
+            all_jmx_checks = JMX_CHECKS + auto_conf_is_jmx_checks
+            jmx_checks = [check for check in checks_to_reload if check in all_jmx_checks]
             py_checks = set(checks_to_reload) - set(jmx_checks)
             self.refresh_specific_checks(hostname, new_checksd, py_checks)
             if self._jmx_service_discovery_enabled:

--- a/config.py
+++ b/config.py
@@ -1129,13 +1129,9 @@ def load_check(agentConfig, hostname, checkname):
 
 def generate_jmx_configs(agentConfig, hostname, checknames=None):
     """Similar logic to load_check_directory for JMX checks"""
-    from jmxfetch import JMX_CHECKS, get_jmx_checks
+    from jmxfetch import get_jmx_checks
 
-    jmx_checks = JMX_CHECKS
-    auto_conf_jmx_checks = get_jmx_checks()
-    for check in auto_conf_jmx_checks:
-        if check not in JMX_CHECKS:
-            jmx_checks.append(check)
+    jmx_checks = get_jmx_checks(auto_conf=True)
 
     if not checknames:
         checknames = jmx_checks

--- a/config.py
+++ b/config.py
@@ -1129,16 +1129,22 @@ def load_check(agentConfig, hostname, checkname):
 
 def generate_jmx_configs(agentConfig, hostname, checknames=None):
     """Similar logic to load_check_directory for JMX checks"""
-    from jmxfetch import JMX_CHECKS
+    from jmxfetch import JMX_CHECKS, get_jmx_checks
+
+    jmx_checks = JMX_CHECKS
+    auto_conf_jmx_checks = get_jmx_checks()
+    for check in auto_conf_jmx_checks:
+        if check not in JMX_CHECKS:
+            jmx_checks.append(check)
 
     if not checknames:
-        checknames = JMX_CHECKS
+        checknames = jmx_checks
     agentConfig['checksd_hostname'] = hostname
 
     # the check was not found, try with service discovery
     generated = {}
     for check_name, service_disco_check_config in _service_disco_configs(agentConfig).iteritems():
-        if check_name in checknames and check_name in JMX_CHECKS:
+        if check_name in checknames and check_name in jmx_checks:
             log.debug('Generating JMX config for: %s' % check_name)
 
             _, (sd_init_config, sd_instances) = service_disco_check_config
@@ -1148,7 +1154,6 @@ def generate_jmx_configs(agentConfig, hostname, checknames=None):
 
             try:
                 yaml = config_to_yaml(check_config)
-                # generated["{}_{}".format(check_name, idx)] = yaml
                 generated["{}_{}".format(check_name, 0)] = yaml
                 log.debug("YAML generated: %s", yaml)
             except Exception:
@@ -1156,9 +1161,7 @@ def generate_jmx_configs(agentConfig, hostname, checknames=None):
 
     return generated
 
-#
 # logging
-
 
 def get_log_date_format():
     return "%Y-%m-%d %H:%M:%S %Z"

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -103,7 +103,7 @@ gce_updated_hostname: yes
 
 # ========================================================================== #
 # Service Discovery                                                          #
-# See https://github.com/DataDog/dd-agent/wiki/Service-Discovery for details #
+# See http://docs.datadoghq.com/guides/servicediscovery/ for details #
 # ========================================================================== #
 #
 # Service discovery allows the agent to look for running services
@@ -125,7 +125,7 @@ gce_updated_hostname: yes
 # and modify its value.
 # sd_template_dir: /datadog/check_configs
 #
-# Enable JMX checks for service disocvery
+# Enable JMX checks for service discovery
 # sd_jmx_enable: no
 #
 # ========================================================================== #

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -197,40 +197,31 @@ class JMXFetch(object):
         tools_jar_path = None
         custom_jar_paths = []
         invalid_checks = {}
+        auto_conf = False
 
-        for conf in glob.glob(os.path.join(confd_path, '*.yaml')):
-            filename = os.path.basename(conf)
-            check_name = filename.split('.')[0]
-
-            if os.path.exists(conf):
-                f = open(conf)
-                try:
-                    check_config = yaml.load(f.read(), Loader=yLoader)
-                    assert check_config is not None
-                    f.close()
-                except Exception:
-                    f.close()
-                    log.error("Unable to parse yaml config in %s" % conf)
-                    continue
-
-                try:
-                    is_jmx, check_java_bin_path, check_java_options, check_tools_jar_path, check_custom_jar_paths = \
-                        cls._is_jmx_check(check_config, check_name, checks_list)
-                    if is_jmx:
-                        jmx_checks.append(filename)
-                        if java_bin_path is None and check_java_bin_path is not None:
-                            java_bin_path = check_java_bin_path
-                        if java_options is None and check_java_options is not None:
-                            java_options = check_java_options
-                        if tools_jar_path is None and check_tools_jar_path is not None:
-                            tools_jar_path = check_tools_jar_path
-                        if check_custom_jar_paths:
-                            custom_jar_paths.extend(check_custom_jar_paths)
-                except InvalidJMXConfiguration as e:
-                    log.error("%s check does not have a valid JMX configuration: %s" % (check_name, e))
-                    # Make sure check_name is a string - Fix issues with Windows
-                    check_name = check_name.encode('ascii', 'ignore')
-                    invalid_checks[check_name] = str(e)
+        jmx_confd_checks = get_jmx_checks(auto_conf, confd_path)
+        for check in jmx_confd_checks:
+            check_config = check['check_config']
+            check_name = check['check_name']
+            filename = check['filename']
+            try:
+                is_jmx, check_java_bin_path, check_java_options, check_tools_jar_path, check_custom_jar_paths = \
+                    cls._is_jmx_check(check_config, check_name, checks_list)
+                if is_jmx:
+                    jmx_checks.append(filename)
+                    if java_bin_path is None and check_java_bin_path is not None:
+                        java_bin_path = check_java_bin_path
+                    if java_options is None and check_java_options is not None:
+                        java_options = check_java_options
+                    if tools_jar_path is None and check_tools_jar_path is not None:
+                        tools_jar_path = check_tools_jar_path
+                    if check_custom_jar_paths:
+                        custom_jar_paths.extend(check_custom_jar_paths)
+            except InvalidJMXConfiguration as e:
+                log.error("%s check does not have a valid JMX configuration: %s" % (check_name, e))
+                # Make sure check_name is a string - Fix issues with Windows
+                check_name = check_name.encode('ascii', 'ignore')
+                invalid_checks[check_name] = str(e)
 
         return (jmx_checks, invalid_checks, java_bin_path, java_options, tools_jar_path, custom_jar_paths)
 
@@ -460,6 +451,40 @@ class JMXFetch(object):
         return os.path.realpath(os.path.join(os.path.abspath(__file__), "..", "..",
                                 "jmxfetch", JMX_FETCH_JAR_NAME))
 
+def get_jmx_checks(auto_conf=True, confd_path=None):
+    jmx_checks = []
+    if not confd_path:
+        confd_path = get_confd_path()
+
+    if auto_conf:
+        path = confd_path + '/auto_conf'
+    else:
+        path = confd_path
+
+    for conf in glob.glob(os.path.join(path, '*.yaml')):
+        filename = os.path.basename(conf)
+        check_name = filename.split('.')[0]
+        if os.path.exists(conf):
+            f = open(conf)
+            try:
+                check_config = yaml.load(f.read(), Loader=yLoader)
+                assert check_config is not None
+                f.close()
+            except Exception:
+                f.close()
+                log.error("Unable to parse yaml config in %s" % conf)
+                continue
+
+        init_config = check_config.get('init_config', {}) or {}
+
+        if init_config.get('is_jmx') or check_name in JMX_CHECKS:
+            # If called by `get_configuration()` we should return the check_config and check_name
+            if auto_conf:
+                jmx_checks.append(check_name)
+            else:
+                jmx_checks.append({'check_config': check_config, 'check_name': check_name, 'filename': filename})
+
+    return jmx_checks
 
 def init(config_path=None):
     agentConfig = get_config(parse_args=False, cfg_path=config_path)

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -224,12 +224,9 @@ class AbstractConfigStore(object):
             return None
 
     def _get_auto_config(self, image_name):
-        from jmxfetch import JMX_CHECKS, get_jmx_checks
+        from jmxfetch import get_jmx_checks
 
-        jmx_checknames = JMX_CHECKS
-        auto_conf_jmx_checks = get_jmx_checks()
-        if auto_conf_jmx_checks:
-            jmx_checknames += auto_conf_jmx_checks
+        jmx_checknames = get_jmx_checks(auto_conf=True)
 
         ident = self._get_image_ident(image_name)
         templates = []

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -16,6 +16,7 @@ from requests.packages.urllib3.exceptions import TimeoutError
 from utils.checkfiles import get_check_class, get_auto_conf, get_auto_conf_images
 from utils.singleton import Singleton
 
+
 log = logging.getLogger(__name__)
 
 CONFIG_FROM_AUTOCONF = 'auto-configuration'
@@ -223,7 +224,12 @@ class AbstractConfigStore(object):
             return None
 
     def _get_auto_config(self, image_name):
-        from jmxfetch import JMX_CHECKS
+        from jmxfetch import JMX_CHECKS, get_jmx_checks
+
+        jmx_checknames = JMX_CHECKS
+        auto_conf_jmx_checks = get_jmx_checks()
+        if auto_conf_jmx_checks:
+            jmx_checknames += auto_conf_jmx_checks
 
         ident = self._get_image_ident(image_name)
         templates = []
@@ -232,11 +238,10 @@ class AbstractConfigStore(object):
 
             for check_name in check_names:
                 # get the check class to verify it matches
-                check = get_check_class(self.agentConfig, check_name) if check_name not in JMX_CHECKS else True
+                check = get_check_class(self.agentConfig, check_name) if check_name not in jmx_checknames else True
                 if check is None:
                     log.info("Failed auto configuring check %s for %s." % (check_name, image_name))
                     continue
-
                 auto_conf = get_auto_conf(check_name)
                 init_config, instances = auto_conf.get('init_config', {}), auto_conf.get('instances', [])
                 templates.append((check_name, init_config, instances[0] or {}))


### PR DESCRIPTION
### What does this PR do?

- Enables configuration of JMX yaml files with any name when they have the `is_jmx: true` flag  in the `init_config` section. This mirrors the same functionality for JMX yaml files in `/conf.d`.
- Adds validation for file names in the `/auto_conf` directory to only configure files with `.yaml` extension. This mirrors the same functionality as in `/conf.d`. For example, `foo.yaml.example` will be ignored.

### Motivation

Support case that found the `is_jmx` limitation.
