### PR TITLE
[win32] disable pgbouncer check

### DIFF
--- a/win32/gui.py
+++ b/win32/gui.py
@@ -129,6 +129,7 @@ EXCLUDED_WINDOWS_CHECKS = [
     'marathon',
     'mcache',
     'mesos',
+    'pgbouncer',
     'postfix',
     'zk',
 ]


### PR DESCRIPTION
The PgBouncer Datadog Agent check depends on `psycopg2` third party,
which is currrently  not shipped with the Windows agent.
Disable PgBouncer check on Windows.