### PR TITLE
[kube] Combine pod phase service check.

### DIFF
--- a/utils/kubernetes/kube_state_processor.py
+++ b/utils/kubernetes/kube_state_processor.py
@@ -142,7 +142,7 @@ class KubeStateProcessor:
     # The phase gets not passed through; rather, it becomes the service check suffix.
     def kube_pod_status_phase(self, message, **kwargs):
         """ Phase a pod is in. """
-        check_basename = NAMESPACE + '.pod.phase.'
+        check_basename = NAMESPACE + '.pod.phase'
         for metric in message.metric:
             # The gauge value is always 1, no point in fetching it.
             phase = ''
@@ -154,7 +154,7 @@ class KubeStateProcessor:
                     tags.append('{}:{}'.format(label.name, label.value))
             #TODO: add deployment/replicaset?
             status = self.pod_phase_to_status.get(phase, self.kube_check.UNKNOWN)
-            self.service_check(check_basename + phase, status, tags=tags)
+            self.service_check(check_basename, status, tags=tags)
 
     def kube_node_status_ready(self, message, **kwargs):
         """ The ready status of a cluster node. """


### PR DESCRIPTION
### What does this PR do?

This PR changes the pod phase check so that instead of having four checks it will have one check for `pod.phase` which will return:
`OK` when phase is `running` or `succeeded`
`WARNING` when phase is`pending`
`CRITICAL` when phase is `failed`

### Motivation

The reason for this pull request is that at the moment we have four checks which will always return the same value e.g `pod.phase.failed` -> `CRITICAL`, `pod.phase.pending` -> `WARNING`. From my understanding checks should return a value based on the state, if it is healthy it should return `OK` if it's failing it should return `CRITICAL` the fact it always returns the same value seems incorrect. At the moment in data dog it shows the following for the current checks, you'll notice that the values are always the same for each of the checks.
![screen shot 2017-07-07 at 3 14 41 pm](https://user-images.githubusercontent.com/918794/27944672-d6b9936e-632b-11e7-960c-e79282a0d726.png)