### PR TITLE
[jmxfetch][auto-discovery] fix windows handling of pipe.

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -284,7 +284,7 @@ class Agent(Daemon):
 
                 if pipe != win32file.INVALID_HANDLE_VALUE:
                     win32pipe.SetNamedPipeHandleState(
-                                pipe, win32pipe.PIPE_READMODE_MESSAGE, None, None)
+                        pipe, win32pipe.PIPE_READMODE_MESSAGE, None, None)
                     pipe_fd = msvcrt.open_osfhandle(pipe, os.O_RDWR)
                     self.sd_pipe = io.open(pipe_fd, os.O_RDWR) # RW to avoid blocking (will only W)
                 else:


### PR DESCRIPTION
### What does this PR do?

This PR attempts to fix the currently broken implementation of windows JMXfetch auto discovery based on named pipes. We must rely on `pywin32` to create, open the pipe. We can then use io.open() to use the file descriptor and get a regular file handle.

### Motivation

Ongoing work on auto-discovery made this issue surface.

### Testing Guidelines

Additional testing is necessary.