### PR TITLE
Update Mac restart command

### DIFF
--- a/packaging/osx/datadog-agent
+++ b/packaging/osx/datadog-agent
@@ -89,6 +89,7 @@ case $1 in
         else
             echo "$DESC was not running"
         fi
+        sleep 5
         "$0" start
         ;;
 

--- a/packaging/osx/datadog-agent
+++ b/packaging/osx/datadog-agent
@@ -90,11 +90,14 @@ case $1 in
         else
             echo "$DESC was not running"
         fi
+        # This section checks to see if supervisor is still running before we attempt a start. We will wait 
+        # up to 10 seconds as this is how long Supervisor waits for processes to stop before force exiting using SIGKILL
+        # http://supervisord.org/configuration.html#program-x-section-values
         checks=0
         pid=$(cat $SUPERVISOR_PIDFILE 2>/dev/null)
         if [ -n $pid ]; then
-            while ps aux $pid | grep $SUPERVISOR_PROCESS >/dev/null && [ $checks -lt 10 ]; do
-                  let "checks = checks + 1"
+            while [ $checks -lt 10 ] && ps aux $pid | grep $SUPERVISOR_PROCESS >/dev/null; do
+                let "checks = checks + 1"
                 sleep 1
             done
         fi

--- a/packaging/osx/datadog-agent
+++ b/packaging/osx/datadog-agent
@@ -77,6 +77,17 @@ case $1 in
         check_status > /dev/null
         if [ $? -ne 2 ]; then
             $SUPERVISORCTL_PATH -c $SUPERVISOR_CONF_FILE shutdown
+        # This section checks to see if supervisor is still running before we attempt a start. We will wait 
+        # up to 10 seconds as this is how long Supervisor waits for processes to stop before force exiting using SIGKILL
+        # http://supervisord.org/configuration.html#program-x-section-values
+        checks=0
+        pid=$(cat $SUPERVISOR_PIDFILE 2>/dev/null)
+        if [ -n $pid ]; then
+            while [ $checks -lt 10 ] && ps aux $pid | grep $SUPERVISOR_PROCESS >/dev/null; do
+                let "checks = checks + 1"
+                sleep 1
+            done
+        fi
         else
             echo "$DESC (supervisor) is not running"
         fi
@@ -89,17 +100,6 @@ case $1 in
             "$0" stop
         else
             echo "$DESC was not running"
-        fi
-        # This section checks to see if supervisor is still running before we attempt a start. We will wait 
-        # up to 10 seconds as this is how long Supervisor waits for processes to stop before force exiting using SIGKILL
-        # http://supervisord.org/configuration.html#program-x-section-values
-        checks=0
-        pid=$(cat $SUPERVISOR_PIDFILE 2>/dev/null)
-        if [ -n $pid ]; then
-            while [ $checks -lt 10 ] && ps aux $pid | grep $SUPERVISOR_PROCESS >/dev/null; do
-                let "checks = checks + 1"
-                sleep 1
-            done
         fi
         "$0" start
         ;;

--- a/packaging/osx/datadog-agent
+++ b/packaging/osx/datadog-agent
@@ -8,6 +8,7 @@ AGENTCONF="/opt/datadog-agent/etc/datadog.conf"
 SUPERVISOR_PIDFILE="/opt/datadog-agent/run/datadog-supervisord.pid"
 SUPERVISOR_CONF_FILE="/opt/datadog-agent/etc/supervisor.conf"
 SUPERVISOR_SOCK="/opt/datadog-agent/run/datadog-supervisor.sock"
+SUPERVISOR_PROCESS="/opt/datadog-agent/bin/supervisord"
 SUPERVISORCTL_PATH="/opt/datadog-agent/bin/supervisorctl"
 SUPERVISORD_PATH="/opt/datadog-agent/bin/supervisord"
 COLLECTOR_PIDFILE="/opt/datadog-agent/run/dd-agent.pid"
@@ -89,7 +90,14 @@ case $1 in
         else
             echo "$DESC was not running"
         fi
-        sleep 5
+        checks=0
+        pid=$(cat $SUPERVISOR_PIDFILE 2>/dev/null)
+        if [ -n $pid ]; then
+            while ps aux $pid | grep $SUPERVISOR_PROCESS >/dev/null && [ $checks -lt 10 ]; do
+                  let "checks = checks + 1"
+                sleep 1
+            done
+        fi
         "$0" start
         ;;
 

--- a/packaging/osx/datadog-agent
+++ b/packaging/osx/datadog-agent
@@ -77,17 +77,17 @@ case $1 in
         check_status > /dev/null
         if [ $? -ne 2 ]; then
             $SUPERVISORCTL_PATH -c $SUPERVISOR_CONF_FILE shutdown
-        # This section checks to see if supervisor is still running before we attempt a start. We will wait 
-        # up to 10 seconds as this is how long Supervisor waits for processes to stop before force exiting using SIGKILL
-        # http://supervisord.org/configuration.html#program-x-section-values
-        checks=0
-        pid=$(cat $SUPERVISOR_PIDFILE 2>/dev/null)
-        if [ -n $pid ]; then
-            while [ $checks -lt 10 ] && ps aux $pid | grep $SUPERVISOR_PROCESS >/dev/null; do
-                let "checks = checks + 1"
-                sleep 1
-            done
-        fi
+            # This section checks to see if supervisor is still running before we attempt a start. We will wait 
+            # up to 10 seconds as this is how long Supervisor waits for processes to stop before force exiting using SIGKILL
+            # http://supervisord.org/configuration.html#program-x-section-values
+            checks=0
+            pid=$(cat $SUPERVISOR_PIDFILE 2>/dev/null)
+            if [ -n $pid ]; then
+                while [ $checks -lt 10 ] && ps aux $pid | grep $SUPERVISOR_PROCESS >/dev/null; do
+                    let "checks = checks + 1"
+                    sleep 1
+                done
+            fi
         else
             echo "$DESC (supervisor) is not running"
         fi


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

This PR modified the restart command of the Mac OSX packaged Agent. The restart command now checks to see if the supervisor process is still running, and waits up to 10 seconds before calling the start command.

### Motivation

Running the `stop` then `start` commands on Mac leads to this error quite often: `Error: Another program is already listening on a port that one of our HTTP servers is configured to use.  Shut this program down first before starting supervisord.`

This seems to be due to the supervisor process taking too long to fully exit and free up ports, so we wait up to 10 seconds for this to be done. 

Thanks @cmatteri For writing this restart

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
