### PR TITLE
kubernetes/kubeutil.py: Tag pods that are created by StatefulSets

### DIFF
--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -49,6 +49,10 @@ class TestKubeUtilCreatorTags(KubeTestCase):
         self.assertEqual(['kube_replica_set:test-5432', 'kube_deployment:test'],
                          self.kube.get_pod_creator_tags(self._fake_pod("ReplicaSet", "test-5432")))
 
+    def test_with_statefulset(self):
+        self.assertEqual(['kube_stateful_set:test-5432'],
+                         self.kube.get_pod_creator_tags(self._fake_pod("StatefulSet", "test-5432")))
+
     def test_with_legacy_repcontroller(self):
         self.assertEqual(['kube_daemon_set:test', 'kube_replication_controller:test'],
                          self.kube.get_pod_creator_tags(self._fake_pod("DaemonSet", "test"), True))

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -30,6 +30,7 @@ CREATOR_KIND_TO_TAG = {
     'DaemonSet': 'kube_daemon_set',
     'ReplicaSet': 'kube_replica_set',
     'ReplicationController': 'kube_replication_controller',
+    'StatefulSet': 'kube_stateful_set',
     'Deployment': 'kube_deployment',
     'Job': 'kube_job'
 }


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

This will tag pod metadata with `kube_stateful_set:<name>` if they are members of a stateful set.

### Motivation

I ultimately want to be able to create timeboards and monitors on the diff between the `desired` and `current` number of pods for a given `StatefulSet`.  I am currently doing something similar with the diff between `desired` and `available` pods for a deployment.  It is unclear to me if these changes are needed for the kube_state integration or not. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
