### PR TITLE
Add support for %%id%% and %%pid%% template variables

### DIFF
--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -39,7 +39,7 @@ class Response(object):
 
 def _get_container_inspect(c_id):
     """Return a mocked container inspect dict from self.container_inspects."""
-    for co, _, _, _, _, _, _ in TestServiceDiscovery.container_inspects:
+    for co, _, _, _, _, _ in TestServiceDiscovery.container_inspects:
         if co.get('Id') == c_id:
             return co
         return None
@@ -106,10 +106,10 @@ class TestServiceDiscovery(unittest.TestCase):
     }
     container_inspects = [
         # (inspect_dict, expected_ip, tpl_var, expected_port, expected_ident, expected_id, expected_pid)
-        (docker_container_inspect, '172.17.0.21', 'port', '443', 'nginx', '69ff25598b2314d1cdb7752cc3a659fb1c1352b32546af4f1454321550e842c0', '1234'),
-        (docker_container_inspect_with_label, '172.17.0.21', 'port', '443', 'custom-nginx', '69ff25598b2314d1cdb7752cc3a659fb1c1352b32546af4f1454321550e842c0', None),
-        (kubernetes_container_inspect, None, 'port', '6379', 'foo', '389dc8a4361f3d6c866e9e9a7b6972b26a31c589c4e2f097375d55656a070bc9', None),  # arbitrarily defined in the mocked pod_list
-        (malformed_container_inspect, None, 'port', KeyError, 'foo', '69ff25598b2314d1cdb7752cc3a659fb1c1352b32546af4f1454321550e842c0', None)
+        (docker_container_inspect, '172.17.0.21', 'port', '443', 'nginx', '1234'),
+        (docker_container_inspect_with_label, '172.17.0.21', 'port', '443', 'custom-nginx', None),
+        (kubernetes_container_inspect, None, 'port', '6379', 'foo', None),  # arbitrarily defined in the mocked pod_list
+        (malformed_container_inspect, None, 'port', KeyError, 'foo', None)
     ]
 
     # templates with variables already extracted
@@ -272,7 +272,7 @@ class TestServiceDiscovery(unittest.TestCase):
         os.path.dirname(__file__), 'fixtures/auto_conf/'))
     @mock.patch('utils.dockerutil.DockerUtil.client', return_value=None)
     def test_get_port(self, *args):
-        for c_ins, _, var_tpl, expected_ports, _, _, _ in self.container_inspects:
+        for c_ins, _, var_tpl, expected_ports, _, _ in self.container_inspects:
             state = _SDDockerBackendConfigFetchState(lambda _: c_ins)
             sd_backend = get_sd_backend(agentConfig=self.auto_conf_agentConfig)
             if isinstance(expected_ports, str):
@@ -285,22 +285,10 @@ class TestServiceDiscovery(unittest.TestCase):
         os.path.dirname(__file__), 'fixtures/auto_conf/'))
     @mock.patch('utils.dockerutil.DockerUtil.client', return_value=None)
     def test_get_container_pid(self, *args):
-        for c_ins, _, var_tpl, _, _, _, expected_pid in self.container_inspects:
+        for c_ins, _, var_tpl, _, _, expected_pid in self.container_inspects:
             state = _SDDockerBackendConfigFetchState(lambda _: c_ins)
             sd_backend = get_sd_backend(agentConfig=self.auto_conf_agentConfig)
             self.assertEquals(sd_backend._get_container_pid(state, 'container id', var_tpl), expected_pid)
-            clear_singletons(self.auto_conf_agentConfig)
-
-    @mock.patch('config.get_auto_confd_path', return_value=os.path.join(
-        os.path.dirname(__file__), 'fixtures/auto_conf/'))
-    @mock.patch('utils.dockerutil.DockerUtil.client', return_value=None)
-    def test_get_container_id(self, *args):
-        # this looks a little silly given we already _have_ the cid,
-        # but it keeps the same form of the other tests
-        for c_ins, _, var_tpl, _, _, cid, _ in self.container_inspects:
-            state = _SDDockerBackendConfigFetchState(lambda _: c_ins)
-            sd_backend = get_sd_backend(agentConfig=self.auto_conf_agentConfig)
-            self.assertEquals(sd_backend._get_container_id(state, cid, var_tpl), cid)
             clear_singletons(self.auto_conf_agentConfig)
 
     @mock.patch('config.get_auto_confd_path', return_value=os.path.join(
@@ -620,7 +608,7 @@ class TestServiceDiscovery(unittest.TestCase):
     def test_get_config_id(self, mock_get_auto_confd_path):
         """Test get_config_id"""
         with mock.patch('utils.dockerutil.DockerUtil.client', return_value=None):
-            for c_ins, _, _, _, expected_ident, _, _ in self.container_inspects:
+            for c_ins, _, _, _, expected_ident, _ in self.container_inspects:
                 sd_backend = get_sd_backend(agentConfig=self.auto_conf_agentConfig)
                 self.assertEqual(
                     sd_backend.get_config_id(DockerUtil().image_name_extractor(c_ins), c_ins.get('Config', {}).get('Labels', {})),

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -102,6 +102,8 @@ class SDDockerBackend(AbstractSDBackend):
 
         self.VAR_MAPPING = {
             'host': self._get_host_address,
+            'id': self._get_container_id,
+            'pid': self._get_container_pid,
             'port': self._get_port,
             'tags': self._get_additional_tags,
         }
@@ -159,6 +161,18 @@ class SDDockerBackend(AbstractSDBackend):
             }
 
         return self.config_store.get_checks_to_refresh(identifier, **platform_kwargs)
+
+    def _get_container_id(self, state, cid, tpl_var):
+        """Extract the container ID from a docker inspect object."""
+        return cid
+
+    def _get_container_pid(self, state, cid, tpl_var):
+        """Extract the host-namespace pid of the container pid 0"""
+        pid = state.inspect_container(cid).get('State', {}).get('Pid')
+        if not pid:
+            return None
+
+        return str(pid)
 
     def _get_host_address(self, state, c_id, tpl_var):
         """Extract the container IP from a docker inspect object, or the kubelet API."""

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -102,7 +102,6 @@ class SDDockerBackend(AbstractSDBackend):
 
         self.VAR_MAPPING = {
             'host': self._get_host_address,
-            'id': self._get_container_id,
             'pid': self._get_container_pid,
             'port': self._get_port,
             'tags': self._get_additional_tags,
@@ -161,10 +160,6 @@ class SDDockerBackend(AbstractSDBackend):
             }
 
         return self.config_store.get_checks_to_refresh(identifier, **platform_kwargs)
-
-    def _get_container_id(self, state, cid, tpl_var):
-        """Extract the container ID from a docker inspect object."""
-        return cid
 
     def _get_container_pid(self, state, cid, tpl_var):
         """Extract the host-namespace pid of the container pid 0"""


### PR DESCRIPTION
### What does this PR do?

This PR adds two new template variables to the service-discovery check configs:

* `pid` the host PID namespace PID of a container processes' PID 0
* `id` the docker container id hash

### Motivation

We have a few custom integrations that collect information from `/proc`. When we were running only one instance of a process per-host (pre-containers), it was easy to determine the correct `pid` to interrogate. Now that we're using Kubernetes and Docker, there is often many such processes per machine. These variables help us find the process we want.

### Notes

This PR Is actually authored by @jnewland - I'm submitting it upstream because I've been working on our dd-agent packaging setup.