### PR TITLE
[dockerutil] break singleton instantiation loop.

### DIFF
--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -135,7 +135,7 @@ class DockerUtil:
     def fetch_swarm_state(self):
         self.swarm_node_state = None
         try:
-            info = DockerUtil().client.info()
+            info = self.client.info()
             self.swarm_node_state = info.get('Swarm', {}).get('LocalNodeState')
         except Exception:
             pass


### PR DESCRIPTION
### What does this PR do?

There was an infinite instantiation loop for DockerUtil(). Since it implements the singleton pattern and `fetch_swarm_state()` is in the constructor, if `fetch_swarm_state()` calls DockerUtil() again, it will call the constructor again (and so forth) and the class instance will never make it to the Singleton class map.

### Motivation

Found the issue while testing another PR branched off `master` that included the `swarm` changes. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
