### PR TITLE
[docker] bogus pid

### DIFF
--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -134,6 +134,10 @@ def compile_filter_rules(rules):
     return patterns, tag_names
 
 
+class BogusPIDException(Exception):
+    pass
+
+
 class DockerDaemon(AgentCheck):
     """Collect metrics and events from Docker API and cgroups."""
 
@@ -575,11 +579,14 @@ class DockerDaemon(AgentCheck):
 
             tags = self._get_tags(container, PERFORMANCE)
 
-            self._report_cgroup_metrics(container, tags)
-            if "_proc_root" not in container:
-                containers_without_proc_root.append(DockerUtil.container_name_extractor(container)[0])
-                continue
-            self._report_net_metrics(container, tags)
+            try:
+                self._report_cgroup_metrics(container, tags)
+                if "_proc_root" not in container:
+                    containers_without_proc_root.append(DockerUtil.container_name_extractor(container)[0])
+                    continue
+                self._report_net_metrics(container, tags)
+            except BogusPIDException:
+                self.log.exception('Unable to report cgroup metrics.')
 
         if containers_without_proc_root:
             message = "Couldn't find pid directory for containers: {0}. They'll be missing network metrics".format(
@@ -592,6 +599,9 @@ class DockerDaemon(AgentCheck):
 
     def _report_cgroup_metrics(self, container, tags):
         cgroup_stat_file_failures = 0
+        if not container.get('_pid'):
+            raise BogusPIDException('Cannot report on bogus pid(0)')
+
         for cgroup in CGROUP_METRICS:
             try:
                 stat_file = self._get_cgroup_from_proc(cgroup["cgroup"], container['_pid'], cgroup['file'])

--- a/checks.d/docker_daemon.py
+++ b/checks.d/docker_daemon.py
@@ -14,7 +14,7 @@ from math import ceil
 # project
 from checks import AgentCheck
 from config import _is_affirmative
-from utils.dockerutil import DockerUtil, MountException
+from utils.dockerutil import DockerUtil, MountException, BogusPIDException
 from utils.kubernetes import KubeUtil
 from utils.platform import Platform
 from utils.service_discovery.sd_backend import get_sd_backend
@@ -132,10 +132,6 @@ def compile_filter_rules(rules):
         tag_names.append(rule.split(':')[0])
 
     return patterns, tag_names
-
-
-class BogusPIDException(Exception):
-    pass
 
 
 class DockerDaemon(AgentCheck):

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -23,7 +23,6 @@ DATADOG_ID = 'com.datadoghq.sd.check.id'
 class MountException(Exception):
     pass
 
-
 class CGroupException(Exception):
     pass
 

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -23,6 +23,9 @@ DATADOG_ID = 'com.datadoghq.sd.check.id'
 class MountException(Exception):
     pass
 
+class BogusPIDException(Exception):
+    pass
+
 class CGroupException(Exception):
     pass
 


### PR DESCRIPTION
### What does this PR do?

This PR attempts to address the case where we either have a bogus container pid reported, or no pid was collected, in which case the container must be skipped. 

### Motivation

Issue has been affecting some customers.

### Testing Guidelines

Further testing must be conducted to reproduce this reliably, I have been unable to so far. But then again I haven't had the time to dedicate a solid half-day to reproducing.

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.
