### PR TITLE
[agent][release] version bumps after 5.13.0 release.

### DIFF
--- a/config.py
+++ b/config.py
@@ -41,7 +41,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 
 # CONSTANTS
-AGENT_VERSION = "5.13.0"
+AGENT_VERSION = "5.14.0"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
 MAC_CONFIG_PATH = '/opt/datadog-agent/etc'

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -11,7 +11,7 @@ set -u
 # SCRIPT KNOBS
 #######################################################################
 # Update for new releases, will pull this tag in the repo
-DEFAULT_AGENT_VERSION="5.12.3"
+DEFAULT_AGENT_VERSION="5.13.0"
 # Pin pip version, in the past there was some buggy releases and get-pip.py
 # always pulls the latest version
 PIP_VERSION="6.1.1"


### PR DESCRIPTION
### What does this PR do?

Bumps the config.py minor for the nightlies, and the source install.

### Motivation
5.13.0 release.