### PR TITLE
[core][emitter] Force source type to system for legacy payload

### DIFF
--- a/emitter.py
+++ b/emitter.py
@@ -125,7 +125,7 @@ def split_payload(legacy_payload):
         sample = {
             "metric": ts[0],
             "points": [(ts[1], ts[2])],
-            "source_type_name": "system",
+            "source_type_name": "System",
         }
 
         if len(ts) >= 4:

--- a/emitter.py
+++ b/emitter.py
@@ -124,7 +124,8 @@ def split_payload(legacy_payload):
     for ts in legacy_payload['metrics']:
         sample = {
             "metric": ts[0],
-            "points": [(ts[1], ts[2])]
+            "points": [(ts[1], ts[2])],
+            "source_type_name": "system",
         }
 
         if len(ts) >= 4:


### PR DESCRIPTION
### What does this PR do?

This PR forces source type to "system" for the payload split in the emitter

### Motivation

Otherwise this will churn contexts as they'll have a different source type name. This can also lead to transient double counting.

