### PR TITLE
remove docker_swarm:inactive host tag, only keep it when detected

### DIFF
--- a/tests/core/test_dockerutil.py
+++ b/tests/core/test_dockerutil.py
@@ -88,7 +88,7 @@ class TestDockerUtil(unittest.TestCase):
     def test_docker_host_tags_ok(self, mock_init, mock_version):
         mock_version.return_value = {'Version': '1.13.1'}
         mock_init.return_value = None
-        self.assertEqual(['docker_version:1.13.1', 'docker_swarm:inactive'], DockerUtil().get_host_tags())
+        self.assertEqual(['docker_version:1.13.1'], DockerUtil().get_host_tags())
         mock_version.assert_called_once()
 
     @mock.patch('docker.Client.version')
@@ -96,7 +96,7 @@ class TestDockerUtil(unittest.TestCase):
     def test_docker_host_tags_invalid_response(self, mock_init, mock_version):
         mock_version.return_value = None
         mock_init.return_value = None
-        self.assertEqual(['docker_swarm:inactive'], DockerUtil().get_host_tags())
+        self.assertEqual([], DockerUtil().get_host_tags())
         mock_version.assert_called_once()
 
     @mock.patch('utils.dockerutil.DockerUtil.is_swarm')

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -251,8 +251,6 @@ class DockerUtil:
 
         if self.is_swarm():
             tags.append('docker_swarm:active')
-        else:
-            tags.append('docker_swarm:inactive')
 
         return tags
 


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/dd-agent/pull/3383 introduced the `docker_swarm` host tag, setting it to `active` or `inactive`. This would be added to every docker host instead of only swarm clusters (like other orchestrator tags).

This PR disables the tag when inactive, and only keeps the `docker_swarm:active` tag, when swarm is actively detected.