### PR TITLE
Fix multi-instance service discovery

### DIFF
--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -116,13 +116,18 @@ class TestServiceDiscovery(unittest.TestCase):
         # image_name: ([(source, (check_name, init_tpl, instance_tpl, variables))], (expected_config_template))
         'image_0': (
             [('template', ('check_0', {}, {'host': '%%host%%'}, ['host']))],
-            ('template', ('check_0', {}, {'host': '127.0.0.1', 'tags': [u'docker_image:nginx', u'image_name:nginx']}))),
+            ('template', ('check_0', {}, [{'host': '127.0.0.1', 'tags': [u'docker_image:nginx', u'image_name:nginx']}]))),
         'image_1': (
             [('template', ('check_1', {}, {'port': '%%port%%'}, ['port']))],
-            ('template', ('check_1', {}, {'port': '1337', 'tags': [u'docker_image:nginx', u'image_name:nginx']}))),
+            ('template', ('check_1', {}, [{'port': '1337', 'tags': [u'docker_image:nginx', u'image_name:nginx']}]))),
         'image_2': (
             [('template', ('check_2', {}, {'host': '%%host%%', 'port': '%%port%%'}, ['host', 'port']))],
-            ('template', ('check_2', {}, {'host': '127.0.0.1', 'port': '1337', 'tags': [u'docker_image:nginx', u'image_name:nginx']}))),
+            ('template', ('check_2', {}, [{'host': '127.0.0.1', 'port': '1337', 'tags': [u'docker_image:nginx', u'image_name:nginx']}]))),
+        'image_3': (
+            [('template', ('check_3', {}, [{'host': '%%host%%', 'port': '%%port%%'}, {"foo": "%%host%%", "bar": "%%port%%"}], ['host', 'port', 'host', 'port']))],
+            ('template', ('check_3', {}, [
+                {'host': '127.0.0.1', 'port': '1337', 'tags': [u'docker_image:nginx', u'image_name:nginx']},
+                {'foo': '127.0.0.1', 'bar': '1337', 'tags': [u'docker_image:nginx', u'image_name:nginx']}]))),
     }
 
     # raw templates coming straight from the config store
@@ -137,6 +142,13 @@ class TestServiceDiscovery(unittest.TestCase):
         'image_2': (
             ('["check_2"]', '[{}]', '[{"host": "%%host%%", "port": "%%port%%"}]'),
             [('template', ('check_2', {}, {"host": "%%host%%", "port": "%%port%%"}))]),
+        'image_3': (
+            ('["check_3"]', '[{}]', '[[{"host": "%%host%%", "port": "%%port%%"},{"foo": "%%host%%", "bar": "%%port%%"}]]'),
+            [('template', ('check_3', {}, [{"host": "%%host%%", "port": "%%port%%"}, {"foo": "%%host%%", "bar": "%%port%%"}]))]),
+        # multi-checks environment
+        'image_4': (
+            ('["check_4a", "check_4b"]', '[{},{}]', '[[{"host": "%%host%%", "port": "%%port%%"}],[{"foo": "%%host%%", "bar": "%%port%%"}]]'),
+            [('template', ('check_4a', {}, [{"host": "%%host%%", "port": "%%port%%"}])), ('template', ('check_4b', {}, [{"foo": "%%host%%", "bar": "%%port%%"}]))]),
         'bad_image_0': ((['invalid template']), []),
         'bad_image_1': (('invalid template'), []),
         'bad_image_2': (None, []),
@@ -558,7 +570,7 @@ class TestServiceDiscovery(unittest.TestCase):
     @mock.patch.object(AbstractConfigStore, 'client_read', side_effect=client_read)
     def test_get_check_tpls_kube(self, *args):
         """Test get_check_tpls for kubernetes annotations"""
-        valid_config = ['image_0', 'image_1', 'image_2']
+        valid_config = ['image_0', 'image_1', 'image_2', 'image_3', 'image_4']
         invalid_config = ['bad_image_0']
         config_store = get_config_store(self.auto_conf_agentConfig)
         for image in valid_config + invalid_config:

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -373,13 +373,20 @@ class SDDockerBackend(AbstractSDBackend):
 
                     # build instances list if needed
                     if configs.get(check_name) is None:
-                        configs[check_name] = (source, (init_config, [instance]))
+                        if isinstance(instance, list):
+                            configs[check_name] = (source, (init_config, instance))
+                        else:
+                            configs[check_name] = (source, (init_config, [instance]))
                     else:
                         conflict_init_msg = 'Different versions of `init_config` found for check {}. ' \
                             'Keeping the first one found.'
                         if configs[check_name][1][0] != init_config:
                             log.warning(conflict_init_msg.format(check_name))
-                        configs[check_name][1][1].append(instance)
+                        if isinstance(instance, list):
+                            for inst in instance:
+                                configs[check_name][1][1].append(inst)
+                        else:
+                            configs[check_name][1][1].append(instance)
             except Exception:
                 log.exception('Building config for container %s based on image %s using service '
                               'discovery failed, leaving it alone.' % (cid[:12], image))
@@ -408,13 +415,26 @@ class SDDockerBackend(AbstractSDBackend):
             source, config_tpl = config_tpl
             check_name, init_config_tpl, instance_tpl, variables = config_tpl
 
-            # insert tags in instance_tpl and process values for template variables
-            instance_tpl, var_values = self._fill_tpl(state, c_id, instance_tpl, variables, tags)
+            # covering mono-instance and multi-instances cases
+            tmpl_array = instance_tpl
+            if not isinstance(instance_tpl, list):
+                tmpl_array = [instance_tpl]
 
-            tpl = self._render_template(init_config_tpl or {}, instance_tpl or {}, var_values)
-            if tpl and len(tpl) == 2:
-                init_config, instance = tpl
-                check_configs.append((source, (check_name, init_config, instance)))
+            # insert tags in instance_tpl and process values for template variables
+            result_instances = []
+            result_init_config = None
+            for inst_tmpl in tmpl_array:
+                instance_tpl, var_values = self._fill_tpl(state, c_id, inst_tmpl, variables, tags)
+                tpl = self._render_template(init_config_tpl or {}, instance_tpl or {}, var_values)
+                if tpl and len(tpl) == 2:
+                    init_config, instance = tpl
+                    result_instances.append(instance)
+                    if not result_init_config:
+                        result_init_config = init_config
+                    elif result_init_config != init_config:
+                        self.log.warning("Different versions of `init_config` found for "
+                            "check {}. Keeping the first one found.".format('check_name'))
+            check_configs.append((source, (check_name, result_init_config, result_instances)))
 
         return check_configs
 
@@ -443,7 +463,7 @@ class SDDockerBackend(AbstractSDBackend):
                 variables = map(lambda x: x.strip('%'), variables)
                 if not isinstance(init_config_tpl, dict):
                     init_config_tpl = json.loads(init_config_tpl or '{}')
-                if not isinstance(instance_tpl, dict):
+                if not isinstance(instance_tpl, dict) and not isinstance(instance_tpl, list):
                     instance_tpl = json.loads(instance_tpl or '{}')
             except json.JSONDecodeError:
                 log.exception('Failed to decode the JSON template fetched for check {0}. Its configuration'


### PR DESCRIPTION
Fixes: #3340

As explained in  #3340, having multiple instances for the same check in the annotations don't work well.
This brings the few adjustments to make it work.

The doc will need to be updated to say that if you want several instances of the same check in the annotations, you'll need to have an array for then inside the annotations array.