### PR TITLE
[docker] fix image name when using sha256 for specs

### DIFF
--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -481,20 +481,20 @@ class DockerUtil:
                     else:
                         image_spec = self.client.inspect_image(image)
                         try:
-                            name = image_spec.get('RepoTags')[0]
+                            name = image_spec['RepoTags'][0]
                             self._image_sha_to_name_mapping[image] = name
                             return name
-                        except Exception:
-                            pass
+                        except (LookupError, TypeError) as e:
+                            log.debug("Failed finding image name in RepoTag, trying RepoDigests: %s", e)
                         try:
-                            name = image_spec.get('RepoDigests')[0]
+                            name = image_spec['RepoDigests'][0]
                             name = name.split('@')[0]   # Last resort, we get the name with no tag
                             self._image_sha_to_name_mapping[image] = name
                             return name
-                        except Exception:
-                            pass
+                        except (LookupError, TypeError) as e:
+                            log.warning("Failed finding image name in RepoTag and RepoDigests: %s", e)
                 except Exception:
-                    pass
+                    log.exception("Exception getting docker image name")
             else:
                 return image
         return None

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -87,7 +87,8 @@ class SDDockerBackend(AbstractSDBackend):
             agentConfig['sd_config_backend'] = None
             self.config_store = get_config_store(agentConfig=agentConfig)
 
-        self.docker_client = DockerUtil(config_store=self.config_store).client
+        self.dockerutil = DockerUtil(config_store=self.config_store)
+        self.docker_client = self.dockerutil.client
         if Platform.is_k8s():
             try:
                 self.kubeutil = KubeUtil()
@@ -347,7 +348,7 @@ class SDDockerBackend(AbstractSDBackend):
         configs = {}
         state = self._make_fetch_state()
         containers = [(
-            container.get('Image'),
+            self.dockerutil.image_name_extractor(container),
             container.get('Id'), container.get('Labels')
         ) for container in self.docker_client.containers()]
 


### PR DESCRIPTION
### What does this PR do?

Some orchestrators init containers with the image sha256 instead of the
image name, and docker inspect returns this. If it's the case, make
a docker image inspect call to get the image name and cache the result

No cache invalidation is coded as image deletion don't trigger events and obsolete image count should be significant on a typical host

### Motivation

Compatibility with k8s 1.6 & Nomad

### Testing Guidelines

Added unit test for the three cases we support
