### PR TITLE
Allow autoconf templates in docker labels

### DIFF
--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -631,9 +631,9 @@ class TestServiceDiscovery(unittest.TestCase):
                 config_store.get_check_tpls(
                     image, auto_conf=True,
                     docker_labels=dict(zip(
-                        ['service-discovery.datadoghq.com/check_names',
-                         'service-discovery.datadoghq.com/init_configs',
-                         'service-discovery.datadoghq.com/instances'],
+                        ['com.datadoghq.sd.check_names',
+                         'com.datadoghq.sd.init_configs',
+                         'com.datadoghq.sd.instances'],
                         self.mock_raw_templates[image][0]))))
 
     @mock.patch('config.get_auto_confd_path', return_value=os.path.join(

--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -631,9 +631,9 @@ class TestServiceDiscovery(unittest.TestCase):
                 config_store.get_check_tpls(
                     image, auto_conf=True,
                     docker_labels=dict(zip(
-                        ['com.datadoghq.sd.check_names',
-                         'com.datadoghq.sd.init_configs',
-                         'com.datadoghq.sd.instances'],
+                        ['com.datadoghq.ad.check_names',
+                         'com.datadoghq.ad.init_configs',
+                         'com.datadoghq.ad.instances'],
                         self.mock_raw_templates[image][0]))))
 
     @mock.patch('config.get_auto_confd_path', return_value=os.path.join(

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -33,6 +33,7 @@ KUBE_ANNOTATIONS = 'kube_annotations'
 KUBE_CONTAINER_NAME = 'kube_container_name'
 DOCKER_LABELS = 'docker_labels'
 KUBE_ANNOTATION_PREFIX = 'service-discovery.datadoghq.com'
+DOCKER_LABEL_PREFIX = 'com.datadoghq.sd'
 
 
 class KeyNotFound(Exception):
@@ -217,7 +218,7 @@ class AbstractConfigStore(object):
         return self._extract_template(identifier, prefix, kube_annotations)
 
     def _get_docker_config(self, identifier, docker_labels):
-        prefix = '{}/'.format(KUBE_ANNOTATION_PREFIX)
+        prefix = '{}.'.format(DOCKER_LABEL_PREFIX)
         return self._extract_template(identifier, prefix, docker_labels)
 
     def _extract_template(self, identifier, key_prefix, source_dict):

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -33,7 +33,7 @@ KUBE_ANNOTATIONS = 'kube_annotations'
 KUBE_CONTAINER_NAME = 'kube_container_name'
 DOCKER_LABELS = 'docker_labels'
 KUBE_ANNOTATION_PREFIX = 'service-discovery.datadoghq.com'
-DOCKER_LABEL_PREFIX = 'com.datadoghq.sd'
+DOCKER_LABEL_PREFIX = 'com.datadoghq.ad'
 
 
 class KeyNotFound(Exception):

--- a/utils/service_discovery/abstract_config_store.py
+++ b/utils/service_discovery/abstract_config_store.py
@@ -279,9 +279,9 @@ class AbstractConfigStore(object):
 
         # then from docker labels
         if docker_labels:
-            kube_config = self._get_docker_config(identifier, docker_labels)
-            if kube_config is not None:
-                to_check.update(kube_config[0])
+            docker_config = self._get_docker_config(identifier, docker_labels)
+            if docker_config is not None:
+                to_check.update(docker_config[0])
         # lastly, try with legacy name for auto-conf
         to_check.update(self.template_cache.get_check_names(self._get_image_ident(identifier)))
 
@@ -300,16 +300,16 @@ class AbstractConfigStore(object):
             docker_labels = kwargs.get(DOCKER_LABELS)
             source = ""
 
-            kube_config = None
+            config = None
             if kube_annotations:
-                kube_config = self._get_kube_config(identifier, kube_annotations, kube_container_name)
+                config = self._get_kube_config(identifier, kube_annotations, kube_container_name)
                 source = CONFIG_FROM_KUBE
-            if kube_config is None and docker_labels is not None:
-                kube_config = self._get_docker_config(identifier, docker_labels)
+            if config is None and docker_labels is not None:
+                config = self._get_docker_config(identifier, docker_labels)
                 source = CONFIG_FROM_LABELS
 
-            if kube_config is not None:
-                check_names, init_config_tpls, instance_tpls = kube_config
+            if config is not None:
+                check_names, init_config_tpls, instance_tpls = config
                 return [(source, vs)
                         for vs in zip(check_names, init_config_tpls, instance_tpls)]
 


### PR DESCRIPTION
### What does this PR do?

Mirroring the kubernetes annotation autodiscovery source, lookup autoconf template in container labels. These templates are expected in the JSON format.

If k8s annotation are present, they take precedence. Else, if valid json is found in the following labels:
- com.datadoghq.ad.check_names
- com.datadoghq.ad.init_configs
- com.datadoghq.ad.instances

**Warning**: the label names changed from the original PR, to reflect the s/ServiceDiscovery/AutoDiscovery/ transition

a template is rendered from them, bypassing the auto_conf files lookup.

If a K/V store backend is configured, this feature is disabled, like k8s annotations.

### Testing Guidelines

- Added the `test_get_check_tpls_labels` test method. We could go further with integration testing.
- For manual testing, one can use the workbench recipe jmx:template_in_labels from https://github.com/DataDog/workbench-recipes/pull/6 and the `datadog/dev-dd-agent:jmx-xvello_template_in_labels` image