### PR TITLE
Collect total system memory for Mac OS X

### DIFF
--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -409,6 +409,7 @@ class Memory(Check):
             return {'physUsed': phys_memory.used / float(1024**2),
                 'physFree': phys_memory.free / float(1024**2),
                 'physUsable': phys_memory.available / float(1024**2),
+                'physTotal': phys_memory.total / float(1024**2),
                 'physPctUsable': (100 - phys_memory.percent) / 100.0,
                 'swapUsed': swap.used / float(1024**2),
                 'swapFree': swap.free / float(1024**2)}


### PR DESCRIPTION
### What does this PR do?

Adds collection of the total system memory for Mac OS X.

### Motivation

I was looking at my default host dashboard and noticed that the memory breakdown was completely negative since there is no `system.mem.total` metric being submitted - https://cl.ly/3F002J2x1Q0u