### PR TITLE
[docker]  use DockerUtil.image_name_extractor for all code paths

### DIFF
--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -17,6 +17,7 @@ from utils.service_discovery.abstract_config_store import AbstractConfigStore, \
     _TemplateCache, CONFIG_FROM_KUBE, CONFIG_FROM_TEMPLATE, CONFIG_FROM_AUTOCONF
 from utils.service_discovery.sd_backend import get_sd_backend
 from utils.service_discovery.sd_docker_backend import SDDockerBackend, _SDDockerBackendConfigFetchState
+from utils.dockerutil import DockerUtil
 
 
 def clear_singletons(agentConfig):
@@ -587,7 +588,7 @@ class TestServiceDiscovery(unittest.TestCase):
             for c_ins, _, _, _, expected_ident in self.container_inspects:
                 sd_backend = get_sd_backend(agentConfig=self.auto_conf_agentConfig)
                 self.assertEqual(
-                    sd_backend.get_config_id(c_ins.get('Image'), c_ins.get('Config', {}).get('Labels', {})),
+                    sd_backend.get_config_id(DockerUtil().image_name_extractor(c_ins), c_ins.get('Config', {}).get('Labels', {})),
                     expected_ident)
                 clear_singletons(self.auto_conf_agentConfig)
 

--- a/utils/configcheck.py
+++ b/utils/configcheck.py
@@ -72,13 +72,14 @@ def get_sd_configcheck(agentConfig, configs):
 
 
 def print_containers():
-    containers = DockerUtil().client.containers()
+    dockerutil = DockerUtil()
+    containers = dockerutil.client.containers()
     print("\nContainers info:\n")
     print("Number of containers found: %s" % len(containers))
     for co in containers:
         c_id = 'ID: %s' % co.get('Id')[:12]
-        c_image = 'image: %s' % co.get('Image')
-        c_name = 'name: %s' % DockerUtil.container_name_extractor(co)[0]
+        c_image = 'image: %s' % dockerutil.image_name_extractor(co)
+        c_name = 'name: %s' % dockerutil.container_name_extractor(co)[0]
         print("\t- %s %s %s" % (c_id, c_image, c_name))
     print('\n')
 

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -144,7 +144,7 @@ class SDDockerBackend(AbstractSDBackend):
             return
 
         identifier = inspect.get('Config', {}).get('Labels', {}).get(DATADOG_ID) or \
-            inspect.get('Config', {}).get('Image')
+            self.dockerutil.image_name_extractor(inspect)
 
         platform_kwargs = {}
         if Platform.is_k8s():


### PR DESCRIPTION
### What does this PR do?

- In https://github.com/DataDog/dd-agent/pull/3326, one SD code path was not fixed and still used get('Image'). This PR fixes it to use image_name_extractor too
- Updated configcheck.py to use it too