### PR TITLE
[config] version bump to 5.11.2.

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ from utils.subprocess_output import (
 )
 
 # CONSTANTS
-AGENT_VERSION = "5.11.1"
+AGENT_VERSION = "5.11.2"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
 MAC_CONFIG_PATH = '/opt/datadog-agent/etc'


### PR DESCRIPTION
Bad release, bumping to 5.11.2.

### Motivation
Bad release for 5.11.1

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
