### PR TITLE
Bump boto version to 2.46.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@
 # fails, so they shouldn't have too many deps
 ###########################################################
 
-boto==2.39.0
+boto==2.46.1
 # utils/platform.py
 docker-py==1.10.6
 # utils/service_discovery/config_stores.py


### PR DESCRIPTION
### What does this PR do?

AWS az "us-east-2" has been added in boto 2.43. We currently ship 2.39.
This bump boto to the latest version (2.46.1 right now)

### Motivation

Customers in us-east-2 could not get EC2 tags from the agent.