### PR TITLE
[docker] Make TLS settings more intuitive

### DIFF
--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -249,13 +249,13 @@ class DockerUtil:
             client_cert_path = init_config.get('tls_client_cert')
             client_key_path = init_config.get('tls_client_key')
             cacert = init_config.get('tls_cacert')
-            verify = init_config.get('tls_verify')
+            verify = init_config.get('tls_verify', False)
 
             client_cert = None
             if client_cert_path is not None and client_key_path is not None:
                 client_cert = (client_cert_path, client_key_path)
 
-            verify = verify if verify is not None else cacert
+            verify = cacert if cacert is not None else verify
             tls_config = tls.TLSConfig(client_cert=client_cert, verify=verify)
             self.settings["tls"] = tls_config
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

TLS settings were confusing. Setting tls_verify to true and tls_cacert to a path would request TLS verification but not pass the ca cert path, causing errors. The solution was to set tls_cacert and omit tls_verify but that's hard to guess.

### Motivation

Support tickets.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
