### PR TITLE
[requirements] Downgrade `requests` to 2.11.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ ntplib==0.3.3
 pyyaml==3.11
 # note: requests is also used in many checks
 # upgrade with caution
-requests==2.13.0
+requests==2.11.1
 # note: simplejson is used in many checks to inteface APIs
 simplejson==3.6.5
 supervisor==3.3.0


### PR DESCRIPTION
Reflects change in omnibus-software, see https://github.com/DataDog/omnibus-software/pull/122