### PR TITLE
[kubernetes] - Do not check for kubernetes auth token secret if we have TLS certs configured

### DIFF
--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -94,9 +94,10 @@ class KubeUtil:
         if apiserver_cacert and os.path.exists(apiserver_cacert):
             tls_settings['apiserver_cacert'] = apiserver_cacert
 
-        token = self.get_auth_token()
-        if token:
-            tls_settings['bearer_token'] = token
+        if 'apiserver_client_cert' not in tls_settings and 'apiserver_cacert' not in tls_settings:
+            token = self.get_auth_token()
+            if token:
+                tls_settings['bearer_token'] = token
 
         return tls_settings
 


### PR DESCRIPTION
### What does this PR do?

This PR makes it so we don't check for the kubernetes auth_token if TLS certs are already provided for authentication to the kube-apiserver (when the dd-agent is running on the host). The pre-existing dd-agent should work, but would log noisy "Token not found at /var/run/secrets/kubernetes.io/serviceaccount/token" errors to the logs. 

### Motivation

What inspired you to submit this pull request? Less noisy logs :) 