### PR TITLE
[fowarder] validate api_key against any endpoint

### DIFF
--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -126,7 +126,7 @@ def validate_api_key(config):
         request_proxy = {}
         if proxy:
             request_proxy = {'https': "http://{user}:{password}@{host}:{port}".format(**proxy)}
-        r = requests.get("https://app.datadoghq.com/api/v1/validate",
+        r = requests.get("%s/api/v1/validate" % config['dd_url'].rstrip('/'),
             params={'api_key': config.get('api_key')}, proxies=request_proxy, timeout=3)
 
         if r.status_code == 403:


### PR DESCRIPTION
Instead of hardcoding the url, politely use the one from the config.