### PR TITLE
[docker] fix cgroup parsing

### DIFF
--- a/tests/core/test_dockerutil.py
+++ b/tests/core/test_dockerutil.py
@@ -1,0 +1,30 @@
+# stdlib
+import unittest
+
+# project
+from utils.dockerutil import DockerUtil
+
+
+class TestDockerUtil(unittest.TestCase):
+
+    def test_parse_subsystem(self):
+        lines = [
+            # (line, expected_result)
+            (
+                ['10', 'memory', '/2ea504688cad325b9105f183b0d7831266a05f95b513c7327a6e9989ce8a450a'],
+                '2ea504688cad325b9105f183b0d7831266a05f95b513c7327a6e9989ce8a450a'
+            ), (
+                ['10', 'memory', '/docker/2ea504688cad325b9105f183b0d7831266a05f95b513c7327a6e9989ce8a450a'],
+                'docker/2ea504688cad325b9105f183b0d7831266a05f95b513c7327a6e9989ce8a450a'
+            ), (
+                ['10', 'memory', '2ea504688cad325b9105f183b0d7831266a05f95b513c7327a6e9989ce8a450a'],
+                '2ea504688cad325b9105f183b0d7831266a05f95b513c7327a6e9989ce8a450a'
+            ), (
+                ['10', 'memory', '/docker/864daa0a0b19aa4703231b6c76f85c6f369b2452a5a7f777f0c9101c0fd5772a/docker/3bac629503293d1bb61e74f3e25b6c525f0c262f22974634c5d6988bb4b07927'],
+                'docker/3bac629503293d1bb61e74f3e25b6c525f0c262f22974634c5d6988bb4b07927'
+            )
+        ]
+
+        du = DockerUtil()
+        for line, exp_res in lines:
+            self.assertEquals(du._parse_subsystem(line), exp_res)

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -346,8 +346,21 @@ class DockerUtil:
 
     @classmethod
     def _parse_subsystem(cls, line):
+        """
+        If 'docker' is in the path, it can be there once or twice:
+        /docker/$CONTAINER_ID
+        /docker/$USER_DOCKER_CID/docker/$CONTAINER_ID
+        so we pick the last one.
+        In /host/sys/fs/cgroup/$CGROUP_FOLDER/ cgroup/container IDs can be at the root
+        or in a docker folder, so if we find 'docker/' in the path we don't strip it away.
+        """
         i = line[2].rfind('docker')
-        return line[2][i:]
+        if i != -1:  # rfind returns -1 if docker is not found
+            return line[2][i:]
+        elif line[2][0] == '/':
+            return line[2][1:]
+        else:
+            return line[2]
 
     @classmethod
     def find_cgroup_from_proc(cls, mountpoints, pid, subsys, docker_root='/'):


### PR DESCRIPTION
### What does this PR do?

cgroup parsing doesn't work if `docker` is not in the string

### Motivation

Regression in 5.12.2

### Testing Guidelines

Now with unit test.