### PR TITLE
Mesos tagging and generic container tagger

### DIFF
--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -42,10 +42,10 @@ class TestBaseUtil(unittest.TestCase):
         def _get_cacheable_tags(self, cid, co=None):
             return ["test:tag"]
 
-    class NeedInspectUtil(BaseUtil):
+    class NeedLabelsUtil(BaseUtil):
         def __init__(self):
             BaseUtil.__init__(self)
-            self.needs_inspect = True
+            self.needs_inspect_labels = True
 
         def _get_cacheable_tags(self, cid, co=None):
             return ["test:tag"]
@@ -53,7 +53,7 @@ class TestBaseUtil(unittest.TestCase):
     class NeedEnvUtil(BaseUtil):
         def __init__(self):
             BaseUtil.__init__(self)
-            self.needs_env = True
+            self.needs_inspect_config = True
 
         def _get_cacheable_tags(self, cid, co=None):
             return ["test:tag"]
@@ -96,7 +96,7 @@ class TestBaseUtil(unittest.TestCase):
     def test_auto_inspect(self, mock_init, mock_inspect):
         mock_init.return_value = None
 
-        dummy = self.NeedInspectUtil()
+        dummy = self.NeedLabelsUtil()
         dummy.reset_cache()
 
         dummy.get_container_tags(cid=CO_ID)
@@ -107,7 +107,7 @@ class TestBaseUtil(unittest.TestCase):
     def test_no_inspect_if_cached(self, mock_init, mock_inspect):
         mock_init.return_value = None
 
-        dummy = self.NeedInspectUtil()
+        dummy = self.NeedLabelsUtil()
         dummy.reset_cache()
 
         dummy.get_container_tags(cid=CO_ID)
@@ -121,11 +121,11 @@ class TestBaseUtil(unittest.TestCase):
     def test_no_useless_inspect(self, mock_init, mock_inspect):
         mock_init.return_value = None
 
-        dummy = self.NeedInspectUtil()
+        dummy = self.NeedLabelsUtil()
         dummy.reset_cache()
-        co = {'Id': CO_ID, 'Created': 1}
+        co = {'Id': CO_ID, 'Created': 1, 'Labels': {}}
 
-        dummy.get_container_tags(cid=1, co=co)
+        dummy.get_container_tags(co=co)
         mock_inspect.assert_not_called()
 
         dummy.get_container_tags(co=co)

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -1,0 +1,154 @@
+# stdlib
+import unittest
+import os
+
+# 3rd party
+import mock
+
+# project
+from utils.orchestrator import MesosUtil, BaseUtil
+
+CO_ID = 1234
+
+
+class TestMesosUtil(unittest.TestCase):
+    @mock.patch('docker.Client.__init__')
+    def test_extract_tags(self, mock_init):
+        mock_init.return_value = None
+        mesos = MesosUtil()
+
+        env = ["CHRONOS_JOB_NAME=test-job",
+               "MARATHON_APP_ID=/system/dd-agent",
+               "MESOS_TASK_ID=system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001"]
+
+        tags = ['chronos_job:test-job', 'marathon_app:/system/dd-agent',
+                'mesos_task:system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001']
+
+        container = {'Config': {'Env': env}}
+
+        self.assertEqual(sorted(tags), sorted(mesos._get_cacheable_tags(CO_ID, co=container)))
+
+    @mock.patch.dict(os.environ, {"MESOS_TASK_ID": "test"})
+    def test_detect(self):
+        self.assertTrue(MesosUtil.is_detected())
+
+    @mock.patch.dict(os.environ, {})
+    def test_no_detect(self):
+        self.assertFalse(MesosUtil.is_detected())
+
+
+class TestBaseUtil(unittest.TestCase):
+    class DummyUtil(BaseUtil):
+        def _get_cacheable_tags(self, cid, co=None):
+            return ["test:tag"]
+
+    class NeedInspectUtil(BaseUtil):
+        def __init__(self):
+            BaseUtil.__init__(self)
+            self.needs_inspect = True
+
+        def _get_cacheable_tags(self, cid, co=None):
+            return ["test:tag"]
+
+    class NeedEnvUtil(BaseUtil):
+        def __init__(self):
+            BaseUtil.__init__(self)
+            self.needs_env = True
+
+        def _get_cacheable_tags(self, cid, co=None):
+            return ["test:tag"]
+
+    @mock.patch('docker.Client.__init__')
+    def test_extract_tags(self, mock_init):
+        mock_init.return_value = None
+        dummy = self.DummyUtil()
+        dummy.reset_cache()
+
+        self.assertEqual(["test:tag"], dummy.get_container_tags(cid=CO_ID))
+
+    @mock.patch('docker.Client.__init__')
+    def test_cache_invalidation_event(self, mock_init):
+        mock_init.return_value = None
+        dummy = self.DummyUtil()
+        dummy.reset_cache()
+
+        dummy.get_container_tags(cid=CO_ID)
+        self.assertTrue(CO_ID in dummy._container_tags_cache)
+
+        EVENT = {'status': 'die', 'id': CO_ID}
+        dummy.invalidate_cache([EVENT])
+        self.assertFalse(CO_ID in dummy._container_tags_cache)
+
+    @mock.patch('docker.Client.__init__')
+    def test_reset_cache(self, mock_init):
+        mock_init.return_value = None
+        dummy = self.DummyUtil()
+        dummy.reset_cache()
+
+        dummy.get_container_tags(cid=CO_ID)
+        self.assertTrue(CO_ID in dummy._container_tags_cache)
+
+        dummy.reset_cache()
+        self.assertFalse(CO_ID in dummy._container_tags_cache)
+
+    @mock.patch('docker.Client.inspect_container')
+    @mock.patch('docker.Client.__init__')
+    def test_auto_inspect(self, mock_init, mock_inspect):
+        mock_init.return_value = None
+
+        dummy = self.NeedInspectUtil()
+        dummy.reset_cache()
+
+        dummy.get_container_tags(cid=CO_ID)
+        mock_inspect.assert_called_once()
+
+    @mock.patch('docker.Client.inspect_container')
+    @mock.patch('docker.Client.__init__')
+    def test_no_inspect_if_cached(self, mock_init, mock_inspect):
+        mock_init.return_value = None
+
+        dummy = self.NeedInspectUtil()
+        dummy.reset_cache()
+
+        dummy.get_container_tags(cid=CO_ID)
+        mock_inspect.assert_called_once()
+
+        dummy.get_container_tags(cid=CO_ID)
+        mock_inspect.assert_called_once()
+
+    @mock.patch('docker.Client.inspect_container')
+    @mock.patch('docker.Client.__init__')
+    def test_no_useless_inspect(self, mock_init, mock_inspect):
+        mock_init.return_value = None
+
+        dummy = self.NeedInspectUtil()
+        dummy.reset_cache()
+        co = {'Id': CO_ID, 'Created': 1}
+
+        dummy.get_container_tags(cid=1, co=co)
+        mock_inspect.assert_not_called()
+
+        dummy.get_container_tags(co=co)
+        mock_inspect.assert_not_called()
+
+    @mock.patch('docker.Client.inspect_container')
+    @mock.patch('docker.Client.__init__')
+    def test_auto_env_inspect(self, mock_init, mock_inspect):
+        mock_init.return_value = None
+
+        dummy = self.NeedEnvUtil()
+        dummy.reset_cache()
+
+        dummy.get_container_tags(co={'Id': CO_ID})
+        mock_inspect.assert_called_once()
+
+    @mock.patch('docker.Client.inspect_container')
+    @mock.patch('docker.Client.__init__')
+    def test_no_useless_env_inspect(self, mock_init, mock_inspect):
+        mock_init.return_value = None
+
+        dummy = self.NeedEnvUtil()
+        dummy.reset_cache()
+
+        dummy.get_container_tags(co={'Id': CO_ID, 'Config': {'Env': {1: 1}}})
+        mock_inspect.assert_not_called()

--- a/utils/orchestrator/__init__.py
+++ b/utils/orchestrator/__init__.py
@@ -7,4 +7,4 @@ from mesosutil import MesosUtil  # noqa: F401
 from nomadutil import NomadUtil  # noqa: F401
 from baseutil import BaseUtil  # noqa: F401
 
-from tagger import Tagger  # noqa: F401
+from metadata_collector import MetadataCollector  # noqa: F401

--- a/utils/orchestrator/__init__.py
+++ b/utils/orchestrator/__init__.py
@@ -2,5 +2,9 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-from nomadutil import NomadUtil  # noqa: F401
 from ecsutil import ECSUtil  # noqa: F401
+from mesosutil import MesosUtil  # noqa: F401
+from nomadutil import NomadUtil  # noqa: F401
+from baseutil import BaseUtil  # noqa: F401
+
+from tagger import Tagger  # noqa: F401

--- a/utils/orchestrator/baseutil.py
+++ b/utils/orchestrator/baseutil.py
@@ -25,10 +25,10 @@ class BaseUtil:
     __metaclass__ = Singleton
 
     def __init__(self):
-        # Whether your get___tags methods need the inspect result
-        self.needs_inspect = False
-        # Whether your methods need the env portion (not in partial inspect)
-        self.needs_env = False
+        # Whether your get___tags methods need the Config section inspect data
+        self.needs_inspect_config = False
+        # Whether your get___tags methods need the Labels section inspect data
+        self.needs_inspect_labels = False
 
         self.log = logging.getLogger(__name__)
         self.docker_util = DockerUtil()
@@ -59,10 +59,11 @@ class BaseUtil:
         if cid in self._container_tags_cache:
             return self._container_tags_cache[cid]
         else:
-            if (self.needs_inspect or self.needs_env) and co is None:
+            if self.needs_inspect_config and (co is None or 'Config' not in co):
                 co = self.docker_util.inspect_container(cid)
-            if self.needs_env and 'Env' not in co.get('Config', {}):
+            if self.needs_inspect_labels and (co is None or 'Labels' not in co):
                 co = self.docker_util.inspect_container(cid)
+
             self._container_tags_cache[cid] = self._get_cacheable_tags(cid, co)
             return self._container_tags_cache[cid]
 

--- a/utils/orchestrator/baseutil.py
+++ b/utils/orchestrator/baseutil.py
@@ -1,0 +1,85 @@
+# (C) Datadog, Inc. 2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+import logging
+
+# project
+from utils.dockerutil import DockerUtil
+from utils.singleton import Singleton
+
+
+class BaseUtil:
+    """
+    Base class for orchestrator utils. Only handles container tags for now.
+    Users should go through the orchestrator.Tagger class to simplify the code
+
+    Children classes can implement:
+      - __init__: to change self.needs_inspect
+      - _get_cacheable_tags: tags will be cached for reuse
+      - _get_transient_tags: tags can change and won't be cached (TODO)
+      - invalidate_cache: custom cache invalidation logic
+      - is_detected (staticmethod)
+    """
+    __metaclass__ = Singleton
+
+    def __init__(self):
+        # Whether your get___tags methods need the inspect result
+        self.needs_inspect = False
+        # Whether your methods need the env portion (not in partial inspect)
+        self.needs_env = False
+
+        self.log = logging.getLogger(__name__)
+        self.docker_util = DockerUtil()
+
+        # Tags cache as a dict {co_id: [tags]}
+        self._container_tags_cache = {}
+
+    def get_container_tags(self, cid=None, co=None):
+        """
+        Returns container tags for the given container, inspecting the container if needed
+        :param container: either the container id or container dict returned by docker-py
+        :return: tags as list<string>, cached
+        """
+
+        if (cid is not None) and (co is not None):
+            self.log.error("Can only pass either a container id or object, not both, returning empty tags")
+            return []
+        if (cid is None) and (co is None):
+            self.log.error("Need one container id or container object, returning empty tags")
+            return []
+        elif co is not None:
+            if 'Id' in co:
+                cid = co.get('Id')
+            else:
+                self.log.warning("Invalid container dict, returning empty tags")
+                return []
+
+        if cid in self._container_tags_cache:
+            return self._container_tags_cache[cid]
+        else:
+            if (self.needs_inspect or self.needs_env) and co is None:
+                co = self.docker_util.inspect_container(cid)
+            if self.needs_env and 'Env' not in co.get('Config', {}):
+                co = self.docker_util.inspect_container(cid)
+            self._container_tags_cache[cid] = self._get_cacheable_tags(cid, co)
+            return self._container_tags_cache[cid]
+
+    def invalidate_cache(self, events):
+        """
+        Allows cache invalidation when containers die
+        :param events from self.get_events
+        """
+        try:
+            for ev in events:
+                if ev.get('status') == 'die' and ev.get('id') in self._container_tags_cache:
+                    del self._container_tags_cache[ev.get('id')]
+        except Exception as e:
+            self.log.warning("Error when invalidating tag cache: " + str(e))
+
+    def reset_cache(self):
+        """
+        Empties all caches to reset the singleton to initial state
+        """
+        self._container_tags_cache = {}

--- a/utils/orchestrator/mesosutil.py
+++ b/utils/orchestrator/mesosutil.py
@@ -1,0 +1,40 @@
+# (C) Datadog, Inc. 2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+import os
+
+from .baseutil import BaseUtil
+
+CHRONOS_JOB_NAME = "CHRONOS_JOB_NAME"
+MARATHON_APP_ID = "MARATHON_APP_ID"
+MESOS_TASK_ID = "MESOS_TASK_ID"
+
+
+class MesosUtil(BaseUtil):
+    def __init__(self):
+        BaseUtil.__init__(self)
+        self.needs_inspect = True
+        self.needs_env = True
+
+    def _get_cacheable_tags(self, cid, co=None):
+        tags = []
+
+        self.log.warning("called")
+
+        envvars = co.get('Config', {}).get('Env', {})
+        self.log.warning(envvars)
+
+        for var in envvars:
+            if var.startswith(CHRONOS_JOB_NAME):
+                tags.append('chronos_job:%s' % var[len(CHRONOS_JOB_NAME) + 1:])
+            elif var.startswith(MARATHON_APP_ID):
+                tags.append('marathon_app:%s' % var[len(MARATHON_APP_ID) + 1:])
+            elif var.startswith(MESOS_TASK_ID):
+                tags.append('mesos_task:%s' % var[len(MESOS_TASK_ID) + 1:])
+
+        return tags
+
+    @staticmethod
+    def is_detected():
+        return MESOS_TASK_ID in os.environ

--- a/utils/orchestrator/mesosutil.py
+++ b/utils/orchestrator/mesosutil.py
@@ -14,8 +14,7 @@ MESOS_TASK_ID = "MESOS_TASK_ID"
 class MesosUtil(BaseUtil):
     def __init__(self):
         BaseUtil.__init__(self)
-        self.needs_inspect = True
-        self.needs_env = True
+        self.needs_inspect_config = True
 
     def _get_cacheable_tags(self, cid, co=None):
         tags = []

--- a/utils/orchestrator/mesosutil.py
+++ b/utils/orchestrator/mesosutil.py
@@ -18,11 +18,7 @@ class MesosUtil(BaseUtil):
 
     def _get_cacheable_tags(self, cid, co=None):
         tags = []
-
-        self.log.warning("called")
-
         envvars = co.get('Config', {}).get('Env', {})
-        self.log.warning(envvars)
 
         for var in envvars:
             if var.startswith(CHRONOS_JOB_NAME):

--- a/utils/orchestrator/metadata_collector.py
+++ b/utils/orchestrator/metadata_collector.py
@@ -7,7 +7,7 @@ from .mesosutil import MesosUtil
 from utils.singleton import Singleton
 
 
-class Tagger():
+class MetadataCollector():
     """
     Wraps several BaseUtil classes with autodetection and allows to query
     them through the same interface as BaseUtil classes

--- a/utils/orchestrator/tagger.py
+++ b/utils/orchestrator/tagger.py
@@ -1,0 +1,59 @@
+# (C) Datadog, Inc. 2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+
+from .mesosutil import MesosUtil
+from utils.singleton import Singleton
+
+
+class Tagger():
+    """
+    Wraps several BaseUtil classes with autodetection and allows to query
+    them through the same interface as BaseUtil classes
+
+    See BaseUtil for apidoc
+    """
+    __metaclass__ = Singleton
+
+    def __init__(self):
+        self._utils = []  # [BaseUtil object]
+        self._has_detected = False
+        self.reset()
+
+    def get_container_tags(self, cid=None, co=None):
+        concat_tags = []
+        for util in self._utils:
+            tags = util.get_container_tags(cid, co)
+            if tags:
+                concat_tags.extend(tags)
+
+        return concat_tags
+
+    def invalidate_cache(self, events):
+        for util in self._utils:
+            util.invalidate_cache(events)
+
+    def reset_cache(self):
+        for util in self._utils:
+            util.reset_cache()
+
+    def reset(self):
+        """
+        Trigger a new autodetection and reset underlying util classes
+        """
+        self._utils = []
+
+        if MesosUtil.is_detected():
+            m = MesosUtil()
+            m.reset_cache()
+            self._utils.append(m)
+
+        self._has_detected = bool(self._utils)
+
+    def has_detected(self):
+        """
+        Returns whether the tagger has detected orchestrators it handles
+        If false, calling get_container_tags will return an empty list
+        """
+        return self._has_detected

--- a/utils/platform.py
+++ b/utils/platform.py
@@ -22,6 +22,7 @@ def get_os():
     else:
         return sys.platform
 
+
 class Platform(object):
     """
     Return information about the given platform.
@@ -108,3 +109,8 @@ class Platform(object):
     @staticmethod
     def is_nomad():
         return 'NOMAD_ALLOC_ID' in os.environ
+
+    @staticmethod
+    def is_mesos():
+        from utils.orchestrator import MesosUtil
+        return MesosUtil.is_detected()

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -22,7 +22,7 @@ from utils.kubernetes import KubeUtil
 from utils.platform import Platform
 from utils.service_discovery.abstract_sd_backend import AbstractSDBackend
 from utils.service_discovery.config_stores import get_config_store
-from utils.orchestrator import NomadUtil, ECSUtil, Tagger
+from utils.orchestrator import NomadUtil, ECSUtil, MetadataCollector
 
 DATADOG_ID = 'com.datadoghq.sd.check.id'
 
@@ -103,7 +103,7 @@ class SDDockerBackend(AbstractSDBackend):
         elif Platform.is_ecs_instance():
             self.ecsutil = ECSUtil()
 
-        self.orchestrator_tagger = Tagger()
+        self.metadata_collector = MetadataCollector()
 
         self.VAR_MAPPING = {
             'host': self._get_host_address,
@@ -338,8 +338,8 @@ class SDDockerBackend(AbstractSDBackend):
             ecs_tags = self.ecsutil.extract_container_tags(c_inspect)
             tags.extend(ecs_tags)
 
-        if self.orchestrator_tagger.has_detected():
-            orch_tags = self.orchestrator_tagger.get_container_tags(co=c_inspect)
+        if self.metadata_collector.has_detected():
+            orch_tags = self.metadata_collector.get_container_tags(co=c_inspect)
             tags.extend(orch_tags)
 
         return tags

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -22,7 +22,7 @@ from utils.kubernetes import KubeUtil
 from utils.platform import Platform
 from utils.service_discovery.abstract_sd_backend import AbstractSDBackend
 from utils.service_discovery.config_stores import get_config_store
-from utils.orchestrator import NomadUtil, ECSUtil
+from utils.orchestrator import NomadUtil, ECSUtil, Tagger
 
 DATADOG_ID = 'com.datadoghq.sd.check.id'
 
@@ -102,6 +102,8 @@ class SDDockerBackend(AbstractSDBackend):
             self.nomadutil = NomadUtil()
         elif Platform.is_ecs_instance():
             self.ecsutil = ECSUtil()
+
+        self.orchestrator_tagger = Tagger()
 
         self.VAR_MAPPING = {
             'host': self._get_host_address,
@@ -335,6 +337,10 @@ class SDDockerBackend(AbstractSDBackend):
         elif Platform.is_ecs_instance():
             ecs_tags = self.ecsutil.extract_container_tags(c_inspect)
             tags.extend(ecs_tags)
+
+        if self.orchestrator_tagger.has_detected():
+            orch_tags = self.orchestrator_tagger.get_container_tags(co=c_inspect)
+            tags.extend(orch_tags)
 
         return tags
 


### PR DESCRIPTION
### What does this PR do?

Introduces a generic container tagger mechanism to support all orchestrators through a common interface instead of expanding `SDDockerBackend.get_tags` and `DockerDaemon._get_tags` once again.

This introduces three classes:

- `Orchestrator.BaseUtil`: provides the common interface and the caching and container inspect logic
- `Orchestrator.MesosUtil`: inherits BaseUtil and just implements `_get_cacheable_tags` and `is_detected`
- `Orchestrator.Tagger`: triggers orchestrator detection and proxies calls to relevant BaseUtil classes

ECSUtil and NomadUtil will be moved to BaseUtil if this PR is approved.

### Test

unit tests in the test_orchestrator.py file