### PR TITLE
[util] Move `Timer` to its own `utils.timer` module

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -34,15 +34,13 @@ from config import get_system_stats, get_version
 import checks.system.unix as u
 import checks.system.win32 as w32
 import modules
-from util import (
-    get_uuid,
-    Timer,
-)
+from util import get_uuid
 from utils.cloud_metadata import GCE, EC2
 from utils.logger import log_exceptions
 from utils.jmx import JMXFiles
 from utils.platform import Platform, get_os
 from utils.subprocess_output import get_subprocess_output
+from utils.timer import Timer
 
 log = logging.getLogger(__name__)
 

--- a/tests/core/test_watchdog.py
+++ b/tests/core/test_watchdog.py
@@ -40,7 +40,7 @@ class TestWatchdog(unittest.TestCase):
         Helper, a context manager to set the current time value.
         """
         # Set the current time within `util` module
-        mock_time = patch("util.time.time")
+        mock_time = patch("utils.timer.time.time")
         mock_time.start().return_value = time
 
         # Yield

--- a/util.py
+++ b/util.py
@@ -6,7 +6,6 @@
 import logging
 import platform
 import re
-import time
 import uuid
 
 # 3p
@@ -26,6 +25,7 @@ except ImportError:
 from utils.pidfile import PidFile  # noqa, see ^^^
 from utils.platform import Platform, get_os # noqa, see ^^^
 from utils.proxy import get_proxy # noqa, see ^^^
+from utils.timer import Timer # noqa, see ^^^
 
 COLON_NON_WIN_PATH = re.compile(':(?!\\\\)')
 
@@ -137,30 +137,6 @@ def config_to_yaml(config):
         raise Exception('You need to have at least one instance defined in your config.')
 
     return yaml_output
-
-
-class Timer(object):
-    """ Helper class """
-
-    def __init__(self):
-        self.start()
-
-    def _now(self):
-        return time.time()
-
-    def start(self):
-        self.started = self._now()
-        self.last = self.started
-        return self
-
-    def step(self):
-        now = self._now()
-        step = now - self.last
-        self.last = now
-        return step
-
-    def total(self, as_sec=True):
-        return self._now() - self.started
 
 """
 Iterable Recipes

--- a/utils/timer.py
+++ b/utils/timer.py
@@ -1,0 +1,29 @@
+# (C) Datadog, Inc. 2010-2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# stdlib
+import time
+
+class Timer(object):
+    """ Helper class """
+
+    def __init__(self):
+        self.start()
+
+    def _now(self):
+        return time.time()
+
+    def start(self):
+        self.started = self._now()
+        self.last = self.started
+        return self
+
+    def step(self):
+        now = self._now()
+        step = now - self.last
+        self.last = now
+        return step
+
+    def total(self, as_sec=True):
+        return self._now() - self.started


### PR DESCRIPTION
### What does this PR do?

Move `Timer` to its own `utils.timer` module

### Motivation

`util.py` is deprecated, and `Timer` was still used in a check
(vsphere). Move to `utils`, and still import it in `util` so that
custom checks importing it from `util` still work (until we finally
remove it in Agent 6.0)

### Testing

No specific manual testing done, relying on CI.
