### PR TITLE
[utils/hostname] better EC2 detection

### DIFF
--- a/utils/cloud_metadata.py
+++ b/utils/cloud_metadata.py
@@ -26,12 +26,12 @@ class GCE(object):
     @staticmethod
     def _get_metadata(agentConfig):
         if GCE.metadata is not None:
-            return GCE.metadata
+            return GCE.metadata.copy()
 
         if not agentConfig['collect_instance_metadata']:
             log.info("Instance metadata collection is disabled. Not collecting it.")
             GCE.metadata = {}
-            return GCE.metadata
+            return {}
 
         try:
             r = requests.get(
@@ -45,7 +45,7 @@ class GCE(object):
             log.debug("Collecting GCE Metadata failed %s", str(e))
             GCE.metadata = {}
 
-        return GCE.metadata
+        return GCE.metadata.copy()
 
 
 
@@ -218,7 +218,7 @@ class EC2(object):
                 log.debug("Collecting EC2 Metadata failed %s", str(e))
                 pass
 
-        return EC2.metadata
+        return EC2.metadata.copy()
 
     @staticmethod
     def get_instance_id(agentConfig):

--- a/utils/hostname.py
+++ b/utils/hostname.py
@@ -94,8 +94,9 @@ def get_hostname(config=None):
             if unix_hostname and is_valid_hostname(unix_hostname):
                 hostname = unix_hostname
 
-    # if we have an ec2 default hostname, see if there's an instance-id available
-    if (Platform.is_ecs_instance()) or (hostname is not None and EC2.is_default(hostname)):
+    # if we don't have a hostname, or we have an ec2 default hostname,
+    # see if there's an instance-id available
+    if not Platform.is_windows() and (hostname is None or Platform.is_ecs_instance() or EC2.is_default(hostname)):
         instanceid = EC2.get_instance_id(config)
         if instanceid:
             hostname = instanceid


### PR DESCRIPTION
If the hostname is None, we should try to get the EC2 instance-id.
This was reported by a customer, and they proposed this fix.
The hostname can be None when `/bin/hostname -f` returns an error, which
can happen at AMI creation when the hosts file is not ready.`