### PR TITLE
[docker_daemon] change container_image to image_name in example

### DIFF
--- a/conf.d/docker_daemon.yaml.example
+++ b/conf.d/docker_daemon.yaml.example
@@ -112,7 +112,7 @@ instances:
     # include: ["docker_image:ubuntu", "docker_image:debian"]
     #
     # include all, except ubuntu and Kubernetes pause containers.
-    # exclude: ["docker_image:ubuntu", "container_image:gcr.io/google_containers/pause.*"]
+    # exclude: ["docker_image:ubuntu", "image_name:gcr.io/google_containers/pause.*"]
     # include: []
     #
     # Default: include all containers except for Kubernetes pause containers.


### PR DESCRIPTION
With `container_image`, I see the following in the collector logs (v 5.10.1)

    WARNING | dd.collector | checks.docker_daemon(__init__.py:675) | container_image isn't a supported tag


### What does this PR do?

Change docker_daemon example docs.

### Motivation

The existing example seems incorrect and leads to warnings in the logs.

### Additional Notes

I haven't fully confirmed using `image_name` actually works as I expect.
