### PR TITLE
Remove requirements for kafka_consumer.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,10 +43,6 @@ pyro4==4.36 # required by adodbapi
 # checks.d/riak.py
 httplib2==0.9
 
-# checks.d/kafka_consumer.py
-kafka-python==1.3.1
-kazoo==2.2.1
-
 # checks.d/postgres.py
 pg8000==1.10.1
 


### PR DESCRIPTION
Now that `kafka_consumer.py` is in integrations-core repo, don't think it's requirements need to be present here anymore.