### PR TITLE
[swarm] tag container metrics with swarm service if available

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -103,6 +103,10 @@ DEFAULT_IMAGE_TAGS = [
     'image_tag'
 ]
 
+DEFAULT_LABELS_AS_TAGS = [
+    DockerUtil.SWARM_SVC_LABEL
+]
+
 
 TAG_EXTRACTORS = {
     "docker_image": lambda c: [c["Image"]],
@@ -187,7 +191,7 @@ class DockerDaemon(AgentCheck):
 
             # Set tagging options
             self.custom_tags = instance.get("tags", [])
-            self.collect_labels_as_tags = instance.get("collect_labels_as_tags", [])
+            self.collect_labels_as_tags = instance.get("collect_labels_as_tags", DEFAULT_LABELS_AS_TAGS)
             self.kube_labels = {}
 
             self.use_histogram = _is_affirmative(instance.get('use_histogram', False))
@@ -398,6 +402,10 @@ class DockerDaemon(AgentCheck):
                                 tags.append("kube_namespace:%s" % namespace)
                                 tags.append("kube_replication_controller:%s" % replication_controller)
                                 tags.append("pod_name:%s" % pod_name)
+
+                        elif k == DockerUtil.SWARM_SVC_LABEL and Platform.is_swarm():
+                            if v:
+                                tags.append("swarm_service:%s" % v)
 
                         elif not v:
                             tags.append(k)

--- a/utils/platform.py
+++ b/utils/platform.py
@@ -94,3 +94,8 @@ class Platform(object):
     @staticmethod
     def is_k8s():
         return 'KUBERNETES_PORT' in os.environ
+
+    @staticmethod
+    def is_swarm():
+        from utils.dockerutil import DockerUtil
+        return DockerUtil().is_swarm()

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -17,6 +17,7 @@ from utils.service_discovery.abstract_sd_backend import AbstractSDBackend
 from utils.service_discovery.config_stores import get_config_store
 
 DATADOG_ID = 'com.datadoghq.sd.check.id'
+
 log = logging.getLogger(__name__)
 
 
@@ -259,6 +260,13 @@ class SDDockerBackend(AbstractSDBackend):
 
             # get kubernetes namespace
             tags.append('kube_namespace:%s' % pod_metadata.get('namespace'))
+
+        elif Platform.is_swarm():
+            c_labels = state.inspect_container(c_id).get('Labels', {})
+            swarm_svc = c_labels.get(DockerUtil.SWARM_SVC_LABEL)
+            if swarm_svc:
+                tags.append('swarm_service:%s' % c_labels)
+
 
         return tags
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

This is a first step towards a Docker Swarm integration.
With this PR, all metrics coming from service discovery as well as container metrics will be tagged with the swarm service.

### Motivation

That's a low hanging fruits regarding container monitoring.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
