### PR TITLE
[k8s] KubeUtil + SD service and creator tags

### DIFF
--- a/tests/core/fixtures/kubeutil/service_cache_events1.json
+++ b/tests/core/fixtures/kubeutil/service_cache_events1.json
@@ -1,0 +1,91 @@
+{
+  "kind": "EventList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/namespaces/default/events",
+    "resourceVersion": "2707"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "frontend-hello.14b2c5c0ac899bef",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/frontend-hello.14b2c5c0ac899bef",
+        "uid": "9a59dcf8-1aad-11e7-8b67-42010a840226",
+        "resourceVersion": "2704",
+        "creationTimestamp": "2017-04-06T09:44:17Z"
+      },
+      "involvedObject": {
+        "kind": "Service",
+        "namespace": "default",
+        "name": "frontend-hello",
+        "uid": "9467fc38-1aad-11e7-8b67-42010a840226",
+        "apiVersion": "v1",
+        "resourceVersion": "661817"
+      },
+      "reason": "CreatingLoadBalancer",
+      "message": "Creating load balancer",
+      "source": {
+        "component": "service-controller"
+      },
+      "firstTimestamp": "2017-04-06T09:44:17Z",
+      "lastTimestamp": "2017-04-06T09:44:17Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "frontend-hello.14b2c5cb738e7515",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/frontend-hello.14b2c5cb738e7515",
+        "uid": "b5f0f2be-1aad-11e7-8b67-42010a840226",
+        "resourceVersion": "2706",
+        "creationTimestamp": "2017-04-06T09:45:04Z"
+      },
+      "involvedObject": {
+        "kind": "Service",
+        "namespace": "default",
+        "name": "frontend-hello",
+        "uid": "9467fc38-1aad-11e7-8b67-42010a840226",
+        "apiVersion": "v1",
+        "resourceVersion": "661817"
+      },
+      "reason": "CreatedLoadBalancer",
+      "message": "Created load balancer",
+      "source": {
+        "component": "service-controller"
+      },
+      "firstTimestamp": "2017-04-06T09:45:04Z",
+      "lastTimestamp": "2017-04-06T09:45:04Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "redis-hello.14b2c5cb741560aa",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/redis-hello.14b2c5cb741560aa",
+        "uid": "b5f2383f-1aad-11e7-8b67-42010a840226",
+        "resourceVersion": "2707",
+        "creationTimestamp": "2017-04-06T09:45:04Z"
+      },
+      "involvedObject": {
+        "kind": "Service",
+        "namespace": "default",
+        "name": "redis-hello",
+        "uid": "9474d98a-1aad-11e7-8b67-42010a840226",
+        "apiVersion": "v1",
+        "resourceVersion": "661821"
+      },
+      "reason": "CreatingLoadBalancer",
+      "message": "Creating load balancer",
+      "source": {
+        "component": "service-controller"
+      },
+      "firstTimestamp": "2017-04-06T09:45:04Z",
+      "lastTimestamp": "2017-04-06T09:45:04Z",
+      "count": 1,
+      "type": "Normal"
+    }
+  ]
+}

--- a/tests/core/fixtures/kubeutil/service_cache_events2.json
+++ b/tests/core/fixtures/kubeutil/service_cache_events2.json
@@ -1,0 +1,145 @@
+{
+  "kind": "EventList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/namespaces/default/events",
+    "resourceVersion": "2709"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "all-hello.14b2c5d6e72d8d72",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/all-hello.14b2c5d6e72d8d72",
+        "uid": "d341d3aa-1aad-11e7-8b67-42010a840226",
+        "resourceVersion": "2709",
+        "creationTimestamp": "2017-04-06T09:45:53Z"
+      },
+      "involvedObject": {
+        "kind": "Service",
+        "namespace": "default",
+        "name": "all-hello",
+        "uid": "94813607-1aad-11e7-8b67-42010a840226",
+        "apiVersion": "v1",
+        "resourceVersion": "661825"
+      },
+      "reason": "CreatingLoadBalancer",
+      "message": "Creating load balancer",
+      "source": {
+        "component": "service-controller"
+      },
+      "firstTimestamp": "2017-04-06T09:45:53Z",
+      "lastTimestamp": "2017-04-06T09:45:53Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "frontend-hello.14b2c5c0ac899bef",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/frontend-hello.14b2c5c0ac899bef",
+        "uid": "9a59dcf8-1aad-11e7-8b67-42010a840226",
+        "resourceVersion": "2704",
+        "creationTimestamp": "2017-04-06T09:44:17Z"
+      },
+      "involvedObject": {
+        "kind": "Service",
+        "namespace": "default",
+        "name": "frontend-hello",
+        "uid": "9467fc38-1aad-11e7-8b67-42010a840226",
+        "apiVersion": "v1",
+        "resourceVersion": "661817"
+      },
+      "reason": "CreatingLoadBalancer",
+      "message": "Creating load balancer",
+      "source": {
+        "component": "service-controller"
+      },
+      "firstTimestamp": "2017-04-06T09:44:17Z",
+      "lastTimestamp": "2017-04-06T09:44:17Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "frontend-hello.14b2c5cb738e7515",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/frontend-hello.14b2c5cb738e7515",
+        "uid": "b5f0f2be-1aad-11e7-8b67-42010a840226",
+        "resourceVersion": "2706",
+        "creationTimestamp": "2017-04-06T09:45:04Z"
+      },
+      "involvedObject": {
+        "kind": "Service",
+        "namespace": "default",
+        "name": "frontend-hello",
+        "uid": "9467fc38-1aad-11e7-8b67-42010a840226",
+        "apiVersion": "v1",
+        "resourceVersion": "661817"
+      },
+      "reason": "CreatedLoadBalancer",
+      "message": "Created load balancer",
+      "source": {
+        "component": "service-controller"
+      },
+      "firstTimestamp": "2017-04-06T09:45:04Z",
+      "lastTimestamp": "2017-04-06T09:45:04Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "redis-hello.14b2c5cb741560aa",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/redis-hello.14b2c5cb741560aa",
+        "uid": "b5f2383f-1aad-11e7-8b67-42010a840226",
+        "resourceVersion": "2707",
+        "creationTimestamp": "2017-04-06T09:45:04Z"
+      },
+      "involvedObject": {
+        "kind": "Service",
+        "namespace": "default",
+        "name": "redis-hello",
+        "uid": "9474d98a-1aad-11e7-8b67-42010a840226",
+        "apiVersion": "v1",
+        "resourceVersion": "661821"
+      },
+      "reason": "CreatingLoadBalancer",
+      "message": "Creating load balancer",
+      "source": {
+        "component": "service-controller"
+      },
+      "firstTimestamp": "2017-04-06T09:45:04Z",
+      "lastTimestamp": "2017-04-06T09:45:04Z",
+      "count": 1,
+      "type": "Normal"
+    },
+    {
+      "metadata": {
+        "name": "redis-hello.14b2c5d6e6a9d51a",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/events/redis-hello.14b2c5d6e6a9d51a",
+        "uid": "d3409bb2-1aad-11e7-8b67-42010a840226",
+        "resourceVersion": "2708",
+        "creationTimestamp": "2017-04-06T09:45:53Z"
+      },
+      "involvedObject": {
+        "kind": "Service",
+        "namespace": "default",
+        "name": "redis-hello",
+        "uid": "9474d98a-1aad-11e7-8b67-42010a840226",
+        "apiVersion": "v1",
+        "resourceVersion": "661821"
+      },
+      "reason": "CreatedLoadBalancer",
+      "message": "Created load balancer",
+      "source": {
+        "component": "service-controller"
+      },
+      "firstTimestamp": "2017-04-06T09:45:53Z",
+      "lastTimestamp": "2017-04-06T09:45:53Z",
+      "count": 1,
+      "type": "Normal"
+    }
+  ]
+}

--- a/tests/core/fixtures/kubeutil/service_cache_services1.json
+++ b/tests/core/fixtures/kubeutil/service_cache_services1.json
@@ -1,0 +1,112 @@
+{
+  "kind": "ServiceList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/namespaces/default/services",
+    "resourceVersion": "661906"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "frontend-hello",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/services/frontend-hello",
+        "uid": "9467fc38-1aad-11e7-8b67-42010a840226",
+        "resourceVersion": "661901",
+        "creationTimestamp": "2017-04-06T09:44:07Z",
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"frontend-hello\",\"creationTimestamp\":null},\"spec\":{\"ports\":[{\"protocol\":\"TCP\",\"port\":80,\"targetPort\":80}],\"selector\":{\"app\":\"hello\",\"tier\":\"frontend\"},\"type\":\"LoadBalancer\"},\"status\":{\"loadBalancer\":{}}}"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 80,
+            "nodePort": 30974
+          }
+        ],
+        "selector": {
+          "app": "hello",
+          "tier": "frontend"
+        },
+        "clusterIP": "10.123.253.108",
+        "type": "LoadBalancer",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {
+          "ingress": [
+            {
+              "ip": "104.155.24.156"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetes",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/services/kubernetes",
+        "uid": "03114268-1615-11e7-8b67-42010a840226",
+        "resourceVersion": "8",
+        "creationTimestamp": "2017-03-31T13:21:55Z",
+        "labels": {
+          "component": "apiserver",
+          "provider": "kubernetes"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "https",
+            "protocol": "TCP",
+            "port": 443,
+            "targetPort": 443
+          }
+        ],
+        "clusterIP": "10.123.240.1",
+        "type": "ClusterIP",
+        "sessionAffinity": "ClientIP"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "metadata": {
+        "name": "redis-hello",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/services/redis-hello",
+        "uid": "9474d98a-1aad-11e7-8b67-42010a840226",
+        "resourceVersion": "661821",
+        "creationTimestamp": "2017-04-06T09:44:08Z",
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"redis-hello\",\"creationTimestamp\":null},\"spec\":{\"ports\":[{\"protocol\":\"TCP\",\"port\":6379,\"targetPort\":6379}],\"selector\":{\"app\":\"hello\",\"tier\":\"db\"},\"type\":\"LoadBalancer\"},\"status\":{\"loadBalancer\":{}}}"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 6379,
+            "targetPort": 6379,
+            "nodePort": 32166
+          }
+        ],
+        "selector": {
+          "app": "hello",
+          "tier": "db"
+        },
+        "clusterIP": "10.123.249.212",
+        "type": "LoadBalancer",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}

--- a/tests/core/fixtures/kubeutil/service_cache_services2.json
+++ b/tests/core/fixtures/kubeutil/service_cache_services2.json
@@ -1,0 +1,144 @@
+{
+  "kind": "ServiceList",
+  "apiVersion": "v1",
+  "metadata": {
+    "selfLink": "/api/v1/namespaces/default/services",
+    "resourceVersion": "661906"
+  },
+  "items": [
+    {
+      "metadata": {
+        "name": "all-hello",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/services/all-hello",
+        "uid": "94813607-1aad-11e7-8b67-42010a840226",
+        "resourceVersion": "661825",
+        "creationTimestamp": "2017-04-06T09:44:08Z",
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"all-hello\",\"creationTimestamp\":null},\"spec\":{\"ports\":[{\"protocol\":\"TCP\",\"port\":6666,\"targetPort\":6666}],\"selector\":{\"app\":\"hello\"},\"type\":\"LoadBalancer\"},\"status\":{\"loadBalancer\":{}}}"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 6666,
+            "targetPort": 6666,
+            "nodePort": 32757
+          }
+        ],
+        "selector": {
+          "app": "hello"
+        },
+        "clusterIP": "10.123.241.90",
+        "type": "LoadBalancer",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "metadata": {
+        "name": "frontend-hello",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/services/frontend-hello",
+        "uid": "9467fc38-1aad-11e7-8b67-42010a840226",
+        "resourceVersion": "661901",
+        "creationTimestamp": "2017-04-06T09:44:07Z",
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"frontend-hello\",\"creationTimestamp\":null},\"spec\":{\"ports\":[{\"protocol\":\"TCP\",\"port\":80,\"targetPort\":80}],\"selector\":{\"app\":\"hello\",\"tier\":\"frontend\"},\"type\":\"LoadBalancer\"},\"status\":{\"loadBalancer\":{}}}"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 80,
+            "targetPort": 80,
+            "nodePort": 30974
+          }
+        ],
+        "selector": {
+          "app": "hello",
+          "tier": "frontend"
+        },
+        "clusterIP": "10.123.253.108",
+        "type": "LoadBalancer",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {
+          "ingress": [
+            {
+              "ip": "104.155.24.156"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetes",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/services/kubernetes",
+        "uid": "03114268-1615-11e7-8b67-42010a840226",
+        "resourceVersion": "8",
+        "creationTimestamp": "2017-03-31T13:21:55Z",
+        "labels": {
+          "component": "apiserver",
+          "provider": "kubernetes"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "https",
+            "protocol": "TCP",
+            "port": 443,
+            "targetPort": 443
+          }
+        ],
+        "clusterIP": "10.123.240.1",
+        "type": "ClusterIP",
+        "sessionAffinity": "ClientIP"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "metadata": {
+        "name": "redis-hello",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/services/redis-hello",
+        "uid": "9474d98a-1aad-11e7-8b67-42010a840226",
+        "resourceVersion": "661821",
+        "creationTimestamp": "2017-04-06T09:44:08Z",
+        "annotations": {
+          "kubectl.kubernetes.io/last-applied-configuration": "{\"kind\":\"Service\",\"apiVersion\":\"v1\",\"metadata\":{\"name\":\"redis-hello\",\"creationTimestamp\":null},\"spec\":{\"ports\":[{\"protocol\":\"TCP\",\"port\":6379,\"targetPort\":6379}],\"selector\":{\"app\":\"hello\",\"tier\":\"db\"},\"type\":\"LoadBalancer\"},\"status\":{\"loadBalancer\":{}}}"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 6379,
+            "targetPort": 6379,
+            "nodePort": 32166
+          }
+        ],
+        "selector": {
+          "app": "hello",
+          "tier": "db"
+        },
+        "clusterIP": "10.123.249.212",
+        "type": "LoadBalancer",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    }
+  ]
+}

--- a/tests/core/test_kube_event_retriever.py
+++ b/tests/core/test_kube_event_retriever.py
@@ -1,0 +1,71 @@
+# stdlib
+import unittest
+
+# 3rd party
+from mock import patch
+
+# project
+from utils.kubernetes import KubeUtil, KubeEventRetriever
+from tests.core.test_kubeutil import KubeTestCase
+
+
+class TestKubeEventRetriever(KubeTestCase):
+    @classmethod
+    def _build_events(cls, specs):
+        """
+        Returns an eventlist from specs in the form [(namespace, kind)]
+        """
+        resVersion = 0
+        items = []
+        for ns, kind in specs:
+            resVersion += 1
+            i = {}
+            i['metadata'] = {'resourceVersion': resVersion, 'namespace': ns}
+            i['involvedObject'] = {'kind': kind, 'namespace': ns}
+            items.append(i)
+        return {'items': items}
+
+    def test_events_resversion_filtering(self):
+        jsons = self._load_json_array(
+            ['service_cache_events1.json', 'service_cache_events2.json', 'service_cache_events2.json'])
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            retr = KubeEventRetriever(self.kube)
+
+            events = retr.get_event_array()
+            self.assertEquals(3, len(events))
+            self.assertEquals(2707, retr.last_resversion)
+            events = retr.get_event_array()
+            self.assertEquals(2, len(events))   # 5 events total
+            self.assertEquals(2709, retr.last_resversion)
+            events = retr.get_event_array()
+            self.assertEquals(0, len(events))   # No new event
+            self.assertEquals(2709, retr.last_resversion)
+
+    def test_namespace_serverside_filtering(self):
+        with patch.object(self.kube, 'retrieve_json_auth', return_value={}) as mock_method:
+            retr = KubeEventRetriever(self.kube, namespaces=['testns'])
+            events = retr.get_event_array()
+        mock_method.assert_called_once_with('https://kubernetes/api/v1/namespaces/testns/events', params={})
+
+    def test_namespace_clientside_filtering(self):
+        val = self._build_events([('ns1', 'k1'), ('ns2', 'k1'), ('testns', 'k1')])
+        with patch.object(self.kube, 'retrieve_json_auth', return_value=val) as mock_method:
+            retr = KubeEventRetriever(self.kube, namespaces=['testns', 'ns2'])
+            events = retr.get_event_array()
+            self.assertEquals(2, len(events))
+        mock_method.assert_called_once_with('https://kubernetes/api/v1/events', params={})
+
+    def test_kind_serverside_filtering(self):
+        with patch.object(self.kube, 'retrieve_json_auth', return_value={}) as mock_method:
+            retr = KubeEventRetriever(self.kube, kinds=['k1'])
+            events = retr.get_event_array()
+        mock_method.assert_called_once_with('https://kubernetes/api/v1/events',
+                                            params={'fieldSelector': 'involvedObject.kind=k1'})
+
+    def test_kind_clientside_filtering(self):
+        val = self._build_events([('ns1', 'k1'), ('ns1', 'k1'), ('ns1', 'k2'), ('ns1', 'k3')])
+        with patch.object(self.kube, 'retrieve_json_auth', return_value=val) as mock_method:
+            retr = KubeEventRetriever(self.kube, kinds=['k1', 'k2'])
+            events = retr.get_event_array()
+            self.assertEquals(3, len(events))
+        mock_method.assert_called_once_with('https://kubernetes/api/v1/events', params={})

--- a/tests/core/test_kube_event_retriever.py
+++ b/tests/core/test_kube_event_retriever.py
@@ -1,11 +1,8 @@
-# stdlib
-import unittest
-
 # 3rd party
 from mock import patch
 
 # project
-from utils.kubernetes import KubeUtil, KubeEventRetriever
+from utils.kubernetes import KubeEventRetriever
 from tests.core.test_kubeutil import KubeTestCase
 
 
@@ -44,7 +41,7 @@ class TestKubeEventRetriever(KubeTestCase):
     def test_namespace_serverside_filtering(self):
         with patch.object(self.kube, 'retrieve_json_auth', return_value={}) as mock_method:
             retr = KubeEventRetriever(self.kube, namespaces=['testns'])
-            events = retr.get_event_array()
+            retr.get_event_array()
         mock_method.assert_called_once_with('https://kubernetes/api/v1/namespaces/testns/events', params={})
 
     def test_namespace_clientside_filtering(self):
@@ -58,7 +55,7 @@ class TestKubeEventRetriever(KubeTestCase):
     def test_kind_serverside_filtering(self):
         with patch.object(self.kube, 'retrieve_json_auth', return_value={}) as mock_method:
             retr = KubeEventRetriever(self.kube, kinds=['k1'])
-            events = retr.get_event_array()
+            retr.get_event_array()
         mock_method.assert_called_once_with('https://kubernetes/api/v1/events',
                                             params={'fieldSelector': 'involvedObject.kind=k1'})
 

--- a/tests/core/test_kube_pod_service_mapper.py
+++ b/tests/core/test_kube_pod_service_mapper.py
@@ -1,0 +1,163 @@
+# 3rd party
+from mock import patch
+
+# project
+from utils.kubernetes import PodServiceMapper
+from tests.core.test_kubeutil import KubeTestCase
+
+ALL_HELLO_UID = "94813607-1aad-11e7-8b67-42010a840226"
+REDIS_HELLO_UID = "9474d98a-1aad-11e7-8b67-42010a840226"
+
+
+class TestKubePodServiceMapper(KubeTestCase):
+    @classmethod
+    def _build_pod_metadata(cls, uid, labels=None):
+        c = {'uid': uid}
+        if labels is not None:
+            c['labels'] = labels
+        return c
+
+    def setUp(self):
+        KubeTestCase.setUp(self)
+        self.mapper = PodServiceMapper(self.kube)
+
+    def tearDown(self):
+        self.mapper = None
+        KubeTestCase.tearDown(self)
+
+    def test_init(self):
+        self.assertEqual(0, len(self.mapper._service_cache_selectors))
+        self.assertEqual(0, len(self.mapper._service_cache_names))
+        self.assertEqual(True, self.mapper._service_cache_invalidated)
+        self.assertEqual(-1, self.mapper._service_cache_last_event_resversion)
+        self.assertEqual(0, len(self.mapper._pod_labels_cache))
+        self.assertEqual(0, len(self.mapper._pod_services_mapping))
+
+    def test_service_cache_fill(self):
+        jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            self.mapper._fill_services_cache()
+        # Kubernetes service not imported because no selector
+        self.assertEqual(3, len(self.mapper._service_cache_selectors))
+        self.assertEqual(3, len(self.mapper._service_cache_names))
+        self.assertEqual(False, self.mapper._service_cache_invalidated)
+        self.assertEqual(2709, self.mapper._service_cache_last_event_resversion)
+
+        self.assertEqual(
+            'redis-hello', self.mapper._service_cache_names['9474d98a-1aad-11e7-8b67-42010a840226'])
+        redis = self.mapper._service_cache_selectors['9474d98a-1aad-11e7-8b67-42010a840226']
+        self.assertEqual(2, len(redis))
+        self.assertEqual('hello', redis['app'])
+        self.assertEqual('db', redis['tier'])
+
+    def test_service_cache_invalidation_true(self):
+        jsons = self._load_json_array(
+            ['service_cache_events1.json', 'service_cache_services1.json', 'service_cache_events2.json'])
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            self.mapper._fill_services_cache()
+            self.assertEqual(2707, self.mapper._service_cache_last_event_resversion)
+            self.mapper.check_services_cache_freshness()
+            self.assertEqual(True, self.mapper._service_cache_invalidated)
+            self.assertEqual(2709, self.mapper._service_cache_last_event_resversion)
+
+    def test_service_cache_invalidation_false(self):
+        jsons = self._load_json_array(
+            ['service_cache_events1.json', 'service_cache_services1.json', 'service_cache_events1.json'])
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            self.mapper._fill_services_cache()
+            self.assertEqual(2707, self.mapper._service_cache_last_event_resversion)
+            self.mapper.check_services_cache_freshness()
+            self.assertEqual(False, self.mapper._service_cache_invalidated)
+            self.assertEqual(2707, self.mapper._service_cache_last_event_resversion)
+
+    def test_pod_to_service_no_match(self):
+        jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            self.mapper._fill_services_cache()
+            no_match = self._build_pod_metadata(0, {'app': 'unknown'})
+            self.assertEqual(0, len(self.mapper.match_services_for_pod(no_match)))
+
+    def test_pod_to_service_two_matches(self):
+        self.assertEqual(0, len(self.mapper._pod_services_mapping))
+        jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            two_matches = self._build_pod_metadata(0, {'app': 'hello', 'tier': 'db'})
+            self.assertEqual(sorted(['9474d98a-1aad-11e7-8b67-42010a840226',
+                                     '94813607-1aad-11e7-8b67-42010a840226']),
+                             sorted(self.mapper.match_services_for_pod(two_matches)))
+            self.assertEqual(sorted(['redis-hello', 'all-hello']),
+                             sorted(self.mapper.match_services_for_pod(two_matches, names=True)))
+
+    def test_pod_to_service_cache(self):
+        self.assertEqual(0, len(self.mapper._pod_services_mapping))
+        jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            two_matches = self._build_pod_metadata(0, {'app': 'hello', 'tier': 'db'})
+            self.assertEqual(sorted(['redis-hello', 'all-hello']),
+                             sorted(self.mapper.match_services_for_pod(two_matches, names=True)))
+            # Mapper should find the uid in the cache and return without label matching
+            self.assertEqual(sorted(['redis-hello', 'all-hello']),
+                             sorted(self.mapper.match_services_for_pod({'uid': 0}, names=True)))
+
+    def test_pods_for_service(self):
+        jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            # Fill pod label cache
+            self.mapper.match_services_for_pod(self._build_pod_metadata(0, {'app': 'hello', 'tier': 'db'}))
+            self.mapper.match_services_for_pod(self._build_pod_metadata(1, {'app': 'hello', 'tier': 'db'}))
+            self.mapper.match_services_for_pod(self._build_pod_metadata(2, {'app': 'nope', 'tier': 'db'}))
+            self.mapper.match_services_for_pod(self._build_pod_metadata(3, {'app': 'hello', 'tier': 'nope'}))
+
+            self.assertEqual([0, 1, 3], sorted(self.mapper.search_pods_for_service(ALL_HELLO_UID)))
+            self.assertEqual([0, 1], sorted(self.mapper.search_pods_for_service(REDIS_HELLO_UID)))
+            self.assertEqual([], sorted(self.mapper.search_pods_for_service("invalid")))
+
+    def _prepare_for_events_tests(self, jsonfiles):
+        jsons = self._load_json_array(jsonfiles)
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            # Fill pod label cache
+            self.mapper.match_services_for_pod(self._build_pod_metadata(0, {'app': 'hello', 'tier': 'db'}))
+            self.mapper.match_services_for_pod(self._build_pod_metadata(1, {'app': 'hello', 'tier': 'db'}))
+            self.mapper.match_services_for_pod(self._build_pod_metadata(2, {'app': 'nope', 'tier': 'db'}))
+            self.mapper.match_services_for_pod(self._build_pod_metadata(3, {'app': 'hello', 'tier': 'nope'}))
+
+    def test_event_pod_invalidation(self):
+        self._prepare_for_events_tests(['service_cache_events2.json', 'service_cache_services2.json'])
+        self.assertTrue(0 in self.mapper._pod_labels_cache)
+        self.assertTrue(0 in self.mapper._pod_services_mapping)
+        self.assertTrue(1 in self.mapper._pod_labels_cache)
+        self.assertTrue(1 in self.mapper._pod_services_mapping)
+
+        event = {'involvedObject': {'kind': 'Pod', 'uid': 0}, 'reason': 'Killing'}
+        self.assertEqual(0, len(self.mapper.process_events([event])))
+
+        self.assertFalse(0 in self.mapper._pod_labels_cache)
+        self.assertFalse(0 in self.mapper._pod_services_mapping)
+        self.assertTrue(1 in self.mapper._pod_labels_cache)
+        self.assertTrue(1 in self.mapper._pod_services_mapping)
+
+    def test_event_service_deleted_invalidation(self):
+        self._prepare_for_events_tests(['service_cache_events2.json', 'service_cache_services2.json'])
+        self.assertEqual(2, len(self.mapper.match_services_for_pod({'uid': 0})))
+
+        event = {'involvedObject': {'kind': 'Service', 'uid': REDIS_HELLO_UID},
+                 'reason': 'DeletedLoadBalancer'}
+        # Two pods must be reloaded
+        self.assertEqual(set([0, 1]), self.mapper.process_events([event]))
+        # redis-hello service removed from pod mapping
+        self.assertEqual(1, len(self.mapper.match_services_for_pod({'uid': 0})))
+
+    def test_event_service_created_invalidation(self):
+        self._prepare_for_events_tests(['service_cache_events1.json', 'service_cache_services1.json'])
+        self.assertEqual(1, len(self.mapper.match_services_for_pod(
+            self._build_pod_metadata(0, {'app': 'hello', 'tier': 'db'}))))
+
+        event = {'involvedObject': {'kind': 'Service', 'uid': ALL_HELLO_UID},
+                 'reason': 'CreatedLoadBalancer'}
+        jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            # Three pods must be reloaded
+            self.assertEqual(set([0, 1, 3]), self.mapper.process_events([event]))
+            # all-hello service added to pod mapping
+            self.assertEqual(2, len(self.mapper.match_services_for_pod(
+                self._build_pod_metadata(0, {'app': 'hello', 'tier': 'db'}))))

--- a/tests/core/test_kube_pod_service_mapper.py
+++ b/tests/core/test_kube_pod_service_mapper.py
@@ -19,33 +19,29 @@ class TestKubePodServiceMapper(KubeTestCase):
 
     def setUp(self):
         KubeTestCase.setUp(self)
-        self.mapper = PodServiceMapper(self.kube)
 
     def tearDown(self):
-        self.mapper = None
         KubeTestCase.tearDown(self)
 
     def test_init(self):
-        self.assertEqual(0, len(self.mapper._service_cache_selectors))
-        self.assertEqual(0, len(self.mapper._service_cache_names))
-        self.assertEqual(True, self.mapper._service_cache_invalidated)
-        self.assertEqual(-1, self.mapper._service_cache_last_event_resversion)
-        self.assertEqual(0, len(self.mapper._pod_labels_cache))
-        self.assertEqual(0, len(self.mapper._pod_services_mapping))
+        mapper = PodServiceMapper(self.kube)
+        self.assertEqual(0, len(mapper._service_cache_selectors))
+        self.assertEqual(0, len(mapper._service_cache_names))
+        self.assertEqual(True, mapper._service_cache_invalidated)
+        self.assertEqual(0, len(mapper._pod_labels_cache))
+        self.assertEqual(0, len(mapper._pod_services_mapping))
 
     def test_service_cache_fill(self):
         jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
         with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
-            self.mapper._fill_services_cache()
+            mapper = PodServiceMapper(self.kube)
+            mapper._fill_services_cache()
         # Kubernetes service not imported because no selector
-        self.assertEqual(3, len(self.mapper._service_cache_selectors))
-        self.assertEqual(3, len(self.mapper._service_cache_names))
-        self.assertEqual(False, self.mapper._service_cache_invalidated)
-        self.assertEqual(2709, self.mapper._service_cache_last_event_resversion)
+        self.assertEqual(3, len(mapper._service_cache_selectors))
+        self.assertEqual(3, len(mapper._service_cache_names))
 
-        self.assertEqual(
-            'redis-hello', self.mapper._service_cache_names['9474d98a-1aad-11e7-8b67-42010a840226'])
-        redis = self.mapper._service_cache_selectors['9474d98a-1aad-11e7-8b67-42010a840226']
+        self.assertEqual('redis-hello', mapper._service_cache_names['9474d98a-1aad-11e7-8b67-42010a840226'])
+        redis = mapper._service_cache_selectors['9474d98a-1aad-11e7-8b67-42010a840226']
         self.assertEqual(2, len(redis))
         self.assertEqual('hello', redis['app'])
         self.assertEqual('db', redis['tier'])
@@ -54,102 +50,107 @@ class TestKubePodServiceMapper(KubeTestCase):
         jsons = self._load_json_array(
             ['service_cache_events1.json', 'service_cache_services1.json', 'service_cache_events2.json'])
         with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
-            self.mapper._fill_services_cache()
-            self.assertEqual(2707, self.mapper._service_cache_last_event_resversion)
-            self.mapper.check_services_cache_freshness()
-            self.assertEqual(True, self.mapper._service_cache_invalidated)
-            self.assertEqual(2709, self.mapper._service_cache_last_event_resversion)
+            mapper = PodServiceMapper(self.kube)
+            mapper._fill_services_cache()
+            mapper.check_services_cache_freshness()
+            self.assertEqual(True, mapper._service_cache_invalidated)
 
     def test_service_cache_invalidation_false(self):
         jsons = self._load_json_array(
             ['service_cache_events1.json', 'service_cache_services1.json', 'service_cache_events1.json'])
         with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
-            self.mapper._fill_services_cache()
-            self.assertEqual(2707, self.mapper._service_cache_last_event_resversion)
-            self.mapper.check_services_cache_freshness()
-            self.assertEqual(False, self.mapper._service_cache_invalidated)
-            self.assertEqual(2707, self.mapper._service_cache_last_event_resversion)
+            mapper = PodServiceMapper(self.kube)
+            self.assertEqual(True, mapper._service_cache_invalidated)
+            mapper._fill_services_cache()
+            self.assertEqual(False, mapper._service_cache_invalidated)
+            mapper.check_services_cache_freshness()
+            self.assertEqual(False, mapper._service_cache_invalidated)
 
     def test_pod_to_service_no_match(self):
         jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
         with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
-            self.mapper._fill_services_cache()
+            mapper = PodServiceMapper(self.kube)
+            mapper._fill_services_cache()
             no_match = self._build_pod_metadata(0, {'app': 'unknown'})
-            self.assertEqual(0, len(self.mapper.match_services_for_pod(no_match)))
+            self.assertEqual(0, len(mapper.match_services_for_pod(no_match)))
 
     def test_pod_to_service_two_matches(self):
-        self.assertEqual(0, len(self.mapper._pod_services_mapping))
         jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
         with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            mapper = PodServiceMapper(self.kube)
             two_matches = self._build_pod_metadata(0, {'app': 'hello', 'tier': 'db'})
             self.assertEqual(sorted(['9474d98a-1aad-11e7-8b67-42010a840226',
                                      '94813607-1aad-11e7-8b67-42010a840226']),
-                             sorted(self.mapper.match_services_for_pod(two_matches)))
+                             sorted(mapper.match_services_for_pod(two_matches)))
             self.assertEqual(sorted(['redis-hello', 'all-hello']),
-                             sorted(self.mapper.match_services_for_pod(two_matches, names=True)))
+                             sorted(mapper.match_services_for_pod(two_matches, names=True)))
 
     def test_pod_to_service_cache(self):
-        self.assertEqual(0, len(self.mapper._pod_services_mapping))
         jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
         with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            mapper = PodServiceMapper(self.kube)
             two_matches = self._build_pod_metadata(0, {'app': 'hello', 'tier': 'db'})
             self.assertEqual(sorted(['redis-hello', 'all-hello']),
-                             sorted(self.mapper.match_services_for_pod(two_matches, names=True)))
+                             sorted(mapper.match_services_for_pod(two_matches, names=True)))
             # Mapper should find the uid in the cache and return without label matching
             self.assertEqual(sorted(['redis-hello', 'all-hello']),
-                             sorted(self.mapper.match_services_for_pod({'uid': 0}, names=True)))
+                             sorted(mapper.match_services_for_pod({'uid': 0}, names=True)))
 
     def test_pods_for_service(self):
         jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
         with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
             # Fill pod label cache
-            self.mapper.match_services_for_pod(self._build_pod_metadata(0, {'app': 'hello', 'tier': 'db'}))
-            self.mapper.match_services_for_pod(self._build_pod_metadata(1, {'app': 'hello', 'tier': 'db'}))
-            self.mapper.match_services_for_pod(self._build_pod_metadata(2, {'app': 'nope', 'tier': 'db'}))
-            self.mapper.match_services_for_pod(self._build_pod_metadata(3, {'app': 'hello', 'tier': 'nope'}))
+            mapper = PodServiceMapper(self.kube)
+            mapper.match_services_for_pod(self._build_pod_metadata(0, {'app': 'hello', 'tier': 'db'}))
+            mapper.match_services_for_pod(self._build_pod_metadata(1, {'app': 'hello', 'tier': 'db'}))
+            mapper.match_services_for_pod(self._build_pod_metadata(2, {'app': 'nope', 'tier': 'db'}))
+            mapper.match_services_for_pod(self._build_pod_metadata(3, {'app': 'hello', 'tier': 'nope'}))
 
-            self.assertEqual([0, 1, 3], sorted(self.mapper.search_pods_for_service(ALL_HELLO_UID)))
-            self.assertEqual([0, 1], sorted(self.mapper.search_pods_for_service(REDIS_HELLO_UID)))
-            self.assertEqual([], sorted(self.mapper.search_pods_for_service("invalid")))
+            self.assertEqual([0, 1, 3], sorted(mapper.search_pods_for_service(ALL_HELLO_UID)))
+            self.assertEqual([0, 1], sorted(mapper.search_pods_for_service(REDIS_HELLO_UID)))
+            self.assertEqual([], sorted(mapper.search_pods_for_service("invalid")))
 
-    def _prepare_for_events_tests(self, jsonfiles):
+    def _prepare_events_tests(self, jsonfiles):
         jsons = self._load_json_array(jsonfiles)
         with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            mapper = PodServiceMapper(self.kube)
             # Fill pod label cache
-            self.mapper.match_services_for_pod(self._build_pod_metadata(0, {'app': 'hello', 'tier': 'db'}))
-            self.mapper.match_services_for_pod(self._build_pod_metadata(1, {'app': 'hello', 'tier': 'db'}))
-            self.mapper.match_services_for_pod(self._build_pod_metadata(2, {'app': 'nope', 'tier': 'db'}))
-            self.mapper.match_services_for_pod(self._build_pod_metadata(3, {'app': 'hello', 'tier': 'nope'}))
+            mapper.match_services_for_pod(self._build_pod_metadata(0, {'app': 'hello', 'tier': 'db'}))
+            mapper.match_services_for_pod(self._build_pod_metadata(1, {'app': 'hello', 'tier': 'db'}))
+            mapper.match_services_for_pod(self._build_pod_metadata(2, {'app': 'nope', 'tier': 'db'}))
+            mapper.match_services_for_pod(self._build_pod_metadata(3, {'app': 'hello', 'tier': 'nope'}))
+
+            return mapper
 
     def test_event_pod_invalidation(self):
-        self._prepare_for_events_tests(['service_cache_events2.json', 'service_cache_services2.json'])
-        self.assertTrue(0 in self.mapper._pod_labels_cache)
-        self.assertTrue(0 in self.mapper._pod_services_mapping)
-        self.assertTrue(1 in self.mapper._pod_labels_cache)
-        self.assertTrue(1 in self.mapper._pod_services_mapping)
+        mapper = self._prepare_events_tests(['service_cache_events2.json', 'service_cache_services2.json'])
+        self.assertTrue(0 in mapper._pod_labels_cache)
+        self.assertTrue(0 in mapper._pod_services_mapping)
+        self.assertTrue(1 in mapper._pod_labels_cache)
+        self.assertTrue(1 in mapper._pod_services_mapping)
 
         event = {'involvedObject': {'kind': 'Pod', 'uid': 0}, 'reason': 'Killing'}
-        self.assertEqual(0, len(self.mapper.process_events([event])))
+        self.assertEqual(0, len(mapper.process_events([event])))
 
-        self.assertFalse(0 in self.mapper._pod_labels_cache)
-        self.assertFalse(0 in self.mapper._pod_services_mapping)
-        self.assertTrue(1 in self.mapper._pod_labels_cache)
-        self.assertTrue(1 in self.mapper._pod_services_mapping)
+        self.assertFalse(0 in mapper._pod_labels_cache)
+        self.assertFalse(0 in mapper._pod_services_mapping)
+        self.assertTrue(1 in mapper._pod_labels_cache)
+        self.assertTrue(1 in mapper._pod_services_mapping)
 
     def test_event_service_deleted_invalidation(self):
-        self._prepare_for_events_tests(['service_cache_events2.json', 'service_cache_services2.json'])
-        self.assertEqual(2, len(self.mapper.match_services_for_pod({'uid': 0})))
+        mapper = self._prepare_events_tests(['service_cache_events2.json', 'service_cache_services2.json'])
+        self.assertEqual(2, len(mapper.match_services_for_pod({'uid': 0})))
 
         event = {'involvedObject': {'kind': 'Service', 'uid': REDIS_HELLO_UID},
                  'reason': 'DeletedLoadBalancer'}
         # Two pods must be reloaded
-        self.assertEqual(set([0, 1]), self.mapper.process_events([event]))
+        self.assertEqual(set([0, 1]), mapper.process_events([event]))
         # redis-hello service removed from pod mapping
-        self.assertEqual(1, len(self.mapper.match_services_for_pod({'uid': 0})))
+        self.assertEqual(1, len(mapper.match_services_for_pod({'uid': 0})))
 
     def test_event_service_created_invalidation(self):
-        self._prepare_for_events_tests(['service_cache_events1.json', 'service_cache_services1.json'])
-        self.assertEqual(1, len(self.mapper.match_services_for_pod(
+        mapper = self._prepare_events_tests(['service_cache_events1.json', 'service_cache_services1.json'])
+        self.assertEqual(1, len(mapper.match_services_for_pod(
             self._build_pod_metadata(0, {'app': 'hello', 'tier': 'db'}))))
 
         event = {'involvedObject': {'kind': 'Service', 'uid': ALL_HELLO_UID},
@@ -157,7 +158,7 @@ class TestKubePodServiceMapper(KubeTestCase):
         jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
         with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
             # Three pods must be reloaded
-            self.assertEqual(set([0, 1, 3]), self.mapper.process_events([event]))
+            self.assertEqual(set([0, 1, 3]), mapper.process_events([event]))
             # all-hello service added to pod mapping
-            self.assertEqual(2, len(self.mapper.match_services_for_pod(
+            self.assertEqual(2, len(mapper.match_services_for_pod(
                 self._build_pod_metadata(0, {'app': 'hello', 'tier': 'db'}))))

--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -1,0 +1,101 @@
+# stdlib
+import unittest
+import os.path
+
+# 3rd party
+from mock import patch
+import json
+
+# project
+from utils.kubernetes import KubeUtil
+
+class KubeTestCase(unittest.TestCase):
+    # Patch _locate_kubelet that is used by KubeUtil.__init__
+    @patch.object(KubeUtil, '_locate_kubelet', return_value='http://localhost:10255')
+    def setUp(self, unused_mock_locate):
+        self.kube = KubeUtil()
+        self.kube.__init__()    # It's a singleton, force re-init
+
+    def tearDown(self):
+        self.kube = None
+
+
+class TestKubeUtilServiceTag(KubeTestCase):
+    @classmethod
+    def _load_json_array(cls, names):
+        json_array = []
+        for filename in names:
+            path = os.path.join(os.path.dirname(__file__), 'fixtures', 'kubeutil', filename)
+            with open(path) as data_file:
+                json_array.append(json.load(data_file))
+        return json_array
+
+    @classmethod
+    def _build_pod_metadata(cls, labels=None):
+        c = {}
+        if labels is not None:
+            c['labels'] = labels
+        return c
+
+    def test_service_cache_init(self):
+        self.assertIsNone(self.kube._services_cache)
+        self.assertEqual(-1, self.kube._services_cache_last_resourceversion)
+
+    def test_service_cache_fill(self):
+        jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            self.kube._fill_services_cache()
+        self.assertIsNotNone(self.kube._services_cache)
+        # Kubernetes service not imported because no selector
+        self.assertEqual(sorted([u'redis-hello', u'frontend-hello', u'all-hello']),
+            sorted(self.kube._services_cache.keys()))
+
+        redis = self.kube._services_cache['redis-hello']
+        self.assertEqual(2, len(redis))
+        self.assertEqual('hello', redis['app'])
+        self.assertEqual('db', redis['tier'])
+
+        self.assertEqual(2709, self.kube._services_cache_last_resourceversion)
+
+    def test_service_cache_invalidation_true(self):
+        jsons = self._load_json_array(['service_cache_events1.json', 'service_cache_services1.json', 'service_cache_events2.json'])
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            self.kube._fill_services_cache()
+            self.assertEqual(2707, self.kube._services_cache_last_resourceversion)
+            self.kube.check_services_cache_freshness()
+            self.assertIsNone(self.kube._services_cache)
+            self.assertEqual(2709, self.kube._services_cache_last_resourceversion)
+
+    def test_service_cache_invalidation_false(self):
+        jsons = self._load_json_array(['service_cache_events1.json', 'service_cache_services1.json', 'service_cache_events1.json'])
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            self.kube._fill_services_cache()
+            self.assertEqual(2707, self.kube._services_cache_last_resourceversion)
+            self.kube.check_services_cache_freshness()
+            self.assertIsNotNone(self.kube._services_cache)
+            self.assertEqual(2707, self.kube._services_cache_last_resourceversion)
+
+    def test_pod_to_service_no_match(self):
+        jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            self.kube._fill_services_cache()
+            no_match = self._build_pod_metadata({'app': 'unknown'})
+            self.assertEqual(0, len(self.kube.match_services_for_pod(no_match)))
+
+    def test_pod_to_service_two_matches(self):
+        jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
+        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
+            self.kube._fill_services_cache()
+            two_matches = self._build_pod_metadata({'app': 'hello', 'tier': 'db'})
+            self.assertEqual(sorted(['redis-hello', 'all-hello']),
+                sorted(self.kube.match_services_for_pod(two_matches)))
+
+
+class TestKubeUtilDeploymentTag(KubeTestCase):
+    def test_deployment_name_nominal(self):
+        self.assertEqual('frontend', self.kube.get_deployment_for_replicaset('frontend-2891696001'))
+        self.assertEqual('front-end', self.kube.get_deployment_for_replicaset('front-end-28916aq96001'))
+
+    def test_deployment_illegal_name(self):
+        self.assertIsNone(self.kube.get_deployment_for_replicaset('frontend2891696001'))
+        self.assertIsNone(self.kube.get_deployment_for_replicaset('-frontend2891696001'))

--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -19,8 +19,6 @@ class KubeTestCase(unittest.TestCase):
     def tearDown(self):
         self.kube = None
 
-
-class TestKubeUtilServiceTag(KubeTestCase):
     @classmethod
     def _load_json_array(cls, names):
         json_array = []
@@ -29,6 +27,9 @@ class TestKubeUtilServiceTag(KubeTestCase):
             with open(path) as data_file:
                 json_array.append(json.load(data_file))
         return json_array
+
+
+class TestKubeUtilServiceTag(KubeTestCase):
 
     @classmethod
     def _build_pod_metadata(cls, labels=None):

--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -11,10 +11,10 @@ from utils.kubernetes import KubeUtil
 
 class KubeTestCase(unittest.TestCase):
     # Patch _locate_kubelet that is used by KubeUtil.__init__
-    @patch.object(KubeUtil, '_locate_kubelet', return_value='http://localhost:10255')
-    def setUp(self, unused_mock_locate):
-        self.kube = KubeUtil()
-        self.kube.__init__()    # It's a singleton, force re-init
+    def setUp(self):
+        with patch.object(KubeUtil, '_locate_kubelet', return_value='http://localhost:10255'):
+            self.kube = KubeUtil()
+            self.kube.__init__()    # It's a singleton, force re-init
 
     def tearDown(self):
         self.kube = None
@@ -27,69 +27,6 @@ class KubeTestCase(unittest.TestCase):
             with open(path) as data_file:
                 json_array.append(json.load(data_file))
         return json_array
-
-
-class TestKubeUtilServiceTag(KubeTestCase):
-
-    @classmethod
-    def _build_pod_metadata(cls, labels=None):
-        c = {}
-        if labels is not None:
-            c['labels'] = labels
-        return c
-
-    def test_service_cache_init(self):
-        self.assertIsNone(self.kube._services_cache)
-        self.assertEqual(-1, self.kube._services_cache_last_resourceversion)
-
-    def test_service_cache_fill(self):
-        jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
-        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
-            self.kube._fill_services_cache()
-        self.assertIsNotNone(self.kube._services_cache)
-        # Kubernetes service not imported because no selector
-        self.assertEqual(sorted([u'redis-hello', u'frontend-hello', u'all-hello']),
-            sorted(self.kube._services_cache.keys()))
-
-        redis = self.kube._services_cache['redis-hello']
-        self.assertEqual(2, len(redis))
-        self.assertEqual('hello', redis['app'])
-        self.assertEqual('db', redis['tier'])
-
-        self.assertEqual(2709, self.kube._services_cache_last_resourceversion)
-
-    def test_service_cache_invalidation_true(self):
-        jsons = self._load_json_array(['service_cache_events1.json', 'service_cache_services1.json', 'service_cache_events2.json'])
-        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
-            self.kube._fill_services_cache()
-            self.assertEqual(2707, self.kube._services_cache_last_resourceversion)
-            self.kube.check_services_cache_freshness()
-            self.assertIsNone(self.kube._services_cache)
-            self.assertEqual(2709, self.kube._services_cache_last_resourceversion)
-
-    def test_service_cache_invalidation_false(self):
-        jsons = self._load_json_array(['service_cache_events1.json', 'service_cache_services1.json', 'service_cache_events1.json'])
-        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
-            self.kube._fill_services_cache()
-            self.assertEqual(2707, self.kube._services_cache_last_resourceversion)
-            self.kube.check_services_cache_freshness()
-            self.assertIsNotNone(self.kube._services_cache)
-            self.assertEqual(2707, self.kube._services_cache_last_resourceversion)
-
-    def test_pod_to_service_no_match(self):
-        jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
-        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
-            self.kube._fill_services_cache()
-            no_match = self._build_pod_metadata({'app': 'unknown'})
-            self.assertEqual(0, len(self.kube.match_services_for_pod(no_match)))
-
-    def test_pod_to_service_two_matches(self):
-        jsons = self._load_json_array(['service_cache_events2.json', 'service_cache_services2.json'])
-        with patch.object(self.kube, 'retrieve_json_auth', side_effect=jsons):
-            self.kube._fill_services_cache()
-            two_matches = self._build_pod_metadata({'app': 'hello', 'tier': 'db'})
-            self.assertEqual(sorted(['redis-hello', 'all-hello']),
-                sorted(self.kube.match_services_for_pod(two_matches)))
 
 
 class TestKubeUtilDeploymentTag(KubeTestCase):

--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -32,11 +32,12 @@ class KubeTestCase(unittest.TestCase):
 class TestKubeUtilDeploymentTag(KubeTestCase):
     def test_deployment_name_nominal(self):
         self.assertEqual('frontend', self.kube.get_deployment_for_replicaset('frontend-2891696001'))
-        self.assertEqual('front-end', self.kube.get_deployment_for_replicaset('front-end-28916aq96001'))
+        self.assertEqual('front-end', self.kube.get_deployment_for_replicaset('front-end-2891696001'))
 
     def test_deployment_illegal_name(self):
         self.assertIsNone(self.kube.get_deployment_for_replicaset('frontend2891696001'))
         self.assertIsNone(self.kube.get_deployment_for_replicaset('-frontend2891696001'))
+        self.assertIsNone(self.kube.get_deployment_for_replicaset('manually-created'))
 
 class TestKubeUtilCreatorTags(KubeTestCase):
     @classmethod

--- a/utils/kubernetes/__init__.py
+++ b/utils/kubernetes/__init__.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+from .pod_service_mapper import PodServiceMapper   # noqa: F401
 from .kube_state_processor import KubeStateProcessor  # noqa: F401
 from .kube_state_processor import NAMESPACE  # noqa: F401
 from .kubeutil import KubeUtil  # noqa: F401

--- a/utils/kubernetes/__init__.py
+++ b/utils/kubernetes/__init__.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+from .kube_event_retriever import KubeEventRetriever  # noqa: F401
 from .pod_service_mapper import PodServiceMapper   # noqa: F401
 from .kube_state_processor import KubeStateProcessor  # noqa: F401
 from .kube_state_processor import NAMESPACE  # noqa: F401

--- a/utils/kubernetes/kube_event_retriever.py
+++ b/utils/kubernetes/kube_event_retriever.py
@@ -36,7 +36,7 @@ class KubeEventRetriever:
                 # Client-side filtering
                 self.namespace_filter = set(namespaces)
         if isinstance(namespaces, basestring):
-            self.request_url = "%s/namespaces/%s/events" % self.kubeutil.kubernetes_api_url, namespaces
+            self.request_url = "%s/namespaces/%s/events" % (self.kubeutil.kubernetes_api_url, namespaces)
 
     def set_kinds(self, kinds):
         self.kind_filter = None
@@ -63,7 +63,7 @@ class KubeEventRetriever:
 
         for event in events.get('items', []):
             resversion = int(event.get('metadata', {}).get('resourceVersion', None))
-            if resversion > self._service_cache_last_event_resversion:
+            if resversion > self.last_resversion:
                 lastest_resversion = max(lastest_resversion, resversion)
 
                 if self.namespace_filter is not None:

--- a/utils/kubernetes/kube_event_retriever.py
+++ b/utils/kubernetes/kube_event_retriever.py
@@ -1,3 +1,7 @@
+import logging
+
+log = logging.getLogger('collector')
+
 class KubeEventRetriever:
     """
     Queries the apiserver for events of given kinds and namespaces
@@ -30,7 +34,7 @@ class KubeEventRetriever:
         self.request_url = self.kubeutil.kubernetes_api_url + '/events'
         self.namespace_filter = None
         if isinstance(namespaces, set) or isinstance(namespaces, list):
-            if len(namespaces == 1):
+            if len(namespaces) == 1:
                 namespaces = namespaces[0]
             else:
                 # Client-side filtering
@@ -42,7 +46,7 @@ class KubeEventRetriever:
         self.kind_filter = None
         self.request_params = {}
         if isinstance(kinds, set) or isinstance(kinds, list):
-            if len(kinds == 1):
+            if len(kinds) == 1:
                 kinds = kinds[0]
             else:
                 # Client-side filtering

--- a/utils/kubernetes/kube_event_retriever.py
+++ b/utils/kubernetes/kube_event_retriever.py
@@ -1,0 +1,71 @@
+class KubeEventRetriever:
+    """
+    Queries the apiserver for events of given kinds and namespaces
+    and filters them on ressourceVersion to return only the new ones
+
+    Best performance is achieved with only one namespace & one kind
+    (server side-filtering), but multiple ns or kinds are supported
+    via client-side filtering
+
+    Needs a KubeUtil objet to route requests through
+    Best way to get one is through KubeUtil.get_event_retriever()
+    """
+    def __init__(self, kubeutil_object, namespaces=None, kinds=None):
+        self.kubeutil = kubeutil_object
+        self.last_resversion = -1
+
+        self.request_url = self.kubeutil.kubernetes_api_url + '/events'
+        self.request_params = {}
+
+        self.namespace_filter = None
+        if isinstance(namespaces, basestring):
+            self.request_url = "%s/namespaces/%s/events" % self.kubeutil.kubernetes_api_url, namespaces
+        elif isinstance(namespaces, set) or isinstance(namespaces, list):
+            if len(namespaces == 1):
+                self.request_url = "%s/namespaces/%s/events" % self.kubeutil.kubernetes_api_url, namespaces[0]
+            else:
+                # Client-side filtering
+                self.namespace_filter = set(namespaces)
+
+        self.kind_filter = None
+        if isinstance(kinds, basestring):
+            self.request_url = "%s/namespaces/%s/events" % self.kubeutil.kubernetes_api_url, namespaces
+            self.request_params['fieldSelector'] = 'involvedObject.kind=' + kinds
+        elif isinstance(kinds, set) or isinstance(kinds, list):
+            if len(kinds == 1):
+                self.request_params['fieldSelector'] = 'involvedObject.kind=' + kinds[0]
+            else:
+                # Client-side filtering
+                self.kind_filter = set(kinds)
+
+
+    def get_events(self):
+        """
+        Fetch latest events from the apiserver for the namespaces and kinds set on init
+        and returns as list of events
+        """
+        filtered_events = []
+        lastest_resversion = None
+
+        events = self.kubeutil.retrieve_json_auth(self.request_url, params=self.request_params)
+
+        for event in events.get('items', []):
+            resversion = int(event.get('metadata', {}).get('resourceVersion', None))
+            if resversion > self._service_cache_last_event_resversion:
+                lastest_resversion = max(lastest_resversion, resversion)
+
+                if self.namespace_filter is not None:
+                    ns = event.get('involvedObject', {}).get('namespace', 'default')
+                    if ns not in self.namespace_filter:
+                        continue
+
+                if self.kind_filter is not None:
+                    kind = event.get('involvedObject', {}).get('kind', None)
+                    if kind is None or kind not in self.kind_filter:
+                        continue
+
+                filtered_events.append(event)
+
+        self.last_resversion = max(self.last_resversion, lastest_resversion)
+
+        return filtered_events

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -366,6 +366,7 @@ class KubeUtil:
         try:
             if self._services_cache_last_resourceversion == -1:
                 # Retrieving latest service event number with check_services_cache_freshness dry run
+                self._services_cache = {}   # check___freshness skips if None
                 self.check_services_cache_freshness()
             reply = self.retrieve_json_auth(self.kubernetes_api_url + '/services')
             self._services_cache = {}
@@ -386,7 +387,11 @@ class KubeUtil:
 
         We use the event's resourceVersion, as using the service's version wouldn't catch deletion
         """
-        log.debug("Testing service cache freshness, current latest: %d", self._services_cache_last_resourceversion)
+
+        # Don't check if cache is already empty
+        if self._services_cache is None:
+            return
+
         lastestVersion = None
         flush = False
         try:

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -376,7 +376,7 @@ class KubeUtil:
         Pass refresh=True if you want to bypass the cached cid->services mapping (after a service change)
         """
         s = self._service_mapper.match_services_for_pod(pod_metadata, refresh, names=True)
-        log.warning("Matches for %s: %s" % (pod_metadata.get('name'), str(s)))
+        #log.warning("Matches for %s: %s" % (pod_metadata.get('name'), str(s)))
         return s
 
     def _process_events_get_cid_to_update(self, events):
@@ -385,13 +385,6 @@ class KubeUtil:
         New / deleted pods are not processed as this would duplicate docker_daemon
         events and lead to double triggers for the same c_id
         """
-
-    def search_docker_cids_for_pods(self, pod_uid_list):
-        container_ids = set()
-
-        # TODO
-
-        return container_ids
 
     def get_event_retriever(self, namespaces=None, kinds=None):
         """
@@ -437,8 +430,6 @@ class KubeUtil:
             pods = set()
             if self._service_mapper:
                 pods.update(self._service_mapper.process_events(event_array))
-
-            log.warning("Processed pods %s for events %s" % (str(pods), str(event_array)))
             return pods
         except Exception as e:
             log.warning("Error processing events %s: %s" % (str(event_array), e))

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -375,7 +375,9 @@ class KubeUtil:
 
         Pass refresh=True if you want to bypass the cached cid->services mapping (after a service change)
         """
-        return self._service_mapper.match_services_for_pod(pod_metadata, refresh)
+        s = self._service_mapper.match_services_for_pod(pod_metadata, refresh, names=True)
+        log.warning("Matches for %s: %s" % (pod_metadata.get('name'), str(s)))
+        return s
 
     def _process_events_get_cid_to_update(self, events):
         """
@@ -436,8 +438,8 @@ class KubeUtil:
             if self._service_mapper:
                 pods.update(self._service_mapper.process_events(event_array))
 
-            self.log.warning("Processed pods %s for events %s" % (str(pods), str(event_array)))
+            log.warning("Processed pods %s for events %s" % (str(pods), str(event_array)))
             return pods
         except Exception as e:
-            self.log.warning("Error processing events %s: %s" % (str(event_array), e))
+            log.warning("Error processing events %s: %s" % (str(event_array), e))
             return set()

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -449,11 +449,11 @@ class KubeUtil:
             tags = []
             creator_kind, creator_name = self.get_pod_creator(pod_metadata)
             if creator_kind in CREATOR_KIND_TO_TAG and creator_name:
-                tags.append(CREATOR_KIND_TO_TAG[creator_kind] + creator_name)
+                tags.append("%s:%s" % (CREATOR_KIND_TO_TAG[creator_kind], creator_name))
                 if creator_kind == 'ReplicaSet':
                     deployment = self.get_deployment_for_replicaset(creator_name)
                     if deployment:
-                        tags.append(CREATOR_KIND_TO_TAG['Deployment'] + deployment)
+                        tags.append("%s:%s" % (CREATOR_KIND_TO_TAG['Deployment'], deployment))
             if legacy_rep_controller_tag and creator_kind != 'ReplicationController' and creator_name:
                 tags.append('kube_replication_controller:{0}'.format(creator_name))
 

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -75,9 +75,6 @@ class KubeUtil:
         self.host_name = os.environ.get('HOSTNAME')
         self.tls_settings = self._init_tls_settings(instance)
 
-        # Service mapping helper class
-        self._service_mapper = PodServiceMapper(self)
-
         # apiserver
         self.kubernetes_api_url = 'https://%s/api/v1' % (os.environ.get('KUBERNETES_SERVICE_HOST') or self.DEFAULT_MASTER_NAME)
 
@@ -89,6 +86,9 @@ class KubeUtil:
         except Exception as ex:
             log.error("Kubernetes check exiting, cannot run without access to kubelet.")
             raise ex
+
+        # Service mapping helper class
+        self._service_mapper = PodServiceMapper(self)
 
         self.kubelet_host = self.kubelet_api_url.split(':')[1].lstrip('/')
         self.pods_list_url = urljoin(self.kubelet_api_url, KubeUtil.PODS_LIST_PATH)

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -252,7 +252,7 @@ class KubeUtil:
         label selectors, which would be very costly, especially matchExpressions matching.
         """
         end = rs_name.rfind("-")
-        if end > 0:
+        if end > 0 and rs_name[end + 1:].isdigit():
             return rs_name[0:end]
         else:
             return None
@@ -385,13 +385,6 @@ class KubeUtil:
         s = self._service_mapper.match_services_for_pod(pod_metadata, refresh, names=True)
         #log.warning("Matches for %s: %s" % (pod_metadata.get('name'), str(s)))
         return s
-
-    def _process_events_get_cid_to_update(self, events):
-        """
-        Process a [k8s_event] list and get a list of docker containers to update for SD
-        New / deleted pods are not processed as this would duplicate docker_daemon
-        events and lead to double triggers for the same c_id
-        """
 
     def get_event_retriever(self, namespaces=None, kinds=None):
         """

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -248,8 +248,8 @@ class KubeUtil:
         Get the deployment name for a given replicaset name
         For now, the rs name's first part always is the deployment's name, see
         https://github.com/kubernetes/kubernetes/blob/release-1.6/pkg/controller/deployment/sync.go#L299
-        But it might change in a future k8s version. The other way to match RS and deployments is comparing
-        label selectors, which would be very costly, especially matchExpressions matching.
+        But it might change in a future k8s version. The other way to match RS and deployments is
+        to parse and cache /apis/extensions/v1beta1/replicasets, mirroring PodServiceMapper
         """
         end = rs_name.rfind("-")
         if end > 0 and rs_name[end + 1:].isdigit():

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -455,20 +455,20 @@ class KubeUtil:
             log.warning('Could not parse creator tags for pod ' + pod_metadata.get('name'))
             return []
 
-    def process_events(self, event_array):
+    def process_events(self, event_array, podlist=None):
         """
         Reads a list of kube events, invalidates caches and and computes a set
-        of pods impacted by the changes, to refresh service discovery
+        of containers impacted by the changes, to refresh service discovery
         Pod creation/deletion events are ignored for now, as docker_daemon already
         sends container creation/deletion events to SD
 
-        Note: pod uids must be matched to docker container ids with match_containers_for_pods
+        Pod->containers matching is done using match_containers_for_pods
         """
         try:
             pods = set()
             if self._service_mapper:
                 pods.update(self._service_mapper.process_events(event_array))
-            return pods
+            return self.match_containers_for_pods(pods, podlist)
         except Exception as e:
             log.warning("Error processing events %s: %s" % (str(event_array), e))
             return set()

--- a/utils/kubernetes/pod_service_mapper.py
+++ b/utils/kubernetes/pod_service_mapper.py
@@ -1,0 +1,124 @@
+# (C) Datadog, Inc. 2015-2016
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+from collections import defaultdict
+import logging
+
+log = logging.getLogger('collector')
+
+class PodServiceMapper:
+    _service_cache_selectors = defaultdict(dict)   # {service_name:{selectors}}
+    _service_cache_invalidated = True              # True to trigger service parsing
+    _service_cache_last_event_resversion = -1      # last event ressource version
+
+    _pod_labels_cache = defaultdict(dict)          # {pod_uid:{label}}
+    _pod_services_mapping = defaultdict(list)      # {pod_uid:[service_name]}
+
+    def __init__(self, kubeutil_object):
+        """
+        Create a new service PodServiceMapper
+        The apiserver requests are routed through the given KubeUtil instance
+        """
+        self.kube = kubeutil_object
+
+    def _fill_services_cache(self):
+        """
+        Get the list of services from the kubelet API and store the label selector dicts.
+        The cache is to be invalidated by the user class by calling check_services_cache_freshness
+        """
+        try:
+            if self._service_cache_last_event_resversion == -1:
+                self._service_cache_invalidated = False
+                # Retrieving latest service event number with check_services_cache_freshness dry run
+                self.check_services_cache_freshness()
+            reply = self.kube.retrieve_json_auth(self.kube.kubernetes_api_url + '/services')
+            self._service_cache_selectors = defaultdict(dict)
+            for service in reply.get('items', []):
+                name = service.get('metadata', {}).get('name', '')
+                selector = service.get('spec', {}).get('selector', {})
+                if len(name) and len(selector):
+                    self._service_cache_selectors[name] = selector
+            self._service_cache_invalidated = False
+            log.warning(self._service_cache_selectors)
+        except Exception as e:
+            log.exception('Unable to read service list from apiserver: %s', e)
+            self._service_cache_selectors = defaultdict(dict)
+            self._service_cache_invalidated = False
+
+    def check_services_cache_freshness(self):
+        """
+        Entry point for sd_docker_backend to check whether to invalidate the cached services
+        For now, we remove the whole cache as the fill_service_cache logic
+        doesn't handle partial lookups
+
+        We use the event's resourceVersion, as using the service's version wouldn't catch deletion
+        """
+
+        # Don't check if cache is already invalidated
+        if self._service_cache_invalidated:
+            return
+
+        lastestVersion = None
+        invalidate = False
+        try:
+            reply = self.kube.retrieve_json_auth(self.kube.kubernetes_api_url + '/events',
+                params={'fieldSelector': 'involvedObject.kind=Service'})
+            for event in reply.get('items', []):
+                version = int(event.get('metadata', {}).get('resourceVersion', None))
+                if version > self._service_cache_last_event_resversion:
+                    invalidate = True
+                    lastestVersion = max(lastestVersion, version)
+            if invalidate:
+                self._service_cache_last_event_resversion = lastestVersion
+                self._service_cache_invalidated = True
+                log.debug("Flushing services cache triggered by resourceVersion %d", lastestVersion)
+        except Exception as e:
+            log.warning("Exception while parsing service events, not invalidating cache: %s", e)
+
+    def match_services_for_pod(self, pod_metadata, refresh=False):
+        """
+        Match the pods labels with services' label selectors to determine the list
+        of services that point to that pod. Returns an array of service names.
+
+        Pass refresh=True if you want to bypass the cached cid->services mapping (after a service change)
+        """
+        matches = []
+
+        try:
+            # Fail intentionally if no uid
+            pod_id = pod_metadata['uid']
+
+            # Mapping cache lookup
+            if (refresh is False and pod_id in self._pod_services_mapping):
+                log.debug("Returning cache for pod %s: pod_id %s", pod_metadata.get('name'), pod_id)
+                return self._pod_services_mapping[pod_id]
+
+            if (self._service_cache_invalidated is True):
+                self._fill_services_cache()
+            for name, label_selectors in self._service_cache_selectors.iteritems():
+                if self._does_pod_fulfill_selectors(pod_metadata.get('labels', {}), label_selectors):
+                    matches.append(name)
+            self._pod_services_mapping[pod_id] = matches
+        except Exception as e:
+            log.exception('Error while matching k8s services: %s', e)
+        finally:
+            log.debug("Services match for pod %s: %s", pod_metadata.get('name'), str(matches))
+            return matches
+
+    @classmethod
+    def _does_pod_fulfill_selectors(cls, pod_labels, label_selectors):
+        """
+        Allows to check if a pod fulfills the label_selectors for a service by
+        iterating over the dictionnary.
+        If the pod's label or label_selectors are empty, the match is assumed false
+        Note: Job, Deployment, ReplicaSet and DaemonSet introduce matchExpressions
+        that are not handled by this method
+        """
+        if len(pod_labels) == 0 or len(label_selectors) == 0:
+            return False
+        for label, value in label_selectors.iteritems():
+            if pod_labels.get(label, '') != value:
+                return False
+        return True

--- a/utils/kubernetes/pod_service_mapper.py
+++ b/utils/kubernetes/pod_service_mapper.py
@@ -48,7 +48,6 @@ class PodServiceMapper:
                 if len(selector):
                     self._service_cache_selectors[uid] = selector
             self._service_cache_invalidated = False
-            log.warning(self._service_cache_selectors)
         except Exception as e:
             log.exception('Unable to read service list from apiserver: %s', e)
             self._service_cache_selectors = defaultdict(dict)
@@ -105,7 +104,6 @@ class PodServiceMapper:
 
             # Mapping cache lookup
             if (refresh is False and pod_id in self._pod_services_mapping):
-                log.debug("Returning cache for pod %s: pod_id %s", pod_metadata.get('name'), pod_id)
                 matches = self._pod_services_mapping[pod_id]
             else:
                 if (self._service_cache_invalidated is True):
@@ -115,7 +113,6 @@ class PodServiceMapper:
                         matches.append(service_uid)
                 self._pod_services_mapping[pod_id] = matches
 
-            log.warning("Services match for pod %s: %s", pod_metadata.get('name'), str(matches))
             if names:
                 return [self._service_cache_names.get(uid) for uid in matches]
             else:
@@ -171,8 +168,6 @@ class PodServiceMapper:
         """
         pod_uids = set()
         service_cache_checked = False
-
-        log.warning("Processing events " + str(event_array))
 
         for event in event_array:
             kind = event.get('involvedObject', {}).get('kind', None)

--- a/utils/kubernetes/pod_service_mapper.py
+++ b/utils/kubernetes/pod_service_mapper.py
@@ -8,6 +8,7 @@ import logging
 
 log = logging.getLogger('collector')
 
+
 class PodServiceMapper:
     _service_cache_selectors = defaultdict(dict)   # {service_name:{selectors}}
     _service_cache_invalidated = True              # True to trigger service parsing
@@ -64,7 +65,7 @@ class PodServiceMapper:
         invalidate = False
         try:
             reply = self.kube.retrieve_json_auth(self.kube.kubernetes_api_url + '/events',
-                params={'fieldSelector': 'involvedObject.kind=Service'})
+                                                 params={'fieldSelector': 'involvedObject.kind=Service'})
             for event in reply.get('items', []):
                 version = int(event.get('metadata', {}).get('resourceVersion', None))
                 if version > self._service_cache_last_event_resversion:

--- a/utils/kubernetes/pod_service_mapper.py
+++ b/utils/kubernetes/pod_service_mapper.py
@@ -195,7 +195,7 @@ class PodServiceMapper:
 
                 # Possible values in kubernetes/pkg/controller/service/servicecontroller.go
                 if reason == 'DeletedLoadBalancer':
-                    for pod, services in self._pod_services_mapping:
+                    for pod, services in self._pod_services_mapping.iteritems():
                         if service_uid in services:
                             services.remove(service_uid)
                             pod_uids.add(pod)

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -315,10 +315,11 @@ class SDDockerBackend(AbstractSDBackend):
             else:
                 log.debug('creator-name for pod %s is empty, this should not happen' % pod_metadata.get('name'))
 
+            # add services tags
             services = self.kubeutil.match_services_for_pod(pod_metadata)
-
             for s in services:
-                tags.append('kube_service:%s' % s)
+                if s is not None:
+                    tags.append('kube_service:%s' % s)
 
         elif Platform.is_swarm():
             c_labels = state.inspect_container(c_id).get('Config', {}).get('Labels', {})

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -366,6 +366,9 @@ class SDDockerBackend(AbstractSDBackend):
             container.get('Id'), container.get('Labels')
         ) for container in self.docker_client.containers()]
 
+        if Platform.is_k8s():
+            self.kubeutil.check_services_cache_freshness()
+
         for image, cid, labels in containers:
             try:
                 # value of the DATADOG_ID tag or the image name if the label is missing

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -316,6 +316,7 @@ class SDDockerBackend(AbstractSDBackend):
                 log.debug('creator-name for pod %s is empty, this should not happen' % pod_metadata.get('name'))
 
             services = self.kubeutil.match_services_for_pod(pod_metadata)
+
             for s in services:
                 tags.append('kube_service:%s' % s)
 

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -306,6 +306,9 @@ class SDDockerBackend(AbstractSDBackend):
                     tags.append('kube_daemon_set:%s' % creator_name)
                 elif creator_kind == 'ReplicaSet':
                     tags.append('kube_replica_set:%s' % creator_name)
+                    deployment = self.kubeutil.get_deployment_for_replicaset(creator_name)
+                    if deployment:
+                        tags.append('kube_deployment:%s' % deployment)                        
             else:
                 log.debug('creator-name for pod %s is empty, this should not happen' % pod_metadata.get('name'))
 


### PR DESCRIPTION
### What does this PR do?

Add deployment and service k8s tags to service discovery tags. 

Logic is in separate kube_event_retriever and pod_service_mapper classes

#### Deployment

The deployment name is inferred from the replicaset name, as this is hardcoded in the k8s source. Matching selectors would be costly, especially if we need to support matchExpressions set selectors

#### Services

The pod->service is implemented by matching every pod to every service's label selectors. The services are kept in memory cache and cache is checked every time service discovery is triggered. If the pod satisfies matches several services, multiple kube_service tags are added.

The cache is invalidated on kubernetes events pushed by the kubernetes check, mirroring how docker_daemon/dockerutils work. These events allow to trigger SD updates on service events.

It is then dependant on https://github.com/DataDog/integrations-core/pull/319

#### Event handling

KubeUtil now has a process_events() method that kubernetes.py calls on every check. New features can hook in this method to:
  - invalidate caches
  - add container_ids to reload SD for