### PR TITLE
[core][sdk][info] fix version detection for WMI Checks

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -49,6 +49,7 @@ AGENT_METRICS_CHECK_NAME = 'agent_metrics'
 
 AGENT_CHECK_FRAME = 2
 NETWORK_CHECK_FRAME = 3
+WMI_CHECK_FRAME = 3
 
 
 # Konstants
@@ -392,17 +393,22 @@ class AgentCheck(object):
             CheckClass.__init__() -> AgentCheck.__init__() -> AgentCheck._get_check_manifest()
         """
         from checks.network_checks import NetworkCheck
+        from checks.wmi_check import WinWMICheck
         if not manifest_path:
             frames = inspect.stack()
             # As we mention in the docstring this is expected to be called from
             # AgentCheck constructor. By doing so we can assume two things:
-            #    - If the caller is a NetworkCheck, the Check() constructor
-            #      frame will be on the third frame in the stack.
+            #    - If the caller is a NetworkCheck/WinWMICheck, the Check()
+            #      constructor frame will be on the third frame in the stack.
             #    - Otherwise it will be a regular check, so the Check()
             #      constructor frame will be the second frame in the stack.
             # In frame[1] we have the __file__ for that particular frame
             # source.
-            frame_idx = NETWORK_CHECK_FRAME if isinstance(self, NetworkCheck) else AGENT_CHECK_FRAME
+            frame_idx = AGENT_CHECK_FRAME
+            if isinstance(self, NetworkCheck):
+                frame_idx = NETWORK_CHECK_FRAME
+            elif isinstance(self, WinWMICheck):
+                frame_idx = WMI_CHECK_FRAME
             caller_frame = frames[frame_idx]  # frame_idx _should_ be the check __init__ frame
             module_path = os.path.dirname(caller_frame[1])  # idx 1 contains the filename.
             manifest_path = os.path.join(module_path, 'manifest.json')

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -393,7 +393,11 @@ class AgentCheck(object):
             CheckClass.__init__() -> AgentCheck.__init__() -> AgentCheck._get_check_manifest()
         """
         from checks.network_checks import NetworkCheck
-        from checks.wmi_check import WinWMICheck
+        try:
+            from checks.wmi_check import WinWMICheck
+        except ImportError:
+            WinWMICheck = None
+
         if not manifest_path:
             frames = inspect.stack()
             # As we mention in the docstring this is expected to be called from
@@ -407,7 +411,7 @@ class AgentCheck(object):
             frame_idx = AGENT_CHECK_FRAME
             if isinstance(self, NetworkCheck):
                 frame_idx = NETWORK_CHECK_FRAME
-            elif isinstance(self, WinWMICheck):
+            elif WinWMICheck and isinstance(self, WinWMICheck):
                 frame_idx = WMI_CHECK_FRAME
             caller_frame = frames[frame_idx]  # frame_idx _should_ be the check __init__ frame
             module_path = os.path.dirname(caller_frame[1])  # idx 1 contains the filename.

--- a/config.py
+++ b/config.py
@@ -935,7 +935,7 @@ def _load_file_config(config_path, check_name, agentConfig):
     except Exception as e:
         log.exception("Unable to parse yaml config in %s" % config_path)
         traceback_message = traceback.format_exc()
-        return False, None, {check_name: {'error': str(e), 'traceback': traceback_message}}
+        return False, None, {check_name: {'error': str(e), 'traceback': traceback_message, 'version': 'unknown'}}
     return True, check_config, {}
 
 


### PR DESCRIPTION
### What does this PR do?

Fixes a small bug where the check version was not properly being reported in the info page for WMI checks.

It also addresses another small issue, when we hit an issue when validating the YAML, we actually fail before attempting to load the check, so the check version is unknown at that point. We were reporting the check version as `None` in that case, this will now report it as `unknown` (as we have not yet loaded the check). Is `unknown` better than `None`? I went for it because it would be more consistent with other error messages when the version cannot be determined (ie. a bad manifest, etc).

### Motivation

Found the bug while testing the RC.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.