### PR TITLE
[spark] no events on job/stage status changes

### DIFF
--- a/checks.d/spark.py
+++ b/checks.d/spark.py
@@ -71,7 +71,6 @@ spark.rdd.disk_used
 '''
 
 # stdlib
-import time
 from urlparse import urljoin, urlsplit, urlunsplit
 
 # 3rd party
@@ -198,10 +197,6 @@ SPARK_RDD_METRICS = {
 
 
 class SparkCheck(AgentCheck):
-    def __init__(self, name, init_config, agentConfig, instances=None):
-        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
-        self.previous_jobs = {}
-        self.previous_stages = {}
 
     def check(self, instance):
         # Get additional tags from the conf file
@@ -440,8 +435,6 @@ class SparkCheck(AgentCheck):
         '''
         Get metrics for each Spark job.
         '''
-        new_jobs = {}
-
         for app_id, (app_name, tracking_url) in running_apps.iteritems():
 
             response = self._rest_request_to_json(tracking_url,
@@ -459,23 +452,10 @@ class SparkCheck(AgentCheck):
                 self._set_metrics_from_json(tags, job, SPARK_JOB_METRICS)
                 self._set_metric('spark.job.count', INCREMENT, 1, tags)
 
-                job_id = job.get('jobId')
-                previous_status = None
-                if app_id in self.previous_jobs and job_id in self.previous_jobs[app_id]:
-                    previous_status = self.previous_jobs[app_id][job_id].get('status')
-
-                self._event_for_job_status_change(job, tags, previous_status)
-
-            # Map application IDs to {job ID: job}
-            new_jobs[app_id] = dict((job['jobId'], job) for job in response)
-
-        self.previous_jobs = new_jobs
-
     def _spark_stage_metrics(self, running_apps, addl_tags):
         '''
         Get metrics for each Spark stage.
         '''
-        new_stages = {}
         for app_id, (app_name, tracking_url) in running_apps.iteritems():
 
             response = self._rest_request_to_json(tracking_url,
@@ -492,18 +472,6 @@ class SparkCheck(AgentCheck):
 
                 self._set_metrics_from_json(tags, stage, SPARK_STAGE_METRICS)
                 self._set_metric('spark.stage.count', INCREMENT, 1, tags)
-
-                stage_id = stage.get('stageId')
-                previous_status = None
-                if app_id in self.previous_stages and stage_id in self.previous_stages[app_id]:
-                    previous_status = self.previous_stages[app_id][stage_id].get('status')
-
-                self._event_for_stage_status_change(stage, tags, previous_status)
-
-            # Map application IDs to {stage ID: stage}
-            new_stages[app_id] = dict((stage['stageId'], stage) for stage in response)
-
-        self.previous_stages = new_stages
 
     def _spark_executor_metrics(self, running_apps, addl_tags):
         '''
@@ -567,60 +535,6 @@ class SparkCheck(AgentCheck):
             self.increment(metric_name, value, tags=tags)
         else:
             self.log.error('Metric type "%s" unknown' % (metric_type))
-
-    def _event_for_job_status_change(self, current_job, tags, previous_status):
-        '''
-        Create an event for a job changing status
-        '''
-        job_name = current_job.get('name')
-        job_id = current_job.get('jobId')
-        current_status = current_job.get('status')
-
-        self._set_event(current_status, previous_status, tags, JOB_EVENT, job_name, job_id)
-
-    def _event_for_stage_status_change(self, current_stage, tags, previous_status):
-        '''
-        Create an event for a stage changing status
-        '''
-        stage_name = current_stage.get('name')
-        stage_id = current_stage.get('stageId')
-        current_status = current_stage.get('status')
-
-        self._set_event(current_status, previous_status, tags, STAGE_EVENT, stage_name, stage_id)
-
-    def _set_event(self, current_status, previous_status, tags, event_type, state_name, state_id):
-        '''
-        Create an event
-        '''
-        if previous_status is None:
-            msg = 'New Spark {type} `{name}` (ID {id}) has status {curr}.'.format(type=event_type,
-                name=state_name, id=state_id, curr=current_status)
-
-        elif previous_status != current_status:
-            msg = 'Spark {type} `{name}` (ID {id}) status changed from {prev} to {curr}.'.format(
-                type=event_type, name=state_name, id=state_id, prev=previous_status,
-                curr=current_status)
-
-        else:
-            return
-
-        msg_title = 'Spark {type} `{stage}` has status {status}'.format(type=event_type,
-            stage=state_name, status=current_status)
-
-        alert_type = None
-        if current_status == ERROR_STATUS:
-            alert_type = 'error'
-        elif current_status in SUCCESS_STATUS:
-            alert_type = 'success'
-
-        self.event({
-            'timestamp': int(time.time()),
-            'source_type_name': SOURCE_TYPE_NAME,
-            'msg_title': msg_title,
-            'msg_text': msg,
-            'tags': tags,
-            'alert_type': alert_type
-        })
 
     def _rest_request(self, address, object_path, service_name, *args, **kwargs):
         '''


### PR DESCRIPTION
Spark commonly runs hundreds of jobs, stages per minute. Sending events
on status changes brings little value but potentially flood the event stream.

Do not send events for Spark job/stage status changes. Instead
`spark.job.*`/`spark.stage.*` metrics should be used.

⚠️  **Backward compatibility change** ⚠️ 
Invite users to update their Spark event monitors before merging.


