### PR TITLE
fix exception when image name is None

### DIFF
--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -433,7 +433,7 @@ class DockerUtil:
 
     def image_tag_extractor(self, entity, key):
         name = self.image_name_extractor(entity)
-        if len(name):
+        if name is not None and len(name):
             split = name.split(":")
             if len(split) <= key:
                 return None


### PR DESCRIPTION
DockerUtil.image_name_extractor() can return None if no name is found (invalid container or image), but image_tag_extractor didn't handle the None case. This fixes the CI break