### PR TITLE
Updates requests to 2.13.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ntplib==0.3.3
 pyyaml==3.11
 # note: requests is also used in many checks
 # upgrade with caution
-requests==2.6.2
+requests==2.13.0
 # note: simplejson is used in many checks to inteface APIs
 simplejson==3.6.5
 supervisor==3.3.0


### PR DESCRIPTION
### What does this PR do?

The version of requests we're on now causes some bugs, bumping it should (hopefully) resolve more than it creates