### PR TITLE
Create more general fix to original problem.

### DIFF
--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -562,7 +562,7 @@ class Processes(Check):
             processLines = output.splitlines()  # Also removes a trailing empty line
 
             del processLines[0]  # Removes the headers
-        except StandardError:
+        except Exception:
             self.logger.exception('getProcesses')
             return False
 


### PR DESCRIPTION
Original submission moved the deletion of list index zero inside the 'try'
block, with the net effect that it would be skipped on any exception.  The
exception that's actually occurring is SubprocessOutputEmptyError.  So,
catch all exceptions and return a failure, rather than attempting to parse
potentially malformed data returned in an exceptoin case.

Original PR https://github.com/DataDog/dd-agent/pull/3043

### What does this PR do?

Updates a submission intended to stop an uncaught exception when 'ps' fails (in the user's case, due to a full filesystem)

### Motivation

Regression testing and review indicated fix was potentially incomplete.

