### PR TITLE
[docker] fix image tag extraction

### DIFF
--- a/tests/checks/integration/test_docker_daemon.py
+++ b/tests/checks/integration/test_docker_daemon.py
@@ -614,10 +614,16 @@ class TestCheckDockerDaemon(AgentCheckTest):
             ({'RepoTags': ['localhost/redis:latest']}, [['localhost/redis'], ['latest']]),
             ({'RepoTags': ['localhost:5000/redis:latest']}, [['localhost:5000/redis'], ['latest']]),
             ({'RepoTags': ['localhost:5000/redis:latest', 'localhost:5000/redis:v1.1']}, [['localhost:5000/redis'], ['latest', 'v1.1']]),
+            ({'RepoTags': [], 'RepoDigests': [u'datadog/docker-dd-agent@sha256:47a59c2ea4f6d9555884aacc608b303f18bde113b1a3a6743844bfc364d73b44']},
+                [['datadog/docker-dd-agent'], None]),
         ]
         for entity in entities:
             self.assertEqual(sorted(DockerUtil.image_tag_extractor(entity[0], 0)), sorted(entity[1][0]))
-            self.assertEqual(sorted(DockerUtil.image_tag_extractor(entity[0], 1)), sorted(entity[1][1]))
+            tags = DockerUtil.image_tag_extractor(entity[0], 1)
+            if isinstance(entity[1][1], list):
+                self.assertEqual(sorted(tags), sorted(entity[1][1]))
+            else:
+                self.assertEqual(tags, entity[1][1])
 
     def test_container_name_extraction(self):
         containers = [

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -382,7 +382,7 @@ class DockerUtil:
                 # the split will be like [repo_url, repo_port/image_name, image_tag]. Let's avoid that
                 split = [':'.join(split[:-1]), split[-1]]
             return [split[key]]
-        if "RepoTags" in entity:
+        if entity.get('RepoTags'):
             splits = [el.split(":") for el in entity["RepoTags"]]
             tags = set()
             for split in splits:
@@ -392,6 +392,14 @@ class DockerUtil:
                     tags.add(split[key])
             if len(tags) > 0:
                 return list(tags)
+        elif entity.get('RepoDigests'):
+            # the human-readable tag is not mentioned in RepoDigests, only the image name
+            if key != 0:
+                return None
+            split = entity['RepoDigests'][0].split('@')
+            if len(split) > 1:
+                return [split[key]]
+
         return None
 
     @classmethod


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Fix `image_tag_extractor` in the case where `RepoTags` is empty.
Also add support for image name extraction from `RepoDigests`.

### Motivation

Working on an other PR I realized we were getting a warning:
```Failed to count Docker images. Exception: 'NoneType' object is not iterable```

### Additional Notes

Fix `test_tags_options`.
