### PR TITLE
[docker] disable mesos_task and chronos_job tags because of high cardinality

### DIFF
--- a/tests/core/test_mesosutil.py
+++ b/tests/core/test_mesosutil.py
@@ -22,8 +22,9 @@ class TestMesosUtil(unittest.TestCase):
                "MARATHON_APP_ID=/system/dd-agent",
                "MESOS_TASK_ID=system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001"]
 
-        tags = ['chronos_job:test-job', 'marathon_app:/system/dd-agent',
-                'mesos_task:system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001']
+        tags = ['marathon_app:/system/dd-agent']
+        ## Removed 'chronos_job:test-job', 'mesos_task:system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001'
+        ## because of high cardinality
 
         container = {'Config': {'Env': env}}
 

--- a/utils/orchestrator/mesosutil.py
+++ b/utils/orchestrator/mesosutil.py
@@ -31,12 +31,13 @@ class MesosUtil(BaseUtil):
         envvars = co.get('Config', {}).get('Env', {})
 
         for var in envvars:
-            if var.startswith(CHRONOS_JOB_NAME):
-                tags.append('chronos_job:%s' % var[len(CHRONOS_JOB_NAME) + 1:])
-            elif var.startswith(MARATHON_APP_ID):
+            if var.startswith(MARATHON_APP_ID):
                 tags.append('marathon_app:%s' % var[len(MARATHON_APP_ID) + 1:])
-            elif var.startswith(MESOS_TASK_ID):
-                tags.append('mesos_task:%s' % var[len(MESOS_TASK_ID) + 1:])
+            ## Disabled for now because of high cardinality (~container card.)
+            #elif var.startswith(CHRONOS_JOB_NAME):
+            #    tags.append('chronos_job:%s' % var[len(CHRONOS_JOB_NAME) + 1:])
+            #elif var.startswith(MESOS_TASK_ID):
+            #    tags.append('mesos_task:%s' % var[len(MESOS_TASK_ID) + 1:])
 
         return tags
 


### PR DESCRIPTION
### What does this PR do?

These tags have a container cardinality.

 - Kept them commented out with a message to explain why
 - Updated unit tests
 - Only `marathon_app` remains (similar to a kube_deployment)

After 5.15 settles in, and if requested, we could patch BaseUtil to support two cardinality tiers for tags and only use the high card for docker metrics.