### PR TITLE
Truncate the URL at the API key when logging to prevent the clear API

### DIFF
--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -22,6 +22,7 @@ import optparse
 import select
 import signal
 import socket
+import string
 import sys
 import threading
 from time import sleep, time
@@ -309,7 +310,7 @@ class Reporter(threading.Thread):
 
     def submit_http(self, url, data, headers):
         headers["DD-Dogstatsd-Version"] = get_version()
-        log.debug("Posting payload to %s" % url)
+        log.debug("Posting payload to %s" % string.split(url, "api_key=")[0])
         try:
             start_time = time()
             r = requests.post(url, data=data, timeout=5, headers=headers)
@@ -320,7 +321,7 @@ class Reporter(threading.Thread):
 
             status = r.status_code
             duration = round((time() - start_time) * 1000.0, 4)
-            log.debug("%s POST %s (%sms)" % (status, url, duration))
+            log.debug("%s POST %s (%sms)" % (status, string.split(url, "api_key=")[0], duration))
         except Exception:
             log.exception("Unable to post payload.")
             try:

--- a/emitter.py
+++ b/emitter.py
@@ -6,6 +6,7 @@
 from hashlib import md5
 import logging
 import re
+import string
 import zlib
 import unicodedata
 
@@ -74,7 +75,7 @@ def sanitize_payload(item, log, sanitize_func):
 
 def post_payload(url, message, agentConfig, log):
 
-    log.debug('http_emitter: attempting postback to ' + url)
+    log.debug('http_emitter: attempting postback to ' + string.split(url, "api_key=")[0])
 
     try:
         try:


### PR DESCRIPTION
key from appearing in the log.

### What does this PR do?

Skims off everything after "api_key=" in the URL when logging, so that the API key doesn't get logged in the clear.

### Motivation

customer request.


### Additional Notes

Intentionally didn't use the code for replacing the key with "****".  As this will be executed each time, whether the agent is logging in debug or not, didn't want to incur the additional overhead.
