### PR TITLE
updates psycopg2 to 2.6.2

### DIFF
--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -42,7 +42,7 @@ paramiko==1.15.2
 
 # checks.d/pgbouncer.py
 # Require libpq
-psycopg2==2.6
+psycopg2==2.6.2
 
 # checks.d/win32_event_log.py
 # checks.d/wmi.py


### PR DESCRIPTION
We updated this in [omnibus software](https://github.com/DataDog/omnibus-software/pull/106) and removed it from the not windows branch in [dd-agent-omnibus](https://github.com/DataDog/dd-agent-omnibus/pull/121).

We did this because 2.6.2 has wheels built for windows!!