### PR TITLE
[checks] Deprecate `AgentCheck.set`

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -563,6 +563,8 @@ class AgentCheck(object):
         :param hostname: (optional) A hostname for this metric. Defaults to the current hostname.
         :param device_name: (optional) The device name for this metric
         """
+        self.warning("Deprecation notice: the `set` method of `AgentCheck` is deprecated and will be removed " +
+            "in the next major version of the Agent, please compute aggregates in your check and use `gauge` instead")
         self.aggregator.set(metric, value, tags, hostname, device_name)
 
     def event(self, event):


### PR DESCRIPTION
### What does this PR do?

Adds a `warning` message when the `set` method is used.

### Motivation

`AgentCheck.set` will be removed in Agent 6.0. Any custom check that currently uses it should be modified.

### Additional Notes

2 core checks currently use `AgentCheck.set`:
- `zk`: see https://github.com/DataDog/integrations-core/pull/473
- `docker`: check that's been deprecated since agent [`5.5.0`](https://github.com/DataDog/dd-agent/blob/master/CHANGELOG.md#550--09-17-2015), so we should probably remove it from the `integrations-core` altogether when Agent 6.0 is released