### PR TITLE
[info+flare] include SDK-relevant information if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     - CONCURRENCY=2
     - NOSE_FILTER="not windows"
     - INTEGRATIONS_DIR=$HOME/embedded
+    - CHECKSD_OVERRIDE=$TRAVIS_BUILD_DIR/tests/checks/fixtures/checks
     - PIP_CACHE=$HOME/.cache/pip
     - VOLATILE_DIR=/tmp
     - DD_CASHER_DIR=/tmp/casher

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,7 @@ unless ENV['CI']
   rakefile_dir = File.dirname(__FILE__)
   ENV['TRAVIS_BUILD_DIR'] = rakefile_dir
   ENV['INTEGRATIONS_DIR'] = File.join(rakefile_dir, 'embedded')
+  ENV['CHECKSD_OVERRIDE'] = File.join(rakefile_dir, 'tests/checks/fixtures/checks')
   ENV['PIP_CACHE'] = File.join(rakefile_dir, '.cache/pip')
   ENV['VOLATILE_DIR'] = '/tmp/dd-agent-testing'
   ENV['CONCURRENCY'] = ENV['CONCURRENCY'] || '2'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ shallow_clone: true
 environment:
   TRAVIS_BUILD_DIR: c:\projects\dd-agent
   INTEGRATIONS_DIR: c:\projects\dd-agent\embedded
+  CHECKSD_OVERRIDE: c:\projects\dd-agent\tests\checks\fixtures\checks
   PIP_CACHE: c:\projects\dd-agent\.cache\pip
   VOLATILE_DIR: c:\projects
   NOSE_FILTER: not unix and not fixme

--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -24,7 +24,10 @@ import yaml
 
 # project
 import config
-from config import _is_affirmative, _windows_commondata_path, get_config
+from config import (_is_affirmative,
+                    _windows_commondata_path,
+                    get_config,
+                    AGENT_VERSION)
 from util import plural
 from utils.jmx import JMXFiles
 from utils.ntp import NTPUtil
@@ -324,7 +327,7 @@ class CheckStatus(object):
                  event_count=None, service_check_count=None, service_metadata=[],
                  init_failed_error=None, init_failed_traceback=None,
                  library_versions=None, source_type_name=None,
-                 check_stats=None):
+                 check_stats=None, check_version=AGENT_VERSION):
         self.name = check_name
         self.source_type_name = source_type_name
         self.instance_statuses = instance_statuses
@@ -336,6 +339,7 @@ class CheckStatus(object):
         self.library_versions = library_versions
         self.check_stats = check_stats
         self.service_metadata = service_metadata
+        self.check_version = check_version
 
     @property
     def status(self):
@@ -392,8 +396,8 @@ class CollectorStatus(AgentStatus):
     @staticmethod
     def check_status_lines(cs):
         check_lines = [
-            '  ' + cs.name,
-            '  ' + '-' * len(cs.name)
+            '  ' + cs.name + ' ({})'.format(cs.check_version),
+            '  ' + '-' * (len(cs.name) + 3 + len(cs.check_version))
         ]
         if cs.init_failed_error:
             check_lines.append("    - initialize check class [%s]: %s" %
@@ -537,8 +541,8 @@ class CollectorStatus(AgentStatus):
         else:
             for cs in check_statuses:
                 check_lines = [
-                    '  ' + cs.name,
-                    '  ' + '-' * len(cs.name)
+                    '  ' + cs.name + ' ({})'.format(cs.check_version),
+                    '  ' + '-' * (len(cs.name) + 3 + len(cs.check_version))
                 ]
                 if cs.init_failed_error:
                     check_lines.append("    - initialize check class [%s]: %s" %

--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -684,6 +684,7 @@ class CollectorStatus(AgentStatus):
         check_statuses = self.check_statuses + get_jmx_status()
         for cs in check_statuses:
             status_info['checks'][cs.name] = {'instances': {}}
+            status_info['checks'][cs.name]['check_version'] = cs.check_version
             if cs.init_failed_error:
                 status_info['checks'][cs.name]['init_failed'] = True
                 status_info['checks'][cs.name]['traceback'] = \
@@ -701,7 +702,6 @@ class CollectorStatus(AgentStatus):
                         status_info['checks'][cs.name]['instances'][s.instance_id]['error'] = s.error
                     if s.has_warnings():
                         status_info['checks'][cs.name]['instances'][s.instance_id]['warnings'] = s.warnings
-                status_info['checks'][cs.name]['check_version'] = cs.check_version
                 status_info['checks'][cs.name]['metric_count'] = cs.metric_count
                 status_info['checks'][cs.name]['event_count'] = cs.event_count
                 status_info['checks'][cs.name]['service_check_count'] = cs.service_check_count

--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -701,6 +701,7 @@ class CollectorStatus(AgentStatus):
                         status_info['checks'][cs.name]['instances'][s.instance_id]['error'] = s.error
                     if s.has_warnings():
                         status_info['checks'][cs.name]['instances'][s.instance_id]['warnings'] = s.warnings
+                status_info['checks'][cs.name]['check_version'] = cs.check_version
                 status_info['checks'][cs.name]['metric_count'] = cs.metric_count
                 status_info['checks'][cs.name]['event_count'] = cs.event_count
                 status_info['checks'][cs.name]['service_check_count'] = cs.service_check_count

--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -690,7 +690,6 @@ class CollectorStatus(AgentStatus):
                 status_info['checks'][cs.name]['traceback'] = \
                     cs.init_failed_traceback or cs.init_failed_error
             else:
-                status_info['checks'][cs.name] = {'instances': {}}
                 status_info['checks'][cs.name]['init_failed'] = False
                 for s in cs.instance_statuses:
                     status_info['checks'][cs.name]['instances'][s.instance_id] = {

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -441,7 +441,7 @@ class Collector(object):
                 event_count, service_check_count, service_metadata=current_check_metadata,
                 library_versions=check.get_library_info(),
                 source_type_name=check.SOURCE_TYPE_NAME or check.name,
-                check_stats=check_stats
+                check_stats=check_stats, check_version=check.check_version
             )
 
             # Service check for Agent checks failures
@@ -476,6 +476,7 @@ class Collector(object):
             if not self.continue_running:
                 return
             check_status = CheckStatus(check_name, None, None, None, None,
+                                       check_version=info.get('version'),
                                        init_failed_error=info['error'],
                                        init_failed_traceback=info['traceback'])
             check_statuses.append(check_status)

--- a/config.py
+++ b/config.py
@@ -968,10 +968,21 @@ def _initialize_check(check_config, check_name, check_class, agentConfig):
     except Exception as e:
         log.exception('Unable to initialize check %s' % check_name)
         traceback_message = traceback.format_exc()
+        # exc_info returns a tuple with traceback in idx 2
         frames = inspect.getinnerframes(sys.exc_info()[2])
+        # This is a best effort. It "hopes" the exception originated
+        # in the check.py and thus the `-1` index when inspecting the
+        # frames. frames[idx][1] because 1 contains the frame's __file__.
+        #
+        # For debugging purposes we still have the flare with the
+        # collected manifests.
         manifest_path = os.path.join(os.path.basedir(frames[-1][1]), 'manifest.json')
         manifest = load_manifest(manifest_path)
-        check_version = manifest.get('version', 'unknown') if manifest else AGENT_VERSION
+        if manifest is not None:
+            check_version = '{core}:{vers}'.format(core=AGENT_VERSION,
+                                                   vers=manifest.get('version', 'unknown'))
+        else:
+            check_version = AGENT_VERSION
 
         return {}, {check_name: {'error': e, 'traceback': traceback_message, 'version': check_version}}
     else:

--- a/tests/checks/mock/test_no_profiling.py
+++ b/tests/checks/mock/test_no_profiling.py
@@ -1,16 +1,10 @@
 import mock
 
-from tests.checks.common import AgentCheckTest, load_check, copy_checks, remove_checks
+from tests.checks.common import AgentCheckTest, load_check
 
 class TestNoProfiling(AgentCheckTest):
 
     CHECK_NAME = 'redisdb'
-
-    def setUp(self):
-        copy_checks()
-
-    def tearDown(self):
-        remove_checks()
 
     def test_no_profiling(self):
         agentConfig = {

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -14,7 +14,7 @@ from checks import (
     UnknownValue,
 )
 from checks.collector import Collector
-from tests.checks.common import load_check, copy_checks, remove_checks
+from tests.checks.common import load_check
 from utils.hostname import get_hostname
 from utils.proxy import get_proxy
 
@@ -211,11 +211,6 @@ class TestCore(unittest.TestCase):
 
 
 class TestCollectionInterval(unittest.TestCase):
-    def setUp(self):
-        copy_checks()
-
-    def tearDown(self):
-        remove_checks()
 
     def test_min_collection_interval(self):
         config = {'instances': [{}], 'init_config': {}}
@@ -299,6 +294,7 @@ class TestCollectionInterval(unittest.TestCase):
             "init_config": {},
             "instances": [{"host": "localhost", "port": 6379}]
         }
+
         checks = [load_check('redisdb', redis_config, agentConfig)]
 
         c = Collector(agentConfig, [], {}, get_hostname(agentConfig))
@@ -336,6 +332,7 @@ class TestCollectionInterval(unittest.TestCase):
             "init_config": {},
             "instances": [{"host": "localhost", "port": 6379}]
         }
+
         checks = [load_check('redisdb', redis_config, agentConfig)]
 
         c = Collector(agentConfig, [], {}, get_hostname(agentConfig))

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -172,7 +172,7 @@ FIXTURE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtur
 @mock.patch('config.get_confd_path', return_value=TEMP_ETC_CONF_DIR)
 @mock.patch('config.get_sdk_integrations_path', return_value=TEMP_SDK_INTEGRATIONS_CHECKS_DIR)
 @mock.patch('config.get_windows_sdk_check',
-            return_value=os.path.join(TEMP_SDK_INTEGRATIONS_CHECKS_DIR, 'test_check', 'check.py'))
+            return_value=(os.path.join(TEMP_SDK_INTEGRATIONS_CHECKS_DIR, 'test_check', 'check.py'), None))
 class TestConfigLoadCheckDirectory(unittest.TestCase):
 
     TEMP_DIRS = [

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -171,7 +171,8 @@ FIXTURE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtur
 @mock.patch('config.get_checksd_path', return_value=TEMP_AGENT_CHECK_DIR)
 @mock.patch('config.get_confd_path', return_value=TEMP_ETC_CONF_DIR)
 @mock.patch('config.get_sdk_integrations_path', return_value=TEMP_SDK_INTEGRATIONS_CHECKS_DIR)
-@mock.patch('config.get_windows_sdk_check', return_value=TEMP_SDK_INTEGRATIONS_CHECKS_DIR)
+@mock.patch('config.get_windows_sdk_check',
+            return_value=os.path.join(TEMP_SDK_INTEGRATIONS_CHECKS_DIR, 'test_check', 'check.py'))
 class TestConfigLoadCheckDirectory(unittest.TestCase):
 
     TEMP_DIRS = [
@@ -263,6 +264,7 @@ class TestConfigLoadCheckDirectory(unittest.TestCase):
         checks = load_check_directory({"additional_checksd": TEMP_ETC_CHECKS_DIR}, "foo")
         self.assertEquals(1, len(checks['init_failed_checks']))
 
+    @mock.patch('utils.platform.Platform.is_windows', return_value=True)
     def testConfig3rdPartyAgent(self, *args):
         copyfile('%s/valid_conf.yaml' % FIXTURE_PATH,
             '%s/test_check.yaml' % TEMP_ETC_CONF_DIR)

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -31,6 +31,7 @@ import traceback
 
 # 3p
 import requests
+import simplejson as json
 
 # DD imports
 from checks.check_status import CollectorStatus, DogstatsdStatus, ForwarderStatus
@@ -46,6 +47,7 @@ from jmxfetch import JMXFetch
 from utils.hostname import get_hostname
 from utils.jmx import jmx_command, JMXFiles
 from utils.platform import Platform
+from utils.sdk import load_manifest
 from utils.configcheck import configcheck, sd_configcheck
 # Globals
 log = logging.getLogger(__name__)
@@ -147,6 +149,8 @@ class Flare(object):
         log.info("  * datadog-agent info output")
         self._add_command_output_tar('info.log', self._info_all)
         self._add_jmxinfo_tar()
+        log.info("  * sdk check output (if any)")
+        self._add_sdk_info_tar()
         log.info("  * pip freeze")
         self._add_command_output_tar('freeze.log', self._pip_freeze,
                                      command_desc="pip freeze --no-cache-dir")
@@ -306,6 +310,20 @@ class Flare(object):
                     self.CHECK_CREDENTIALS
                 )
 
+    # Collect SDK-package related information
+    def _add_sdk_info_tar(self):
+        sdk_manifest = {}
+        for file_path in glob.glob(os.path.join(self._get_sdk_integrations_path(), '**' ,'manifest.json')):
+            if self._can_read(file_path, output=False):
+                manifest = load_manifest(file_path)
+                if manifest:
+                    sdk_manifest[manifest['name']] = manifest
+
+        if sdk_manifest:
+            target_full_path = os.path.join(self._prefix, 'sdk_manifests.json')
+            self._add_object_tar(target_full_path,
+                                 json.dumps(sdk_manifest, sort_keys=True, indent=4 * ' '))
+
     # Collect JMXFetch-specific info and save to jmxinfo directory if jmx config
     # files are present and valid
     def _add_jmxinfo_tar(self):
@@ -361,6 +379,14 @@ class Flare(object):
             self._permissions_file.write(self._permissions_file_format.format(stat_file_path, mode, uname, gname))
 
         self._tar.add(file_path, target_full_path)
+
+    # Add in-memory object to tarfile
+    def _add_object_tar(self, file_path, contents):
+        iobuff = StringIO.StringIO(contents)
+
+        obj = tarfile.TarInfo(name=file_path)
+        obj.size = len(iobuff.buf)
+        self._tar.addfile(obj, fileobj=iobuff)
 
     # Returns whether JMXFetch should run or not
     def _should_run_jmx(self):
@@ -498,6 +524,15 @@ class Flare(object):
                 '../../bin/agent'
             )
         return agent_exec
+
+    # Find SDK integrations path
+    def _get_sdk_integrations_path(self):
+        sdk_path = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            '../../integrations/'
+        )
+
+        return sdk_path
 
     # Find the supervisor exec (package or source)
     def _get_path_supervisor_exec(self):

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -75,7 +75,7 @@ class Flare(object):
             'password in a uri'
         ),
         CredentialPattern(
-            re.compile('^\s*(community_string): *.+$'),
+            re.compile('^(\s*community_string:) *.+$'),
             r'\1 ********',
             'SNMP community string'
         ),

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -324,7 +324,7 @@ class Flare(object):
             integrations = get_sdk_integration_paths()
             for integration, path in integrations.iteritems():
                 manifest_path = os.path.join(path, 'manifest.json')
-                if self.can_read(manifest_path):
+                if self._can_read(manifest_path):
                     manifest = load_manifest(manifest_path)
                     if manifest:
                         sdk_manifest[integration] = manifest
@@ -401,7 +401,7 @@ class Flare(object):
         iobuff = StringIO.StringIO(contents)
 
         obj = tarfile.TarInfo(name=file_path)
-        obj.size = len(iobuff.buf)
+        obj.size = len(iobuff.getvalue())
         self._tar.addfile(obj, fileobj=iobuff)
 
     # Returns whether JMXFetch should run or not

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -74,6 +74,11 @@ class Flare(object):
             r'\1://\2:********@',
             'password in a uri'
         ),
+        CredentialPattern(
+            re.compile('^\s*(community_string): *.+$'),
+            r'\1 ********',
+            'SNMP community string'
+        ),
     ]
     MAIN_CREDENTIALS = [
         CredentialPattern(

--- a/utils/sdk.py
+++ b/utils/sdk.py
@@ -21,7 +21,8 @@ def load_manifest(path):
         if os.path.exists(path):
             with open(path) as fp:
                 manifest = json.load(fp)
-    except Exception:
-        log.warn("Unable to read manifest at %s", path)
+    except (IOError, json.JSONDecodeError) as e:
+        log.warn("Unable to read manifest at %s : %s", path, e)
+        manifest = {}
 
     return manifest

--- a/utils/sdk.py
+++ b/utils/sdk.py
@@ -1,0 +1,27 @@
+# (C) Datadog, Inc. 2010-2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+import logging
+import os
+
+# 3p
+import simplejson as json
+
+# project
+
+
+log = logging.getLogger(__name__)
+
+
+def load_manifest(path):
+    manifest = None
+    try:
+        if os.path.exists(path):
+            with open(path) as fp:
+                manifest = json.load(fp)
+    except Exception:
+        log.warn("Unable to read manifest at %s", path)
+
+    return manifest

--- a/utils/windows_configuration.py
+++ b/utils/windows_configuration.py
@@ -67,7 +67,7 @@ def get_sdk_integration_paths():
                 integration_name = integration_subkey.split('\\')[-1]
                 try:
                     directory = get_sdk_integration_path(reg_key, integration_subkey)
-                    integrations[integration_name] = os.path.join(directory, 'Integrations', integration_name)
+                    integrations[integration_name] = directory
                 except WindowsError as e:
                     log.error('Unable to get keys from Registry for %s: %s', integration_name, e)
     except WindowsError as e:

--- a/win32/status.html
+++ b/win32/status.html
@@ -176,7 +176,7 @@
           {% if collector['checks'] %}
           <ul id="checks" style ="list-style-type: None; padding-left: 0;">
             {% for name, check in collector['checks'].iteritems() %}
-            <li><h4>{{ name }}</h4>
+            <li><h4>{{ name }} ({{ check['check_version'] }})</h4>
             <ul>
             {% if check['init_failed'] %}
               <li>Initialization error: {{check['traceback']}}</li></ul>

--- a/win32/status.html
+++ b/win32/status.html
@@ -176,7 +176,7 @@
           {% if collector['checks'] %}
           <ul id="checks" style ="list-style-type: None; padding-left: 0;">
             {% for name, check in collector['checks'].iteritems() %}
-            <li><h4>{{ name }} ({{ check['check_version'] }})</h4>
+            <li><h4>{{ name }} ({{ check.get('check_version') }})</h4>
             <ul>
             {% if check['init_failed'] %}
               <li>Initialization error: {{check['traceback']}}</li></ul>


### PR DESCRIPTION
### What does this PR do?

This PR adds certain SDK-related facilities/improvements to the `flare` and `CheckStatus`, and as a result to the `info` page.

It also fixes several issues encountered with the testing infrastructure including build issues on `travis` and `appveyor` (also local).

I have also snuck in a fix to the SNMP flare. In particular, the `community_string` should be considered a credential and as such should be redacted.

### Motivation

With the advent of the SDK we need to be able to track what integration versions users have installed. This will allow them and us to understand what code actually got loaded, and what versions of the checks they're running at a glance.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
