### PR TITLE
[mesos] extract chronos_job and chronos_job_owner if not empty

### DIFF
--- a/tests/core/test_mesosutil.py
+++ b/tests/core/test_mesosutil.py
@@ -18,14 +18,31 @@ class TestMesosUtil(unittest.TestCase):
         mock_init.return_value = None
         mesos = MesosUtil()
 
-        env = ["CHRONOS_JOB_NAME=test-job",
+        env = ["CHRONOS_JOB_NAME=app1_process-orders",
+               "CHRONOS_JOB_OWNER=qa",
                "MARATHON_APP_ID=/system/dd-agent",
                "MESOS_TASK_ID=system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001"]
 
-        tags = ['marathon_app:/system/dd-agent']
-        ## Removed 'chronos_job:test-job', 'mesos_task:system_dd-agent.dcc75b42-4b87-11e7-9a62-70b3d5800001'
-        ## because of high cardinality
+        tags = ['marathon_app:/system/dd-agent',
+                'chronos_job_owner:qa',
+                'chronos_job:app1_process-orders']
+        # Removed 'mesos_task:' because of high cardinality
 
+        container = {'Config': {'Env': env}}
+
+        self.assertEqual(sorted(tags), sorted(mesos._get_cacheable_tags(CO_ID, co=container)))
+
+    @mock.patch('docker.Client.__init__')
+    def test_dont_extract_empty_owner(self, mock_init):
+        mock_init.return_value = None
+        mesos = MesosUtil()
+
+        env = ["CHRONOS_JOB_NAME=app1_process-orders",
+               "CHRONOS_JOB_OWNER=",
+               "MARATHON_APP_ID=/system/dd-agent"]
+
+        tags = ['marathon_app:/system/dd-agent',
+                'chronos_job:app1_process-orders']
         container = {'Config': {'Env': env}}
 
         self.assertEqual(sorted(tags), sorted(mesos._get_cacheable_tags(CO_ID, co=container)))

--- a/utils/orchestrator/mesosutil.py
+++ b/utils/orchestrator/mesosutil.py
@@ -8,6 +8,7 @@ import requests
 from .baseutil import BaseUtil
 
 CHRONOS_JOB_NAME = "CHRONOS_JOB_NAME"
+CHRONOS_JOB_OWNER = "CHRONOS_JOB_OWNER"
 MARATHON_APP_ID = "MARATHON_APP_ID"
 MESOS_TASK_ID = "MESOS_TASK_ID"
 
@@ -33,9 +34,11 @@ class MesosUtil(BaseUtil):
         for var in envvars:
             if var.startswith(MARATHON_APP_ID):
                 tags.append('marathon_app:%s' % var[len(MARATHON_APP_ID) + 1:])
+            elif var.startswith(CHRONOS_JOB_NAME) and len(var) > len(CHRONOS_JOB_NAME) + 1:
+                tags.append('chronos_job:%s' % var[len(CHRONOS_JOB_NAME) + 1:])
+            elif var.startswith(CHRONOS_JOB_OWNER) and len(var) > len(CHRONOS_JOB_OWNER) + 1:
+                tags.append('chronos_job_owner:%s' % var[len(CHRONOS_JOB_OWNER) + 1:])
             ## Disabled for now because of high cardinality (~container card.)
-            #elif var.startswith(CHRONOS_JOB_NAME):
-            #    tags.append('chronos_job:%s' % var[len(CHRONOS_JOB_NAME) + 1:])
             #elif var.startswith(MESOS_TASK_ID):
             #    tags.append('mesos_task:%s' % var[len(MESOS_TASK_ID) + 1:])
 


### PR DESCRIPTION
### What does this PR do?

Following up on this comment https://github.com/DataDog/dd-agent/pull/3414#issuecomment-313382842, re-enable `chronos_job` and extract `chronos_job_owner` if not empty.

### Testing

Unit tests updated accordingly