### PR TITLE
[flare] Use "/" path separator in TarInfo name

### DIFF
--- a/utils/flare.py
+++ b/utils/flare.py
@@ -400,6 +400,10 @@ class Flare(object):
     def _add_object_tar(self, file_path, contents):
         iobuff = StringIO.StringIO(contents)
 
+        # All paths in the tar should be "/"-separated. Python does the replacement for us in TarFile.add
+        # but not in TarFile.addfile (in TarInfo neither for that matter)
+        file_path = file_path.replace(os.sep, "/")
+
         obj = tarfile.TarInfo(name=file_path)
         obj.size = len(iobuff.getvalue())
         self._tar.addfile(obj, fileobj=iobuff)


### PR DESCRIPTION
### What does this PR do?

Creates the `sdk_manifests.json` file in the same directory as the other files of the tar.

Without this change it would get added as a `<main_dir>\sdk_manifests.json` file one level above all the other files when extracted on a unix env.

### Testing Guidelines

Built a windows agent against this branch and checked that a flare tar doesn't have the issue anymore.

### Additional Notes

The change is done by python in `TarFile.add` (see https://github.com/python/cpython/blob/v2.7.13/Lib/tarfile.py#L1863-L1869), but not in `Tarfile.addfile`
