### PR TITLE
fix string formatting in kube_api_root_url init

### DIFF
--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -103,7 +103,7 @@ class KubeUtil:
         else:
             master_host = os.environ.get('KUBERNETES_SERVICE_HOST') or self.DEFAULT_MASTER_NAME
             master_port = os.environ.get('KUBERNETES_SERVICE_PORT') or self.DEFAULT_MASTER_PORT
-            self.kubernetes_api_root_url = 'https://%s:%d' % (master_host, master_port)
+            self.kubernetes_api_root_url = 'https://%s:%s' % (master_host, master_port)
 
         self.kubernetes_api_url = '%s/api/v1' % self.kubernetes_api_root_url
 


### PR DESCRIPTION
### What does this PR do?

If `api_server_url` is not set and the envvar `KUBERNETES_SERVICE_PORT` is set, `master_port` will be a str instead of the intended int type, making the `%d` formatter sad. Moving to a `%s` formatter as it can handle both int and str types.