### PR TITLE
[config] Make supervisor socket consistent with default

### DIFF
--- a/packaging/datadog-agent/source/agent
+++ b/packaging/datadog-agent/source/agent
@@ -6,7 +6,7 @@ PATH=$BASEDIR/../venv/bin:$PATH
 
 SUPERVISOR_NOT_RUNNING="Supervisor is not running"
 SUPERVISOR_CONF_FILE='agent/supervisor.conf'
-SOCK_FILE='run/agent-supervisor.sock'
+SOCK_FILE='run/datadog-supervisor.sock'
 PID_FILE='run/supervisord.pid'
 COLLECTOR_PIDFILE='run/dd-agent.pid'
 action=$1

--- a/packaging/datadog-agent/source/supervisor.conf
+++ b/packaging/datadog-agent/source/supervisor.conf
@@ -11,11 +11,11 @@ pidfile = %(here)s/../run/supervisord.pid
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [unix_http_server]
-file = %(here)s/../run/agent-supervisor.sock
+file = %(here)s/../run/datadog-supervisor.sock
 
 [supervisorctl]
 prompt = datadog
-serverurl = unix://%(here)s/../run/agent-supervisor.sock
+serverurl = unix://%(here)s/../run/datadog-supervisor.sock
 
 [program:collector]
 command=python agent/agent.py foreground --use-local-forwarder


### PR DESCRIPTION
### What does this PR do?

The default supervisor socket is named `datadog-supervisor.sock` and
most other `supervisor.conf` configs use the default name. This change
keeps the socket filename in sync with the default, otherwise
it breaks service discovery.

### Motivation

Service discovery was breaking because it could not communicate with supervisor.
```
2017-05-08 20:57:25,609 | ERROR | dd.collector | collector(agent.py:604) | Uncaught error running the Agent
Traceback (most recent call last):
  File "agent/agent.py", line 600, in <module>
    sys.exit(main())
  File "agent/agent.py", line 543, in main
    agent.start(foreground=True)
  File "/opt/datadog-agent/agent/daemon.py", line 174, in start
    self.run()
  File "agent/agent.py", line 284, in run
    self._submit_jmx_service_discovery(jmx_sd_configs)
  File "agent/agent.py", line 433, in _submit_jmx_service_discovery
    jmx_state = self.supervisor_proxy.supervisor.getProcessInfo(JMX_SUPERVISOR_ENTRY)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1243, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1602, in __request
    verbose=self.__verbose
  File "/opt/datadog-agent/venv/lib/python2.7/site-packages/supervisor/xmlrpc.py", line 500, in request
    self.connection.request('POST', handler, request_body, self.headers)
  File "/usr/lib/python2.7/httplib.py", line 1042, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python2.7/httplib.py", line 1082, in _send_request
    self.endheaders(body)
  File "/usr/lib/python2.7/httplib.py", line 1038, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python2.7/httplib.py", line 882, in _send_output
    self.send(msg)
  File "/usr/lib/python2.7/httplib.py", line 844, in send
    self.connect()
  File "/opt/datadog-agent/venv/lib/python2.7/site-packages/supervisor/xmlrpc.py", line 521, in connect
    self.sock.connect(self.socketfile)
  File "/usr/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
error: [Errno 2] No such file or directory
```

### Testing Guidelines

If you spin up dd-agent, verify that checks from auto_conf (SD) are booted up properly via `agent info`. There should be no errors in the `collector.log`.

### Additional Notes
Default supervisor socket
https://github.com/DataDog/dd-agent/blame/21fb41c6d1c86787a371bdb3a3c82f24ceead21d/agent.py#L78

#### Confs using the default filename
* https://github.com/DataDog/dd-agent/blob/master/packaging/supervisor.conf#L5
* https://github.com/DataDog/dd-agent/blob/master/packaging/osx/supervisor.conf#L11
* https://github.com/DataDog/dd-agent/blob/master/packaging/supervisor_32.conf#L5
