### PR TITLE
[check] Fix misattribution of check instance warning

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -816,6 +816,8 @@ class AgentCheck(object):
                 )
             finally:
                 self._roll_up_instance_metadata()
+                # Discard any remaining warning so that next instance starts clean
+                self.get_warnings()
 
             instance_statuses.append(instance_status)
 

--- a/tests/core/test_check_status.py
+++ b/tests/core/test_check_status.py
@@ -9,6 +9,7 @@ from checks.check_status import (
     CollectorStatus,
     InstanceStatus,
     STATUS_ERROR,
+    STATUS_WARNING,
     STATUS_OK,
 )
 
@@ -16,6 +17,8 @@ from checks.check_status import (
 class DummyAgentCheck(AgentCheck):
 
     def check(self, instance):
+        if instance.get('warning'):
+            self.warning("warning")
         if not instance['pass']:
             raise Exception("failure")
 
@@ -46,6 +49,21 @@ def test_check_status_pass():
     assert len(instances_status) == 2
     for i in instances_status:
         assert i.status == STATUS_OK
+
+
+def test_check_status_warning():
+    instances = [
+        {'pass': True, 'warning': True},
+        {'pass': False, 'warning': True},
+        {'pass': True, 'warning': False}
+    ]
+
+    check = DummyAgentCheck('dummy_agent_check', {}, {}, instances)
+    instance_statuses = check.run()
+    assert len(instance_statuses) == 3
+    assert instance_statuses[0].status == STATUS_WARNING
+    assert instance_statuses[1].status == STATUS_ERROR
+    assert instance_statuses[2].status == STATUS_OK
 
 
 @attr(requires='core_integration')


### PR DESCRIPTION
### What does this PR do?

If a check has multiple instances, and the first instance adds a
warning and then raises an exception, the next instance of the check
would actually have that warning in its status (even if this second
instance ran fine).

Fix this by always discarding remaining warnings at the end of each
instance run.

Also, add a test reproducing the issue.

### Motivation

Reported on a support case.

### Testing Guidelines

Adds a test reproducing the issue

### Additional Notes

"Warnings" are one of the info that gets printed on the info page and sent as a service check, e.g.:

```
    elastic (5.13.0)
    ----------------
      - instance #0 [WARNING]
          Warning: full warning message
      - instance #1 [ERROR]: FooException
         Traceback: [...]
      - instance #3 [OK]
        
      - Collected 189 metrics, 0 events & 3 service checks
```
