### PR TITLE
[requirements][scandir] Sync dep version with integrations-core

### DIFF
--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -52,4 +52,4 @@ psycopg2==2.6.2
 wmi==1.4.9
 
 # checks.d/directory.py
-scandir==1.2
+scandir==1.5


### PR DESCRIPTION
Don't know if we should keep these check deps in the requirements files of dd-agent, but right now any discrepancy makes the integrations-core CI build fail (https://github.com/DataDog/integrations-core/pull/262 upgraded the dep in `integrations-core`)