### PR TITLE
[source] bumping version for source install to 5.11.2.

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -11,7 +11,7 @@ set -u
 # SCRIPT KNOBS
 #######################################################################
 # Update for new releases, will pull this tag in the repo
-DEFAULT_AGENT_VERSION="5.11.1"
+DEFAULT_AGENT_VERSION="5.11.2"
 # Pin pip version, in the past there was some buggy releases and get-pip.py
 # always pulls the latest version
 PIP_VERSION="6.1.1"


### PR DESCRIPTION
# All Agent Checks are now frozen in preparation for the release of the [Integration SDK](https://github.com/DataDog/dd-agent/wiki/Integration-SDK).
## We will review and merge a few more PRs, but no new PRs will be accepted.
## All changes to checks from here on out should go to the [integrations-core repo](https://github.com/datadog/integrations-core) and all new checks should go to the [integrations-extras repo](https://github.com/datadog/integrations-extras). To learn more about how to contribute to them, please check out our [documentation](http://docs.datadoghq.com/guides/integration_sdk/).

### What does this PR do?

Bumps source install to `5.11.2`.

### Motivation

New release.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
