### PR TITLE
[jmxfetch] bump to 0.15.0.

### DIFF
--- a/config.py
+++ b/config.py
@@ -42,7 +42,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 # CONSTANTS
 AGENT_VERSION = "5.15.0"
-JMX_VERSION = "0.14.0"
+JMX_VERSION = "0.15.0"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
 MAC_CONFIG_PATH = '/opt/datadog-agent/etc'

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -23,12 +23,13 @@ import yaml
 # project
 from config import (
     DEFAULT_CHECK_FREQUENCY,
+    SD_PIPE_NAME,
     get_confd_path,
     get_config,
     get_jmx_pipe_path,
     get_logging_config,
     PathNotFound,
-    _is_affirmative
+    _is_affirmative,
 )
 from util import yLoader
 from utils.jmx import JMX_FETCH_JAR_NAME, JMXFiles
@@ -273,6 +274,8 @@ class JMXFetch(object):
                 pipe_path = get_jmx_pipe_path()
                 subprocess_args.insert(4, '--tmp_directory')
                 subprocess_args.insert(5, pipe_path)
+                subprocess_args.insert(4, '--sd_pipe')
+                subprocess_args.insert(5, SD_PIPE_NAME)
                 subprocess_args.insert(4, '--sd_enabled')
 
             if jmx_checks:


### PR DESCRIPTION
### What does this PR do?
It bumps the version to 0.15.0 and explicitly passes the pipe name as the `dd-service_discovery` pipe name is the legacy pipe.

### Motivation
Required with the latest jmxfetch release.
