### PR TITLE
[kube] Allow to run agent on the node

### DIFF
--- a/tests/core/test_kube_event_retriever.py
+++ b/tests/core/test_kube_event_retriever.py
@@ -69,7 +69,7 @@ class TestKubeEventRetriever(KubeTestCase):
         with patch.object(self.kube, 'retrieve_json_auth', return_value={}) as mock_method:
             retr = KubeEventRetriever(self.kube, namespaces=['testns'])
             retr.get_event_array()
-        mock_method.assert_called_once_with('https://kubernetes/api/v1/namespaces/testns/events', params={})
+        mock_method.assert_called_once_with('https://kubernetes:443/api/v1/namespaces/testns/events', params={})
 
     def test_namespace_clientside_filtering(self):
         val = self._build_events([('ns1', 'k1'), ('ns2', 'k1'), ('testns', 'k1')])
@@ -77,13 +77,13 @@ class TestKubeEventRetriever(KubeTestCase):
             retr = KubeEventRetriever(self.kube, namespaces=['testns', 'ns2'])
             events = retr.get_event_array()
             self.assertEquals(2, len(events))
-        mock_method.assert_called_once_with('https://kubernetes/api/v1/events', params={})
+        mock_method.assert_called_once_with('https://kubernetes:443/api/v1/events', params={})
 
     def test_kind_serverside_filtering(self):
         with patch.object(self.kube, 'retrieve_json_auth', return_value={}) as mock_method:
             retr = KubeEventRetriever(self.kube, kinds=['k1'])
             retr.get_event_array()
-        mock_method.assert_called_once_with('https://kubernetes/api/v1/events',
+        mock_method.assert_called_once_with('https://kubernetes:443/api/v1/events',
                                             params={'fieldSelector': 'involvedObject.kind=k1'})
 
     def test_kind_clientside_filtering(self):
@@ -92,4 +92,4 @@ class TestKubeEventRetriever(KubeTestCase):
             retr = KubeEventRetriever(self.kube, kinds=['k1', 'k2'])
             events = retr.get_event_array()
             self.assertEquals(3, len(events))
-        mock_method.assert_called_once_with('https://kubernetes/api/v1/events', params={})
+        mock_method.assert_called_once_with('https://kubernetes:443/api/v1/events', params={})

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -14,7 +14,6 @@ import time
 from docker import Client, tls
 
 # project
-from utils.platform import Platform
 from utils.singleton import Singleton
 
 SWARM_SVC_LABEL = 'com.docker.swarm.service.name'
@@ -80,6 +79,7 @@ class DockerUtil:
         # Try to detect if an orchestrator is running
         self._is_ecs = False
         self._is_rancher = False
+        self._is_k8s = False
 
         try:
             containers = self.client.containers()
@@ -94,12 +94,18 @@ class DockerUtil:
             log.warning("Error while detecting orchestrator: %s" % e)
             pass
 
+        try:
+            from utils.kubernetes import detect_is_k8s
+            self._is_k8s = detect_is_k8s()
+        except Exception:
+            self._is_k8s = False
+
         # Build include/exclude patterns for containers
         self._include, self._exclude = instance.get('include', []), instance.get('exclude', [])
         if not self._exclude:
             # In Kubernetes, pause containers are not interesting to monitor.
             # This part could be reused for other platforms where containers can be safely ignored.
-            if Platform.is_k8s():
+            if self.is_k8s():
                 self.filtering_enabled = True
                 self._exclude = DEFAULT_CONTAINER_EXCLUDE
             else:
@@ -146,6 +152,9 @@ class DockerUtil:
 
     def is_rancher(self):
         return self._is_rancher
+
+    def is_k8s(self):
+        return self._is_k8s
 
     def is_swarm(self):
         if self.swarm_node_state == 'pending':

--- a/utils/kubernetes/__init__.py
+++ b/utils/kubernetes/__init__.py
@@ -6,4 +6,5 @@ from .kube_event_retriever import KubeEventRetriever  # noqa: F401
 from .pod_service_mapper import PodServiceMapper   # noqa: F401
 from .kube_state_processor import KubeStateProcessor  # noqa: F401
 from .kube_state_processor import NAMESPACE  # noqa: F401
+from .kubeutil import detect_is_k8s  # noqa: F401
 from .kubeutil import KubeUtil  # noqa: F401

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -35,6 +35,23 @@ CREATOR_KIND_TO_TAG = {
 }
 
 
+def detect_is_k8s():
+    """
+    Logic for DockerUtil to detect whether to enable Kubernetes code paths
+    It check whether we have a KUBERNETES_PORT environment variable (running
+    in a pod) or a valid kubernetes.yaml conf file
+    """
+    if 'KUBERNETES_PORT' in os.environ:
+        return True
+    else:
+        try:
+            k8_config_file_path = get_conf_path(KUBERNETES_CHECK_NAME)
+            k8_check_config = check_yaml(k8_config_file_path)
+            return len(k8_check_config['instances']) > 0
+        except Exception:
+            return False
+
+
 class KubeUtil:
     __metaclass__ = Singleton
 
@@ -66,6 +83,7 @@ class KubeUtil:
             # kubernetes.yaml was not found
             except IOError as ex:
                 log.error(ex.message)
+
                 instance = {}
             except Exception:
                 log.error('Kubernetes configuration file is invalid. '

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -153,10 +153,6 @@ class KubeUtil:
         if apiserver_cacert and os.path.exists(apiserver_cacert):
             tls_settings['apiserver_cacert'] = apiserver_cacert
 
-        token = self.get_auth_token(instance)
-        if token:
-            tls_settings['bearer_token'] = token
-
         # kubelet
         kubelet_client_crt = instance.get('kubelet_client_crt')
         kubelet_client_key = instance.get('kubelet_client_key')
@@ -168,6 +164,12 @@ class KubeUtil:
             tls_settings['kubelet_verify'] = cert
         else:
             tls_settings['kubelet_verify'] = instance.get('kubelet_tls_verify', DEFAULT_TLS_VERIFY)
+
+        if ('apiserver_client_cert' not in tls_settings) or ('kubelet_client_cert' not in tls_settings):
+            # Only lookup token if we don't have client certs for both
+            token = self.get_auth_token(instance)
+            if token:
+                tls_settings['bearer_token'] = token
 
         return tls_settings
 

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -48,7 +48,8 @@ def detect_is_k8s():
             k8_config_file_path = get_conf_path(KUBERNETES_CHECK_NAME)
             k8_check_config = check_yaml(k8_config_file_path)
             return len(k8_check_config['instances']) > 0
-        except Exception:
+        except Exception as err:
+            log.debug("Error detecting kubernetes: %s" % str(err))
             return False
 
 
@@ -96,9 +97,12 @@ class KubeUtil:
         self.tls_settings = self._init_tls_settings(instance)
 
         # apiserver
-        master_host = instance.get('api_server_host', (os.environ.get('KUBERNETES_SERVICE_HOST') or self.DEFAULT_MASTER_NAME))
-        master_port = instance.get('api_server_port', self.DEFAULT_MASTER_PORT)
-        self.kubernetes_api_root_url = 'https://%s:%d' % (master_host, master_port)
+        if 'api_server_url' in instance:
+            self.kubernetes_api_root_url = instance.get('api_server_url')
+        else:
+            master_host = os.environ.get('KUBERNETES_SERVICE_HOST') or self.DEFAULT_MASTER_NAME
+            master_port = os.environ.get('KUBERNETES_SERVICE_PORT') or self.DEFAULT_MASTER_PORT
+            self.kubernetes_api_root_url = 'https://%s:%d' % (master_host, master_port)
 
         self.kubernetes_api_url = '%s/api/v1' % self.kubernetes_api_root_url
 

--- a/utils/orchestrator/kubeutilproxy.py
+++ b/utils/orchestrator/kubeutilproxy.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 from utils.kubernetes import KubeUtil
+from utils.platform import Platform
 from .baseutil import BaseUtil
 
 
@@ -12,11 +13,7 @@ class KubeUtilProxy(BaseUtil):
 
     @staticmethod
     def is_detected():
-        try:
-            tags = KubeUtil().get_node_hosttags()
-            return bool(tags)
-        except Exception:
-            return False
+        return Platform.is_k8s()
 
     def get_host_tags(self):
         return KubeUtil().get_node_hosttags()

--- a/utils/platform.py
+++ b/utils/platform.py
@@ -94,7 +94,8 @@ class Platform(object):
 
     @staticmethod
     def is_k8s():
-        return 'KUBERNETES_PORT' in os.environ
+        from utils.dockerutil import DockerUtil
+        return DockerUtil().is_k8s()
 
     @staticmethod
     def is_rancher():


### PR DESCRIPTION
### What does this PR do?

- Allows the user to set bearer token path and api_server hostname and credentials manually, to allow running directly on the node.
- If `kubernetes.yaml` is present and valid, enable k8s tagging for Docker and SD metrics
- If both client certs are configured, skip token lookup to remove the error

Sister PR for configuration: https://github.com/DataDog/integrations-core/pull/508


Tested on container (datadog/dev-dd-agent:xvello_kube_on_host image) and deb package on ubuntu host.

fixes #3221 