### PR TITLE
[dogstatsd] Parse distribution metrics and ignore them

### DIFF
--- a/aggregator.py
+++ b/aggregator.py
@@ -399,6 +399,8 @@ class Aggregator(object):
     """
     # Types of metrics that allow strings
     ALLOW_STRINGS = ['s', ]
+    # Types that are not implemented and ignored
+    IGNORE_TYPES = ['d', ]
 
     def __init__(self, hostname, interval=1.0, expiry_seconds=300,
             formatter=None, recent_point_threshold=None,
@@ -472,6 +474,8 @@ class Aggregator(object):
 
             if metric_type in self.ALLOW_STRINGS:
                 value = raw_value
+            elif metric_type in self.IGNORE_TYPES:
+                continue
             else:
                 # Try to cast as an int first to avoid precision issues, then as a
                 # float.

--- a/tests/core/test_aggregator.py
+++ b/tests/core/test_aggregator.py
@@ -288,6 +288,18 @@ class TestMetricsAggregator(unittest.TestCase):
         # Assert there are no more sets
         assert not stats.flush()
 
+    def test_ignore_distribution(self):
+        stats = MetricsAggregator('myhost')
+        stats.submit_packets('my.dist:5.0|d')
+        stats.submit_packets('my.gauge:1|g')
+
+        # Assert that it's treated normally, and that the distribution is ignored
+        metrics = stats.flush()
+        nt.assert_equal(len(metrics), 1)
+        m = metrics[0]
+        nt.assert_equal(m['metric'], 'my.gauge')
+        nt.assert_equal(m['points'][0][1], 1)
+
     @attr(requires='core_integration')
     def test_rate(self):
         stats = MetricsAggregator('myhost')


### PR DESCRIPTION
### What does this PR do?

Parses `distribution` metrics and ignores them.

### Motivation

`distribution` is a new dogstatsd metric type that this implementation doesn't
support.

Instead of failing on known but unsupported metric types, ignore these
metrics and continue parsing the rest of the packet.

Without this, sending a new "distribution" type metric in a datagram
makes dogstatsd drop the whole datagram.

### Additional Notes

This change has virtually no impact on the performance of the dogstatsd
parser.
