### PR TITLE
[flare] Add regex for auth tokens

### DIFF
--- a/tests/core/fixtures/flare/auth_token.yaml
+++ b/tests/core/fixtures/flare/auth_token.yaml
@@ -1,0 +1,3 @@
+instances:
+  - auth_token: foo-bar
+    other_token: token

--- a/tests/core/fixtures/flare/password.yaml
+++ b/tests/core/fixtures/flare/password.yaml
@@ -1,0 +1,3 @@
+instances:
+  - pass: foo
+    other_password: bar

--- a/tests/core/test_flare.py
+++ b/tests/core/test_flare.py
@@ -282,6 +282,44 @@ class FlareTest(unittest.TestCase):
     @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
     @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
     @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
+    def test_auth_token_regex(self, mock_config, mock_tempdir, mock_strftime, mock_os_remove):
+        f = Flare()
+        file_path, credentials_log = f._strip_credentials(
+            os.path.join(get_mocked_temp(), 'auth_token.yaml'),
+            f.CHECK_CREDENTIALS
+        )
+        with open(file_path) as f:
+            contents = f.read()
+        self.assertEqual(
+            contents,
+            "instances:\n"
+            "  - auth_token: ********\n"
+            "    other_token: ********\n"
+        )
+
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
+    @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
+    @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
+    @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
+    def test_password_regex(self, mock_config, mock_tempdir, mock_strftime, mock_os_remove):
+        f = Flare()
+        file_path, credentials_log = f._strip_credentials(
+            os.path.join(get_mocked_temp(), 'password.yaml'),
+            f.CHECK_CREDENTIALS
+        )
+        with open(file_path) as f:
+            contents = f.read()
+        self.assertEqual(
+            contents,
+            "instances:\n"
+            "  - pass: ********\n"
+            "    other_password: ********\n"
+        )
+
+    @mock.patch('os.remove', side_effect=mocked_os_remove)
+    @mock.patch('utils.flare.strftime', side_effect=mocked_strftime)
+    @mock.patch('tempfile.gettempdir', side_effect=get_mocked_temp)
+    @mock.patch('utils.flare.get_config', side_effect=get_mocked_config)
     def test_whitespace_proxy_user_pass_regex(self, mock_config, mock_tempdir, mock_strftime, mock_os_remove):
         f = Flare()
         file_path, _ = f._strip_credentials(

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -71,6 +71,11 @@ class Flare(object):
             'password'
         ),
         CredentialPattern(
+            re.compile('( *(\w|_)*token:).+'),
+            r'\1 ********',
+            'access token'
+        ),
+        CredentialPattern(
             re.compile('(.*\ [A-Za-z0-9]+)\:\/\/([A-Za-z0-9_]+)\:(.+)\@'),
             r'\1://\2:********@',
             'password in a uri'

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -463,7 +463,7 @@ class Flare(object):
         with os.fdopen(fh, 'w') as temp_file:
             with open(file_path, 'r') as orig_file:
                 for line in orig_file.readlines():
-                    if not self.COMMENT_REGEX.match(line):
+                    if not self.COMMENT_REGEX.search(line):
                         clean_line, credential_found = self._clean_credentials(line, credential_patterns)
                         temp_file.write(clean_line)
                         if credential_found:
@@ -485,7 +485,7 @@ class Flare(object):
     def _clean_credentials(self, line, credential_patterns):
         credential_found = None
         for credential_pattern in credential_patterns:
-            if credential_pattern.pattern.match(line):
+            if credential_pattern.pattern.search(line):
                 line = re.sub(credential_pattern.pattern, credential_pattern.replacement, line)
                 credential_found = credential_pattern.label
                 # only one pattern should match per line


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

- Add regex for auth tokens
- Use `re.search()` instead of `re.match()`. `re.match()` only matches at the beginning of the line.
That would prevent the replacement of password or token if it was the first option of an instance (i.e. there would be a dash `-` before the parameter). Noticed this while writing the tests.

### Motivation

Added functionality to auth via token in the consul check: https://github.com/DataDog/integrations-core/pull/521
Need to sanitize config file

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?