### PR TITLE
Add kafka to the list of jmx checks

### DIFF
--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -58,6 +58,7 @@ JMX_CHECKS = [
     'jmx',
     'solr',
     'tomcat',
+    'kafka',
 ]
 JMX_COLLECT_COMMAND = 'collect'
 JMX_LIST_COMMANDS = {


### PR DESCRIPTION
### What does this PR do?

When SD uses `auto_conf` to init JMX-fetch related checks, it verifies that the check name is listed in the list `JMX_CHECKS`. Kafka was missing, making impossible to use SD with JMX an the autoconf config storage.