### PR TITLE
[snmp] pinning subdependency to avoid breakage.

### DIFF
--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -27,6 +27,7 @@ protobuf==3.1.0
 # checks.d/snmp.py
 # Require a compiler because pycrypto is a dep
 pysnmp-mibs==0.1.4
+pyasn1==0.1.9
 pysnmp==4.2.5
 
 # checks.d/mongo.py


### PR DESCRIPTION
### What does this PR do?
Pins pysnmp subdependency `pyasn1`

### Motivation
Regression in 5.11.0

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.