### PR TITLE
[packaging] implement condrestart.

### DIFF
--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -177,6 +177,12 @@ restart() {
     start
 }
 
+condrestart() {
+    if [ -f "$LOCKFILE" ]; then
+        restart
+    fi
+}
+
 info() {
     shift # Shift 'info' out of the args so we can pass any
           # additional options to the real command
@@ -214,6 +220,10 @@ case "$1" in
 
     restart)
         restart
+        ;;
+
+    condrestart|try-reload)
+        condrestart
         ;;
 
     status)

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -213,6 +213,14 @@ case "$1" in
         $0 start
         ;;
 
+    condrestart|try-reload)
+        check_status essential > /dev/null
+        if [ $? -eq 0 ]; then
+            $0 stop
+            $0 start
+        fi
+        ;;
+
     configcheck)
         su $AGENTUSER -c "$AGENTPATH configcheck"
         exit $?


### PR DESCRIPTION
### What does this PR do?

Implements `condrestart` in our sysvinit scripts. Differs from `restart` in that it will only actually restart the service (`dd-agent`) if the service is up. Otherwise it's a NOP.

### Motivation

It should've been implemented, earlier. We might need to consider this as the default `post-inst` behavior in our scripts (not sure yet).

