### PR TITLE
Collect Kubernetes daemonset readiness metric

### DIFF
--- a/utils/kubernetes/kube_state_processor.py
+++ b/utils/kubernetes/kube_state_processor.py
@@ -47,6 +47,7 @@ class KubeStateProcessor:
             'kube_daemonset_status_current_number_scheduled': NAMESPACE + '.daemonset.scheduled',
             'kube_daemonset_status_number_misscheduled': NAMESPACE + '.daemonset.misscheduled',
             'kube_daemonset_status_desired_number_scheduled': NAMESPACE + '.daemonset.desired',
+            'kube_daemonset_status_number_ready': NAMESPACE + '.daemonset.ready',
             # pods
             'kube_pod_status_ready' : NAMESPACE + '.pod.ready',
             'kube_pod_status_scheduled': NAMESPACE + '.pod.scheduled',


### PR DESCRIPTION
### What does this PR do?

This PR collects the `kube_daemonset_status_number_ready` metric as part of the Kubernetes State Metrics integration.

### Motivation

We need the `kube_daemonset_status_number_ready` metric to alert when an instance of one of our Kubernetes Daemonsets goes unhealthy.

@maggie-lou and I worked on this together.