### PR TITLE
Modify the tag generated by the tag_by_filesystem parameter in the disk integration

### DIFF
--- a/checks.d/disk.py
+++ b/checks.d/disk.py
@@ -112,7 +112,7 @@ class Disk(AgentCheck):
             self._valid_disks[part.device] = (part.fstype, part.mountpoint)
             self.log.debug('Passed: {0}'.format(part.device))
 
-            tags = [part.fstype] if self._tag_by_filesystem else []
+            tags = ['fstype:' + part.fstype] if self._tag_by_filesystem else []
             device_name = part.mountpoint if self._use_mount else part.device
 
             # legacy check names c: vs psutil name C:\\

--- a/conf.d/disk.yaml.default
+++ b/conf.d/disk.yaml.default
@@ -24,7 +24,7 @@ instances:
     # excluded_disk_re: /dev/sde.*
     #
     # The (optional) tag_by_filesystem parameter will instruct the check to
-    # tag all disks with their filesystem (for ex: nfs)
+    # tag all disks with their filesystem (for ex: fstype:nfs)
     # tag_by_filesystem: no
     #
     # The (optional) excluded_mountpoint_re parameter will instruct the check to


### PR DESCRIPTION
   ### What does this PR do?

   Modifies the tag generated by the `tag_by_filesystem` parameter in the disk integration to include a prefix of `fstype`.
   For example example: `fstype:nfs`

   ### Motivation

   This PR was motivated by a feature request.
   https://trello.com/c/19XM76R5/2680-tag-prefix-for-tag-by-filesystem-in-disk-integration