### PR TITLE
[emitter][payload split] make sure to have a hostname

### DIFF
--- a/emitter.py
+++ b/emitter.py
@@ -128,10 +128,15 @@ def split_payload(legacy_payload):
         }
 
         if len(ts) >= 4:
-            if ts[3].get('type'):
-                sample['type'] = ts[3]['type']
+            # Default to the metric hostname if present
             if ts[3].get('hostname'):
                 sample['host'] = ts[3]['hostname']
+            else:
+                # If not use the general payload one
+                sample['host'] = legacy_payload['internalHostname']
+
+            if ts[3].get('type'):
+                sample['type'] = ts[3]['type']
             if ts[3].get('tags'):
                 sample['tags'] = ts[3]['tags']
             if ts[3].get('device_name'):


### PR DESCRIPTION
In some scenarios: only for windows system metrics using the old check
interface, hostname was not passed. In that case we should use the
internalHostname one.
