### PR TITLE
[jmxfetch] Pass `--sd-enabled` option when JMXFetch-SD is enabled

### DIFF
--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -272,7 +272,7 @@ class JMXFetch(object):
                 pipe_path = get_jmx_pipe_path()
                 subprocess_args.insert(4, '--tmp_directory')
                 subprocess_args.insert(5, pipe_path)
-                subprocess_args.insert(4, '--sd_standby')
+                subprocess_args.insert(4, '--sd_enabled')
 
             if jmx_checks:
                 subprocess_args.insert(4, '--check')


### PR DESCRIPTION
### What does this PR do?

Passes `--sd-enabled` option when JMXFetch-SD is enabled

See https://github.com/DataDog/jmxfetch/pull/135 for details

### Additional Notes

The new option replaces the `sd-standby` option that wasn't used anywhere on JMXFetch
side.
