### PR TITLE
[auto-discovery] tags could be a dict of KV pairs

### DIFF
--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -434,6 +434,13 @@ class TestServiceDiscovery(unittest.TestCase):
                  ['host', 'port_1'], ['foo', 'bar:baz']),
                 ({'host': '%%host%%', 'port': '%%port_1%%', 'tags': ['env:test', 'foo', 'bar:baz']},
                  {'host': '127.0.0.1', 'port_1': '42'})
+            ),
+            (
+                ({'NetworkSettings': {'IPAddress': '127.0.0.1', 'Ports': {'42/tcp': None, '22/tcp': None}}},
+                 {'host': '%%host%%', 'port': '%%port_1%%', 'tags': {'env': 'test'}},
+                 ['host', 'port_1'], ['foo', 'bar:baz']),
+                ({'host': '%%host%%', 'port': '%%port_1%%', 'tags': ['env:test', 'foo', 'bar:baz']},
+                 {'host': '127.0.0.1', 'port_1': '42'})
             )
         ]
 
@@ -529,6 +536,7 @@ class TestServiceDiscovery(unittest.TestCase):
                     for key in instance_tpl.keys():
                         if isinstance(instance_tpl[key], list):
                             self.assertEquals(len(instance_tpl[key]), len(co[1][0].get(key)))
+
                             for elem in instance_tpl[key]:
                                 self.assertTrue(elem in co[1][0].get(key))
                         else:

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -491,7 +491,11 @@ class SDDockerBackend(AbstractSDBackend):
         # add default tags to the instance
         if tags:
             tpl_tags = instance_tpl.get('tags', [])
-            tags += tpl_tags if isinstance(tpl_tags, list) else [tpl_tags]
+            if isinstance(tpl_tags, dict):
+                for key, val in tpl_tags.iteritems():
+                    tags.append("{}:{}".format(key, val))
+            else:
+                tags += tpl_tags if isinstance(tpl_tags, list) else [tpl_tags]
             instance_tpl['tags'] = list(set(tags))
 
         for var in variables:


### PR DESCRIPTION
### What does this PR do?

Tags could be dicts.

Also, I believe `kube_state_processor` has been deprecated after the migration to prometheus checks.

### Motivation

Encountered this issue testing.
