### PR TITLE
[checks][proxy] fix helper function flag is `no_proxy`

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -395,7 +395,7 @@ class AgentCheck(object):
         proxies = self.proxies.copy()
         proxies['no'] = get_no_proxy_from_env()
 
-        return config_proxy_skip(proxies, uri, _is_affirmative(instance.get('skip_proxy', False)))
+        return config_proxy_skip(proxies, uri, _is_affirmative(instance.get('no_proxy', False)))
 
     def instance_count(self):
         """ Return the number of instances that are configured for this check. """


### PR DESCRIPTION
### What does this PR do?

The flag to enable/disable the proxy checks is `no_proxy` not `skip_proxy`. This fixes it.

### Motivation

Bug identified during testing.