### PR TITLE
Jaime/ostack

### DIFF
--- a/checks.d/openstack.py
+++ b/checks.d/openstack.py
@@ -19,6 +19,7 @@ V21_NOVA_API_VERSION = 'v2.1'
 
 DEFAULT_KEYSTONE_API_VERSION = 'v3'
 DEFAULT_NOVA_API_VERSION = V21_NOVA_API_VERSION
+FALLBACK_NOVA_API_VERSION = 'v2'
 DEFAULT_NEUTRON_API_VERSION = 'v2.0'
 
 DEFAULT_API_REQUEST_TIMEOUT = 5 # seconds
@@ -167,9 +168,14 @@ class OpenStackProjectScope(object):
 
         auth_token = auth_resp.headers.get('X-Subject-Token')
 
-        service_catalog = KeystoneCatalog.from_auth_response(
-            auth_resp.json(), nova_api_version
-        )
+        try:
+            service_catalog = KeystoneCatalog.from_auth_response(
+                auth_resp.json(), nova_api_version
+            )
+        except MissingNovaEndpoint:
+            service_catalog = KeystoneCatalog.from_auth_response(
+                auth_resp.json(), FALLBACK_NOVA_API_VERSION
+            )
 
         # (NOTE): aaditya
         # In some cases, the nova url is returned without the tenant id suffixed


### PR DESCRIPTION
### What does this PR do?

Fallback to `nova` endpoints in `novav21` is failing.

### Motivation

Several customers had encountered this and the fix was actually a bit of a hack. This should address it as far as this particular problem is concerned.

### Testing Guidelines

Added a couple tests to verify the correct behavior.