### PR TITLE
[core][sdk][win] add paths to sys.path if bundled with libs.

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -62,6 +62,7 @@ from utils.profile import AgentProfiler
 from utils.service_discovery.config_stores import get_config_store
 from utils.service_discovery.sd_backend import get_sd_backend
 from utils.watchdog import Watchdog
+from utils.windows_configuration import get_sdk_integration_paths
 
 # Constants
 PID_NAME = "dd-agent"
@@ -231,6 +232,12 @@ class Agent(Daemon):
 
             # A SIGHUP signals a configuration reload
             signal.signal(signal.SIGHUP, self._handle_sighup)
+        else:
+            sdk_integrations = get_sdk_integration_paths()
+            for name, path in sdk_integrations.iteritems():
+                lib_path = os.path.join(path, 'lib')
+                if os.path.exists(lib_path):
+                    sys.path.append(lib_path)
 
         # Save the agent start-up stats.
         CollectorStatus().persist()


### PR DESCRIPTION
### What does this PR do?

This PR attempts to add to the relevant locations to `sys.path` before the checks are loaded in the collector solving potential library dependency issues in integrations-extras. It does not affect `core` integrations as these already bundle their deps with the `dd-agent` core package. It does not affect `unix` systems either because in those cases we **_do_** enfore the target location for the packages so we can drop the preferable `pth` files instead.  

### Motivation

On windows, integrations can be installed to an arbitrary location, meaning we don't know at build time what the `pth` files we'd drop in `site-packages` should look like. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.
