### PR TITLE
[docker] add docker/mesos version host tags

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -41,6 +41,7 @@ from utils.jmx import JMXFiles
 from utils.platform import Platform, get_os
 from utils.subprocess_output import get_subprocess_output
 from utils.timer import Timer
+from utils.orchestrator import MetadataCollector
 
 log = logging.getLogger(__name__)
 
@@ -658,6 +659,11 @@ class Collector(object):
 
             if self.agentConfig['collect_ec2_tags']:
                 host_tags.extend(EC2.get_tags(self.agentConfig))
+
+            if self.agentConfig['collect_orchestrator_tags'] and Platform.is_containerized():
+                host_docker_tags = MetadataCollector().get_host_tags()
+                if host_docker_tags:
+                    host_tags.extend(host_docker_tags)
 
             if host_tags:
                 payload['host-tags']['system'] = host_tags

--- a/config.py
+++ b/config.py
@@ -584,6 +584,10 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
         if config.has_option("Main", "collect_ec2_tags"):
             agentConfig["collect_ec2_tags"] = _is_affirmative(config.get("Main", "collect_ec2_tags"))
 
+        agentConfig["collect_orchestrator_tags"] = True
+        if config.has_option("Main", "collect_orchestrator_tags"):
+            agentConfig["collect_orchestrator_tags"] = _is_affirmative(config.get("Main", "collect_orchestrator_tags"))
+
         agentConfig["utf8_decoding"] = False
         if config.has_option("Main", "utf8_decoding"):
             agentConfig["utf8_decoding"] = _is_affirmative(config.get("Main", "utf8_decoding"))

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -30,6 +30,9 @@ api_key:
 # Set the host's tags (optional)
 # tags: mytag, env:prod, role:database
 
+# Collect docker orchestrator name and version as agent tags
+# collect_orchestrator_tags: yes
+
 # Set timeout in seconds for outgoing requests to Datadog. (default: 20)
 # When a request timeout, it will be retried after some time.
 # It will only be deleted if the forwarder queue becomes too big. (30 MB by default)

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -283,6 +283,7 @@ class TestCollectionInterval(unittest.TestCase):
             'api_key': 'test_apikey',
             'check_timings': True,
             'collect_ec2_tags': True,
+            'collect_orchestrator_tags': False,
             'collect_instance_metadata': False,
             'create_dd_check_tags': False,
             'version': 'test',
@@ -321,6 +322,7 @@ class TestCollectionInterval(unittest.TestCase):
         agentConfig = {
             'api_key': 'test_apikey',
             'collect_ec2_tags': False,
+            'collect_orchestrator_tags': False,
             'collect_instance_metadata': False,
             'create_dd_check_tags': True,
             'version': 'test',

--- a/tests/core/test_dockerutil.py
+++ b/tests/core/test_dockerutil.py
@@ -88,7 +88,7 @@ class TestDockerUtil(unittest.TestCase):
     def test_docker_host_tags_ok(self, mock_init, mock_version):
         mock_version.return_value = {'Version': '1.13.1'}
         mock_init.return_value = None
-        self.assertEqual(['docker_version:1.13.1'], DockerUtil().get_host_tags())
+        self.assertEqual(['docker_version:1.13.1', 'docker_swarm:inactive'], DockerUtil().get_host_tags())
         mock_version.assert_called_once()
 
     @mock.patch('docker.Client.version')
@@ -96,7 +96,7 @@ class TestDockerUtil(unittest.TestCase):
     def test_docker_host_tags_invalid_response(self, mock_init, mock_version):
         mock_version.return_value = None
         mock_init.return_value = None
-        self.assertEqual([], DockerUtil().get_host_tags())
+        self.assertEqual(['docker_swarm:inactive'], DockerUtil().get_host_tags())
         mock_version.assert_called_once()
 
     @mock.patch('utils.dockerutil.DockerUtil.is_swarm')

--- a/tests/core/test_dockerutil.py
+++ b/tests/core/test_dockerutil.py
@@ -82,3 +82,29 @@ class TestDockerUtil(unittest.TestCase):
         ]
         for test in test_data:
             self.assertEqual(test[1], DockerUtil().extract_container_tags(test[0]))
+
+    @mock.patch('docker.Client.version')
+    @mock.patch('docker.Client.__init__')
+    def test_docker_host_tags_ok(self, mock_init, mock_version):
+        mock_version.return_value = {'Version': '1.13.1'}
+        mock_init.return_value = None
+        self.assertEqual(['docker_version:1.13.1'], DockerUtil().get_host_tags())
+        mock_version.assert_called_once()
+
+    @mock.patch('docker.Client.version')
+    @mock.patch('docker.Client.__init__')
+    def test_docker_host_tags_invalid_response(self, mock_init, mock_version):
+        mock_version.return_value = None
+        mock_init.return_value = None
+        self.assertEqual([], DockerUtil().get_host_tags())
+        mock_version.assert_called_once()
+
+    @mock.patch('utils.dockerutil.DockerUtil.is_swarm')
+    @mock.patch('docker.Client.version')
+    @mock.patch('docker.Client.__init__')
+    def test_docker_host_tags_swarm_ok(self, mock_init, mock_version, mock_isswarm):
+        mock_isswarm.return_value = True
+        mock_version.return_value = {'Version': '1.13.1'}
+        mock_init.return_value = None
+        self.assertEqual(['docker_version:1.13.1', 'docker_swarm:active'], DockerUtil().get_host_tags())
+        mock_version.assert_called_once()

--- a/tests/core/test_mesosutil.py
+++ b/tests/core/test_mesosutil.py
@@ -1,0 +1,80 @@
+# stdlib
+import unittest
+import os
+
+# 3rd party
+import mock
+
+# project
+from utils.orchestrator import MesosUtil
+
+# MockResponse class
+from .test_orchestrator import MockResponse, CO_ID
+
+
+class TestMesosUtil(unittest.TestCase):
+    @mock.patch('docker.Client.__init__')
+    def test_extract_tags(self, mock_init):
+        mock_init.return_value = None
+        mesos = MesosUtil()
+
+        env = ["CHRONOS_JOB_NAME=test-job",
+               "MARATHON_APP_ID=/system/dd-agent",
+               "MESOS_TASK_ID=system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001"]
+
+        tags = ['chronos_job:test-job', 'marathon_app:/system/dd-agent',
+                'mesos_task:system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001']
+
+        container = {'Config': {'Env': env}}
+
+        self.assertEqual(sorted(tags), sorted(mesos._get_cacheable_tags(CO_ID, co=container)))
+
+    @mock.patch.dict(os.environ, {"MESOS_TASK_ID": "test"})
+    def test_detect(self):
+        self.assertTrue(MesosUtil.is_detected())
+
+    @mock.patch.dict(os.environ, {})
+    def test_no_detect(self):
+        self.assertFalse(MesosUtil.is_detected())
+
+    @mock.patch.dict(os.environ, {"LIBPROCESS_IP": "a", "HOST": "b", "HOSTNAME": "c"})
+    @mock.patch('requests.get')
+    @mock.patch('docker.Client.__init__')
+    def test_agents_detection(self, mock_init, mock_get):
+        mock_get.side_effect = [
+            MockResponse({}, 404),  # LIBPROCESS_IP fails
+            MockResponse({'badfield': 'fail'}, 200),  # HOST is invalid reply
+            MockResponse({'version': '1.2.1'}, 200),  # HOSTNAME is valid reply
+            MockResponse({'dcos_version': '1.9.0'}, 200),  # LIBPROCESS_IP works for DCOS
+            # _detect_agent might run twice if first MesosUtil instance, duplicating test data
+            MockResponse({}, 404),  # LIBPROCESS_IP fails
+            MockResponse({'badfield': 'fail'}, 200),  # HOST is invalid reply
+            MockResponse({'version': '1.2.1'}, 200),  # HOSTNAME is valid reply
+            MockResponse({'dcos_version': '1.9.0'}, 200),  # LIBPROCESS_IP works for DCOS
+        ]
+        mock_init.return_value = None
+
+        mesos, dcos = MesosUtil()._detect_agents()
+        self.assertEqual('http://c:5051/version', mesos)
+        self.assertEqual('http://a:61001/system/health/v1', dcos)
+
+    @mock.patch.dict(os.environ, {"LIBPROCESS_IP": "a"})
+    @mock.patch('requests.get')
+    @mock.patch('docker.Client.__init__')
+    def test_host_tags(self, mock_init, mock_get):
+        mock_get.side_effect = [
+            MockResponse({'version': '1.2.1'}, 200),
+            MockResponse({'dcos_version': '1.9.0'}, 200),
+            MockResponse({'version': '1.2.1'}, 200),
+            MockResponse({'dcos_version': '1.9.0'}, 200),
+            # _detect_agent might run twice if first MesosUtil instance, duplicating test data
+            MockResponse({'version': '1.2.1'}, 200),
+            MockResponse({'dcos_version': '1.9.0'}, 200),
+        ]
+        mock_init.return_value = None
+
+        util = MesosUtil()
+        util.__init__()
+        tags = util.get_host_tags()
+
+        self.assertEqual(['mesos_version:1.2.1', 'dcos_version:1.9.0'], tags)

--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -1,13 +1,12 @@
 # stdlib
 import unittest
-import os
 
 # 3rd party
 import mock
 import requests  # noqa: F401
 
 # project
-from utils.orchestrator import MesosUtil, BaseUtil
+from utils.orchestrator import BaseUtil
 
 CO_ID = 1234
 
@@ -22,74 +21,6 @@ class MockResponse:
 
     def json(self):
         return self.json_data
-
-
-class TestMesosUtil(unittest.TestCase):
-    @mock.patch('docker.Client.__init__')
-    def test_extract_tags(self, mock_init):
-        mock_init.return_value = None
-        mesos = MesosUtil()
-
-        env = ["CHRONOS_JOB_NAME=test-job",
-               "MARATHON_APP_ID=/system/dd-agent",
-               "MESOS_TASK_ID=system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001"]
-
-        tags = ['chronos_job:test-job', 'marathon_app:/system/dd-agent',
-                'mesos_task:system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001']
-
-        container = {'Config': {'Env': env}}
-
-        self.assertEqual(sorted(tags), sorted(mesos._get_cacheable_tags(CO_ID, co=container)))
-
-    @mock.patch.dict(os.environ, {"MESOS_TASK_ID": "test"})
-    def test_detect(self):
-        self.assertTrue(MesosUtil.is_detected())
-
-    @mock.patch.dict(os.environ, {})
-    def test_no_detect(self):
-        self.assertFalse(MesosUtil.is_detected())
-
-    @mock.patch.dict(os.environ, {"LIBPROCESS_IP": "a", "HOST": "b", "HOSTNAME": "c"})
-    @mock.patch('requests.get')
-    @mock.patch('docker.Client.__init__')
-    def test_agents_detection(self, mock_init, mock_get):
-        mock_get.side_effect = [
-            MockResponse({}, 404),  # LIBPROCESS_IP fails
-            MockResponse({'badfield': 'fail'}, 200),  # HOST is invalid reply
-            MockResponse({'version': '1.2.1'}, 200),  # HOSTNAME is valid reply
-            MockResponse({'dcos_version': '1.9.0'}, 200),  # LIBPROCESS_IP works for DCOS
-            # _detect_agent might run twice if first MesosUtil instance, duplicating test data
-            MockResponse({}, 404),  # LIBPROCESS_IP fails
-            MockResponse({'badfield': 'fail'}, 200),  # HOST is invalid reply
-            MockResponse({'version': '1.2.1'}, 200),  # HOSTNAME is valid reply
-            MockResponse({'dcos_version': '1.9.0'}, 200),  # LIBPROCESS_IP works for DCOS
-        ]
-        mock_init.return_value = None
-
-        mesos, dcos = MesosUtil()._detect_agents()
-        self.assertEqual('http://c:5051/version', mesos)
-        self.assertEqual('http://a:61001/system/health/v1', dcos)
-
-    @mock.patch.dict(os.environ, {"LIBPROCESS_IP": "a"})
-    @mock.patch('requests.get')
-    @mock.patch('docker.Client.__init__')
-    def test_host_tags(self, mock_init, mock_get):
-        mock_get.side_effect = [
-            MockResponse({'version': '1.2.1'}, 200),
-            MockResponse({'dcos_version': '1.9.0'}, 200),
-            MockResponse({'version': '1.2.1'}, 200),
-            MockResponse({'dcos_version': '1.9.0'}, 200),
-            # _detect_agent might run twice if first MesosUtil instance, duplicating test data
-            MockResponse({'version': '1.2.1'}, 200),
-            MockResponse({'dcos_version': '1.9.0'}, 200),
-        ]
-        mock_init.return_value = None
-
-        util = MesosUtil()
-        util.__init__()
-        tags = util.get_host_tags()
-
-        self.assertEqual(['mesos_version:1.2.1', 'dcos_version:1.9.0'], tags)
 
 
 class TestBaseUtil(unittest.TestCase):

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -239,8 +239,12 @@ class DockerUtil:
             tags.append('docker_version:%s' % version['Version'])
         else:
             log.debug("Could not determine Docker version")
+
         if self.is_swarm():
             tags.append('docker_swarm:active')
+        else:
+            tags.append('docker_swarm:inactive')
+
         return tags
 
     @property

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -232,6 +232,17 @@ class DockerUtil:
 
         return self._default_gateway
 
+    def get_host_tags(self):
+        tags = []
+        version = self.client.version()
+        if version and 'Version' in version:
+            tags.append('docker_version:%s' % version['Version'])
+        else:
+            log.debug("Could not determine Docker version")
+        if self.is_swarm():
+            tags.append('docker_swarm:active')
+        return tags
+
     @property
     def client(self):
         return Client(**self.settings)

--- a/utils/orchestrator/mesosutil.py
+++ b/utils/orchestrator/mesosutil.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import os
+import requests
 
 from .baseutil import BaseUtil
 
@@ -10,11 +11,25 @@ CHRONOS_JOB_NAME = "CHRONOS_JOB_NAME"
 MARATHON_APP_ID = "MARATHON_APP_ID"
 MESOS_TASK_ID = "MESOS_TASK_ID"
 
+MESOS_AGENT_IP_ENV = ["LIBPROCESS_IP", "HOST", "HOSTNAME"]
+MESOS_AGENT_HTTP_PORT = 5051
+DCOS_AGENT_HTTP_PORT = 61001
+DOCS_AGENT_HTTPS_PORT = 61002
+
+
+def MESOS_AGENT_VALIDATION(r):
+    return "version" in r.json()
+
+
+def DCOS_AGENT_VALIDATION(r):
+    return "dcos_version" in r.json()
+
 
 class MesosUtil(BaseUtil):
     def __init__(self):
         BaseUtil.__init__(self)
         self.needs_inspect_config = True
+        self.mesos_agent_url, self.dcos_agent_url = self._detect_agents()
 
     def _get_cacheable_tags(self, cid, co=None):
         tags = []
@@ -30,6 +45,66 @@ class MesosUtil(BaseUtil):
 
         return tags
 
+    def _detect_agents(self):
+        """
+        The Mesos agent runs on every node and listens to http port 5051
+        See https://mesos.apache.org/documentation/latest/endpoints/
+        We'll use the unauthenticated endpoint /version
+
+        The DCOS agent runs on every node and listens to ports 61001 or 61002
+        See https://dcos.io/docs/1.9/api/agent-routes/
+        We'll use the unauthenticated endpoint /system/health/v1
+        """
+        mesos_urls = []
+        dcos_urls = []
+        for var in MESOS_AGENT_IP_ENV:
+            if var in os.environ:
+                mesos_urls.append("http://%s:%d/version" %
+                                  (os.environ.get(var), MESOS_AGENT_HTTP_PORT))
+                dcos_urls.append("http://%s:%d/system/health/v1" %
+                                 (os.environ.get(var), DCOS_AGENT_HTTP_PORT))
+                dcos_urls.append("https://%s:%d/system/health/v1" %
+                                 (os.environ.get(var), DOCS_AGENT_HTTPS_PORT))
+        # Try network gateway last
+        gw = self.docker_util.get_gateway()
+        if gw:
+            mesos_urls.append("http://%s:%d/version" % (gw, MESOS_AGENT_HTTP_PORT))
+            dcos_urls.append("http://%s:%d/system/health/v1" % (gw, DCOS_AGENT_HTTP_PORT))
+            dcos_urls.append("https://%s:%d/system/health/v1" % (gw, DOCS_AGENT_HTTPS_PORT))
+
+        mesos_url = self._try_urls(mesos_urls, validation_lambda=MESOS_AGENT_VALIDATION)
+        if mesos_url:
+            self.log.debug("Found Mesos agent at " + mesos_url)
+        else:
+            self.log.debug("Count not find Mesos agent at urls " + str(mesos_urls))
+        dcos_url = self._try_urls(dcos_urls, validation_lambda=DCOS_AGENT_VALIDATION)
+        if dcos_url:
+            self.log.debug("Found DCOS agent at " + dcos_url)
+        else:
+            self.log.debug("Count not find DCOS agent at urls " + str(dcos_urls))
+
+        return (mesos_url, dcos_url)
+
     @staticmethod
     def is_detected():
         return MESOS_TASK_ID in os.environ
+
+    def get_host_tags(self):
+        tags = []
+        if self.mesos_agent_url:
+            try:
+                resp = requests.get(self.mesos_agent_url, timeout=1).json()
+                if "version" in resp:
+                    tags.append('mesos_version:%s' % resp.get("version"))
+            except Exception as e:
+                self.log.debug("Error getting Mesos version: %s" % str(e))
+
+        if self.dcos_agent_url:
+            try:
+                resp = requests.get(self.dcos_agent_url, timeout=1).json()
+                if "dcos_version" in resp:
+                    tags.append('dcos_version:%s' % resp.get("dcos_version"))
+            except Exception as e:
+                self.log.debug("Error getting DCOS version: %s" % str(e))
+
+        return tags

--- a/utils/orchestrator/metadata_collector.py
+++ b/utils/orchestrator/metadata_collector.py
@@ -5,6 +5,7 @@
 
 from .mesosutil import MesosUtil
 from utils.singleton import Singleton
+from utils.dockerutil import DockerUtil
 
 
 class MetadataCollector():
@@ -37,6 +38,15 @@ class MetadataCollector():
     def reset_cache(self):
         for util in self._utils:
             util.reset_cache()
+
+    def get_host_tags(self):
+        concat_tags = DockerUtil().get_host_tags()
+        for util in self._utils:
+            meta = util.get_host_tags()
+            if meta:
+                concat_tags.extend(meta)
+
+        return concat_tags
 
     def reset(self):
         """


### PR DESCRIPTION
### What does this PR do?

- add orchestrator.MetadataCollector.get_host_tags() and method in Mesosutil
- add DockerUtil.get_host_tags() for docker_version
- detect mesos and dcos agents via http/https tests
- retrieve docker_version, docker_swarm, mesos_version and dcos_version host tags
- add new collect_orchestrator_tags conf option (default True)

### Motivation

Allows easier troubleshooting for version-specific orchestrator issues

### Testing Guidelines

Unit tests in the CI
