### PR TITLE
[Windows]  Changed the registry value in the installer to point to the

### DIFF
--- a/utils/windows_configuration.py
+++ b/utils/windows_configuration.py
@@ -37,8 +37,8 @@ def get_windows_sdk_check(name):
     try:
         with _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, sdk_reg_path) as reg_key:
             directory = _winreg.QueryValueEx(reg_key, "InstallPath")[0]
-            return (os.path.join(directory, 'Integrations', name, 'check.py'),
-                    os.path.join(directory, 'Integrations', name, 'manifest.json'))
+            return (os.path.join(directory, 'check.py'),
+                    os.path.join(directory, 'manifest.json'))
     except WindowsError:
         pass
     return None, None


### PR DESCRIPTION
full path (not the root of the installation directory).  Make associated
change here so SDK checks will load

### Motivation

Companion PR https://github.com/DataDog/dd-agent-omnibus/pull/150