### PR TITLE
[windows wmi]  When the WMI type returned is a UINT32, python struggles

### DIFF
--- a/checks/libs/wmi/sampler.py
+++ b/checks/libs/wmi/sampler.py
@@ -560,7 +560,7 @@ class WMISampler(object):
                 try:
                     fval = float(wmi_property.Value)
                     if self._property_data_types is not None:
-                        if self._property_data_types[wmi_property.Name]:
+                        if wmi_property.Name in self._property_data_types:
                             if self._property_data_types[wmi_property.Name] == "uint32":
                                 val = wmi_property.Value
                                 if val < 0:


### PR DESCRIPTION
because python doesn't have the concept of unsigned integers. So, it
just converts to a negative number.

If the type returned is supposed to be UINT32, convert it accordingly.


### Motivation

Customer report.

