### PR TITLE
Revert "[core] SpooledTemporaryFile for subprocess output"

### DIFF
--- a/utils/subprocess_output.py
+++ b/utils/subprocess_output.py
@@ -3,7 +3,6 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 # stdlib
-from contextlib import nested
 from functools import wraps
 import logging
 import subprocess
@@ -11,21 +10,21 @@ import tempfile
 
 log = logging.getLogger(__name__)
 
+
 class SubprocessOutputEmptyError(Exception):
     pass
 
-# FIXME: python 2.7 has a far better way to do this
+
 def get_subprocess_output(command, log, raise_on_empty_output=True):
     """
-    Run the given subprocess command and return it's output. Raise an Exception
+    Run the given subprocess command and return its output. Raise an Exception
     if an error occurs.
     """
 
     # Use tempfile, allowing a larger amount of memory. The subprocess.Popen
     # docs warn that the data read is buffered in memory. They suggest not to
     # use subprocess.PIPE if the data size is large or unlimited.
-    with nested(tempfile.TemporaryFile(), tempfile.TemporaryFile()) as (stdout_f, stderr_f):
-
+    with tempfile.TemporaryFile() as stdout_f, tempfile.TemporaryFile() as stderr_f:
         proc = subprocess.Popen(command, stdout=stdout_f, stderr=stderr_f)
         proc.wait()
         stderr_f.seek(0)


### PR DESCRIPTION
Reverts DataDog/dd-agent#3002

Unfortunately, SpooledTemporaryFile and TemporaryFile behave the same in this case, because subprocess.Popen needs actual files.

Let's revert to avoid confusing people.