### PR TITLE
bumps config.py version to 5.12

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ from utils.subprocess_output import (
 )
 
 # CONSTANTS
-AGENT_VERSION = "5.11.0"
+AGENT_VERSION = "5.12.0"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
 MAC_CONFIG_PATH = '/opt/datadog-agent/etc'


### PR DESCRIPTION
### What does this PR do?

Because of the release, we're bumping the config.py to the new version.
