### PR TITLE
[core][test] fix test on endpoints, we're not sending 400 if series missing.

### DIFF
--- a/tests/core/test_transaction.py
+++ b/tests/core/test_transaction.py
@@ -218,9 +218,13 @@ class TestTransaction(unittest.TestCase):
         self.assertEqual(endpoints, expected, (endpoints, expected))
 
         for url in endpoints:
-            r = requests.post(url, data=json.dumps({"foo": "bar"}),
-                              headers={'Content-Type': "application/json"})
-            r.raise_for_status()
+            try:
+                r = requests.post(url, data=json.dumps({"foo": "bar"}),
+                                headers={'Content-Type': "application/json"})
+                r.raise_for_status()
+            except requests.HTTPError:
+                if r.status_code != 400 or 'No series present in the payload' not in r.content:
+                    raise
 
         # API Service Check Transaction
         APIServiceCheckTransaction._trManager = trManager


### PR DESCRIPTION
### What does this PR do?

Fixes endpoint test.

### Motivation

A changed was rolled on intake that would 400 if the API request contained no api series.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.