### PR TITLE
[core] Adds fraction of file handles in use over system limit

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -206,7 +206,7 @@ class Collector(object):
             'processes': u.Processes(log),
             'cpu': u.Cpu(log),
             'system': u.System(log),
-            'fh': u.File_Handlers(log)
+            'file_handles': u.FileHandles(log)
         }
 
         # Win32 System `Checks
@@ -302,7 +302,7 @@ class Collector(object):
             # Unix system checks
             sys_checks = self._unix_system_checks
 
-            for check_name in ['load', 'system', 'cpu', 'fh']:
+            for check_name in ['load', 'system', 'cpu', 'file_handles']:
                 try:
                     result_check = sys_checks[check_name].check(self.agentConfig)
                     if result_check:

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -205,7 +205,8 @@ class Collector(object):
             'memory': u.Memory(log),
             'processes': u.Processes(log),
             'cpu': u.Cpu(log),
-            'system': u.System(log)
+            'system': u.System(log),
+            'fh': u.File_Handlers(log)
         }
 
         # Win32 System `Checks
@@ -301,7 +302,7 @@ class Collector(object):
             # Unix system checks
             sys_checks = self._unix_system_checks
 
-            for check_name in ['load', 'system', 'cpu']:
+            for check_name in ['load', 'system', 'cpu', 'fh']:
                 try:
                     result_check = sys_checks[check_name].check(self.agentConfig)
                     if result_check:

--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -808,7 +808,7 @@ def main():
         print(mem.check(config))
         print("--- System ---")
         print(system.check(config))
-        print("--- File Handlers ---")
+        print("--- File Handles ---")
         print(fh.check(config))
         print("\n\n\n")
         # print("--- Processes ---")

--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -228,9 +228,12 @@ class File_Handlers(Check):
         if not Platform.is_linux():
             return False
 
-        with open('/proc/sys/fs/file-nr', 'r') as file_handlers:
-            handler_contents = file_handlers.read()
-        file_handlers.close()
+        try:
+            with open('/proc/sys/fs/file-nr', 'r') as file_handlers:
+                handler_contents = file_handlers.read()
+        except Exception:
+            self.logger.exception("Cannot extract system file handler stats")
+            return False
 
         handler_metrics = handler_contents.split()
 


### PR DESCRIPTION
### What does this PR do?

Adds a metric for the percent of allocated and used file handlers over the system's max. Uses `/proc/sys/fs/file-nr` as noted here - https://www.kernel.org/doc/Documentation/sysctl/fs.txt

This metric will be displayed as a fraction between 0 and 1, and is named: `system.fs.file_handles_in_use` to keep syntactically similar to `system.disk_in_use` which has similar units. 

This would look like this in app: https://cl.ly/3u2E2S3l2j0K

### Motivation

Users would like to be able to be alerted if the number of handlers being used was approaching the limit available. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
