### PR TITLE
[kubernetes] make apiserver cacert configurable

### DIFF
--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -158,7 +158,10 @@ class Kubernetes(AgentCheck):
 
         # kubelet events
         if _is_affirmative(instance.get('collect_events', DEFAULT_COLLECT_EVENTS)):
-            self._process_events(instance, pods_list)
+            try:
+                self._process_events(instance, pods_list)
+            except Exception as ex:
+                self.log.error("Event collection failed: %s" % str(ex))
 
     def _publish_raw_metrics(self, metric, dat, tags, depth=0):
         if depth >= self.max_depth:

--- a/conf.d/kubernetes.yaml.example
+++ b/conf.d/kubernetes.yaml.example
@@ -22,6 +22,10 @@ instances:
   # apiserver_client_crt: /path/to/client.crt
   # apiserver_client_key: /path/to/client.key
   #
+  # Similarly we use the default CA cert of the agent's service account to verify the
+  # apiserver's identity, but a custom one can be specified here.
+  # apiserver_ca_cert: /path/to/cacert.crt
+  #
   # collect_events controls whether the agent should fetch events from the kubernetes API and
   # ingest them in Datadog. To avoid duplicates, only one agent at a time across the entire
   # cluster should have this feature enabled. To enable the feature, set the parameter to `true`.

--- a/tests/checks/mock/test_kubernetes.py
+++ b/tests/checks/mock/test_kubernetes.py
@@ -390,9 +390,9 @@ class TestKubeutil(unittest.TestCase):
         self.assertEqual(self.kubeutil._init_tls_settings({}), {})
         self.assertEqual(self.kubeutil._init_tls_settings({'apiserver_client_crt': 'foo.crt'}), {})
 
-        instance = {'apiserver_client_crt': 'foo.crt', 'apiserver_client_key': 'foo.key'}
+        instance = {'apiserver_client_crt': 'foo.crt', 'apiserver_client_key': 'foo.key', 'apiserver_ca_cert': 'ca.crt'}
         with mock.patch('utils.kubernetes.kubeutil.os.path.exists', return_value=True):
-            expected_res = {'apiserver_client_cert': ('foo.crt', 'foo.key')}
+            expected_res = {'apiserver_client_cert': ('foo.crt', 'foo.key'), 'apiserver_cacert': 'ca.crt'}
             self.assertEqual(self.kubeutil._init_tls_settings(instance), expected_res)
 
         with mock.patch('utils.kubernetes.kubeutil.os.path.exists', return_value=False):

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -86,12 +86,17 @@ class KubeUtil:
 
         client_crt = instance.get('apiserver_client_crt')
         client_key = instance.get('apiserver_client_key')
+        apiserver_cacert = instance.get('apiserver_ca_cert')
+
         if client_crt and client_key and os.path.exists(client_crt) and os.path.exists(client_key):
             tls_settings['apiserver_client_cert'] = (client_crt, client_key)
 
+        if apiserver_cacert and os.path.exists(apiserver_cacert):
+            tls_settings['apiserver_cacert'] = apiserver_cacert
+
         token = self.get_auth_token()
         if token:
-            tls_settings['bearer_token']
+            tls_settings['bearer_token'] = token
 
         return tls_settings
 
@@ -187,7 +192,9 @@ class KubeUtil:
 
         We try to verify the server TLS cert if the public cert is available.
         """
-        verify = self.CA_CRT_PATH if os.path.exists(self.CA_CRT_PATH) else False
+        verify = self.tls_settings.get('apiserver_cacert')
+        if not verify:
+            verify = self.CA_CRT_PATH if os.path.exists(self.CA_CRT_PATH) else False
         log.debug('ssl validation: {}'.format(verify))
 
         cert = self.tls_settings.get('apiserver_client_cert')


### PR DESCRIPTION
### What does this PR do?

To verify the identity of the Kubernetes API server we use the CA cert passed in the agent pod service account by default. This PR makes it possible to pass a custom ca cert instead.

### Motivation

User request

### Testing Guidelines

Test updated accordingly
