### PR TITLE
pkg: Add process-agent to supervisor and flares

### DIFF
--- a/config.py
+++ b/config.py
@@ -1251,6 +1251,7 @@ def get_logging_config(cfg_path=None):
         logging_config['jmxfetch_log_file'] = '/var/log/datadog/jmxfetch.log'
         logging_config['go-metro_log_file'] = '/var/log/datadog/go-metro.log'
         logging_config['trace-agent_log_file'] = '/var/log/datadog/trace-agent.log'
+        logging_config['process-agent_log_file'] = '/var/log/datadog/process-agent.log'
         logging_config['log_to_syslog'] = True
 
     config_path = get_config_path(cfg_path, os_name=system_os)

--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -40,7 +40,7 @@ SUPERVISOR_PIDFILE="/opt/datadog-agent/run/datadog-supervisord.pid"
 COLLECTOR_PIDFILE="/opt/datadog-agent/run/dd-agent.pid"
 
 # Captures processes in the supervisord group that are 'optional' i.e. not essential for the agent to run
-DD_OPT_PROC_REGEX="dogstatsd|jmxfetch|go-metro|trace-agent"
+DD_OPT_PROC_REGEX="dogstatsd|jmxfetch|go-metro|trace-agent|process-agent"
 
 # Source function library.
 . /etc/rc.d/init.d/functions

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -31,7 +31,7 @@ COLLECTOR_PIDFILE="/opt/datadog-agent/run/dd-agent.pid"
 SYSTEM_PATH=/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:$PATH
 
 # Captures processes in the supervisord group that are 'optional' i.e. not essential for the agent to run
-DD_OPT_PROC_REGEX="dogstatsd|jmxfetch|go-metro|trace-agent"
+DD_OPT_PROC_REGEX="dogstatsd|jmxfetch|go-metro|trace-agent|process-agent"
 
 if [ ! -x $AGENTPATH ]; then
     echo "$AGENTPATH not found. Exiting."

--- a/packaging/supervisor.conf
+++ b/packaging/supervisor.conf
@@ -78,5 +78,16 @@ user=dd-agent
 autorestart=unexpected
 exitcodes=0
 
+[program:process-agent]
+command=/opt/datadog-agent/bin/process-agent
+stdout_logfile=NONE
+stderr_logfile=NONE
+startsecs=5
+startretries=3
+priority=998
+user=dd-agent
+autorestart=unexpected
+exitcodes=0
+
 [group:datadog-agent]
-programs=forwarder,collector,dogstatsd,jmxfetch,go-metro,trace-agent
+programs=forwarder,collector,dogstatsd,jmxfetch,go-metro,trace-agent,process-agent

--- a/packaging/suse/datadog-agent.init
+++ b/packaging/suse/datadog-agent.init
@@ -31,7 +31,7 @@ COLLECTOR_PIDFILE="/opt/datadog-agent/run/dd-agent.pid"
 SYSTEM_PATH=/opt/datadog-agent/embedded/bin:/opt/datadog-agent/bin:$PATH
 
 # Captures processes in the supervisord group that are 'optional' i.e. not essential for the agent to run
-DD_OPT_PROC_REGEX="dogstatsd|jmxfetch|go-metro|trace-agent"
+DD_OPT_PROC_REGEX="dogstatsd|jmxfetch|go-metro|trace-agent|process-agent"
 
 if [ ! -x $AGENTPATH ]; then
     echo "$AGENTPATH not found. Exiting."

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -261,6 +261,7 @@ class Flare(object):
         self._jmxfetch_log = config.get('jmxfetch_log_file')
         self._gometro_log = config.get('go-metro_log_file')
         self._trace_agent_log = config.get('trace-agent_log_file')
+        self._process_agent_log = config.get('process-agent_log_file')
 
     # Add logs to the tarfile
     def _add_logs_tar(self):
@@ -270,6 +271,7 @@ class Flare(object):
         self._add_log_file_tar(self._jmxfetch_log)
         self._add_log_file_tar(self._gometro_log)
         self._add_log_file_tar(self._trace_agent_log)
+        self._add_log_file_tar(self._process_agent_log)
         if not Platform.is_windows():
             self._add_log_file_tar(
                 "{0}/*supervisord.log".format(os.path.dirname(self._collector_log))


### PR DESCRIPTION
### What does this PR do?

Adds the [datadog-process-agent](https://github.com/DataDog/datadog-process-agent) to the supervisor file so it will run as part of the Agent. As with the trace-agent, you must enable a flag in the config for the Agent to actually run without immediately stoppign.

The omnibus change is https://github.com/DataDog/dd-agent-omnibus/pull/181

### Testing Guidelines

Once both this and omnibus build are in place we will be able to validate it's running. If you run the omnibus build on this and the omnibus branch you will get a pkg that installs things correctly.

cc @shang-wang 
