### PR TITLE
[docker] Support Nomad for SD and tags

### DIFF
--- a/config.py
+++ b/config.py
@@ -591,6 +591,11 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
         if config.has_option("Main", "gce_updated_hostname"):
             agentConfig["gce_updated_hostname"] = _is_affirmative(config.get("Main", "gce_updated_hostname"))
 
+        agentConfig["docker_orchestrator"] = None
+        if config.has_option('Main', 'docker_orchestrator'):
+            agentConfig['docker_orchestrator'] = config.get("docker_orchestrator", None)
+
+
     except ConfigParser.NoSectionError as e:
         sys.stderr.write('Config file not found or incorrectly formatted.\n')
         sys.exit(2)

--- a/config.py
+++ b/config.py
@@ -591,11 +591,6 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
         if config.has_option("Main", "gce_updated_hostname"):
             agentConfig["gce_updated_hostname"] = _is_affirmative(config.get("Main", "gce_updated_hostname"))
 
-        agentConfig["docker_orchestrator"] = None
-        if config.has_option('Main', 'docker_orchestrator'):
-            agentConfig['docker_orchestrator'] = config.get("docker_orchestrator", None)
-
-
     except ConfigParser.NoSectionError as e:
         sys.stderr.write('Config file not found or incorrectly formatted.\n')
         sys.exit(2)

--- a/tests/core/test_nomadutil.py
+++ b/tests/core/test_nomadutil.py
@@ -1,0 +1,67 @@
+# stdlib
+import unittest
+
+# 3rd party
+import mock
+
+# project
+from utils.orchestrator import NomadUtil
+
+ENV = ['NOMAD_TASK_NAME=test-task',
+       'NOMAD_JOB_NAME=test-job',
+       'NOMAD_ALLOC_NAME=test-task.test-group[0]']
+EXPECTED_TAGS = ['nomad_task:test-task', 'nomad_job:test-job', 'nomad_group:test-group']
+CO_ID = 1234
+
+
+class TestNomadUtil(unittest.TestCase):
+    @mock.patch('docker.Client.inspect_container')
+    @mock.patch('docker.Client.__init__')
+    def test_extract_tags(self, mock_init, mock_inspect):
+        nomad = NomadUtil()
+
+        mock_inspect.return_value = {'Config': {'Env': ENV}}
+        mock_init.return_value = None
+        co = {'Id': CO_ID, 'Created': 1}
+
+        tags = nomad.extract_container_tags(co)
+
+        self.assertEqual(sorted(EXPECTED_TAGS), sorted(tags))
+
+    @mock.patch('docker.Client.inspect_container')
+    @mock.patch('docker.Client.__init__')
+    def test_cache_invalidation_created_timestamp(self, mock_init, mock_inspect):
+        nomad = NomadUtil()
+
+        mock_inspect.return_value = {'Config': {'Env': ENV}}
+        mock_init.return_value = None
+        co = {'Id': CO_ID, 'Created': 1}
+        nomad.extract_container_tags(co)
+
+        self.assertTrue(CO_ID in nomad._container_tags_cache)
+        mock_inspect.assert_called_once()
+
+        # Cache is used
+        nomad.extract_container_tags(co)
+        mock_inspect.assert_called_once()
+
+        # Different timestamp: cache is invalidated
+        nomad.extract_container_tags({'Id': CO_ID, 'Created': 2})
+        self.assertEqual(2, mock_inspect.call_count)
+
+    @mock.patch('docker.Client.inspect_container')
+    @mock.patch('docker.Client.__init__')
+    def test_cache_invalidation_event(self, mock_init, mock_inspect):
+        nomad = NomadUtil()
+
+        mock_inspect.return_value = {'Config': {'Env': ENV}}
+        mock_init.return_value = None
+        co = {'Id': CO_ID, 'Created': 1}
+        nomad.extract_container_tags(co)
+
+        self.assertTrue(CO_ID in nomad._container_tags_cache)
+
+        EVENT = {'status': 'die', 'id': CO_ID}
+        nomad.invalidate_cache([EVENT])
+
+        self.assertFalse(CO_ID in nomad._container_tags_cache)

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -85,26 +85,25 @@ class DockerUtil:
         self._is_rancher = False
         self._is_nomad = False
 
-        try:
-            containers = self.client.containers()
-            for co in containers:
-                log.warning("bla")
-                if '/ecs-agent' in co.get('Names', ''):
-                    self._is_ecs = True
+        configured_orch = os.environ.get('DOCKER_ORCHESTRATOR', '').lower()
 
-                elif '/rancher-agent' in co.get('Names', ''):
-                    self._is_rancher = True
+        if configured_orch == 'nomad':
+            self._is_nomad = True
+        else:
+            try:
+                containers = self.client.containers()
+                for co in containers:
+                    if '/ecs-agent' in co.get('Names', ''):
+                        self._is_ecs = True
+                        break
 
-                    break
-                if self._detect_nomad(co):
-                    self._is_nomad = True
-                    log.warning("found nomad")
-                    # FIXME : will break if no nomad jobs are running, should try again later
-                    break
+                    elif '/rancher-agent' in co.get('Names', ''):
+                        self._is_rancher = True
+                        break
 
-        except Exception as e:
-            log.warning("Error while detecting orchestrator: %s" % e)
-            pass
+            except Exception as e:
+                log.warning("Error while detecting orchestrator: %s" % e)
+                pass
 
         # Build include/exclude patterns for containers
         self._include, self._exclude = instance.get('include', []), instance.get('exclude', [])
@@ -161,16 +160,6 @@ class DockerUtil:
 
     def is_nomad(self):
         return self._is_nomad
-
-    def _detect_nomad(self, container):
-        log.warning("testing nomad")
-        is_found = False
-        inspect_info = self.client.inspect_container(container.get('Id', ''))
-        for env in inspect_info.get('Config', {}).get('Env', []):
-            if env.startswith('NOMAD_'):
-                is_found = True
-                break
-        return is_found
 
     def is_swarm(self):
         if self.swarm_node_state == 'pending':

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -80,7 +80,6 @@ class DockerUtil:
         # Try to detect if an orchestrator is running
         self._is_ecs = False
         self._is_rancher = False
-        self._is_nomad = False
 
         try:
             containers = self.client.containers()

--- a/utils/orchestrator/__init__.py
+++ b/utils/orchestrator/__init__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-from nomadutil import NomadUtil
+from nomadutil import NomadUtil  # noqa: F401

--- a/utils/orchestrator/__init__.py
+++ b/utils/orchestrator/__init__.py
@@ -1,0 +1,5 @@
+# (C) Datadog, Inc. 2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+from nomadutil import NomadUtil

--- a/utils/orchestrator/nomadutil.py
+++ b/utils/orchestrator/nomadutil.py
@@ -1,0 +1,106 @@
+# (C) Datadog, Inc. 2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+import logging
+from utils.dockerutil import DockerUtil
+from utils.singleton import Singleton
+
+
+log = logging.getLogger(__name__)
+
+NOMAD_TASK_NAME = 'NOMAD_TASK_NAME'
+NOMAD_JOB_NAME = 'NOMAD_JOB_NAME'
+NOMAD_ALLOC_NAME = 'NOMAD_ALLOC_NAME'
+
+
+class NomadUtil:
+    __metaclass__ = Singleton
+
+    def __init__(self, instance=None):
+        self.docker_util = DockerUtil()
+        if instance is None:
+            log.debug("New NomadUtil instance")
+            self._container_tags_cache = {}
+            self._enabled = None
+
+    def init_platform(self, agentConfig):
+        """
+        Enable/disable Nomad support depending on the docker_orchestrator config file entry
+        :param agentConfig: dict from config.get_config()
+        """
+        self._enabled = agentConfig.get('docker_orchestrator', None) == 'nomad'
+
+    def is_enabled(self):
+        """
+        Allows user classes to check whether nomad is to be activated.
+        init_platform has to be called once first
+        :return: True/False
+        """
+        if self._enabled is None:
+            log.warning("Calling nomad.is_nomad before init_platform, replying False")
+            return False
+        else:
+            return self._enabled
+
+    def extract_container_tags(self, co):
+        """
+        Queries docker inspect to get nomad tags in the container's environment vars.
+        As this is expensive, it is cached in the self._nomad_tags_cache dict.
+        The cache invalidation goes through invalidate_nomad_cache, called by docker_daemon
+
+        :param co: container dict returned by docker-py
+        :return: tags as list<string>, cached
+        """
+
+        co_id = co.get('Id', 'INVALID')
+
+        if co_id == 'INVALID':
+            log.warning("Invalid container object in extract_nomad_tags")
+            return
+
+        # Cache lookup on Id, verified on Created timestamp
+        if co_id in self._container_tags_cache:
+            created, tags = self._container_tags_cache[co_id]
+            if created == co.get('Created', -1):
+                log.debug("Gettings nomad tags from cache")
+                return tags
+
+        tags = []
+        try:
+            inspect_info = self.docker_util.inspect_container(co_id)
+            envvars = inspect_info.get('Config', {}).get('Env', {})
+            for var in envvars:
+                if var.startswith(NOMAD_TASK_NAME):
+                    tags.append('nomad_task:%s' % var[len(NOMAD_TASK_NAME)+1:])
+                elif var.startswith(NOMAD_JOB_NAME):
+                    tags.append('nomad_job:%s' % var[len(NOMAD_JOB_NAME)+1:])
+                elif var.startswith(NOMAD_ALLOC_NAME):
+                    try:
+                        start = var.index('.', len(NOMAD_ALLOC_NAME)) + 1
+                        end = var.index('[')
+                        tags.append('nomad_group:%s' % var[start:end])
+                        log.debug("Gettings nomad tags from docker")
+                    except ValueError:
+                        pass
+                    self._container_tags_cache[co_id] = (co.get('Created'), tags)
+                    log.debug(self._container_tags_cache)
+        except Exception as e:
+            log.warning("Error while parsing Nomad tags: %s" % str(e))
+        finally:
+            return tags
+
+    def invalidate_cache(self, events):
+        """
+        Allows cache invalidation when containers dies
+        :param events from self.get_events
+        """
+        try:
+            for ev in events:
+                if ev.get('status') == 'die' and ev.get('id') in self._container_tags_cache:
+                    log.debug("Invalidating nomad cache for %s" % ev.get('id'))
+                    del self._container_tags_cache[ev.get('id')]
+                    log.debug(self._container_tags_cache)
+        except Exception as e:
+            log.warning("Error when invalidating nomad cache: " + str(e))

--- a/utils/orchestrator/nomadutil.py
+++ b/utils/orchestrator/nomadutil.py
@@ -18,11 +18,9 @@ NOMAD_ALLOC_NAME = 'NOMAD_ALLOC_NAME'
 class NomadUtil:
     __metaclass__ = Singleton
 
-    def __init__(self, instance=None):
+    def __init__(self):
         self.docker_util = DockerUtil()
-        if instance is None:
-            log.debug("New NomadUtil instance")
-            self._container_tags_cache = {}
+        self._container_tags_cache = {}
 
     def extract_container_tags(self, co):
         """

--- a/utils/orchestrator/nomadutil.py
+++ b/utils/orchestrator/nomadutil.py
@@ -44,7 +44,6 @@ class NomadUtil:
         if co_id in self._container_tags_cache:
             created, tags = self._container_tags_cache[co_id]
             if created == co.get('Created', -1):
-                log.debug("Gettings nomad tags from cache")
                 return tags
 
         tags = []
@@ -61,11 +60,9 @@ class NomadUtil:
                         start = var.index('.', len(NOMAD_ALLOC_NAME)) + 1
                         end = var.index('[')
                         tags.append('nomad_group:%s' % var[start:end])
-                        log.debug("Gettings nomad tags from docker")
                     except ValueError:
                         pass
                     self._container_tags_cache[co_id] = (co.get('Created'), tags)
-                    log.debug(self._container_tags_cache)
         except Exception as e:
             log.warning("Error while parsing Nomad tags: %s" % str(e))
         finally:
@@ -79,7 +76,6 @@ class NomadUtil:
         try:
             for ev in events:
                 if ev.get('status') == 'die' and ev.get('id') in self._container_tags_cache:
-                    log.debug("Invalidating nomad cache for %s" % ev.get('id'))
                     del self._container_tags_cache[ev.get('id')]
                     log.debug(self._container_tags_cache)
         except Exception as e:

--- a/utils/orchestrator/nomadutil.py
+++ b/utils/orchestrator/nomadutil.py
@@ -23,26 +23,6 @@ class NomadUtil:
         if instance is None:
             log.debug("New NomadUtil instance")
             self._container_tags_cache = {}
-            self._enabled = None
-
-    def init_platform(self, agentConfig):
-        """
-        Enable/disable Nomad support depending on the docker_orchestrator config file entry
-        :param agentConfig: dict from config.get_config()
-        """
-        self._enabled = agentConfig.get('docker_orchestrator', None) == 'nomad'
-
-    def is_enabled(self):
-        """
-        Allows user classes to check whether nomad is to be activated.
-        init_platform has to be called once first
-        :return: True/False
-        """
-        if self._enabled is None:
-            log.warning("Calling nomad.is_nomad before init_platform, replying False")
-            return False
-        else:
-            return self._enabled
 
     def extract_container_tags(self, co):
         """

--- a/utils/orchestrator/nomadutil.py
+++ b/utils/orchestrator/nomadutil.py
@@ -59,6 +59,8 @@ class NomadUtil:
                     try:
                         start = var.index('.', len(NOMAD_ALLOC_NAME)) + 1
                         end = var.index('[')
+                        if end <= start:
+                            raise ValueError("Error extracting group from %s, check format" % var)
                         tags.append('nomad_group:%s' % var[start:end])
                     except ValueError:
                         pass
@@ -77,6 +79,5 @@ class NomadUtil:
             for ev in events:
                 if ev.get('status') == 'die' and ev.get('id') in self._container_tags_cache:
                     del self._container_tags_cache[ev.get('id')]
-                    log.debug(self._container_tags_cache)
         except Exception as e:
             log.warning("Error when invalidating nomad cache: " + str(e))

--- a/utils/platform.py
+++ b/utils/platform.py
@@ -104,3 +104,8 @@ class Platform(object):
     def is_swarm():
         from utils.dockerutil import DockerUtil
         return DockerUtil().is_swarm()
+
+    @staticmethod
+    def is_nomad():
+        from utils.dockerutil import DockerUtil
+        return DockerUtil().is_nomad()

--- a/utils/platform.py
+++ b/utils/platform.py
@@ -107,5 +107,5 @@ class Platform(object):
 
     @staticmethod
     def is_nomad():
-        from utils.dockerutil import DockerUtil
-        return DockerUtil().is_nomad()
+        from orchestrator import NomadUtil
+        return NomadUtil().is_enabled()

--- a/utils/platform.py
+++ b/utils/platform.py
@@ -107,5 +107,5 @@ class Platform(object):
 
     @staticmethod
     def is_nomad():
-        from orchestrator import NomadUtil
-        return NomadUtil().is_enabled()
+        return 'NOMAD_ALLOC_ID' in os.environ
+

--- a/utils/platform.py
+++ b/utils/platform.py
@@ -108,4 +108,3 @@ class Platform(object):
     @staticmethod
     def is_nomad():
         return 'NOMAD_ALLOC_ID' in os.environ
-

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -316,7 +316,7 @@ class SDDockerBackend(AbstractSDBackend):
             if swarm_svc:
                 tags.append('swarm_service:%s' % swarm_svc)
 
-        if Platform.is_rancher():
+        elif Platform.is_rancher():
             c_inspect = state.inspect_container(c_id)
             service_name = c_inspect.get('Config', {}).get('Labels', {}).get(RANCHER_SVC_NAME)
             stack_name = c_inspect.get('Config', {}).get('Labels', {}).get(RANCHER_STACK_NAME)
@@ -327,6 +327,11 @@ class SDDockerBackend(AbstractSDBackend):
                 tags.append('rancher_stack:%s' % stack_name)
             if container_name:
                 tags.append('rancher_container:%s' % container_name)
+
+        elif Platform.is_nomad():
+            nomad_tags = DockerUtil.extract_nomad_tags(state.inspect_container(c_id))
+            if nomad_tags:
+                tags.extend(list(nomad_tags))
 
         return tags
 

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -98,8 +98,8 @@ class SDDockerBackend(AbstractSDBackend):
                 log.error("Couldn't instantiate the kubernetes client, "
                     "subsequent kubernetes calls will fail as well. Error: %s" % str(ex))
 
-        self.nomadutil = NomadUtil()
-        self.nomadutil.init_platform(agentConfig)
+        if Platform.is_nomad():
+            self.nomadutil = NomadUtil()
 
         self.VAR_MAPPING = {
             'host': self._get_host_address,

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -22,6 +22,7 @@ from utils.kubernetes import KubeUtil
 from utils.platform import Platform
 from utils.service_discovery.abstract_sd_backend import AbstractSDBackend
 from utils.service_discovery.config_stores import get_config_store
+from utils.orchestrator import NomadUtil
 
 DATADOG_ID = 'com.datadoghq.sd.check.id'
 
@@ -96,6 +97,10 @@ class SDDockerBackend(AbstractSDBackend):
                 self.kubeutil = None
                 log.error("Couldn't instantiate the kubernetes client, "
                     "subsequent kubernetes calls will fail as well. Error: %s" % str(ex))
+
+        self.nomadutil = NomadUtil()
+        self.nomadutil.init_platform(agentConfig)
+
         self.VAR_MAPPING = {
             'host': self._get_host_address,
             'port': self._get_port,
@@ -329,7 +334,7 @@ class SDDockerBackend(AbstractSDBackend):
                 tags.append('rancher_container:%s' % container_name)
 
         elif Platform.is_nomad():
-            nomad_tags = DockerUtil().extract_nomad_tags(state.inspect_container(c_id))
+            nomad_tags = self.nomadutil.extract_container_tags(state.inspect_container(c_id))
             if nomad_tags:
                 tags.extend(list(nomad_tags))
 

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -336,7 +336,7 @@ class SDDockerBackend(AbstractSDBackend):
         elif Platform.is_nomad():
             nomad_tags = self.nomadutil.extract_container_tags(state.inspect_container(c_id))
             if nomad_tags:
-                tags.extend(list(nomad_tags))
+                tags.extend(nomad_tags)
 
         return tags
 

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -329,7 +329,7 @@ class SDDockerBackend(AbstractSDBackend):
                 tags.append('rancher_container:%s' % container_name)
 
         elif Platform.is_nomad():
-            nomad_tags = DockerUtil.extract_nomad_tags(state.inspect_container(c_id))
+            nomad_tags = DockerUtil().extract_nomad_tags(state.inspect_container(c_id))
             if nomad_tags:
                 tags.extend(list(nomad_tags))
 


### PR DESCRIPTION
### What does this PR do?

Detects the Nomad orchestrator and:
- adds job/group/task names as tags
- tags caching and cache invalidation

Auto-detection works via the NOMAD_ALLOC_ID envvar, so the dd-agent must run in a container started via Nomad (we need to write an example specfile)

## What's to do?
- docker_deamon intergration PR is https://github.com/DataDog/integrations-core/pull/305
