### PR TITLE
Added if else statement around the default  agent_headers, also added…

### DIFF
--- a/checks.d/http_check.py
+++ b/checks.d/http_check.py
@@ -169,7 +169,12 @@ class HTTPCheck(NetworkCheck):
         http_response_status_code = str(instance.get('http_response_status_code', DEFAULT_EXPECTED_CODE))
         timeout = int(instance.get('timeout', 10))
         config_headers = instance.get('headers', {})
-        headers = agent_headers(self.agentConfig)
+        default_headers=instance.get("include_default_headers", True)
+        if default_headers:
+            headers = agent_headers(self.agentConfig)
+        else:
+            headers={}
+
         headers.update(config_headers)
         url = instance.get('url')
         content_match = instance.get('content_match')

--- a/conf.d/http_check.yaml.example
+++ b/conf.d/http_check.yaml.example
@@ -124,6 +124,13 @@ instances:
     #
     # allow_redirects: true
 
+    # The (optional) include_default_header parameter can include the default headers.
+    # Default headers can be found at https://github.com/DataDog/dd-agent/blob/master/util.py#L54-L63
+    #
+    # Defaults to True.
+    #
+    #include_default_headers: false
+
     # tags:
     #   - url:http://alternative.host.example.com
     #   - env:production


### PR DESCRIPTION
… an example to the http_check.yaml. With this we can disable  the default headers that are shipped with datadog agent.

*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

# All Agent Checks are now frozen in preparation for the release of the [Integration SDK](https://github.com/DataDog/dd-agent/wiki/Integration-SDK).
## We will review and merge a few more PRs, but no new PRs will be accepted.
## All changes to checks from here on out should go to the [integrations-core repo](https://github.com/datadog/integrations-core) and all new checks should go to the [integrations-extras repo](https://github.com/datadog/integrations-extras). To learn more about how to contribute to them, please check out our [documentation](http://docs.datadoghq.com/guides/integration_sdk/).

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
