### PR TITLE
[dogstatsd] Add statsd_so_rcvbuf config variable

### DIFF
--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -186,6 +186,13 @@ gce_updated_hostname: yes
 # server. This will be taken care of properly in the new gen agent core.
 # utf8_decoding: false
 
+# The number of bytes allocated to the statsd socket receive buffer. By default,
+# this value is set to the value of `/proc/sys/net/core/rmem_default`. If you
+# need to increase the size of this buffer but keep the OS default value the
+# same, you can set dogstats's receive buffer size here. The maximum allowed
+# value is the value of `/proc/sys/net/core/rmem_max`.
+# statsd_so_rcvbuf:
+
 # ========================================================================== #
 # Service-specific configuration                                             #
 # ========================================================================== #

--- a/tests/core/test_dogstatsd.py
+++ b/tests/core/test_dogstatsd.py
@@ -45,6 +45,20 @@ class TestFunctions(TestCase):
         self.assertEqual(args[1], '0.0.0.0')
 
 
+    @mock.patch('dogstatsd.get_config')
+    @mock.patch('dogstatsd.Server')
+    def test_init_with_so_rcvbuf(self, s, gc):
+        gc.return_value = defaultdict(str)
+        gc.return_value['use_dogstatsd'] = True
+        gc.return_value['statsd_so_rcvbuf'] = '1024'
+
+        init()
+
+        s.assert_called_once()
+        _, kwargs = s.call_args
+        self.assertEqual(kwargs['so_rcvbuf'], '1024')
+
+
 class TestServer(TestCase):
     def test_init(self):
         s = Server(None, 'localhost', '1234')
@@ -59,9 +73,12 @@ class TestServer(TestCase):
         s1.start()
         self.assertEqual(s1.socket.family, socket.AF_INET6)
 
-        s2 = Server(mock.MagicMock(), '127.0.0.1', '2345')
+        original_so_rcvbuf = s1.socket.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF)
+
+        s2 = Server(mock.MagicMock(), '127.0.0.1', '2345', so_rcvbuf=1023)
         s2.start()
         self.assertEqual(s2.socket.family, socket.AF_INET6)
+        self.assertNotEquals(original_so_rcvbuf, s2.socket.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF))
 
         s2 = Server(mock.MagicMock(), 'foo', '80')
         s2.start()


### PR DESCRIPTION
### What does this PR do?

Adds a config variable that allows the SO_RCVBUF socket option to be set on dogstatsd's UDP socket.

### Motivation

Tons of `RcvbufErrors` on hosts running a highly-trafficked `dogstatsd` and [this blog post](https://blog.packagecloud.io/eng/2016/06/22/monitoring-tuning-linux-networking-stack-receiving-data/#udpqueuercvskb), especially this bit:

> You can also set the sk->sk_rcvbuf size by calling setsockopt from your application and passing SO_RCVBUF. The maximum you can set with setsockopt is net.core.rmem_max.

This change is in production and seems to be performing well.

### Additional Notes

> Anything else we should know when reviewing?

I'm a python noob, and am totally open to adjusting this PR given your feedback!