### PR TITLE
[docker] support systemd slices in cgroup paths

### DIFF
--- a/tests/core/test_dockerutil.py
+++ b/tests/core/test_dockerutil.py
@@ -22,6 +22,9 @@ class TestDockerUtil(unittest.TestCase):
             ), (
                 ['10', 'memory', '/docker/864daa0a0b19aa4703231b6c76f85c6f369b2452a5a7f777f0c9101c0fd5772a/docker/3bac629503293d1bb61e74f3e25b6c525f0c262f22974634c5d6988bb4b07927'],
                 'docker/3bac629503293d1bb61e74f3e25b6c525f0c262f22974634c5d6988bb4b07927'
+            ), (
+                ['7', 'memory', '/system.slice/docker-71116698eb215f2a5819f11ece7ea721f0e8d45169c7484d1cd7812596fad454.scope'],
+                'system.slice/docker-71116698eb215f2a5819f11ece7ea721f0e8d45169c7484d1cd7812596fad454.scope'
             )
         ]
 

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -347,13 +347,18 @@ class DockerUtil:
     @classmethod
     def _parse_subsystem(cls, line):
         """
-        If 'docker' is in the path, it can be there once or twice:
-        /docker/$CONTAINER_ID
-        /docker/$USER_DOCKER_CID/docker/$CONTAINER_ID
-        so we pick the last one.
+        Parse cgroup path.
+        - If the path is a slice (see https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Resource_Management_Guide/sec-Default_Cgroup_Hierarchies.html)
+          we return the path as-is (we still strip out any leading '/')
+        - If 'docker' is in the path, it can be there once or twice:
+          /docker/$CONTAINER_ID
+          /docker/$USER_DOCKER_CID/docker/$CONTAINER_ID
+          so we pick the last one.
         In /host/sys/fs/cgroup/$CGROUP_FOLDER/ cgroup/container IDs can be at the root
         or in a docker folder, so if we find 'docker/' in the path we don't strip it away.
         """
+        if '.slice' in line[2]:
+            return line[2].lstrip('/')
         i = line[2].rfind('docker')
         if i != -1:  # rfind returns -1 if docker is not found
             return line[2][i:]


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Some systems still use the systemd slice hierarchy for Docker. Let's support them.

### Motivation

Customer request

### Testing Guidelines

Updated the relevant unit test