### PR TITLE
[auto-discovery] re-pipe configurations after JMXFetch restart

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -345,9 +345,12 @@ class Agent(Daemon):
                         self._agentConfig).crawl_config_template()
 
                     # JMXFetch restarts should prompt reload
-                    jmx_launch = JMXFetch._get_jmx_launchtime()
-                    if self.last_jmx_piped and self.last_jmx_piped < jmx_launch:
-                        self.sd_backend.reload_check_configs = True
+                    try:
+                        jmx_launch = JMXFetch._get_jmx_launchtime()
+                        if self.last_jmx_piped and self.last_jmx_piped < jmx_launch:
+                            self.sd_backend.reload_check_configs = True
+                    except OSError as e:
+                        log.debug("could not stat JMX lunch file: %s", e)
 
                 except Exception as e:
                     log.warn('Something went wrong while looking for config template changes: %s' % str(e))

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -70,6 +70,8 @@ JMX_LIST_COMMANDS = {
     'list_limited_attributes': "List attributes that do match one of your instances configuration but that are not being collected because it would exceed the number of metrics that can be collected",
     JMX_COLLECT_COMMAND: "Start the collection of metrics based on your current configuration and display them in the console"}
 
+JMX_LAUNCH_FILE = 'jmx.launch'
+
 LINK_TO_DOC = "See http://docs.datadoghq.com/integrations/java/ for more information"
 
 
@@ -335,6 +337,16 @@ class JMXFetch(object):
         except Exception:
             log.exception("Couldn't launch JMXFetch")
             raise
+
+    @staticmethod
+    def _get_jmx_launchtime():
+        fpath = os.path.join(get_jmx_pipe_path(), JMX_LAUNCH_FILE)
+        try:
+            _stat = os.stat(fpath)
+        except OSError as e:
+            raise e
+
+        return _stat.st_atime
 
     @staticmethod
     def _is_jmx_check(check_config, check_name, checks_list):

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -346,7 +346,7 @@ class JMXFetch(object):
         except OSError as e:
             raise e
 
-        return _stat.st_atime
+        return _stat.st_mtime
 
     @staticmethod
     def _is_jmx_check(check_config, check_name, checks_list):


### PR DESCRIPTION
### What does this PR do?

If JMXFetch happens to go down, use the `atime` stat date on the JMX launch file to decide if the auto-discovery configurations should be re-piped to JMX. JMXFetch will touch that file when coming up so we should have a relatively good idea of when JMXFetch started - alternatively, we could look at the process table to figure this stuff out (but that would be computationally more expensive).

### Motivation

Customer bug.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Sister PR: https://github.com/DataDog/jmxfetch/pull/143
