### PR TITLE
[kubernetes]  - The kube_pod_container_status_restarts function should use metric.counter instead of metric.gauge 

### DIFF
--- a/utils/kubernetes/kube_state_processor.py
+++ b/utils/kubernetes/kube_state_processor.py
@@ -202,7 +202,7 @@ class KubeStateProcessor:
         """ Number of desired pods for a deployment. """
         metric_name = NAMESPACE + '.container.restarts'
         for metric in message.metric:
-            val = metric.gauge.value
+            val = metric.counter.value
             tags = ['{}:{}'.format(label.name, label.value) for label in metric.label]
             self.gauge(metric_name, val, tags)
 


### PR DESCRIPTION

*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?
[kubernetes]  - The kube_pod_container_status_restarts function should use metric.counter instead of metric.gauge 


### Motivation

What inspired you to submit this pull request?
metrics doesn't work! 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
