### PR TITLE
Add hostname detection for azure cloud provider

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -35,7 +35,7 @@ import checks.system.unix as u
 import checks.system.win32 as w32
 import modules
 from util import get_uuid
-from utils.cloud_metadata import GCE, EC2, CloudFoundry
+from utils.cloud_metadata import GCE, EC2, CloudFoundry, Azure
 from utils.logger import log_exceptions
 from utils.jmx import JMXFiles
 from utils.platform import Platform, get_os
@@ -764,6 +764,11 @@ class Collector(object):
             metadata["host_aliases"] = []
 
         host_aliases = GCE.get_host_aliases(self.agentConfig)
+        if host_aliases:
+            metadata['host_aliases'] += host_aliases
+
+        # Try to get Azure VM ID
+        host_aliases = Azure.get_host_aliases(self.agentConfig)
         if host_aliases:
             metadata['host_aliases'] += host_aliases
 

--- a/tests/core/fixtures/azure/metadata_instance.json
+++ b/tests/core/fixtures/azure/metadata_instance.json
@@ -1,0 +1,39 @@
+{
+	"compute": {
+		"location": "westcentralus",
+		"name": "IMDSSample",
+		"offer": "UbuntuServer",
+		"osType": "Linux",
+		"platformFaultDomain": "0",
+		"platformUpdateDomain": "0",
+		"publisher": "Canonical",
+		"sku": "16.04.0-LTS",
+		"version": "16.04.201610200",
+		"vmId": "5d33a910-a7a0-4443-9f01-6a807801b29b",
+		"vmSize": "Standard_A1"
+	},
+	"network": {
+		"interface": [
+			{
+				"ipv4": {
+					"ipAddress": [
+						{
+							"privateIpAddress": "10.1.0.4",
+							"publicIpAddress": "X.X.X.X"
+						}
+					],
+					"subnet": [
+						{
+							"address": "10.1.0.0",
+							"prefix": "24"
+						}
+					]
+				},
+				"ipv6": {
+					"ipAddress": []
+				},
+				"macAddress": "000D3AF806EC"
+			}
+		]
+	}
+}

--- a/tests/core/test_azure.py
+++ b/tests/core/test_azure.py
@@ -1,0 +1,44 @@
+# stdlib
+import unittest
+import os
+import json
+
+# 3rd party
+import mock
+
+# project
+from utils.cloud_metadata import Azure
+
+
+class TestAzure(unittest.TestCase):
+    @mock.patch('requests.get')
+    def test_host_aliases(self, mock_get):
+        resp = mock.Mock()
+        with open(os.path.join(os.path.dirname(__file__), 'fixtures', 'azure', 'metadata_instance.json')) as f:
+                data = json.load(f)
+                resp.json = lambda: data
+
+        mock_get.return_value = resp
+
+        vm_id = Azure.get_host_aliases({})
+        self.assertEqual(vm_id, ["5d33a910-a7a0-4443-9f01-6a807801b29b"])
+
+    @mock.patch('requests.get')
+    def test_host_aliases_exception(self, mock_get):
+        def raise_error():
+            raise Exception("test error")
+        resp = mock.Mock()
+        resp.raise_for_status = raise_error
+        mock_get.return_value = resp
+
+        vm_id = Azure.get_host_aliases({})
+        self.assertEqual(vm_id, [])
+
+    @mock.patch('requests.get')
+    def test_hostname_bad_format(self, mock_get):
+        resp = mock.Mock()
+        resp.json = lambda: "{}"
+        mock_get.return_value = resp
+
+        vm_id = Azure.get_host_aliases({})
+        self.assertEqual(vm_id, [])


### PR DESCRIPTION
### What does this PR do?

Detect an Azure host using the metadata instance service and use the VM ID as hostname.