### PR TITLE
[kubernetes] catch errors from kubeutil init

### DIFF
--- a/utils/hostname.py
+++ b/utils/hostname.py
@@ -82,10 +82,15 @@ def get_hostname(config=None):
             hostname = docker_hostname
 
         elif Platform.is_k8s(): # Let's try from the kubelet
-            kube_util = KubeUtil()
-            _, kube_hostname = kube_util.get_node_info()
-            if kube_hostname is not None and is_valid_hostname(kube_hostname):
-                hostname = kube_hostname
+            try:
+                kube_util = KubeUtil()
+            except Exception as ex:
+                log.error("Couldn't instantiate the kubernetes client, "
+                    "getting the k8s hostname won't work. Error: %s" % str(ex))
+            else:
+                _, kube_hostname = kube_util.get_node_info()
+                if kube_hostname is not None and is_valid_hostname(kube_hostname):
+                    hostname = kube_hostname
 
     # then move on to os-specific detection
     if hostname is None:


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Kubeutil raises an exception if it can't reach the kubelet. We should catch it.

### Motivation

Ugly collector logs

### Testing Guidelines

Run the agent on a non-k8s node, see that the exception is now caught.

### Additional Notes

sister PR: https://github.com/DataDog/integrations-core/pull/345
