### PR TITLE
fixes install script for sles 11

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -173,10 +173,10 @@ elif [ $OS = "SUSE" ]; then
   $sudo_cmd sh -c "echo -e '[datadog]\nname=datadog\nenabled=1\nbaseurl=https://yum.datadoghq.com/suse/rpm/x86_64\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public' > /etc/zypp/repos.d/datadog.repo"
 
   echo -e "\033[34m\n* Refreshing repositories\n\033[0m"
-  $sudo_cmd zypper --non-interactive refresh
+  $sudo_cmd zypper --non-interactive --no-gpg-check refresh
 
   echo -e "\033[34m\n* Installing Datadog Agent\n\033[0m"
-  $sudo_cmd zypper --non-interactive --no-gpg-check install datadog-agent
+  $sudo_cmd zypper --non-interactive install datadog-agent
 
 else
     printf "\033[31mYour OS or distribution are not supported by this install script.

--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -176,7 +176,7 @@ elif [ $OS = "SUSE" ]; then
   $sudo_cmd zypper --non-interactive refresh
 
   echo -e "\033[34m\n* Installing Datadog Agent\n\033[0m"
-  $sudo_cmd zypper --non-interactive install datadog-agent
+  $sudo_cmd zypper --non-interactive --no-gpg-check install datadog-agent
 
 else
     printf "\033[31mYour OS or distribution are not supported by this install script.


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

This will ensure that all sles 11 sp4's can install it.

On a more updated zypper (which is default on sles 12), it allows you to disable the repo gpg check. Our repos aren't signed anyway, so the gpg check is just accepting that the repo isn't signed.

However, on sles 11, the zypper that's on the base image doesn't have this option. So you have to use `--no-gpg-check`.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
