### PR TITLE
Moves common wait_for_async network function out to the Agent

### DIFF
--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -184,6 +184,25 @@ class AgentCheckTest(unittest.TestCase):
     def is_travis(self):
         return "TRAVIS" in os.environ
 
+        
+    def wait_for_async(self, method, attribute, count):
+        """
+        Loop on `self.check.method` until `self.check.attribute >= count`.
+
+        Raise after
+        """
+        i = 0
+        while i < RESULTS_TIMEOUT:
+            self.check._process_results()
+            if len(getattr(self.check, attribute)) >= count:
+                return getattr(self.check, method)()
+            time.sleep(1.1)
+            i += 1
+        raise Exception("Didn't get the right count of service checks in time, {0}/{1} in {2}s: {3}"
+                        .format(len(getattr(self.check, attribute)), count, i,
+                                getattr(self.check, attribute)))
+
+
     def load_check(self, config, agent_config=None):
         agent_config = agent_config or self.DEFAULT_AGENT_CONFIG
         self.check = load_check(self.CHECK_NAME, config, agent_config)

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -184,24 +184,27 @@ class AgentCheckTest(unittest.TestCase):
     def is_travis(self):
         return "TRAVIS" in os.environ
 
-        
+
     def wait_for_async(self, method, attribute, count):
         """
         Loop on `self.check.method` until `self.check.attribute >= count`.
-
         Raise after
         """
+
+        # Check the initial values to see if we already have results before waiting for the async
+        # instances to finish
+        initial_values = getattr(self, attribute)
+
         i = 0
         while i < RESULTS_TIMEOUT:
             self.check._process_results()
-            if len(getattr(self.check, attribute)) >= count:
-                return getattr(self.check, method)()
+            if len(getattr(self.check, attribute)) + len(initial_values) >= count:
+                return getattr(self.check, method)() + initial_values
             time.sleep(1.1)
             i += 1
         raise Exception("Didn't get the right count of service checks in time, {0}/{1} in {2}s: {3}"
                         .format(len(getattr(self.check, attribute)), count, i,
                                 getattr(self.check, attribute)))
-
 
     def load_check(self, config, agent_config=None):
         agent_config = agent_config or self.DEFAULT_AGENT_CONFIG

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -26,6 +26,8 @@ from utils.platform import get_os
 
 log = logging.getLogger('tests')
 
+RESULTS_TIMEOUT = 20
+
 def _is_sdk():
     return "SDK_TESTING" in os.environ
 

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -26,8 +26,6 @@ from utils.platform import get_os
 
 log = logging.getLogger('tests')
 
-RESULTS_TIMEOUT = 20
-
 def _is_sdk():
     return "SDK_TESTING" in os.environ
 
@@ -187,7 +185,7 @@ class AgentCheckTest(unittest.TestCase):
         return "TRAVIS" in os.environ
 
 
-    def wait_for_async(self, method, attribute, count):
+    def wait_for_async(self, method, attribute, count, results_timeout):
         """
         Loop on `self.check.method` until `self.check.attribute >= count`.
         Raise after
@@ -198,7 +196,7 @@ class AgentCheckTest(unittest.TestCase):
         initial_values = getattr(self, attribute)
 
         i = 0
-        while i < RESULTS_TIMEOUT:
+        while i < results_timeout:
             self.check._process_results()
             if len(getattr(self.check, attribute)) + len(initial_values) >= count:
                 return getattr(self.check, method)() + initial_values


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Moves the ` wait_for_async` function to the Agent instead of duplicated in each Network Integration test

### Motivation

The Network based Integrations were using the same function. Due to how fast the localhost test was returning, there seemed to be some flakiness in the network based checks. 

A previous PR added a solution to catching the quickly returned localhost service check for the TCP check. This PR takes that modified function out of the Integrations repo, places it into the Agent so that it can be used for all Network based checks. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
