### PR TITLE
allows integrations core to download jmx fetch from rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,7 +48,9 @@ task 'setup_libs' do
   in_venv = system "python -c \"import sys ; exit(not hasattr(sys, 'real_prefix'))\""
   raise 'Not in dev venv/CI environment/Integrations - bailing out.' if !in_venv && !ENV['CI'] && !ENV['SDK_HOME']
 
-  jmx_version = `python -c "import config ; print config.JMX_VERSION"`
+  Rake::Task["setup_env"].invoke
+
+  jmx_version = `venv/bin/python -c "import config ; print config.JMX_VERSION"`
   jmx_version = jmx_version.delete("\n")
   puts "jmx-fetch version: #{jmx_version}"
   jmx_artifact = "jmxfetch-#{jmx_version}-jar-with-dependencies.jar"

--- a/Rakefile
+++ b/Rakefile
@@ -46,7 +46,7 @@ end
 desc 'Grab libs'
 task 'setup_libs' do
   in_venv = system "python -c \"import sys ; exit(not hasattr(sys, 'real_prefix'))\""
-  raise 'Not in dev venv/CI environment - bailing out.' if !in_venv && !ENV['CI']
+  raise 'Not in dev venv/CI environment/Integrations - bailing out.' if !in_venv && !ENV['CI'] && !ENV['SDK_HOME']
 
   jmx_version = `python -c "import config ; print config.JMX_VERSION"`
   jmx_version = jmx_version.delete("\n")

--- a/Rakefile
+++ b/Rakefile
@@ -48,7 +48,7 @@ task 'setup_libs' do
   in_venv = system "python -c \"import sys ; exit(not hasattr(sys, 'real_prefix'))\""
   raise 'Not in dev venv/CI environment/Integrations - bailing out.' if !in_venv && !ENV['CI'] && !ENV['SDK_HOME']
 
-  Rake::Task["setup_env"].invoke
+  Rake::Task['setup_env'].invoke
 
   jmx_version = `venv/bin/python -c "import config ; print config.JMX_VERSION"`
   jmx_version = jmx_version.delete("\n")


### PR DESCRIPTION
### What does this PR do?

Integrations core does not use a proper venv when testing, meaning that when you call the rake task, it doesn't download jmx fetch. This will allow it to download JMX fetch

### Motivation

I was working on a JMX Check

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
