### PR TITLE
[core] add a DNS cache

### DIFF
--- a/ddagent.py
+++ b/ddagent.py
@@ -22,6 +22,7 @@ from Queue import Full, Queue
 from socket import error as socket_error, gaierror
 import sys
 import threading
+from urlparse import urlparse
 import zlib
 
 # For pickle & PID files, see issue 293
@@ -440,8 +441,10 @@ class Application(tornado.web.Application):
             log.debug('Caching disabled, not resolving.')
             return url
 
-        resolve = self._dns_cache.resolve(url)
-        return resolve
+        location = urlparse(url)
+        resolve = self._dns_cache.resolve(location.netloc)
+        return "{scheme}://{ip}".format(scheme=location.scheme,
+                                        ip=resolve)
 
 
     def log_request(self, handler):

--- a/ddagent.py
+++ b/ddagent.py
@@ -427,7 +427,7 @@ class Application(tornado.web.Application):
         self._watchdog = None
         self.skip_ssl_validation = skip_ssl_validation or _is_affirmative(agentConfig.get('skip_ssl_validation'))
         self.agent_dns_caching = _is_affirmative(agentConfig.get('dns_caching'))
-        self.agent_dns_ttl = agentConfig.get('dns_ttl', DEFAULT_DNS_TTL)
+        self.agent_dns_ttl = int(agentConfig.get('dns_ttl', DEFAULT_DNS_TTL))
         if self.agent_dns_caching:
             self._dns_cache = DNSCache(ttl=self.agent_dns_ttl)
         self.use_simple_http_client = use_simple_http_client

--- a/ddagent.py
+++ b/ddagent.py
@@ -422,7 +422,7 @@ class Application(tornado.web.Application):
         self._watchdog = None
         self.skip_ssl_validation = skip_ssl_validation or agentConfig.get('skip_ssl_validation', False)
         self.agent_dns_caching = agentConfig.get('dns_caching', False)
-        self.agent_dns_ttl = agentConfig.get('dns_caching', DEFAULT_DNS_TTL)
+        self.agent_dns_ttl = agentConfig.get('dns_ttl', DEFAULT_DNS_TTL)
         if self.agent_dns_caching:
             self._dns_cache = DNSCache(ttl=self.agent_dns_ttl)
         self.use_simple_http_client = use_simple_http_client

--- a/ddagent.py
+++ b/ddagent.py
@@ -48,7 +48,8 @@ from config import (
     get_config,
     get_logging_config,
     get_url_endpoint,
-    get_version
+    get_version,
+    _is_affirmative
 )
 import modules
 from transaction import Transaction, TransactionManager
@@ -424,8 +425,8 @@ class Application(tornado.web.Application):
         AgentTransaction.set_tr_manager(self._tr_manager)
 
         self._watchdog = None
-        self.skip_ssl_validation = skip_ssl_validation or agentConfig.get('skip_ssl_validation', False)
-        self.agent_dns_caching = agentConfig.get('dns_caching', False)
+        self.skip_ssl_validation = skip_ssl_validation or _is_affirmative(agentConfig.get('skip_ssl_validation'))
+        self.agent_dns_caching = _is_affirmative(agentConfig.get('dns_caching'))
         self.agent_dns_ttl = agentConfig.get('dns_ttl', DEFAULT_DNS_TTL)
         if self.agent_dns_caching:
             self._dns_cache = DNSCache(ttl=self.agent_dns_ttl)

--- a/ddagent.py
+++ b/ddagent.py
@@ -297,6 +297,8 @@ class APIMetricTransaction(MetricTransaction):
 
     def get_url(self, endpoint, api_key):
         endpoint_base_url = get_url_endpoint(endpoint)
+        if self._application.agent_dns_caching:
+            endpoint_base_url = self._application.get_from_dns_cache(endpoint_base_url)
         return "{0}/api/v1/series/?api_key={1}".format(endpoint_base_url, api_key)
 
     def get_data(self):
@@ -308,6 +310,8 @@ class APIServiceCheckTransaction(AgentTransaction):
 
     def get_url(self, endpoint, api_key):
         endpoint_base_url = get_url_endpoint(endpoint)
+        if self._application.agent_dns_caching:
+            endpoint_base_url = self._application.get_from_dns_cache(endpoint_base_url)
         return "{0}/api/v1/check_run/?api_key={1}".format(endpoint_base_url, api_key)
 
 

--- a/tests/core/test_transaction.py
+++ b/tests/core/test_transaction.py
@@ -149,6 +149,7 @@ class TestTransaction(unittest.TestCase):
 
         app = Application()
         app.skip_ssl_validation = False
+        app.agent_dns_caching = False
         app._agentConfig = config
         app.use_simple_http_client = True
 
@@ -183,6 +184,7 @@ class TestTransaction(unittest.TestCase):
 
         app = Application()
         app.skip_ssl_validation = False
+        app.agent_dns_caching = False
         app._agentConfig = config
         app.use_simple_http_client = True
 

--- a/tests/core/test_utils_net.py
+++ b/tests/core/test_utils_net.py
@@ -17,6 +17,8 @@ from config import get_url_endpoint
 DEFAULT_ENDPOINT = "https://app.datadoghq.com"
 
 class TestUtilsNet(TestCase):
+    DNS_TTL = 3
+
     def test__inet_pton_win(self):
 
         if _inet_pton_win != inet_pton:
@@ -40,11 +42,11 @@ class TestUtilsNet(TestCase):
         side_effects = [(None, None, ['1.1.1.1', '2.2.2.2']),
                         (None, None, ['3.3.3.3'])]
         mock_resolve = MagicMock(side_effect=side_effects)
-        cache = DNSCache(3)
+        cache = DNSCache(self.DNS_TTL)
         with patch('socket.gethostbyaddr', mock_resolve):
             ip = cache.resolve('foo')
             self.assertTrue(ip in side_effects[0][2])
-            sleep(3)
+            sleep(self.DNS_TTL + 1)
             ip = cache.resolve('foo')
             self.assertTrue(ip in side_effects[1][2])
 

--- a/tests/core/test_utils_net.py
+++ b/tests/core/test_utils_net.py
@@ -1,6 +1,6 @@
 # stdlib
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
+from mock import MagicMock, patch
 import socket
 from time import sleep
 

--- a/tests/core/test_utils_net.py
+++ b/tests/core/test_utils_net.py
@@ -2,6 +2,7 @@
 from unittest import TestCase
 from mock import MagicMock, patch
 import socket
+from urlparse import urlparse
 from time import sleep
 
 # 3p
@@ -11,7 +12,9 @@ from nose.plugins.skip import SkipTest
 from utils.net import inet_pton, _inet_pton_win
 from utils.net import IPV6_V6ONLY, IPPROTO_IPV6
 from utils.net import DNSCache
+from config import get_url_endpoint
 
+DEFAULT_ENDPOINT = "https://app.datadoghq.com"
 
 class TestUtilsNet(TestCase):
     def test__inet_pton_win(self):
@@ -44,3 +47,9 @@ class TestUtilsNet(TestCase):
             sleep(3)
             ip = cache.resolve('foo')
             self.assertTrue(ip in side_effects[1][2])
+
+        # resolve intake
+        endpoint = get_url_endpoint(DEFAULT_ENDPOINT)
+        location = urlparse(endpoint)
+        ip = cache.resolve(location.netloc)
+        self.assertNotEqual(ip, location.netloc)

--- a/utils/net.py
+++ b/utils/net.py
@@ -53,8 +53,8 @@ class DNSCache(object):
             now = int(time.time())
             if not ts or ts < now:
                 _, _, entry = socket.gethostbyaddr(url)
-                ttl = now + self.agent_dns_ttl
-                self._dns_cache[url] = ttl, entry
+                ttl = now + self._ttl
+                self._cache[url] = ttl, entry
 
             resolve = entry[random.randint(0, len(entry)-1)]
         except Exception:

--- a/utils/net.py
+++ b/utils/net.py
@@ -4,7 +4,10 @@
 
 # lib
 import ctypes
+import time
+import random
 import socket
+
 
 # 3p
 
@@ -26,6 +29,7 @@ try:
 except AttributeError:
     IPV6_V6ONLY = 27  # from `Ws2ipdef.h`
 
+DEFAULT_DNS_TTL = 300
 
 class sockaddr(ctypes.Structure):
     _fields_ = [("sa_family", ctypes.c_short),
@@ -34,6 +38,29 @@ class sockaddr(ctypes.Structure):
                 ("ipv6_addr", ctypes.c_byte * 16),
                 ("__pad2", ctypes.c_ulong)]
 
+class DNSCache(object):
+    """
+    Simple, rudimentary DNS cache
+    """
+    def __init__(self, ttl=DEFAULT_DNS_TTL):
+        self._cache = {}
+        self._ttl = ttl
+        random.seed()
+
+    def resolve(self, url):
+        try:
+            ts, entry = self._cache.get(url, (None, None))
+            now = int(time.time())
+            if not ts or ts < now:
+                _, _, entry = socket.gethostbyaddr(url)
+                ttl = now + self.agent_dns_ttl
+                self._dns_cache[url] = ttl, entry
+
+            resolve = entry[random.randint(0, len(entry)-1)]
+        except Exception:
+            resolve = url
+
+        return resolve
 
 def _inet_pton_win(address_family, ip_string):
     """


### PR DESCRIPTION
### What does this PR do?
This PR adds a DNS cache to the agent, if disabled the agent just skips any local DNS resolution. Otherwise we've implemented a very simple cache that should allow us to reduce the number of DNS queries made.

### Motivation

A customer was complaining about too many DNS queries. We suggested some local caching like `dnsmasq`, apparently that was not an option for them. Unfortunately there was no way to do this using `requests`, which was the preferred approach.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.