### PR TITLE
[SD] better docker tag extraction logic + tests

### DIFF
--- a/tests/core/test_dockerutil.py
+++ b/tests/core/test_dockerutil.py
@@ -38,7 +38,6 @@ class TestDockerUtil(unittest.TestCase):
     def test_image_name_from_container(self):
         co = {'Image': 'redis:3.2'}
         self.assertEqual('redis:3.2', DockerUtil().image_name_extractor(co))
-        pass
 
     @mock.patch('docker.Client.inspect_image')
     @mock.patch('docker.Client.__init__')
@@ -62,3 +61,15 @@ class TestDockerUtil(unittest.TestCase):
         mock_init.return_value = None
         co = {'Image': 'sha256:e48e77eee11b6d9ac9fc35a23992b4158355a8ec3fd3725526eba3f467e4b6d9'}
         self.assertEqual('alpine', DockerUtil().image_name_extractor(co))
+
+    def test_extract_container_tags(self):
+        test_data = [
+            # Nominal case
+            [{'Image': 'redis:3.2'}, ['docker_image:redis:3.2', 'image_name:redis', 'image_tag:3.2']],
+            # No tag
+            [{'Image': 'redis'}, ['docker_image:redis', 'image_name:redis']],
+            # No image
+            [{}, []],
+        ]
+        for test in test_data:
+            self.assertEqual(test[1], DockerUtil().extract_container_tags(test[0]))

--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -116,13 +116,13 @@ class TestServiceDiscovery(unittest.TestCase):
         # image_name: ([(source, (check_name, init_tpl, instance_tpl, variables))], (expected_config_template))
         'image_0': (
             [('template', ('check_0', {}, {'host': '%%host%%'}, ['host']))],
-            ('template', ('check_0', {}, {'host': '127.0.0.1'}))),
+            ('template', ('check_0', {}, {'host': '127.0.0.1', 'tags': [u'docker_image:nginx', u'image_name:nginx']}))),
         'image_1': (
             [('template', ('check_1', {}, {'port': '%%port%%'}, ['port']))],
-            ('template', ('check_1', {}, {'port': '1337'}))),
+            ('template', ('check_1', {}, {'port': '1337', 'tags': [u'docker_image:nginx', u'image_name:nginx']}))),
         'image_2': (
             [('template', ('check_2', {}, {'host': '%%host%%', 'port': '%%port%%'}, ['host', 'port']))],
-            ('template', ('check_2', {}, {'host': '127.0.0.1', 'port': '1337'}))),
+            ('template', ('check_2', {}, {'host': '127.0.0.1', 'port': '1337', 'tags': [u'docker_image:nginx', u'image_name:nginx']}))),
     }
 
     # raw templates coming straight from the config store

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -441,6 +441,25 @@ class DockerUtil:
 
         raise MountException("Cannot find Docker cgroup directory. Be sure your system is supported.")
 
+    def extract_container_tags(self, co):
+        """
+        Retrives docker_image, image_name and image_tag tags as a list for a
+        container. If the container or image is invalid, will gracefully
+        return an empty list
+        """
+        tags = []
+        docker_image = self.image_name_extractor(co)
+        image_name_array = self.image_tag_extractor(co, 0)
+        image_tag_array = self.image_tag_extractor(co, 1)
+
+        if docker_image:
+            tags.append('docker_image:%s' % docker_image)
+        if image_name_array and len(image_name_array) > 0:
+            tags.append('image_name:%s' % image_name_array[0])
+        if image_tag_array and len(image_tag_array) > 0:
+            tags.append('image_tag:%s' % image_tag_array[0])
+        return tags
+
     def image_tag_extractor(self, entity, key):
         name = self.image_name_extractor(entity)
         if name is not None and len(name):


### PR DESCRIPTION
- move SD docker tags extraction to dockerutil.extract_container_tags with error handling
- only inspect the container once in a shared c_inspect var
- update sd unit test fixtures
- extend test_dockerutil to test new method