### PR TITLE
[AD] add support for etcd auth

### DIFF
--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -122,6 +122,11 @@ gce_updated_hostname: yes
 # sd_backend_host: 127.0.0.1
 # sd_backend_port: 4001
 #
+# If you use etcd, you can set a username and password for auth
+#
+# sd_backend_username:
+# sd_backend_password:
+#
 # By default, the agent will look for the configuration templates under the
 # `/datadog/check_configs` key in the back-end. If you wish otherwise, uncomment this option
 # and modify its value.

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ ntplib==0.3.3
 # utils/service_discovery/config_stores.py
 python-consul==0.4.7
 # utils/service_discovery/config_stores.py
-python-etcd==0.4.2
+python-etcd==0.4.5
 # the libyaml bindings are optional
 pyyaml==3.11
 # note: requests is also used in many checks

--- a/utils/service_discovery/etcd_config_store.py
+++ b/utils/service_discovery/etcd_config_store.py
@@ -25,6 +25,8 @@ class EtcdStore(AbstractConfigStore):
         settings = {
             'host': config.get('sd_backend_host', DEFAULT_ETCD_HOST),
             'port': int(config.get('sd_backend_port', -1)),
+            'username': config.get('sd_backend_username', None),
+            'password': config.get('sd_backend_password', None),
             # these two are always set to their default value for now
             'allow_reconnect': config.get('etcd_allow_reconnect', DEFAULT_RECO),
             'protocol': config.get('etcd_protocol', DEFAULT_ETCD_PROTOCOL),
@@ -45,6 +47,8 @@ class EtcdStore(AbstractConfigStore):
                 self.client = etcd_client(
                     host=self.settings.get('host'),
                     port=port,
+                    username=self.settings.get('username'),
+                    password=self.settings.get('password'),
                     allow_reconnect=self.settings.get('allow_reconnect'),
                     protocol=self.settings.get('protocol'),
                 )


### PR DESCRIPTION
### What does this PR do?

Add `sd_backend_username` & `sd_backend_password` options to enable authentication when connecting to the etcd datastore.

Depends on https://github.com/DataDog/omnibus-software/pull/145 for dependency bump.

### Motivation

Allows for fine-grained access control for clients that need it

### Testing guidelines

Debian package built with both PR available on request.