### PR TITLE
[dogstatsd] Log hostname on initialization

### DIFF
--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -509,6 +509,7 @@ def init(config_path=None, use_watchdog=False, use_forwarder=False, args=None):
         target = c['dogstatsd_target']
 
     hostname = get_hostname(c)
+    log.debug("Using hostname \"%s\"", hostname)
 
     # Create the aggregator (which is the point of communication between the
     # server and reporting threads.


### PR DESCRIPTION
### What does this PR do?

In dogstatsd, logs hostname on initialization

### Motivation

When running the agent as a dogstatsd server only (see for instance the dogstatsd-only docker image), it's useful to know which hostname the dogstatsd server will apply to metrics that have no explicit host tag attached.
