### PR TITLE
[spark] fix event source type name

### DIFF
--- a/checks.d/spark.py
+++ b/checks.d/spark.py
@@ -124,7 +124,7 @@ ERROR_STATUS = 'FAILED'
 SUCCESS_STATUS = ['SUCCEEDED', 'COMPLETE']
 
 # Event source type
-SOURCE_TYPE_NAME = 'spark.application.server'
+SOURCE_TYPE_NAME = 'spark'
 
 # Metric types
 INCREMENT = 'increment'


### PR DESCRIPTION
Set Spark events source type name to `spark` so it gets properly resolved by the backend.
