### PR TITLE
[win32] Remove `run_check`

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -33,7 +33,6 @@ from config import AGENT_VERSION, _is_affirmative
 from util import get_next_id, yLoader
 from utils.hostname import get_hostname
 from utils.proxy import get_proxy
-from utils.platform import Platform
 from utils.profile import pretty_statistics
 from utils.proxy import get_no_proxy_from_env, config_proxy_skip
 

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -36,8 +36,6 @@ from utils.proxy import get_proxy
 from utils.platform import Platform
 from utils.profile import pretty_statistics
 from utils.proxy import get_no_proxy_from_env, config_proxy_skip
-if Platform.is_windows():
-    from utils.debug import run_check  # noqa - windows debug purpose
 
 log = logging.getLogger(__name__)
 

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -13,35 +13,6 @@ from config import get_checksd_path, get_confd_path
 from utils.platform import get_os
 
 
-def run_check(name, path=None):
-    """
-    Test custom checks on Windows.
-    """
-    # Read the config file
-
-    confd_path = path or os.path.join(get_confd_path(get_os()), '%s.yaml' % name)
-
-    try:
-        f = open(confd_path)
-    except IOError:
-        raise Exception('Unable to open configuration at %s' % confd_path)
-
-    config_str = f.read()
-    f.close()
-
-    # Run the check
-    check, instances = get_check(name, config_str)
-    if not instances:
-        raise Exception('YAML configuration returned no instances.')
-    for instance in instances:
-        check.check(instance)
-        if check.has_events():
-            print "Events:\n"
-            pprint(check.get_events(), indent=4)
-        print "Metrics:\n"
-        pprint(check.get_metrics(), indent=4)
-
-
 def get_check(name, config_str):
     from checks import AgentCheck
 

--- a/utils/debug.py
+++ b/utils/debug.py
@@ -3,13 +3,11 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 # stdlib
-from pprint import pprint
 import inspect
-import os
 import sys
 
 # datadog
-from config import get_checksd_path, get_confd_path
+from config import get_checksd_path
 from utils.platform import get_os
 
 


### PR DESCRIPTION
### What does this PR do?

Removes the `run_check` method.

### Motivation

`run_check` dates back from pre-5.12 windows agents, when we weren't
shipping a full python interpreter and needed this specific method
to allow users to run custom checks from `shell.exe`.

This doesn't make sense anymore now that we ship a full python
interpreter that the agent processes use. That interpreter has the
necessary modules to run checks. The correct way to run checks
(shipped by default or custom) is now similar to Linux/macOS, i.e.:

```
# From the `<install_dir>\agent` directory
> ..\embedded\python.exe agent.py check <check_name>
```

`shell.exe` should only be used to troubleshoot the python environment
that the windows service and the windows GUI use.
