### PR TITLE
Add deprecation warning for KubeStateProcessor

### DIFF
--- a/utils/kubernetes/kube_state_processor.py
+++ b/utils/kubernetes/kube_state_processor.py
@@ -2,6 +2,13 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+######################
+# DEPRECATION NOTICE #
+######################
+#
+# KubeStateProcess is deprecated and will disappear
+# with agent 5.16. Please use PrometheusCheck instead.
+
 NAMESPACE = 'kubernetes_state'
 
 # message.type is the index in this array
@@ -74,6 +81,8 @@ class KubeStateProcessor:
             - call check method with the same name as the metric
             - log some info if none of the above worked
         """
+        self.log.warn("[DEPRECATION WARNING] KubeStateProcess is deprecated "
+            "and will disappear with agent 5.16. Please use PrometheusCheck instead.")
         try:
             if message.name in self.metric_to_gauge:
                 self._submit_gauges(self.metric_to_gauge[message.name], message)


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Add a deprecation warning in preparation for the removal of KubeStateProcessor in 5.16.

### Motivation

Don't wanna be to quick with code 🔥 in case users rely on it for custom checks.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Note the PR is against 5.15.x. There is #3440 against master for the actual removal.
