### PR TITLE
[core] Collect OpenStack metadata and tags

### DIFF
--- a/config.py
+++ b/config.py
@@ -618,6 +618,14 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
         if config.has_option("Main", "enable_gohai"):
             agentConfig["enable_gohai"] = _is_affirmative(config.get("Main", "enable_gohai"))
 
+        agentConfig["openstack_use_uuid"] = False
+        if config.has_option("Main", "openstack_use_uuid"):
+            agentConfig["openstack_use_uuid"] = _is_affirmative(config.get("Main", "openstack_use_uuid"))
+
+        agentConfig["openstack_use_metadata_tags"] = True
+        if config.has_option("Main", "openstack_use_metadata_tags"):
+            agentConfig["openstack_use_metadata_tags"] = _is_affirmative(config.get("Main", "openstack_use_metadata_tags"))
+
     except ConfigParser.NoSectionError as e:
         sys.stderr.write('Config file not found or incorrectly formatted.\n')
         sys.exit(2)

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -67,6 +67,13 @@ api_key:
 # when not specified, default: no
 gce_updated_hostname: yes
 
+# when using OpenStack, use the instance's "uuid"
+# the OpenStack instance-id can be recycled but the uuid is not
+# openstack_use_uuid: no
+
+# when using OpenStack, use the instance's metadata as tags
+# openstack_use_metadata_tags: yes
+
 # Set the threshold for accepting points to allow anything
 # within recent_point_threshold seconds (default: 30)
 # recent_point_threshold: 30

--- a/tests/core/test_ec2.py
+++ b/tests/core/test_ec2.py
@@ -23,7 +23,7 @@ class TestEC2(unittest.TestCase):
         assert len(d) == 0 or len(d) >= 7, d
         if "instance-id" in d:
             assert d["instance-id"].startswith("i-"), d
-        assert end - start <= 1.15, "It took %s seconds to get ec2 metadata" % (end-start)
+        assert end - start <= 1.25, "It took %s seconds to get ec2 metadata" % (end-start)
 
     def test_is_default_hostname(self):
         for hostname in ['ip-172-31-16-235', 'domU-12-31-38-00-A4-A2', 'domU-12-31-39-02-14-35']:


### PR DESCRIPTION
### What does this PR do?

- Collects the OpenStack instance's `uuid` and `name` for `host_aliases` from `meta_data.json`
- Collects the OpenStack instance's `meta` key/value pairs as agent `tags` from `meta_data.json`
- Allows you to use the OpenStack instance's `uuid` instead of its `instance-id`

### Motivation

- We need the OpenStack instance's metadata tagging to work similar to the AWS EC2 tag collection.
- We want the `uuid` and `name` to appear in the "also known as" part of the UI.
- OpenStack nova recycles the `instance-id` so it isn't guaranteed to be unique where the `uuid` is. The `uuid` value is also what you use when calling the nova api.

### Additional Notes

Created a config option called `openstack_use_metadata_tags` (defaults to true) in case someone doesn't want those tags to be agent tags.
