### PR TITLE
[auto_conf] Allow multiple instances per check

### DIFF
--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -241,7 +241,8 @@ class AbstractConfigStore(object):
                     continue
                 auto_conf = get_auto_conf(check_name)
                 init_config, instances = auto_conf.get('init_config', {}), auto_conf.get('instances', [])
-                templates.append((check_name, init_config, instances[0] or {}))
+                for instance in instances:
+                    templates.append((check_name, init_config, instance or {}))
 
         return templates
 


### PR DESCRIPTION
### What does this PR do?

Allows configuring multiple instances of the same check with `auto_conf`.

### Motivation

In some cases (and for some checks), it makes sense to have multiple
instances of the same check running against a container. Example:
`php_fpm` check when the user wants to run the check against multiple `status_url`s.

### Testing Guidelines

I did some basic manual testing. Haven't written unit tests but if needed I can add some.

### Additional Notes

Opening this PR after discussing with @sdwr98 on a use case for #3259 (the use case being: having the ability to define multiple instances of the same check with `auto_conf`, which is useful for `php_fpm` for example)