### PR TITLE
Add container_name to additional tags

### DIFF
--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -338,8 +338,19 @@ class SDDockerBackend(AbstractSDBackend):
 
         return tags
 
+    def _get_container_name(self, state, c_id):
+        container_inspect = state.inspect_container(c_id)
+        name = container_inspect.get('Name', '')
+        if name.startswith('/'):
+            name = name[1:]
+        return name
+
     def _get_additional_tags(self, state, c_id, *args):
         tags = []
+        container_name = self._get_container_name(state, c_id)
+        if container_name:
+            tags.append('container_name:%s' % container_name)
+
         if Platform.is_k8s():
             pod_metadata = state.get_kube_config(c_id, 'metadata')
             pod_spec = state.get_kube_config(c_id, 'spec')


### PR DESCRIPTION
Hello!

Sometimes, we have two docker containers with same image and same service but different container names on one physical host and we need to distinguish metrics from this two containers in datadog. Currently it is impossible, because metrics are not tagged by container name. This PR adds ability to use container name variable in auto_check templates, so you can add such tags.

We have applied this patch on our servers and it works.

Configuration example:

```
docker_images:
  - someimage
init_config:
instances:
  - nginx_status_url: 'http://%%host%%:8080/nginx_status/'
    tags:
      - 'container_name:%%containername%%'
```

### Tests
Looks like this functionality has already covered by tests.
