### PR TITLE
Add instance name to tags on response_time metric

### DIFF
--- a/checks.d/tcp_check.py
+++ b/checks.d/tcp_check.py
@@ -95,7 +95,7 @@ class TCPCheck(NetworkCheck):
             return Status.DOWN, "%s. Connection failed after %s ms" % (str(e), length)
 
         if response_time:
-            self.gauge('network.tcp.response_time', time.time() - start, tags=['url:%s:%s' % (instance.get('host', None), port)] + custom_tags)
+            self.gauge('network.tcp.response_time', time.time() - start, tags=['url:%s:%s' % (instance.get('host', None), port), 'instance: %s' % instance.get('name')] + custom_tags)
 
         self.log.debug("%s:%s is UP" % (addr, port))
         return Status.UP, "UP"

--- a/checks.d/tcp_check.py
+++ b/checks.d/tcp_check.py
@@ -95,7 +95,7 @@ class TCPCheck(NetworkCheck):
             return Status.DOWN, "%s. Connection failed after %s ms" % (str(e), length)
 
         if response_time:
-            self.gauge('network.tcp.response_time', time.time() - start, tags=['url:%s:%s' % (instance.get('host', None), port), 'instance: %s' % instance.get('name')] + custom_tags)
+            self.gauge('network.tcp.response_time', time.time() - start, tags=['url:%s:%s' % (instance.get('host', None), port), 'instance:%s' % instance.get('name')] + custom_tags)
 
         self.log.debug("%s:%s is UP" % (addr, port))
         return Status.UP, "UP"


### PR DESCRIPTION
### What does this PR do?
Add the instance name to the tags of the network.tcp.response_time metric.

### Additional Notes

It will also be merged to integration-core once approved.
