### PR TITLE
[forwarder] Fix error on removal of transactions

### DIFF
--- a/transaction.py
+++ b/transaction.py
@@ -134,9 +134,7 @@ class TransactionManager(object):
             new_trs = sorted(self._transactions,key=attrgetter('_next_flush'), reverse = True)
             for tr2 in new_trs:
                 if (self._total_size + tr_size) > self._MAX_QUEUE_SIZE:
-                    self._transactions.remove(tr2)
-                    self._total_count = self._total_count - 1
-                    self._total_size = self._total_size - tr2.get_size()
+                    self._remove(tr2)
                     log.warn("Removed transaction %s from queue" % tr2.get_id())
 
         # Done
@@ -147,6 +145,18 @@ class TransactionManager(object):
 
         log.debug("Transaction %s added" % (tr.get_id()))
         self.print_queue_stats()
+
+    def _remove(self, tr):
+        '''Safely remove transaction from list'''
+        try:
+            self._transactions.remove(tr)
+        except ValueError:
+            # Should not happen if we order the queue consistently, but we should catch the error anyway
+            log.warn("Tried to remove transaction %s from queue but it was not in the queue anymore.", tr.get_id())
+            pass
+        else:
+            self._total_count -= 1
+            self._total_size -= tr.get_size()
 
     def flush(self):
 
@@ -281,9 +291,7 @@ class TransactionManager(object):
                  "It will not be replayed.",
                  tr.get_id(),
                  tr.get_size() / 1024)
-        self._transactions.remove(tr)
-        self._total_count -= 1
-        self._total_size -= tr.get_size()
+        self._remove(tr)
         self._transactions_flushed += 1
         self.print_queue_stats()
         self._transactions_rejected += 1
@@ -299,8 +307,6 @@ class TransactionManager(object):
         self._running_flushes -= 1
         self._finished_flushes += 1
         log.debug("Transaction %d completed",  tr.get_id())
-        self._transactions.remove(tr)
-        self._total_count -= 1
-        self._total_size -= tr.get_size()
+        self._remove(tr)
         self._transactions_flushed += 1
         self.print_queue_stats()

--- a/transaction.py
+++ b/transaction.py
@@ -201,6 +201,10 @@ class TransactionManager(object):
             # Running for too long?
             if datetime.utcnow() - self._flush_time >= self._MAX_FLUSH_DURATION:
                 log.warn('Flush %s is taking more than 10s, stopping it', self._flush_count)
+                for tr in self._trs_to_flush:
+                    # Recompute these transactions' next flush so that if we hit the max queue size
+                    # newer transactions are preserved
+                    tr.compute_next_flush(self._MAX_WAIT_FOR_REPLAY)
                 self._trs_to_flush = []
                 return self.flush_next()
 

--- a/transaction.py
+++ b/transaction.py
@@ -153,7 +153,6 @@ class TransactionManager(object):
         except ValueError:
             # Should not happen if we order the queue consistently, but we should catch the error anyway
             log.warn("Tried to remove transaction %s from queue but it was not in the queue anymore.", tr.get_id())
-            pass
         else:
             self._total_count -= 1
             self._total_size -= tr.get_size()


### PR DESCRIPTION
### What does this PR do?

Fixes a case where the removal of a transaction from the TransactionManager would raise `ValueError: list.remove(x): x not in list` and crash the forwarding ioloop.

This would happen when:
1. the endpoint is not available
2. the transaction queue is full
3. a flush is "timed out" (when flush time > 10 seconds), and
4. the endpoint becomes available again

In that scenario a transaction could be removed first by the code handling the size of the queue (see https://github.com/DataDog/dd-agent/blob/5.12.1/transaction.py#L137, which can run while the transaction is being sent) and then from the `on_success` callback once the transaction has been successfully sent.

The fix has 2 parts (see related 2 commit descriptions): the first should fix the issue in most cases, the second should ensure that the transaction removal never raises errors in unforeseen cases when we'd still try to remove transactions that have already been removed.

### Testing Guidelines

Haven't tested this in the exact scenario where the issue happened, but the fix is rather straightforward.