### PR TITLE
[docker] Add kube/ecs/nomad host tags + port to BaseUtil

### DIFF
--- a/config.py
+++ b/config.py
@@ -343,6 +343,7 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
     # General config
     agentConfig = {
         'check_freq': DEFAULT_CHECK_FREQUENCY,
+        'collect_orchestrator_tags': True,
         'dogstatsd_port': 8125,
         'dogstatsd_target': 'http://localhost:17123',
         'graphite_listen_port': None,

--- a/tests/core/test_ecsutil.py
+++ b/tests/core/test_ecsutil.py
@@ -1,0 +1,68 @@
+# stdlib
+import unittest
+
+# 3rd party
+import mock
+
+# project
+from utils.orchestrator import ECSUtil
+
+# MockResponse class
+from .test_orchestrator import MockResponse
+
+CO_ID = "123456789123456789"
+
+
+class TestECSUtil(unittest.TestCase):
+    @mock.patch('requests.get')
+    @mock.patch('docker.Client.__init__')
+    def test_extract_tags(self, mock_init, mock_get):
+        mock_get.return_value = MockResponse({}, 404)
+        mock_init.return_value = None
+        util = ECSUtil()
+        util.agent_url = 'http://dummy'
+
+        mock_get.reset_mock()
+        mock_get.return_value = MockResponse({"Tasks": [{"Family": "dd-agent-latest", "Version": "12",
+                                                         "Containers": [{"DockerId": CO_ID}]}]}, 200)
+
+        tags = util._get_cacheable_tags(CO_ID)
+        self.assertEqual(['task_name:dd-agent-latest', 'task_version:12'], tags)
+        mock_get.assert_called_once_with('http://dummy/v1/tasks', timeout=1)
+
+    @mock.patch('requests.get')
+    @mock.patch('utils.dockerutil.DockerUtil.inspect_container')
+    @mock.patch('docker.Client.__init__')
+    def test_detect_agent(self, mock_init, mock_inspect, mock_get):
+        mock_get.return_value = MockResponse({}, 404)
+        mock_init.return_value = None
+
+        mock_inspect.return_value = {'NetworkSettings': {'IPAddress': '10.0.0.42',
+                                                         'Ports': {'1234/tcp': '1234/tcp'}}}
+
+        probe_calls = [mock.call('http://10.0.0.42:1234/', timeout=1),
+                       mock.call('http://10.0.2.2:51678/', timeout=1),
+                       mock.call('http://localhost:51678/', timeout=1)]
+
+        util = ECSUtil()
+
+        mock_get.reset_mock()
+        util._detect_agent()
+        mock_get.assert_has_calls(probe_calls)
+
+    @mock.patch('requests.get')
+    @mock.patch('utils.dockerutil.DockerUtil.inspect_container')
+    @mock.patch('docker.Client.__init__')
+    def test_host_tags(self, mock_init, mock_inspect, mock_get):
+        mock_inspect.return_value = {}
+        mock_get.return_value = MockResponse({"Cluster": "default-xvello",
+                                              "Version": "Amazon ECS Agent - v1.14.1 (467c3d7)"}, 200)
+        mock_init.return_value = None
+
+        util = ECSUtil()
+        util.agent_url = 'http://dummy'
+
+        mock_get.reset_mock()
+        tags = util.get_host_tags()
+        self.assertEqual(['ecs_version:1.14.1'], tags)
+        mock_get.assert_called_once_with('http://dummy/v1/metadata', timeout=1)

--- a/tests/core/test_ecsutil.py
+++ b/tests/core/test_ecsutil.py
@@ -31,11 +31,13 @@ class TestECSUtil(unittest.TestCase):
         mock_get.assert_called_once_with('http://dummy/v1/tasks', timeout=1)
 
     @mock.patch('requests.get')
+    @mock.patch('utils.dockerutil.DockerUtil.get_gateway')
     @mock.patch('utils.dockerutil.DockerUtil.inspect_container')
     @mock.patch('docker.Client.__init__')
-    def test_detect_agent(self, mock_init, mock_inspect, mock_get):
+    def test_detect_agent(self, mock_init, mock_inspect, mock_gw, mock_get):
         mock_get.return_value = MockResponse({}, 404)
         mock_init.return_value = None
+        mock_gw.return_value = "10.0.2.2"
 
         mock_inspect.return_value = {'NetworkSettings': {'IPAddress': '10.0.0.42',
                                                          'Ports': {'1234/tcp': '1234/tcp'}}}

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -78,8 +78,8 @@ class KubeUtil:
         self.tls_settings = self._init_tls_settings(instance)
 
         # apiserver
-        self.kubernetes_api_root_url = 'https://%s/' % (os.environ.get('KUBERNETES_SERVICE_HOST') or
-                                                        self.DEFAULT_MASTER_NAME)
+        self.kubernetes_api_root_url = 'https://%s' % (os.environ.get('KUBERNETES_SERVICE_HOST') or
+                                                       self.DEFAULT_MASTER_NAME)
         self.kubernetes_api_url = '%s/api/v1' % self.kubernetes_api_root_url
         # kubelet
         try:
@@ -350,6 +350,8 @@ class KubeUtil:
         # Kubelet version
         try:
             _, node_name = self.get_node_info()
+            if not node_name:
+                raise ValueError("node name missing or empty")
             request_url = "%s/nodes/%s" % (self.kubernetes_api_url, node_name)
             node_info = self.retrieve_json_auth(request_url)
             version = node_info.get("status").get("nodeInfo").get("kubeletVersion")

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -78,8 +78,9 @@ class KubeUtil:
         self.tls_settings = self._init_tls_settings(instance)
 
         # apiserver
-        self.kubernetes_api_url = 'https://%s/api/v1' % (os.environ.get('KUBERNETES_SERVICE_HOST') or self.DEFAULT_MASTER_NAME)
-
+        self.kubernetes_api_root_url = 'https://%s/' % (os.environ.get('KUBERNETES_SERVICE_HOST') or
+                                                        self.DEFAULT_MASTER_NAME)
+        self.kubernetes_api_url = '%s/api/v1' % self.kubernetes_api_root_url
         # kubelet
         try:
             self.kubelet_api_url = self._locate_kubelet(instance)
@@ -331,6 +332,32 @@ class KubeUtil:
         if None in (self._node_ip, self._node_name):
             self._fetch_host_data()
         return self._node_ip, self._node_name
+
+    def get_node_hosttags(self):
+        tags = []
+
+        # API server version
+        try:
+            request_url = "%s/version" % self.kubernetes_api_root_url
+            master_info = self.retrieve_json_auth(request_url)
+            version = master_info.get("gitVersion")
+            tags.append("kube_master_version:%s" % version[1:])
+        except Exception as e:
+            # Intentional use of non-safe lookups to get the exception in the debug logs
+            # if the parsing were to fail
+            log.debug("Error getting Kube master version: %s" % str(e))
+
+        # Kubelet version
+        try:
+            _, node_name = self.get_node_info()
+            request_url = "%s/nodes/%s" % (self.kubernetes_api_url, node_name)
+            node_info = self.retrieve_json_auth(request_url)
+            version = node_info.get("status").get("nodeInfo").get("kubeletVersion")
+            tags.append("kubelet_version:%s" % version[1:])
+        except Exception as e:
+            log.debug("Error getting Kubelet version: %s" % str(e))
+
+        return tags
 
     def _fetch_host_data(self):
         """

--- a/utils/orchestrator/baseutil.py
+++ b/utils/orchestrator/baseutil.py
@@ -113,5 +113,7 @@ class BaseUtil:
                 continue
             except ValueError:  # JSON parsing or dict search
                 continue
+            except TypeError:  # NoneType errors
+                continue
 
         return None

--- a/utils/orchestrator/dockerutilproxy.py
+++ b/utils/orchestrator/dockerutilproxy.py
@@ -1,0 +1,24 @@
+# (C) Datadog, Inc. 2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+from utils.dockerutil import DockerUtil
+from .baseutil import BaseUtil
+
+
+class DockerUtilProxy(BaseUtil):
+    def get_container_tags(self, cid=None, co=None):
+        return None  # Docker tags are fetched directly
+
+    @staticmethod
+    def is_detected():
+        try:
+            if "Version" in DockerUtil().client.version():
+                return True
+            else:
+                return False
+        except Exception:
+            return False
+
+    def get_host_tags(self):
+        return self.docker_util.get_host_tags()

--- a/utils/orchestrator/ecsutil.py
+++ b/utils/orchestrator/ecsutil.py
@@ -19,10 +19,6 @@ ECS_AGENT_TASKS_PATH = '/v1/tasks'
 AGENT_VERSION_EXP = re.compile(r'v([0-9.]+)')
 
 
-def ECS_AGENT_VALIDATION(r):
-    return "/v1/metadata" in r.json().get("AvailableCommands", [])
-
-
 class ECSUtil(BaseUtil):
     # FIXME: move the ecs detection logic from DockerUtil here?
     @staticmethod
@@ -35,6 +31,10 @@ class ECSUtil(BaseUtil):
         self.agent_url = self._detect_agent()
         self.ecs_tags = {}
         self._populate_ecs_tags()
+
+    @staticmethod
+    def ecs_agent_validation(r):
+        return ECS_AGENT_METADATA_PATH in r.json().get("AvailableCommands", [])
 
     def _detect_agent(self):
         """
@@ -59,11 +59,11 @@ class ECSUtil(BaseUtil):
         # Try localhost (both ecs-agent and dd-agent in host networking)
         urls.append("http://localhost:%d/" % ECS_AGENT_DEFAULT_PORT)
 
-        url = self._try_urls(urls, validation_lambda=ECS_AGENT_VALIDATION)
+        url = self._try_urls(urls, validation_lambda=ECSUtil.ecs_agent_validation)
         if url:
             self.log.debug("Found ECS agent at " + url)
         else:
-            self.log.debug("Count not find ECS agent at urls " + str(urls))
+            self.log.debug("Could not find ECS agent at urls " + str(urls))
 
         return url
 

--- a/utils/orchestrator/ecsutil.py
+++ b/utils/orchestrator/ecsutil.py
@@ -3,47 +3,73 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 # stdlib
-import logging
+import re
+
+# 3rd
 import requests
-import socket
 
 # project
-from utils.dockerutil import DockerUtil
-from utils.platform import Platform
-from utils.singleton import Singleton
+from .baseutil import BaseUtil
 
-
-log = logging.getLogger(__name__)
-
-ECS_INTROSPECT_DEFAULT_PORT = 51678
+ECS_AGENT_DEFAULT_PORT = 51678
 ECS_AGENT_CONTAINER_NAME = 'ecs-agent'
+ECS_AGENT_METADATA_PATH = '/v1/metadata'
+ECS_AGENT_TASKS_PATH = '/v1/tasks'
 
-class ECSUtil:
-    __metaclass__ = Singleton
+AGENT_VERSION_EXP = re.compile(r'v([0-9.]+)')
+
+
+def ECS_AGENT_VALIDATION(r):
+    return "/v1/metadata" in r.json().get("AvailableCommands", [])
+
+
+class ECSUtil(BaseUtil):
+    # FIXME: move the ecs detection logic from DockerUtil here?
+    @staticmethod
+    def is_detected():
+        from utils.dockerutil import DockerUtil
+        return DockerUtil().is_ecs()
+
+    # FIXME: backwards compat to remove
+    def extract_container_tags(self, c_inspect):
+        return []
 
     def __init__(self):
-        self.docker_util = DockerUtil()
-        self.ecs_agent_local = None
-
+        BaseUtil.__init__(self)
+        self.agent_url = self._detect_agent()
         self.ecs_tags = {}
         self._populate_ecs_tags()
 
-    def _get_ecs_address(self):
-        """Detect how to connect to the ecs-agent"""
+    def _detect_agent(self):
+        """
+        The ECS agent runs on a container and listens to port 51678
+        We'll test the response on / for detection
+        """
+        urls = []
+
+        # Try to detect the ecs-agent container's IP (net=bridge)
         ecs_config = self.docker_util.inspect_container('ecs-agent')
         ip = ecs_config.get('NetworkSettings', {}).get('IPAddress')
-        ports = ecs_config.get('NetworkSettings', {}).get('Ports')
-        port = ports.keys()[0].split('/')[0] if ports else None
-        if not ip:
-            port = ECS_INTROSPECT_DEFAULT_PORT
-            if self._is_ecs_agent_local():
-                ip = "localhost"
-            elif Platform.is_containerized():
-                ip = self.docker_util.get_gateway()
-            else:
-                raise Exception("Unable to determine ecs-agent IP address")
+        if ip:
+            ports = ecs_config.get('NetworkSettings', {}).get('Ports')
+            port = ports.keys()[0].split('/')[0] if ports else str(ECS_AGENT_DEFAULT_PORT)
+            urls.append("http://%s:%s/" % (ip, port))
 
-        return ip, port
+        # Try the default gateway (ecs-agent in net=host mode)
+        gw = self.docker_util.get_gateway()
+        if gw:
+            urls.append("http://%s:%d/" % (gw, ECS_AGENT_DEFAULT_PORT))
+
+        # Try localhost (both ecs-agent and dd-agent in host networking)
+        urls.append("http://localhost:%d/" % ECS_AGENT_DEFAULT_PORT)
+
+        url = self._try_urls(urls, validation_lambda=ECS_AGENT_VALIDATION)
+        if url:
+            self.log.debug("Found ECS agent at " + url)
+        else:
+            self.log.debug("Count not find ECS agent at urls " + str(urls))
+
+        return url
 
     def _populate_ecs_tags(self, skip_known=False):
         """
@@ -51,14 +77,12 @@ class ECSUtil:
         If we just want to update new containers quickly (single task api call)
         (because we detected that a new task started for example)
         """
-        try:
-            ip, port = self._get_ecs_address()
-        except Exception as ex:
-            log.warning("Failed to connect to ecs-agent, skipping task tagging: %s" % ex)
+        if self.agent_url is None:
+            self.log.warning("ecs-agent not found, skipping task tagging")
             return
 
         try:
-            tasks = requests.get('http://%s:%s/v1/tasks' % (ip, port)).json()
+            tasks = requests.get(self.agent_url + ECS_AGENT_TASKS_PATH, timeout=1).json()
             for task in tasks.get('Tasks', []):
                 for container in task.get('Containers', []):
                     cid = container['DockerId']
@@ -69,73 +93,42 @@ class ECSUtil:
                     tags = ['task_name:%s' % task['Family'], 'task_version:%s' % task['Version']]
                     self.ecs_tags[container['DockerId']] = tags
         except requests.exceptions.HTTPError as ex:
-            log.warning("Unable to collect ECS task names: %s" % ex)
+            self.log.warning("Unable to collect ECS task names: %s" % ex)
 
-    def _get_container_tags(self, cid):
-        """
-        This method triggers a fast fill of the tag cache (useful when a new task starts
-        and we want the new containers to be cached with a single api call) and returns
-        the tags (or an empty list) from the fresh cache.
-        """
+    def _get_cacheable_tags(self, cid, co=None):
         self._populate_ecs_tags(skip_known=True)
 
         if cid in self.ecs_tags:
             return self.ecs_tags[cid]
         else:
-            log.debug("Container %s doesn't seem to be an ECS task, skipping." % cid[:12])
+            self.log.debug("Container %s doesn't seem to be an ECS task, skipping." % cid[:12])
             self.ecs_tags[cid] = []
         return []
 
-    def _is_ecs_agent_local(self):
-        """Return True if we can reach the ecs-agent over localhost, False otherwise.
-        This is needed because if the ecs-agent is started with --net=host it won't have an IP address attached.
-        """
-        if self.ecs_agent_local is not None:
-            return self.ecs_agent_local
-
-        self.ecs_agent_local = False
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(5)
-        try:
-            result = sock.connect_ex(('localhost', ECS_INTROSPECT_DEFAULT_PORT))
-        except Exception as e:
-            log.debug("Unable to connect to ecs-agent. Exception: {0}".format(e))
-        else:
-            if result == 0:
-                self.ecs_agent_local = True
-            else:
-                log.debug("ecs-agent is not available locally, encountered error code: {0}".format(result))
-        sock.close()
-        return self.ecs_agent_local
-
-    def extract_container_tags(self, co):
-        """
-        Queries the ecs-agent to get ECS tags (task and task version) for a containers.
-        As this is expensive, it is cached in the self.ecs_tags dict.
-        The cache invalidation goes through invalidate_ecs_cache, called by the docker_daemon check
-
-        :param co: container dict returned by docker-py
-        :return: tags as list<string>, cached
-        """
-        co_id = co.get('Id', None)
-
-        if co_id is None:
-            log.warning("Invalid container object in extract_container_tags")
-            return []
-
-        if co_id in self.ecs_tags:
-            return self.ecs_tags[co_id]
-        else:
-            return self._get_container_tags(co_id)
-
+    # We extend the cache invalidation methods to handle the cid->task mapping cache
     def invalidate_cache(self, events):
-        """
-        Allows cache invalidation when containers die
-        :param events from self.get_events
-        """
+        BaseUtil.invalidate_cache(self, events)
         try:
             for ev in events:
                 if ev.get('status') == 'die' and ev.get('id') in self.ecs_tags:
                     del self.ecs_tags[ev.get('id')]
         except Exception as e:
-            log.warning("Error when invalidating ecs cache: " + str(e))
+            self.log.warning("Error when invalidating tag cache: " + str(e))
+
+    def reset_cache(self):
+        BaseUtil.reset_cache(self)
+        self.ecs_tags = {}
+
+    def get_host_tags(self):
+        tags = []
+        if self.agent_url:
+            try:
+                resp = requests.get(self.agent_url + ECS_AGENT_METADATA_PATH, timeout=1).json()
+                if "Version" in resp:
+                    match = AGENT_VERSION_EXP.search(resp.get("Version"))
+                    if match is not None and len(match.groups()) == 1:
+                        tags.append('ecs_version:%s' % match.group(1))
+            except Exception as e:
+                self.log.debug("Error getting ECS version: %s" % str(e))
+
+        return tags

--- a/utils/orchestrator/ecsutil.py
+++ b/utils/orchestrator/ecsutil.py
@@ -30,10 +30,6 @@ class ECSUtil(BaseUtil):
         from utils.dockerutil import DockerUtil
         return DockerUtil().is_ecs()
 
-    # FIXME: backwards compat to remove
-    def extract_container_tags(self, c_inspect):
-        return []
-
     def __init__(self):
         BaseUtil.__init__(self)
         self.agent_url = self._detect_agent()

--- a/utils/orchestrator/kubeutilproxy.py
+++ b/utils/orchestrator/kubeutilproxy.py
@@ -1,0 +1,22 @@
+# (C) Datadog, Inc. 2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+from utils.kubernetes import KubeUtil
+from .baseutil import BaseUtil
+
+
+class KubeUtilProxy(BaseUtil):
+    def get_container_tags(self, cid=None, co=None):
+        return None  # Kube tags are fetched directly
+
+    @staticmethod
+    def is_detected():
+        try:
+            tags = KubeUtil().get_node_hosttags()
+            return bool(tags)
+        except Exception:
+            return False
+
+    def get_host_tags(self):
+        return KubeUtil().get_node_hosttags()

--- a/utils/orchestrator/metadata_collector.py
+++ b/utils/orchestrator/metadata_collector.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 
-from .mesosutil import MesosUtil
+from .mesosutil import MesosUtil, NomadUtil
 from utils.singleton import Singleton
 from utils.dockerutil import DockerUtil
 
@@ -55,9 +55,13 @@ class MetadataCollector():
         self._utils = []
 
         if MesosUtil.is_detected():
-            m = MesosUtil()
-            m.reset_cache()
-            self._utils.append(m)
+            util = MesosUtil()
+            util.reset_cache()
+            self._utils.append(util)
+        if NomadUtil.is_detected():
+            util = NomadUtil()
+            util.reset_cache()
+            self._utils.append(util)
 
         self._has_detected = bool(self._utils)
 

--- a/utils/orchestrator/metadata_collector.py
+++ b/utils/orchestrator/metadata_collector.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 
-from . import NomadUtil, MesosUtil
+from . import NomadUtil, MesosUtil, ECSUtil
 from utils.singleton import Singleton
 from utils.dockerutil import DockerUtil
 
@@ -60,6 +60,10 @@ class MetadataCollector():
             self._utils.append(util)
         if NomadUtil.is_detected():
             util = NomadUtil()
+            util.reset_cache()
+            self._utils.append(util)
+        if ECSUtil.is_detected():
+            util = ECSUtil()
             util.reset_cache()
             self._utils.append(util)
 

--- a/utils/orchestrator/metadata_collector.py
+++ b/utils/orchestrator/metadata_collector.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 
-from .mesosutil import MesosUtil, NomadUtil
+from . import NomadUtil, MesosUtil
 from utils.singleton import Singleton
 from utils.dockerutil import DockerUtil
 

--- a/utils/orchestrator/metadata_collector.py
+++ b/utils/orchestrator/metadata_collector.py
@@ -4,8 +4,10 @@
 
 
 from . import NomadUtil, MesosUtil, ECSUtil
+from .dockerutilproxy import DockerUtilProxy
+from .kubeutilproxy import KubeUtilProxy
+
 from utils.singleton import Singleton
-from utils.dockerutil import DockerUtil
 
 
 class MetadataCollector():
@@ -40,7 +42,7 @@ class MetadataCollector():
             util.reset_cache()
 
     def get_host_tags(self):
-        concat_tags = DockerUtil().get_host_tags()
+        concat_tags = []
         for util in self._utils:
             meta = util.get_host_tags()
             if meta:
@@ -54,6 +56,14 @@ class MetadataCollector():
         """
         self._utils = []
 
+        if DockerUtilProxy.is_detected():
+            util = DockerUtilProxy()
+            util.reset_cache()
+            self._utils.append(util)
+        if KubeUtilProxy.is_detected():
+            util = KubeUtilProxy()
+            util.reset_cache()
+            self._utils.append(util)
         if MesosUtil.is_detected():
             util = MesosUtil()
             util.reset_cache()

--- a/utils/orchestrator/nomadutil.py
+++ b/utils/orchestrator/nomadutil.py
@@ -25,10 +25,6 @@ class NomadUtil(BaseUtil):
         self.needs_inspect_config = True
         self.agent_url = self._detect_agent()
 
-    # FIXME: backwards compat to remove
-    def extract_container_tags(self, c_inspect):
-        return []
-
     def _get_cacheable_tags(self, cid, co=None):
         tags = []
         envvars = co.get('Config', {}).get('Env', {})

--- a/utils/orchestrator/nomadutil.py
+++ b/utils/orchestrator/nomadutil.py
@@ -15,10 +15,6 @@ NOMAD_ALLOC_ID = 'NOMAD_ALLOC_ID'
 NOMAD_AGENT_URL = "http://%s:4646/v1/agent/self"
 
 
-def NOMAD_AGENT_VALIDATION(r):
-    return "Version" in r.json().get('config', {})
-
-
 class NomadUtil(BaseUtil):
     def __init__(self):
         BaseUtil.__init__(self)
@@ -48,6 +44,10 @@ class NomadUtil(BaseUtil):
     def is_detected():
         return NOMAD_ALLOC_ID in os.environ
 
+    @staticmethod
+    def nomad_agent_validation(r):
+        return "Version" in r.json().get('config', {})
+
     def _detect_agent(self):
         """
         The Nomad agent runs on every node and listens to http port 4646
@@ -66,11 +66,11 @@ class NomadUtil(BaseUtil):
             urls.append(NOMAD_AGENT_URL % gw)
         urls.append(NOMAD_AGENT_URL % "127.0.0.1")
 
-        nomad_url = self._try_urls(urls, validation_lambda=NOMAD_AGENT_VALIDATION)
+        nomad_url = self._try_urls(urls, validation_lambda=NomadUtil.nomad_agent_validation)
         if nomad_url:
             self.log.debug("Found Nomad agent at " + nomad_url)
         else:
-            self.log.debug("Count not find Nomad agent at urls " + str(urls))
+            self.log.debug("Could not find Nomad agent at urls " + str(urls))
 
         return nomad_url
 

--- a/utils/orchestrator/nomadutil.py
+++ b/utils/orchestrator/nomadutil.py
@@ -2,82 +2,42 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-# stdlib
-import logging
-from utils.dockerutil import DockerUtil
-from utils.singleton import Singleton
+import os
 
-
-log = logging.getLogger(__name__)
+from .baseutil import BaseUtil
 
 NOMAD_TASK_NAME = 'NOMAD_TASK_NAME'
 NOMAD_JOB_NAME = 'NOMAD_JOB_NAME'
 NOMAD_ALLOC_NAME = 'NOMAD_ALLOC_NAME'
+NOMAD_ALLOC_ID = 'NOMAD_ALLOC_ID'
+
+NOMAD_AGENT_URL = "http://%s:4646/v1/agent/self"
 
 
-class NomadUtil:
-    __metaclass__ = Singleton
-
+class NomadUtil(BaseUtil):
     def __init__(self):
-        self.docker_util = DockerUtil()
+        BaseUtil.__init__(self)
+        self.needs_inspect_config = True
 
-        # Tags cache as a dict {co_id: (create_timestamp, [tags])}
-        self._container_tags_cache = {}
-
-    def extract_container_tags(self, co):
-        """
-        Queries docker inspect to get nomad tags in the container's environment vars.
-        As this is expensive, it is cached in the self._nomad_tags_cache dict.
-        The cache invalidation goes through invalidate_nomad_cache, called by the docker_daemon check
-
-        :param co: container dict returned by docker-py
-        :return: tags as list<string>, cached
-        """
-
-        co_id = co.get('Id', None)
-
-        if co_id is None:
-            log.warning("Invalid container object in extract_container_tags")
-            return
-
-        # Cache lookup on Id, verified on Created timestamp
-        if co_id in self._container_tags_cache:
-            created, tags = self._container_tags_cache[co_id]
-            if created == co.get('Created', -1):
-                return tags
-
+    def _get_cacheable_tags(self, cid, co=None):
         tags = []
-        try:
-            inspect_info = self.docker_util.inspect_container(co_id)
-            envvars = inspect_info.get('Config', {}).get('Env', {})
-            for var in envvars:
-                if var.startswith(NOMAD_TASK_NAME):
-                    tags.append('nomad_task:%s' % var[len(NOMAD_TASK_NAME) + 1:])
-                elif var.startswith(NOMAD_JOB_NAME):
-                    tags.append('nomad_job:%s' % var[len(NOMAD_JOB_NAME) + 1:])
-                elif var.startswith(NOMAD_ALLOC_NAME):
-                    try:
-                        start = var.index('.', len(NOMAD_ALLOC_NAME)) + 1
-                        end = var.index('[')
-                        if end <= start:
-                            raise ValueError("Error extracting group from %s, check format" % var)
-                        tags.append('nomad_group:%s' % var[start:end])
-                    except ValueError:
-                        pass
-                    self._container_tags_cache[co_id] = (co.get('Created'), tags)
-        except Exception as e:
-            log.warning("Error while parsing Nomad tags: %s" % str(e))
-        finally:
-            return tags
+        envvars = co.get('Config', {}).get('Env', {})
+        for var in envvars:
+            if var.startswith(NOMAD_TASK_NAME):
+                tags.append('nomad_task:%s' % var[len(NOMAD_TASK_NAME) + 1:])
+            elif var.startswith(NOMAD_JOB_NAME):
+                tags.append('nomad_job:%s' % var[len(NOMAD_JOB_NAME) + 1:])
+            elif var.startswith(NOMAD_ALLOC_NAME):
+                try:
+                    start = var.index('.', len(NOMAD_ALLOC_NAME)) + 1
+                    end = var.index('[')
+                    if end <= start:
+                        raise ValueError("Error extracting group from %s, check format" % var)
+                    tags.append('nomad_group:%s' % var[start:end])
+                except ValueError:
+                    pass
+        return tags
 
-    def invalidate_cache(self, events):
-        """
-        Allows cache invalidation when containers dies
-        :param events from self.get_events
-        """
-        try:
-            for ev in events:
-                if ev.get('status') == 'die' and ev.get('id') in self._container_tags_cache:
-                    del self._container_tags_cache[ev.get('id')]
-        except Exception as e:
-            log.warning("Error when invalidating nomad cache: " + str(e))
+    @staticmethod
+    def is_detected():
+        return NOMAD_ALLOC_ID in os.environ

--- a/utils/platform.py
+++ b/utils/platform.py
@@ -108,7 +108,8 @@ class Platform(object):
 
     @staticmethod
     def is_nomad():
-        return 'NOMAD_ALLOC_ID' in os.environ
+        from utils.orchestrator import NomadUtil
+        return NomadUtil.is_detected()
 
     @staticmethod
     def is_mesos():

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -22,7 +22,7 @@ from utils.kubernetes import KubeUtil
 from utils.platform import Platform
 from utils.service_discovery.abstract_sd_backend import AbstractSDBackend
 from utils.service_discovery.config_stores import get_config_store
-from utils.orchestrator import NomadUtil, ECSUtil, MetadataCollector
+from utils.orchestrator import MetadataCollector
 
 DATADOG_ID = 'com.datadoghq.sd.check.id'
 
@@ -97,11 +97,6 @@ class SDDockerBackend(AbstractSDBackend):
                 self.kubeutil = None
                 log.error("Couldn't instantiate the kubernetes client, "
                     "subsequent kubernetes calls will fail as well. Error: %s" % str(ex))
-
-        if Platform.is_nomad():
-            self.nomadutil = NomadUtil()
-        elif Platform.is_ecs_instance():
-            self.ecsutil = ECSUtil()
 
         self.metadata_collector = MetadataCollector()
 
@@ -326,15 +321,6 @@ class SDDockerBackend(AbstractSDBackend):
                 tags.append('rancher_stack:%s' % stack_name)
             if container_name:
                 tags.append('rancher_container:%s' % container_name)
-
-        elif Platform.is_nomad():
-            nomad_tags = self.nomadutil.extract_container_tags(c_inspect)
-            if nomad_tags:
-                tags.extend(nomad_tags)
-
-        elif Platform.is_ecs_instance():
-            ecs_tags = self.ecsutil.extract_container_tags(c_inspect)
-            tags.extend(ecs_tags)
 
         if self.metadata_collector.has_detected():
             orch_tags = self.metadata_collector.get_container_tags(co=c_inspect)


### PR DESCRIPTION
**Warning: the need to merge https://github.com/DataDog/dd-agent/pull/3383 and rebase on master first**

### What does this PR do?

This PR:
- ports ECSUtil and NomadUtil to BaseUtil and MetadataCollector for container tags (see https://github.com/DataDog/dd-agent/pull/3383)
- adds host tags for:
  - ECS: `ecs_version`
  - Nomad: `nomad_version`, `nomad_region`, `nomad_datacenter`
  - Kube: `kube_master_version` and `kubelet_version` through a KubeUtilProxy class
- gets Docker host tags through a DockerUtilProxy class in orchestrator package for consistency
- adds unit tests for detection and tags extraction

What's more to do:
  - remove references to ECSUtil and NomadUtil in docker_daemon (sister PR to come)
  - decide whether is_* methods should stay in utils.Platform or be removed (as we abstract the orchestrator via MetadataCollector)

### Motivation

See https://github.com/DataDog/dd-agent/pull/3383