### PR TITLE
Get real host aliases for Cloud Foundry

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -751,13 +751,13 @@ class Collector(object):
             except Exception:
                 pass
 
-        if self.agentConfig.get('use_socket_hostname_as_alias'):
-            try:
-                if not metadata["host_aliases"]:
-                    metadata["host_aliases"] = []
-                metadata["host_aliases"] += CloudFoundry.get_host_aliases
-            except Exception:
-                pass
+        if not metadata["host_aliases"]:
+            metadata["host_aliases"] = []
+
+        try:
+            metadata["host_aliases"] += CloudFoundry.get_host_aliases
+        except Exception:
+            pass
 
         try:
             metadata["socket-fqdn"] = socket.getfqdn()
@@ -770,8 +770,6 @@ class Collector(object):
         # Add cloud provider aliases
         host_aliases = GCE.get_host_aliases(self.agentConfig)
         if host_aliases:
-            if not metadata["host_aliases"]:
-                metadata["host_aliases"] = []
             metadata['host_aliases'] += host_aliases
 
         return metadata

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -751,7 +751,7 @@ class Collector(object):
             except Exception:
                 pass
 
-        if not metadata["host_aliases"]:
+        if not metadata.get("host_aliases"):
             metadata["host_aliases"] = []
 
         try:

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -745,11 +745,17 @@ class Collector(object):
 
         if self.agentConfig.get('hostname'):
             metadata['agent-hostname'] = self.agentConfig.get('hostname')
+        else:
+            try:
+                metadata["socket-hostname"] = socket.gethostname()
+            except Exception:
+                pass
 
-        try:
-            metadata["socket-hostname"] = socket.gethostname()
-        except Exception:
-            pass
+        if self.agentConfig.get('danger_always_add_socket_hostname'):
+            try:
+                metadata["socket-hostname"] = socket.gethostname()
+            except Exception:
+                pass
 
         try:
             metadata["socket-fqdn"] = socket.getfqdn()

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -745,11 +745,12 @@ class Collector(object):
 
         if self.agentConfig.get('hostname'):
             metadata['agent-hostname'] = self.agentConfig.get('hostname')
-        else:
-            try:
-                metadata["socket-hostname"] = socket.gethostname()
-            except Exception:
-                pass
+
+        try:
+            metadata["socket-hostname"] = socket.gethostname()
+        except Exception:
+            pass
+
         try:
             metadata["socket-fqdn"] = socket.getfqdn()
         except Exception:

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -751,14 +751,6 @@ class Collector(object):
             except Exception:
                 pass
 
-        if not metadata.get("host_aliases"):
-            metadata["host_aliases"] = []
-
-        try:
-            metadata["host_aliases"] += CloudFoundry.get_host_aliases
-        except Exception:
-            pass
-
         try:
             metadata["socket-fqdn"] = socket.getfqdn()
         except Exception:
@@ -768,9 +760,17 @@ class Collector(object):
         metadata["timezones"] = self._decode_tzname(time.tzname)
 
         # Add cloud provider aliases
+        if not metadata.get("host_aliases"):
+            metadata["host_aliases"] = []
+
         host_aliases = GCE.get_host_aliases(self.agentConfig)
         if host_aliases:
             metadata['host_aliases'] += host_aliases
+
+        try:
+            metadata["host_aliases"] += CloudFoundry.get_host_aliases(self.agentConfig)
+        except Exception:
+            pass
 
         return metadata
 

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -751,9 +751,11 @@ class Collector(object):
             except Exception:
                 pass
 
-        if self.agentConfig.get('danger_always_add_socket_hostname'):
+        if self.agentConfig.get('use_socket_hostname_as_alias'):
             try:
-                metadata["socket-hostname"] = socket.gethostname()
+                if not metadata["host_aliases"]:
+                    metadata["host_aliases"] = []
+                metadata["host_aliases"] += [socket.gethostname()]
             except Exception:
                 pass
 

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -35,7 +35,7 @@ import checks.system.unix as u
 import checks.system.win32 as w32
 import modules
 from util import get_uuid
-from utils.cloud_metadata import GCE, EC2
+from utils.cloud_metadata import GCE, EC2, CloudFoundry
 from utils.logger import log_exceptions
 from utils.jmx import JMXFiles
 from utils.platform import Platform, get_os
@@ -755,7 +755,7 @@ class Collector(object):
             try:
                 if not metadata["host_aliases"]:
                     metadata["host_aliases"] = []
-                metadata["host_aliases"] += [socket.gethostname()]
+                metadata["host_aliases"] += CloudFoundry.get_host_aliases
             except Exception:
                 pass
 

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -770,7 +770,9 @@ class Collector(object):
         # Add cloud provider aliases
         host_aliases = GCE.get_host_aliases(self.agentConfig)
         if host_aliases:
-            metadata['host_aliases'] = host_aliases
+            if not metadata["host_aliases"]:
+                metadata["host_aliases"] = []
+            metadata['host_aliases'] += host_aliases
 
         return metadata
 

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -64,9 +64,11 @@ api_key:
 # when not specified, default: no
 gce_updated_hostname: yes
 
-# Always add the socket hostname to the host aliases
-# This is very dangerous and could, in the worst case, merge all your VMs into one.
-# Do not use unless you know what you're going to get.
+# Always add the socket hostname to the host aliases.
+# This is mostly useful for Cloud Foundry.
+# This is dangerous to enable,
+# as many hosts could have the same socket hostname and it could merge dozens of VMs into one.
+# Do not use it unless you know what you're going to get.
 # use_socket_hostname_as_alias: no
 
 # Set the threshold for accepting points to allow anything

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -64,6 +64,11 @@ api_key:
 # when not specified, default: no
 gce_updated_hostname: yes
 
+# Always add the socket hostname to the host aliases
+# This is very dangerous and could, in the worst case, merge all your VMs into one.
+# Do not use unless you know what you're going to get.
+# danger_always_add_socket_hostname: no
+
 # Set the threshold for accepting points to allow anything
 # within recent_point_threshold seconds (default: 30)
 # recent_point_threshold: 30

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -67,7 +67,7 @@ gce_updated_hostname: yes
 # Always add the socket hostname to the host aliases
 # This is very dangerous and could, in the worst case, merge all your VMs into one.
 # Do not use unless you know what you're going to get.
-# danger_always_add_socket_hostname: no
+# use_socket_hostname_as_alias: no
 
 # Set the threshold for accepting points to allow anything
 # within recent_point_threshold seconds (default: 30)

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -64,13 +64,6 @@ api_key:
 # when not specified, default: no
 gce_updated_hostname: yes
 
-# Always add the socket hostname to the host aliases.
-# This is mostly useful for Cloud Foundry.
-# This is dangerous to enable,
-# as many hosts could have the same socket hostname and it could merge dozens of VMs into one.
-# Do not use it unless you know what you're going to get.
-# use_socket_hostname_as_alias: no
-
 # Set the threshold for accepting points to allow anything
 # within recent_point_threshold seconds (default: 30)
 # recent_point_threshold: 30

--- a/utils/cloud_metadata.py
+++ b/utils/cloud_metadata.py
@@ -247,7 +247,6 @@ class CloudFoundry(object):
             CloudFoundry.host_aliases.append(socket.gethostname())
         return []
 
-
     @staticmethod
     def is_cloud_foundry(agentConfig):
         if agentConfig.get("cloud_foundry"):

--- a/utils/cloud_metadata.py
+++ b/utils/cloud_metadata.py
@@ -238,14 +238,16 @@ class CloudFoundry(object):
         if not CloudFoundry.is_cloud_foundry(agentConfig):
             return CloudFoundry.host_aliases
         if os.environ.get("DD_BOSH_ID"):
-            CloudFoundry.host_aliases.append(os.environ.get("DD_BOSH_ID"))
+            if os.environ.get("DD_BOSH_ID") not in CloudFoundry.host_aliases:
+                CloudFoundry.host_aliases.append(os.environ.get("DD_BOSH_ID"))
         if agentConfig.get("bosh_id"):
-            CloudFoundry.host_aliases.append(agentConfig.get("bosh_id"))
+            if agentConfig.get("bosh_id") not in CloudFoundry.host_aliases:
+                CloudFoundry.host_aliases.append(agentConfig.get("bosh_id"))
         if len(CloudFoundry.host_aliases) == 0:
             # Only use this if the prior one fails
             # The reliability of the socket hostname is not assured
             CloudFoundry.host_aliases.append(socket.gethostname())
-        return []
+        return CloudFoundry.host_aliases
 
     @staticmethod
     def is_cloud_foundry(agentConfig):

--- a/utils/cloud_metadata.py
+++ b/utils/cloud_metadata.py
@@ -238,6 +238,8 @@ class CloudFoundry(object):
             return CloudFoundry.host_aliases
         if os.environ.get("DD_BOSH_ID"):
             CloudFoundry.host_aliases.append(os.environ.get("DD_BOSH_ID"))
+        if agentConfig.get("bosh_id"):
+            CloudFoundry.host_aliases.append(agentConfig.get("bosh_id"))
         if len(DD_BOSH_NAME) == 0:
             # Only use this if the prior one fails
             # The reliability of the socket hostname is not assured

--- a/utils/cloud_metadata.py
+++ b/utils/cloud_metadata.py
@@ -255,10 +255,4 @@ class CloudFoundry(object):
             return True
         elif os.environ.get("CLOUD_FOUNDRY"):
             return True
-        elif os.environ.get("JOB_DIR") == "/var/vcap/jobs/dd-agent":
-            return True
-        elif os.environ.get("HOME") == "/home/vcap":
-            return True
-        elif getpass.getuser() == "vcap":
-            return True
         return False

--- a/utils/cloud_metadata.py
+++ b/utils/cloud_metadata.py
@@ -7,6 +7,7 @@ import logging
 import types
 import os
 import getpass
+import socket
 
 # 3rd party
 import requests
@@ -234,13 +235,13 @@ class CloudFoundry(object):
 
     @staticmethod
     def get_host_aliases(agentConfig):
-        if not is_cloud_foundry(agentConfig):
+        if not CloudFoundry.is_cloud_foundry(agentConfig):
             return CloudFoundry.host_aliases
         if os.environ.get("DD_BOSH_ID"):
             CloudFoundry.host_aliases.append(os.environ.get("DD_BOSH_ID"))
         if agentConfig.get("bosh_id"):
             CloudFoundry.host_aliases.append(agentConfig.get("bosh_id"))
-        if len(DD_BOSH_NAME) == 0:
+        if len(CloudFoundry.host_aliases) == 0:
             # Only use this if the prior one fails
             # The reliability of the socket hostname is not assured
             CloudFoundry.host_aliases.append(socket.gethostname())


### PR DESCRIPTION
### What does this PR do?

I added a few ways to get the proper host alias for cloud foundry, including some undocumented options in the config file and environment variables. I can use or remove any that people think is a good idea. But, basically it will detect if it's cloud foundry and then grab the proper host alias from a few places.

### Motivation

I want the firehose nozzle metrics to be associated with their respective host, this will make that easier to do.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
