### PR TITLE
[packaging] Remove agent/checks from PYTHONPATH

### DIFF
--- a/packaging/osx/supervisor.conf
+++ b/packaging/osx/supervisor.conf
@@ -17,7 +17,7 @@ logfile_maxbytes = 50MB
 nodaemon = false
 pidfile = /opt/datadog-agent/run/datadog-supervisord.pid
 logfile_backups = 10
-environment=PYTHONPATH=/opt/datadog-agent/agent:/opt/datadog-agent/agent/checks,LANG=POSIX
+environment=PYTHONPATH=/opt/datadog-agent/agent,LANG=POSIX
 
 [program:collector]
 command=/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/agent.py foreground --use-local-forwarder

--- a/packaging/supervisor.conf
+++ b/packaging/supervisor.conf
@@ -18,7 +18,7 @@ nodaemon = false
 pidfile = /opt/datadog-agent/run/datadog-supervisord.pid
 logfile_backups = 10
 user=dd-agent
-environment=PYTHONPATH=/opt/datadog-agent/agent:/opt/datadog-agent/agent/checks,LANG=POSIX
+environment=PYTHONPATH=/opt/datadog-agent/agent,LANG=POSIX
 
 [program:collector]
 command=/opt/datadog-agent/embedded/bin/python /opt/datadog-agent/agent/agent.py foreground --use-local-forwarder


### PR DESCRIPTION
### What does this PR do?

Remove `/opt/datadog-agent/agent/checks` from the `PYTHONPATH` set up by supervisor.

### Motivation

Seems to have been there forever, but I don't think we need it in the
python path for any (good) reason. From what I've checked we always
import with `import checks.abc` instead of `import abc`.

Having it in the python path pollutes the module root namespace. For
instance it prevents importing the `datadog` module (i.e. module from
`datadogpy`) correctly (its name collides with `checks/datadog.py`).

### Testing Guidelines

Haven't tested this in depth but I applied the changes on an installed agent and haven't seen any import error.

### Additional Notes

The only use case that this change would break is if custom checks
are doing direct imports (e.g. `import wmi_check` to import
`checks/wmi_check.py`). The fix is trivial so it doesn't sound
blocking to me.

