### PR TITLE
bumps agent version in config.py to 5.13.0

### DIFF
--- a/config.py
+++ b/config.py
@@ -41,7 +41,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 
 # CONSTANTS
-AGENT_VERSION = "5.12.0"
+AGENT_VERSION = "5.13.0"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
 MAC_CONFIG_PATH = '/opt/datadog-agent/etc'


### PR DESCRIPTION
After the release the agent version should be 5.13.0