### PR TITLE
try collecting docker+orchestrator host tags even if not containerised

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -661,7 +661,7 @@ class Collector(object):
             if self.agentConfig['collect_ec2_tags']:
                 host_tags.extend(EC2.get_tags(self.agentConfig))
 
-            if self.agentConfig['collect_orchestrator_tags'] and Platform.is_containerized():
+            if self.agentConfig['collect_orchestrator_tags']:
                 host_docker_tags = MetadataCollector().get_host_tags()
                 if host_docker_tags:
                     host_tags.extend(host_docker_tags)

--- a/utils/orchestrator/metadata_collector.py
+++ b/utils/orchestrator/metadata_collector.py
@@ -60,6 +60,11 @@ class MetadataCollector():
             util = DockerUtilProxy()
             util.reset_cache()
             self._utils.append(util)
+        else:
+            # Skip orchestrator detection if docker not found: agent5 is docker-only anyway
+            self._has_detected = False
+            return
+
         if KubeUtilProxy.is_detected():
             util = KubeUtilProxy()
             util.reset_cache()


### PR DESCRIPTION
### What does this PR do?

Enable orchestrator.MetadataCollector even when not containerised, in case the agent is installed on the host.

To reduce boot time on non-docker hosts, orchestrator detection is passed if docker is not found, as we only support docker as a runtime for now.
