### PR TITLE
Add container name tag in auto discovery

### DIFF
--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -104,6 +104,7 @@ class SDDockerBackend(AbstractSDBackend):
             'host': self._get_host_address,
             'pid': self._get_container_pid,
             'port': self._get_port,
+            'container-name': self._get_container_name,
             'tags': self._get_additional_tags,
         }
 
@@ -337,18 +338,12 @@ class SDDockerBackend(AbstractSDBackend):
 
         return tags
 
-    def _get_container_name(self, state, c_id):
+    def _get_container_name(self, state, c_id, tpl_var):
         container_inspect = state.inspect_container(c_id)
-        name = container_inspect.get('Name', '')
-        if name.startswith('/'):
-            name = name[1:]
-        return name
+        return container_inspect.get('Name', '').lstrip('/')
 
     def _get_additional_tags(self, state, c_id, *args):
         tags = []
-        container_name = self._get_container_name(state, c_id)
-        if container_name:
-            tags.append('container_name:%s' % container_name)
 
         if Platform.is_k8s():
             pod_metadata = state.get_kube_config(c_id, 'metadata')

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -337,8 +337,19 @@ class SDDockerBackend(AbstractSDBackend):
 
         return tags
 
+    def _get_container_name(self, state, c_id):
+        container_inspect = state.inspect_container(c_id)
+        name = container_inspect.get('Name', '')
+        if name.startswith('/'):
+            name = name[1:]
+        return name
+
     def _get_additional_tags(self, state, c_id, *args):
         tags = []
+        container_name = self._get_container_name(state, c_id)
+        if container_name:
+            tags.append('container_name:%s' % container_name)
+
         if Platform.is_k8s():
             pod_metadata = state.get_kube_config(c_id, 'metadata')
             pod_spec = state.get_kube_config(c_id, 'spec')


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Rework #3365 to move back to a different template variable name.

### Motivation

This is something we actually don't want included by default in `%%tags%%`. It should be used with care as it could flood the tag auto complete menu with a useless tag if used carelessly (typically: in a highly volatile environment where containers churn often and have different names each time).

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Sorry for the back and forth @subuk, your first version was actually the good one!
