### PR TITLE
[docker] parse subsystem

### DIFF
--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -335,11 +335,16 @@ class DockerUtil:
         return False
 
     @classmethod
+    def _parse_subsystem(cls, line):
+        i = line[2].rfind('docker')
+        return line[2][i:]
+
+    @classmethod
     def find_cgroup_from_proc(cls, mountpoints, pid, subsys, docker_root='/'):
         proc_path = os.path.join(docker_root, 'proc', str(pid), 'cgroup')
         with open(proc_path, 'r') as fp:
             lines = map(lambda x: x.split(':'), fp.read().splitlines())
-            subsystems = dict(zip(map(lambda x: x[1], lines), map(lambda x: x[2] if x[2][0] != '/' else x[2][1:], lines)))
+            subsystems = dict(zip(map(lambda x: x[1], lines), map(cls._parse_subsystem, lines)))
 
         if subsys not in subsystems and subsys == 'cpuacct':
             for form in "{},cpu", "cpu,{}":


### PR DESCRIPTION
related to #2466

Lines in `/proc/$PID/cgroup` don't have the same format for all systems.

- In CoreOS they look like: `3:cpu,cpuacct:/system.slice/docker-$CONTAINER_ID.scope`
- In RancherOS: `5:cpu,cpuacct:/docker/$USER_DOCKER_CID/docker/$CONTAINER_ID`
- In Ubuntu: `4:cpuacct:/docker/$CONTAINER_ID`

For RancherOS we were parsing the `$USER_DOCKER_CID` not the `$CONTAINER_ID`.