### PR TITLE
[core][sdk][version_manifest] Fix version comparison

### DIFF
--- a/config.py
+++ b/config.py
@@ -125,6 +125,11 @@ def get_version():
     return AGENT_VERSION
 
 
+def _version_string_to_tuple(version_string):
+    '''Return a (X, Y, Z) version tuple from an 'X.Y.Z' version string'''
+    return tuple(int(version_elem) for version_elem in version_string.split('.'))
+
+
 # Return url endpoint, here because needs access to version number
 def get_url_endpoint(default_url, endpoint_type='app'):
     parsed_url = urlparse(default_url)
@@ -1003,12 +1008,13 @@ def validate_sdk_check(manifest_path):
     try:
         with open(manifest_path, 'r') as fp:
             manifest = json.load(fp)
+            current_version = _version_string_to_tuple(get_version())
             for maxfield in MANIFEST_VALIDATION['max']:
                 max_version = manifest.get(maxfield)
                 if not max_version:
                     continue
 
-                max_validated = False if max_version < get_version() else True
+                max_validated = _version_string_to_tuple(max_version) >= current_version
                 break
 
             for minfield in MANIFEST_VALIDATION['min']:
@@ -1016,7 +1022,7 @@ def validate_sdk_check(manifest_path):
                 if not min_version:
                     continue
 
-                min_validated = False if min_version > get_version() else True
+                min_validated = _version_string_to_tuple(min_version) <= current_version
                 break
     except IOError:
         log.debug("Manifest file (%s) not present." % manifest_path)

--- a/config.py
+++ b/config.py
@@ -133,7 +133,8 @@ def _version_string_to_tuple(version_string):
             elem_int = int(elem)
         except ValueError:
             log.warning("Unable to parse element '%s' of version string '%s'", elem, version_string)
-            elem_int = 0
+            raise
+
         version_list.append(elem_int)
 
     return tuple(version_list)
@@ -1037,6 +1038,8 @@ def validate_sdk_check(manifest_path):
         log.debug("Manifest file (%s) not present." % manifest_path)
     except json.JSONDecodeError:
         log.debug("Manifest file (%s) has badly formatted json." % manifest_path)
+    except ValueError:
+        log.debug("Versions in manifest file (%s) can't be validated.", manifest_path)
 
     return (min_validated and max_validated)
 

--- a/config.py
+++ b/config.py
@@ -127,7 +127,16 @@ def get_version():
 
 def _version_string_to_tuple(version_string):
     '''Return a (X, Y, Z) version tuple from an 'X.Y.Z' version string'''
-    return tuple(int(version_elem) for version_elem in version_string.split('.'))
+    version_list = []
+    for elem in version_string.split('.'):
+        try:
+            elem_int = int(elem)
+        except ValueError:
+            log.warning("Unable to parse element '%s' of version string '%s'", elem, version_string)
+            elem_int = 0
+        version_list.append(elem_int)
+
+    return tuple(version_list)
 
 
 # Return url endpoint, here because needs access to version number

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -15,7 +15,8 @@ from config import (
     get_config,
     load_check_directory,
     validate_sdk_check,
-    _conf_path_to_check_name
+    _conf_path_to_check_name,
+    _version_string_to_tuple
 )
 from util import windows_friendly_colon_split
 from utils.hostname import is_valid_hostname
@@ -330,14 +331,11 @@ class TestConfigLoadCheckDirectory(unittest.TestCase):
 
 
 class TestManifestValidation(unittest.TestCase):
+    @mock.patch('config.get_version', return_value='5.12.0')
     def testManifestValidateOK(self, *args):
         manifest_path = '{}/manifest.json'.format(FIXTURE_PATH)
-        with mock.patch('config.get_version', return_value='5.9.1'):
-            validate = validate_sdk_check(manifest_path)
-            self.assertEquals(True, validate)
-        with mock.patch('config.get_version', return_value='5.12.0'):
-            validate = validate_sdk_check(manifest_path)
-            self.assertEquals(True, validate)
+        validate = validate_sdk_check(manifest_path)
+        self.assertEquals(True, validate)
 
     @mock.patch('config.get_version', return_value='4.0.1')
     def testManifestValidateNOKHigh(self, *args):
@@ -351,3 +349,6 @@ class TestManifestValidation(unittest.TestCase):
         validate = validate_sdk_check(manifest_path)
         self.assertEquals(False, validate)
 
+    def testVersionStringToTupleResilience(self, *args):
+        version_tuple = _version_string_to_tuple('5.10.4a')
+        self.assertEquals((5, 10, 0), version_tuple)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -349,6 +349,6 @@ class TestManifestValidation(unittest.TestCase):
         validate = validate_sdk_check(manifest_path)
         self.assertEquals(False, validate)
 
-    def testVersionStringToTupleResilience(self, *args):
-        version_tuple = _version_string_to_tuple('5.10.4a')
-        self.assertEquals((5, 10, 0), version_tuple)
+    def testVersionStringToTupleBadVersion(self, *args):
+        with self.assertRaises(ValueError):
+            _version_string_to_tuple('5.10.4a')

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -324,11 +324,20 @@ class TestConfigLoadCheckDirectory(unittest.TestCase):
         self.assertEquals(1, len(checks['initialized_checks']))
         self.assertEquals(2, checks['initialized_checks'][0].instance_count())  # check that we picked the right conf
 
-    @mock.patch('config.get_version', return_value='5.9.1')
+    def tearDown(self):
+        for _dir in self.TEMP_DIRS:
+            rmtree(_dir)
+
+
+class TestManifestValidation(unittest.TestCase):
     def testManifestValidateOK(self, *args):
         manifest_path = '{}/manifest.json'.format(FIXTURE_PATH)
-        validate = validate_sdk_check(manifest_path)
-        self.assertEquals(True, validate)
+        with mock.patch('config.get_version', return_value='5.9.1'):
+            validate = validate_sdk_check(manifest_path)
+            self.assertEquals(True, validate)
+        with mock.patch('config.get_version', return_value='5.12.0'):
+            validate = validate_sdk_check(manifest_path)
+            self.assertEquals(True, validate)
 
     @mock.patch('config.get_version', return_value='4.0.1')
     def testManifestValidateNOKHigh(self, *args):
@@ -342,6 +351,3 @@ class TestConfigLoadCheckDirectory(unittest.TestCase):
         validate = validate_sdk_check(manifest_path)
         self.assertEquals(False, validate)
 
-    def tearDown(self):
-        for _dir in self.TEMP_DIRS:
-            rmtree(_dir)


### PR DESCRIPTION
### What does this PR do?

Fixes the version comparison in `validate_sdk_check` (added in #3251)

### Testing

Added a test case covering what this fixes.

### Additional Notes

We have to use tuples of integers if we want the comparison
to work as expected
