### PR TITLE
[core][sdk] ensure manifest validation when running checks.

### DIFF
--- a/config.py
+++ b/config.py
@@ -904,7 +904,7 @@ def get_checks_places(osname, agentConfig):
 
     try:
         if Platform.is_windows():
-            places.append(get_windows_sdk_check)
+            places.append(lambda name: (get_windows_sdk_check(name), None))
         else:
             sdk_integrations = get_sdk_integrations_path(osname)
             places.append(lambda name: (os.path.join(sdk_integrations, name, 'check.py'),

--- a/config.py
+++ b/config.py
@@ -904,7 +904,7 @@ def get_checks_places(osname, agentConfig):
 
     try:
         if Platform.is_windows():
-            places.append(lambda name: (get_windows_sdk_check(name), None))
+            places.append(get_windows_sdk_check)
         else:
             sdk_integrations = get_sdk_integrations_path(osname)
             places.append(lambda name: (os.path.join(sdk_integrations, name, 'check.py'),
@@ -997,8 +997,9 @@ def validate_sdk_check(manifest_path):
                 min_validated = False if min_version > get_version() else True
                 break
     except IOError:
-        log.warn("Manifest file (%s) not present " % manifest_path)
-        pass
+        log.debug("Manifest file (%s) not present." % manifest_path)
+    except json.JSONDecodeError:
+        log.debug("Manifest file (%s) has badly formatted json." % manifest_path)
 
     return (min_validated and max_validated)
 

--- a/tests/core/fixtures/checks/manifest.json
+++ b/tests/core/fixtures/checks/manifest.json
@@ -1,0 +1,16 @@
+{
+  "maintainer": "help@datadoghq.com",
+  "manifest_version": "0.1.0",
+  "max_agent_version": "6.0.0",
+  "min_agent_version": "5.6.3",
+  "name": "test-check",
+  "short_description": "test-check description.",
+  "support": "Test check for a test integration we need to test.",
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
+  "version": "0.1.0",
+  "guid": "d91d91bd-4a8e-4489-bfb1-b119d4cc388a"
+}

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -11,7 +11,12 @@ from shutil import copyfile, rmtree
 import ntpath
 
 # project
-from config import get_config, load_check_directory, _conf_path_to_check_name
+from config import (
+    get_config,
+    load_check_directory,
+    validate_sdk_check,
+    _conf_path_to_check_name
+)
 from util import windows_friendly_colon_split
 from utils.hostname import is_valid_hostname
 from utils.pidfile import PidFile
@@ -316,6 +321,24 @@ class TestConfigLoadCheckDirectory(unittest.TestCase):
         checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
         self.assertEquals(1, len(checks['initialized_checks']))
         self.assertEquals(2, checks['initialized_checks'][0].instance_count())  # check that we picked the right conf
+
+    @mock.patch('config.get_version', return_value='5.9.1')
+    def testManifestValidateOK(self, *args):
+        manifest_path = '{}/manifest.json'.format(FIXTURE_PATH)
+        validate = validate_sdk_check(manifest_path)
+        self.assertEquals(True, validate)
+
+    @mock.patch('config.get_version', return_value='4.0.1')
+    def testManifestValidateNOKHigh(self, *args):
+        manifest_path = '{}/manifest.json'.format(FIXTURE_PATH)
+        validate = validate_sdk_check(manifest_path)
+        self.assertEquals(False, validate)
+
+    @mock.patch('config.get_version', return_value='6.0.1')
+    def testManifestValidateNOKLow(self, *args):
+        manifest_path = '{}/manifest.json'.format(FIXTURE_PATH)
+        validate = validate_sdk_check(manifest_path)
+        self.assertEquals(False, validate)
 
     def tearDown(self):
         for _dir in self.TEMP_DIRS:

--- a/utils/checkfiles.py
+++ b/utils/checkfiles.py
@@ -38,7 +38,7 @@ def get_check_class(agentConfig, check_name):
     osname = get_os()
     checks_places = get_checks_places(osname, agentConfig)
     for check_path_builder in checks_places:
-        check_path = check_path_builder(check_name)
+        check_path, _ = check_path_builder(check_name)
         if not os.path.exists(check_path):
             continue
 

--- a/utils/windows_configuration.py
+++ b/utils/windows_configuration.py
@@ -37,10 +37,11 @@ def get_windows_sdk_check(name):
     try:
         with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, sdk_reg_path) as reg_key:
             directory = _winreg.QueryValueEx(reg_key, "InstallPath")[0]
-            return os.path.join(directory, 'Integrations', name, 'check.py')
+            return (os.path.join(directory, 'Integrations', name, 'check.py'),
+                    os.path.join(directory, 'Integrations', name, 'manifest.json'))
     except WindowsError:
         pass
-    return None
+    return None, None
 
 def update_conf_file(registry_conf, config_path):
     config_dir = os.path.dirname(config_path)


### PR DESCRIPTION
### What does this PR do?

Let's validate the SDK checks to ensure we can detect checks with the wrong manifests.

### Motivation

We might need this to warn/default to core checks if the core agent is updated from under an SDK installed check. Otherwise checks might break and we wouldn't have anything meaningful to debug in that aspect.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.