### PR TITLE
[service_discovery] add consul_token to datadog.conf

### DIFF
--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -125,6 +125,9 @@ gce_updated_hostname: yes
 # and modify its value.
 # sd_template_dir: /datadog/check_configs
 #
+# If you Consul store requires token authentication for service discovery, you can define that token here.
+# consul_token:
+#
 # Enable JMX checks for service discovery
 # sd_jmx_enable: no
 #


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Adds `consul_token` parameter to datadog.conf.example. This didn't exist although [our docs](http://docs.datadoghq.com/guides/servicediscovery/#configuring-etcd-or-consul-in-datadogconf) lists it in the example. When configuring the docker agent with the env var `SD_CONSUL_TOKEN` our [`sed` command](https://github.com/DataDog/docker-dd-agent/blob/master/entrypoint.sh#L110-L111) was failing.

### Motivation

Customer support ticket.