### PR TITLE
[core][cloud_metadata] Use Metadata-Flavor header to avoid request exception for GCE tags

### DIFF
--- a/utils/cloud_metadata.py
+++ b/utils/cloud_metadata.py
@@ -37,7 +37,7 @@ class GCE(object):
             r = requests.get(
                 GCE.URL,
                 timeout=GCE.TIMEOUT,
-                headers={'X-Google-Metadata-Request': True}
+                headers={'Metadata-Flavor': 'Google'}
             )
             r.raise_for_status()
             GCE.metadata = r.json()


### PR DESCRIPTION
### What does this PR do?

We get the following log when we start the dd-agent on an instance in GCE. 
`dd.collector | utils.cloud_metadata(cloud_metadata.py:45) | Collecting GCE Metadata failed Header value True must be of type str or bytes, not <type 'bool'>`

It looks like the header in the request sent to GCE to get the metadata is in the wrong format. Also I think this is now deprecated in favour of `Metadata-Flavor: Google` (see https://cloud.google.com/compute/docs/metadata#transitioning)

This PR uses the new `Metadata-Flavor: Google`

### Motivation

We're relying on GCE tags to identify important groups of instances and none of these tags are coming through.
