### PR TITLE
Proposing a way to customize aggregations and percentils for histograms

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,6 +17,7 @@ import os
 import platform
 import re
 from socket import gaierror, gethostbyname
+import sre_constants
 import string
 import sys
 import traceback
@@ -244,51 +245,77 @@ def get_default_bind_host():
 
 
 def get_histogram_aggregates(configstr=None):
-    if configstr is None:
-        return None
+    return _get_histogram_config(configstr, 'aggregate', _parse_histogram_aggregates_values)
 
-    try:
-        vals = configstr.split(',')
-        valid_values = ['min', 'max', 'median', 'avg', 'sum', 'count']
-        result = []
+def _parse_histogram_aggregates_values(vals):
+    result = []
+    valid_values = ['min', 'max', 'median', 'avg', 'sum', 'count']
 
-        for val in vals:
-            val = val.strip()
-            if val not in valid_values:
-                log.warning("Ignored histogram aggregate {0}, invalid".format(val))
-                continue
-            else:
-                result.append(val)
-    except Exception:
-        log.exception("Error when parsing histogram aggregates, skipping")
-        return None
+    for val in vals:
+        val = val.strip()
+        if val not in valid_values:
+            log.warning("Ignored histogram aggregate {0}, invalid".format(val))
+            continue
+        else:
+            result.append(val)
 
     return result
 
-
 def get_histogram_percentiles(configstr=None):
+    return _get_histogram_config(configstr, 'percentile', _parse_histogram_percentiles_values)
+
+def _parse_histogram_percentiles_values(vals):
+    result = []
+
+    for val in vals:
+        try:
+            val = val.strip()
+            floatval = float(val)
+            if floatval <= 0 or floatval >= 1:
+                raise ValueError
+            if len(val) > 4:
+                log.warning("Histogram percentiles are rounded to 2 digits: {0} rounded"
+                            .format(floatval))
+            result.append(float(val[0:4]))
+        except ValueError:
+            log.warning("Bad histogram percentile value {0}, must be float in ]0;1[, skipping"
+                        .format(val))
+
+    return result
+
+def _get_histogram_config(configstr, type_str, parse_callback):
     if configstr is None:
         return None
 
-    result = []
     try:
-        vals = configstr.split(',')
-        for val in vals:
-            try:
-                val = val.strip()
-                floatval = float(val)
-                if floatval <= 0 or floatval >= 1:
-                    raise ValueError
-                if len(val) > 4:
-                    log.warning("Histogram percentiles are rounded to 2 digits: {0} rounded"
-                                .format(floatval))
-                result.append(float(val[0:4]))
-            except ValueError:
-                log.warning("Bad histogram percentile value {0}, must be float in ]0;1[, skipping"
-                            .format(val))
+        return _parse_histogram_config(configstr, type_str, parse_callback)
     except Exception:
-        log.exception("Error when parsing histogram percentiles, skipping")
+        log.exception('Error when parsing histogram {0}s, skipping'.format(type_str))
         return None
+
+def _parse_histogram_config(configstr, type_str, parse_callback):
+    groups = configstr.split(';')
+
+    result = []
+    for group in groups:
+        group_config = group.rsplit(':', 1)
+        if len(group_config) == 1:
+            # general config
+            result.append((None, parse_callback(group.split(','))))
+        elif len(group_config) == 2:
+            # only applies to metrics matching a given regex
+            regex = group_config[0].strip()
+            if not regex:
+                log.warning('Ignoring empty regex for histogram {0}s'.format(type_str))
+                continue
+            try:
+                compiled_regex = re.compile(regex)
+            except sre_constants.error as exception:
+                log.warning('Ignoring invalid regex {0} for histogram {1}s: {2}'
+                            .format(regex, type_str, exception.message))
+                continue
+
+            result.append((compiled_regex, parse_callback(group_config[1].split(','))))
 
     return result
 

--- a/tests/core/test_aggregator.py
+++ b/tests/core/test_aggregator.py
@@ -89,7 +89,7 @@ class TestMetricsAggregator(unittest.TestCase):
         stats = MetricsAggregator(
             'myhost',
             interval=10,
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min']
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])]
         )
         for i in range(5):
             stats.submit_packets('h1:1|h')
@@ -342,7 +342,7 @@ class TestMetricsAggregator(unittest.TestCase):
         # The min is not enabled by default
         stats = MetricsAggregator(
             'myhost',
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min']
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])]
         )
 
         # Sample all numbers between 1-100 many times. This
@@ -377,7 +377,7 @@ class TestMetricsAggregator(unittest.TestCase):
         # The min is not enabled by default
         stats = MetricsAggregator(
             'myhost',
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min']
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])]
         )
         stats.submit_packets('sampled.hist:5|h|@0.5')
 
@@ -410,13 +410,13 @@ class TestMetricsAggregator(unittest.TestCase):
         # The min is not enabled by default
         stats = MetricsAggregator(
             'host',
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min']
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])]
         )
         stats.submit_packets('test_hist:0.3|ms:2.5|ms|@0.5:3|ms')
 
         stats_ref = MetricsAggregator(
             'host',
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min']
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])]
         )
         packets = [
             'test_hist:0.3|ms',
@@ -458,13 +458,13 @@ class TestMetricsAggregator(unittest.TestCase):
         # The min is not enabled by default
         stats = MetricsAggregator(
             'host',
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min']
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])]
         )
         stats.submit_packets('test_metric:1.5|c|#tag1:one,tag2:two:2.3|g|#tag3:three:3|g:42|h|#tag1:12,tag42:42|@0.22')
 
         stats_ref = MetricsAggregator(
             'host',
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min']
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])]
         )
         packets = [
             'test_metric:1.5|c|#tag1:one,tag2:two',
@@ -517,7 +517,7 @@ class TestMetricsAggregator(unittest.TestCase):
             'myhost',
             interval=ag_interval,
             expiry_seconds=expiry,
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min']
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])]
         )
         stats.submit_packets('test.counter:123|c')
         stats.submit_packets('test.gauge:55|g')
@@ -779,7 +779,7 @@ class TestMetricsAggregator(unittest.TestCase):
         stats = MetricsAggregator(
             'myhost',
             recent_point_threshold=threshold,
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min']
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])]
         )
         timestamp_beyond_threshold = time.time() - threshold*2
         timestamp_within_threshold = time.time() - threshold/2

--- a/tests/core/test_bucket_aggregator.py
+++ b/tests/core/test_bucket_aggregator.py
@@ -78,7 +78,7 @@ class TestUnitMetricsBucketAggregator(unittest.TestCase):
         ag_interval = 10
         # The min is not enabled by default
         stats = MetricsBucketAggregator('myhost', interval=ag_interval,
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min'])
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])])
         for i in range(5):
             stats.submit_packets('h1:1|h')
         for i in range(20):
@@ -551,7 +551,7 @@ class TestUnitMetricsBucketAggregator(unittest.TestCase):
         ag_interval = self.interval
         # The min is not enabled by default
         stats = MetricsBucketAggregator('myhost', interval=ag_interval,
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min'])
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])])
         self.wait_for_bucket_boundary(ag_interval)
 
         # Sample all numbers between 1-100 many times. This
@@ -589,7 +589,7 @@ class TestUnitMetricsBucketAggregator(unittest.TestCase):
         stats = MetricsBucketAggregator(
             'myhost',
             interval=self.interval,
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min']
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])]
         )
         stats.submit_packets('sampled.hist:5|h|@0.5')
 
@@ -607,7 +607,7 @@ class TestUnitMetricsBucketAggregator(unittest.TestCase):
         ag_interval = 1
         # The min is not enabled by default
         stats = MetricsBucketAggregator('myhost', interval=ag_interval,
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min'])
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])])
 
         # Sample all numbers between 1-100 many times. This
         # means our percentiles should be relatively close to themselves.
@@ -665,7 +665,7 @@ class TestUnitMetricsBucketAggregator(unittest.TestCase):
         ag_interval = 1
         # The min is not enabled by default
         stats = MetricsBucketAggregator('myhost', interval=ag_interval,
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min'])
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])])
 
         # Sample all numbers between 1-100 many times. This
         # means our percentiles should be relatively close to themselves.
@@ -768,7 +768,7 @@ class TestUnitMetricsBucketAggregator(unittest.TestCase):
         # The min is not enabled by default
         stats = MetricsBucketAggregator('myhost', interval=ag_interval,
             expiry_seconds=expiry,
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min'])
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])])
         stats.submit_packets('test.counter:123|c')
         stats.submit_packets('test.gauge:55|g')
         stats.submit_packets('test.set:44|s')
@@ -974,7 +974,7 @@ class TestUnitMetricsBucketAggregator(unittest.TestCase):
             'myhost',
             recent_point_threshold=threshold,
             interval=ag_interval,
-            histogram_aggregates=DEFAULT_HISTOGRAM_AGGREGATES+['min']
+            histogram_aggregates=[(None, DEFAULT_HISTOGRAM_AGGREGATES+['min'])]
         )
         timestamp_beyond_threshold = time.time() - threshold*2
 


### PR DESCRIPTION
### What does this PR do?

Currently, it's only possible to do this at a system-wide level, using
the following agent configuration options:

```
histogram_aggregates: max, median, avg, count
histogram_percentiles: 0.95
```

This patch makes this behaviour customizable on a metric basis, based
on a list of regexes and their corresponding configs; e.g. the following
agent configuration:
```
histogram_aggregates: ^my_prefix: max ; max, median, avg, count
histogram_percentiles: ^my_prefix: 0.95, 0.90 ; 0.95
```
would run only the `max` aggregation but report both the 90th and 95th
percentiles on any prefix starting with `my_prefix`; but any other metric
would have the same aggregations as above (ie `max, median, avg, count`),
and report only the 95th percentile.

The first matching regex in the configuration will be applied. If none
match, defaults to the config with no regex, or else to the hard-coded
agent default.

In particular, that makes this patch entirely backward compatible.

### Motivation

This would come in handy to be able to limit aggregations for some
metrics but not all of them on any given box; in particular to avoid
pushing too many custom metrics with respect to plan limits.

For example, we use Datadog to do some high-level profiling in some
of our codebases; we'd be perfectly happy having only the `median`
aggregation for these metrics, which would allow us to lower our
number of custom metrics; but we do not want to stop pushing
other aggregations for other histogram metrics on the same boxes.

### Tests

Updated exisiting tests, and added a minimal test on the new feature, but
will add more if/when the Datadog dev team validates the approach. In particular,
tests should be added at least for:
 - several matching regexes: the 1st matching one should prevail
 - no defined default: the hard-coded default should be applied
 - invalid regex in config gets ignored with a warning

### Additional Notes

Related to customer ticket 82067.