### PR TITLE
Fix typo in the network exception log

### DIFF
--- a/checks/network_checks.py
+++ b/checks/network_checks.py
@@ -158,7 +158,7 @@ class NetworkCheck(AgentCheck):
 
         except Exception:
             self.log.exception(
-                u"Failed to process instance '%s'.", instance.get('Name', u"")
+                u"Failed to process instance '%s'.", instance.get('name', u"")
             )
             result = (FAILURE, FAILURE, FAILURE, instance)
             self.resultsq.put(result)


### PR DESCRIPTION
### What does this PR do?

Fix typo in the network exception log, the right key in configuration are lowercase.

### Motivation

see: #3354 