### PR TITLE
[kubernetes] strip spaces around bearer token

### DIFF
--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -445,7 +445,7 @@ class KubeUtil:
         token_path = instance.get('bearer_token_path', cls.AUTH_TOKEN_PATH)
         try:
             with open(token_path) as f:
-                return f.read()
+                return f.read().strip()
         except IOError as e:
             log.error('Unable to read token from {}: {}'.format(token_path, e))
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Strips spaces and new lines around the bearer token.

### Motivation

The token is extracted from a file, which more often than not ends with a new line. This makes the token end with `\n`. Let's remove that.

### Testing Guidelines

Tested it on a cluster, it works fine.

### Additional Notes

Anything else we should know when reviewing?
