### PR TITLE
[dockerutil] adding bogus PID exception.

### DIFF
--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -21,6 +21,10 @@ SWARM_SVC_LABEL = 'com.docker.swarm.service.name'
 DATADOG_ID = 'com.datadoghq.sd.check.id'
 
 
+class BogusPIDException(Exception):
+    pass
+
+
 class MountException(Exception):
     pass
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?
Simply adds a bogus PID exception. Used by `docker_daemon`, has potential to be useful elsewhere so dockerutil seems to be a nice place for it.

### Motivation

https://github.com/DataDog/integrations-core/pull/237

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
