### PR TITLE
[docker] fix net metrics in host mode

### DIFF
--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -482,6 +482,12 @@ class DockerUtil:
 
             docker_gateways = {}
             for netname, netconf in container['NetworkSettings']['Networks'].iteritems():
+
+                if netname == 'host' or netconf.get(u'Gateway') == '':
+                    log.debug("Empty network gateway, container %s is in network host mode, "
+                        "its network metrics are for the whole host." % container['Id'][:12])
+                    return {'eth0': 'bridge'}
+
                 docker_gateways[netname] = struct.unpack('<L', socket.inet_aton(netconf.get(u'Gateway')))[0]
 
             mapping = {}


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

If a container is in host mode we shouldn't call `socket.inet_aton` on its network gateway because it's empty and will fail, resulting in a warning in the integration. We can't not report the metrics either because existing behavior reports network metrics even in host mode (so network metrics are actually for the whole host). So let's keep the same behavior but avoid the buggy call to inet_aton.

### Motivation

Getting rid of a warning.

### Testing Guidelines

Run the agent in host mode (or any other container on the same machine), see that the warning disappeared compared to the RC, replaced with a debug log.
