### PR TITLE
[trace-agent] restart on unexpected error code

### DIFF
--- a/packaging/supervisor.conf
+++ b/packaging/supervisor.conf
@@ -75,6 +75,8 @@ startsecs=5
 startretries=3
 priority=998
 user=dd-agent
+autorestart=unexpected
+exitcodes=0
 
 [group:datadog-agent]
 programs=forwarder,collector,dogstatsd,jmxfetch,go-metro,trace-agent


### PR DESCRIPTION
### What does this PR do?

This patch restarts the trace agent if it exits with an error code
that is different from 0. Else, it would restart in some cases but
would consider as 'expected' the return code 2 which is what Go
returns for builtin runtime errors.

### Motivation

Currently, some of our trace agents are dead and not restarted.

### Testing Guidelines

I tested it by replacing the trace agent by a dummy program that
would exit with code error 2 after some time (don't return it too
fast otherwise program is not considered as started).

* test it actually restarts the program when exiting on code 2
* test it still restarts the program when receiving a signal

Example testing session log:

```
2017-03-30 09:13:53,580 INFO success: trace-agent entered RUNNING state, process has stayed up for > than 5 seconds (startsecs)
2017-03-30 09:14:48,213 INFO exited: trace-agent (exit status 2; not expected)
2017-03-30 09:14:48,214 INFO spawned: 'trace-agent' with pid 14031
2017-03-30 09:14:54,089 INFO success: trace-agent entered RUNNING state, process has stayed up for > than 5 seconds (startsecs)
2017-03-30 09:15:20,051 INFO exited: trace-agent (terminated by SIGTERM; not expected)
2017-03-30 09:15:20,586 INFO spawned: 'trace-agent' with pid 14108
```

### Additional Notes

Related to https://github.com/DataDog/datadog-trace-agent/pull/254 and https://github.com/DataDog/datadog-trace-agent/pull/255

`exitcodes` and `autorestart` require at least version 3.0 of supervisord http://supervisord.org/configuration.html
