### PR TITLE
[auto_config][jmxfetch] Remove yaml dump in log

### DIFF
--- a/config.py
+++ b/config.py
@@ -1188,7 +1188,6 @@ def generate_jmx_configs(agentConfig, hostname, checknames=None):
             try:
                 yaml = config_to_yaml(check_config)
                 generated["{}_{}".format(check_name, 0)] = yaml
-                log.debug("YAML generated: %s", yaml)
             except Exception:
                 log.exception("Unable to generate YAML config for %s", check_name)
 


### PR DESCRIPTION
### What does this PR do?

Removes a dump of a jmx check yaml config in the logs

### Motivation

Could potentially contain sensitive information that shouldn't be
logged