### PR TITLE
[kazoo] bumping to 2.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ boto==2.46.1
 # utils/platform.py
 docker-py==1.10.6
 # utils/service_discovery/config_stores.py
-kazoo==2.2.1
+kazoo==2.4.0
 ntplib==0.3.3
 # utils/service_discovery/config_stores.py
 python-consul==0.4.7


### PR DESCRIPTION
### What does this PR do?

Bumps kazoo to `2.4.0`

### Motivation

@jeffwidman wants to upgrade kazoo for kafka_consumer, apparently there are several improvements and bugfixes in the latest versions. Unfortunately most of the affected elements have mocked tests, so we maybe wouldn't know of any fallout until QA time comes along. 

Sister PRs:
 - https://github.com/DataDog/omnibus-software/pull/154 
 - https://github.com/DataDog/integrations-core/pull/623