### PR TITLE
[core] adds logic for windows sdk check loading

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,7 +33,7 @@ from utils.subprocess_output import (
     get_subprocess_output,
     SubprocessOutputEmptyError,
 )
-from utils.windows_configuration import get_registry_conf
+from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 
 # CONSTANTS
@@ -893,8 +893,11 @@ def get_checks_places(osname, agentConfig):
     places = [lambda name: os.path.join(agentConfig['additional_checksd'], '%s.py' % name)]
 
     try:
-        sdk_integrations = get_sdk_integrations_path(osname)
-        places.append(lambda name: os.path.join(sdk_integrations, name, 'check.py'))
+        if Platform.is_windows():
+            places.append(get_windows_sdk_check)
+        else:
+            sdk_integrations = get_sdk_integrations_path(osname)
+            places.append(lambda name: os.path.join(sdk_integrations, name, 'check.py'))
     except PathNotFound:
         log.debug('No sdk integrations path found')
 
@@ -968,6 +971,9 @@ def load_check_from_places(check_config, check_name, checks_places, agentConfig)
     load_success, load_failure = {}, {}
     for check_path_builder in checks_places:
         check_path = check_path_builder(check_name)
+        # The windows SDK function will return None, so we should also skip 
+        if not check_path:
+            continue
         if not os.path.exists(check_path):
             continue
 

--- a/config.py
+++ b/config.py
@@ -971,7 +971,8 @@ def load_check_from_places(check_config, check_name, checks_places, agentConfig)
     load_success, load_failure = {}, {}
     for check_path_builder in checks_places:
         check_path = check_path_builder(check_name)
-        # The windows SDK function will return None, so we should also skip 
+        # The windows SDK function will return None,
+        # so the loop should also continue if there is no path.
         if not check_path:
             continue
         if not os.path.exists(check_path):

--- a/config.py
+++ b/config.py
@@ -973,9 +973,7 @@ def load_check_from_places(check_config, check_name, checks_places, agentConfig)
         check_path = check_path_builder(check_name)
         # The windows SDK function will return None,
         # so the loop should also continue if there is no path.
-        if not check_path:
-            continue
-        if not os.path.exists(check_path):
+        if not (check_path and os.path.exists(check_path)):
             continue
 
         check_is_valid, check_class, load_failure = get_valid_check_class(check_name, check_path)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -166,6 +166,7 @@ FIXTURE_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'fixtur
 @mock.patch('config.get_checksd_path', return_value=TEMP_AGENT_CHECK_DIR)
 @mock.patch('config.get_confd_path', return_value=TEMP_ETC_CONF_DIR)
 @mock.patch('config.get_sdk_integrations_path', return_value=TEMP_SDK_INTEGRATIONS_CHECKS_DIR)
+@mock.patch('config.get_windows_sdk_check', return_value=TEMP_SDK_INTEGRATIONS_CHECKS_DIR)
 class TestConfigLoadCheckDirectory(unittest.TestCase):
 
     TEMP_DIRS = [

--- a/utils/windows_configuration.py
+++ b/utils/windows_configuration.py
@@ -35,7 +35,8 @@ def get_windows_sdk_check(name):
     sdk_reg_path = WINDOWS_REG_PATH + "\\Integrations\\" + name
     try:
         with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,sdk_reg_path) as reg_key:
-            return _winreg.QueryValueEx(reg_key, "InstallDir")
+            directory = _winreg.QueryValueEx(reg_key, "InstallDir")
+            return os.path.join(directory, 'check.py')
     except WindowsError:
         pass
     return None

--- a/utils/windows_configuration.py
+++ b/utils/windows_configuration.py
@@ -32,12 +32,12 @@ def get_registry_conf(agentConfig):
     return registry_conf
 
 def get_windows_sdk_check(name):
-    sdk_reg_path = WINDOWS_REG_PATH + "\\Integrations\\" + name
+    sdk_reg_path = "SOFTWARE\\Datadog\\Datadog Agent\\Integrations\\{}".format(name)
     try:
         with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,sdk_reg_path) as reg_key:
-            directory = _winreg.QueryValueEx(reg_key, "InstallDir")
-            return os.path.join(directory, 'check.py')
-    except WindowsError:
+            directory = _winreg.QueryValueEx(reg_key, "InstallPath")[0]
+            return os.path.join(directory, 'Integrations', name, 'check.py')
+    except WindowsError as e:
         pass
     return None
 

--- a/utils/windows_configuration.py
+++ b/utils/windows_configuration.py
@@ -31,6 +31,14 @@ def get_registry_conf(agentConfig):
 
     return registry_conf
 
+def get_windows_sdk_check(name):
+    sdk_reg_path = WINDOWS_REG_PATH + "\\Integrations\\" + name
+    try:
+        with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,sdk_reg_path) as reg_key:
+            return _winreg.QueryValueEx(reg_key, "InstallDir")
+    except WindowsError:
+        pass
+    return None
 
 def update_conf_file(registry_conf, config_path):
     config_dir = os.path.dirname(config_path)

--- a/utils/windows_configuration.py
+++ b/utils/windows_configuration.py
@@ -12,6 +12,7 @@ except ImportError:
 
 
 WINDOWS_REG_PATH = 'SOFTWARE\\Datadog\\Datadog Agent'
+SDK_REG_PATH = WINDOWS_REG_PATH + '\\Integrations\\'
 
 
 log = logging.getLogger(__name__)
@@ -32,9 +33,9 @@ def get_registry_conf(agentConfig):
     return registry_conf
 
 def get_windows_sdk_check(name):
-    sdk_reg_path = "SOFTWARE\\Datadog\\Datadog Agent\\Integrations\\{}".format(name)
+    sdk_reg_path = SDK_REG_PATH + name
     try:
-        with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,sdk_reg_path) as reg_key:
+        with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, sdk_reg_path) as reg_key:
             directory = _winreg.QueryValueEx(reg_key, "InstallPath")[0]
             return os.path.join(directory, 'Integrations', name, 'check.py')
     except WindowsError:

--- a/utils/windows_configuration.py
+++ b/utils/windows_configuration.py
@@ -37,7 +37,7 @@ def get_windows_sdk_check(name):
         with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,sdk_reg_path) as reg_key:
             directory = _winreg.QueryValueEx(reg_key, "InstallPath")[0]
             return os.path.join(directory, 'Integrations', name, 'check.py')
-    except WindowsError as e:
+    except WindowsError:
         pass
     return None
 


### PR DESCRIPTION
On Windows, the integrations installer will allow them to place an integration anywhere they want, and it will write that location in the registry.

This forces our sdk loader to act a differently than otherwise, it grabs the key from the registry, then it loads the check from it.