### PR TITLE
[kubernetes] reduce log message from error to debug

### DIFF
--- a/checks.d/kubernetes.py
+++ b/checks.d/kubernetes.py
@@ -384,7 +384,7 @@ class Kubernetes(AgentCheck):
                             continue
                         self.publish_gauge(self, '{}.{}.requests'.format(NAMESPACE, request), values[0], _tags)
                 except (KeyError, AttributeError) as e:
-                    self.log.error("Unable to retrieve container requests for %s: %s", c_name, e)
+                    self.log.debug("Unable to retrieve container requests for %s: %s", c_name, e)
                     self.log.debug("Container object for {}: {}".format(c_name, container))
 
         self._update_pods_metrics(instance, pods_list)


### PR DESCRIPTION
A PodSpec with containers with no explicit [ResourceRequirements](https://kubernetes.io/docs/resources-reference/v1.5/#resourcerequirements-v1) results in error logs from the collector:

    Unable to retrieve container requests for $container: 'requests'
    Unable to retrieve container requests for $container: 'requests'
    Unable to retrieve container requests for $container: 'requests'
    ...

### What does this PR do?

Reduce a noisy log from ERROR to DEBUG level.

### Motivation

This is a normal config; no reason to fill the log.
