### PR TITLE
[kubernetes] implement leader election among agent for event collection

### DIFF
--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -8,6 +8,7 @@ import json
 
 # project
 from utils.kubernetes import KubeUtil
+from .test_orchestrator import MockResponse
 
 class KubeTestCase(unittest.TestCase):
     # Patch _locate_kubelet that is used by KubeUtil.__init__
@@ -28,6 +29,10 @@ class KubeTestCase(unittest.TestCase):
                 json_array.append(json.load(data_file))
         return json_array
 
+    @classmethod
+    def _load_resp_array(cls, names):
+        json_array = cls._load_json_array(names)
+        return map(lambda x: MockResponse(x, 200), json_array)
 
 class TestKubeUtilDeploymentTag(KubeTestCase):
     def test_deployment_name_nominal(self):

--- a/tests/core/test_leader_elector.py
+++ b/tests/core/test_leader_elector.py
@@ -1,0 +1,166 @@
+# stdlib
+import datetime
+import time
+
+# 3rd party
+import mock
+
+# project
+from utils.kubernetes import LeaderElector
+from tests.core.test_kubeutil import KubeTestCase
+
+
+HEALTH_ENDPOINT = '/healthz'
+DEFAULT_NAMESPACE = 'default'  # TODO: use agent's own ns
+CM_ENDPOINT = '/namespaces/{namespace}/configmaps'
+CM_NAME = 'datadog-leader-elector'
+CREATOR_ANNOTATION = 'creator'
+ACQUIRE_TIME_ANNOTATION = 'acquired_time'
+
+
+class TestLeaderElector(KubeTestCase):
+    def test_is_cm_mine(self):
+        elector = LeaderElector(self.kube)
+        self.kube.host_name = 'foo'
+
+        error_cm = [
+            ({}, KeyError),
+            ({'metadata': {}}, KeyError),
+        ]
+        for cm, ex in error_cm:
+            self.assertRaises(ex, elector._is_cm_mine, cm)
+
+        cm = {'metadata': {'annotations': {CREATOR_ANNOTATION: 'foo'}}}
+        self.assertEqual(elector._is_cm_mine(cm), True)
+        cm = {'metadata': {'annotations': {}}}
+        self.assertEqual(elector._is_cm_mine(cm), False)
+        cm = {'metadata': {'annotations': {CREATOR_ANNOTATION: 'bar'}}}
+        self.assertEqual(elector._is_cm_mine(cm), False)
+
+    def test_build_update_cm_payload(self):
+        now = datetime.datetime.utcnow()
+        self.kube.host_name = 'foo'
+        elector = LeaderElector(self.kube)
+
+        cm = {
+            'kind': 'ConfigMap',
+            'apiVersion': 'v1',
+            'data': {},
+            'metadata': {
+                'name': 'datadog-leader-elector',
+                'namespace': 'default',
+                'resourceVersion': '5563782',
+                'creationTimestamp': '2017-08-21T17:37:32Z',
+                'annotations': {'acquired_time': datetime.datetime.strftime(now, "%Y-%m-%dT%H:%M:%S.%f"),
+                'creator': 'dd-agent-284pl'
+            },
+            'selfLink': '/api/v1/namespaces/default/configmaps/datadog-leader-elector',
+            'uid': '697b957c-8697-11e7-b62f-42010af002d4'}
+        }
+        time.sleep(1)
+        pl = elector._build_update_cm_payload(cm)
+        self.assertEqual(pl['data'], cm['data'])
+        self.assertEqual(pl['metadata']['name'], cm['metadata']['name'])
+        self.assertEqual(pl['metadata']['namespace'], cm['metadata']['namespace'])
+        self.assertEqual(pl['metadata']['annotations'][CREATOR_ANNOTATION], cm['metadata']['annotations'][CREATOR_ANNOTATION])
+        self.assertTrue(pl['metadata']['annotations'][ACQUIRE_TIME_ANNOTATION] > cm['metadata']['annotations'][ACQUIRE_TIME_ANNOTATION])
+
+    def test_build_create_cm_payload(self):
+        now = datetime.datetime.utcnow()
+        self.kube.host_name = 'foo'
+        elector = LeaderElector(self.kube)
+
+        cm = {
+            'data': {},
+            'metadata': {
+                'name': CM_NAME,
+                'namespace': DEFAULT_NAMESPACE,
+                'annotations': {
+                    CREATOR_ANNOTATION: 'foo',
+                    ACQUIRE_TIME_ANNOTATION: datetime.datetime.strftime(now, "%Y-%m-%dT%H:%M:%S.%f")
+                }
+            }
+        }
+        pl = elector._build_create_cm_payload()
+        self.assertEqual(pl['data'], cm['data'])
+        self.assertEqual(pl['metadata']['name'], cm['metadata']['name'])
+        self.assertEqual(pl['metadata']['namespace'], cm['metadata']['namespace'])
+        self.assertEqual(pl['metadata']['annotations'][CREATOR_ANNOTATION], cm['metadata']['annotations'][CREATOR_ANNOTATION])
+        self.assertTrue(pl['metadata']['annotations'][ACQUIRE_TIME_ANNOTATION] > cm['metadata']['annotations'][ACQUIRE_TIME_ANNOTATION])
+
+    def test_is_lock_expired(self):
+        elector = LeaderElector(self.kube)
+
+        cm = {
+            'kind': 'ConfigMap',
+            'apiVersion': 'v1',
+            'data': {},
+            'metadata': {
+                'name': 'datadog-leader-elector',
+                'namespace': 'default',
+                'resourceVersion': '5563782',
+                'creationTimestamp': '2017-08-21T17:37:32Z',
+                'annotations': {'acquired_time': '2017-08-21T17:37:32.514660',
+                'creator': 'dd-agent-284pl'
+            },
+            'selfLink': '/api/v1/namespaces/default/configmaps/datadog-leader-elector',
+            'uid': '697b957c-8697-11e7-b62f-42010af002d4'}
+        }
+
+        self.assertTrue(elector._is_lock_expired(cm))
+        cm['metadata']['annotations'][ACQUIRE_TIME_ANNOTATION] = '3017-08-21T17:37:32.514660'
+        self.assertFalse(elector._is_lock_expired(cm))
+
+    @mock.patch.object(LeaderElector, '_get_cm', return_value=None)
+    @mock.patch.object(LeaderElector, '_try_lock_cm', return_value=False)
+    @mock.patch.object(LeaderElector, '_is_cm_mine', return_value=False)
+    @mock.patch.object(LeaderElector, '_is_lock_expired', return_value=True)
+    @mock.patch.object(LeaderElector, '_try_refresh_cm', return_value=True)
+    def test_try_refresh(self, m_refresh_cm, m_lock_expired, m_cm_mine, m_lock_cm, m_get_cm):
+        elector = LeaderElector(self.kube)
+
+        # First test uses the decorator return values
+        self.assertFalse(elector._try_refresh())
+
+        m_get_cm.return_value = {'some': 'thing'}
+
+        m_lock_expired.return_value = True
+        self.assertFalse(elector._try_refresh())
+
+        m_lock_cm.return_value = True
+        self.assertTrue(elector._try_refresh())
+
+        m_cm_mine.return_value = True
+        self.assertTrue(elector._try_refresh())
+
+        m_get_cm.return_value = None
+        m_lock_cm.return_value = False
+        m_refresh_cm.return_value = False
+        self.assertFalse(elector._try_refresh())
+
+    @mock.patch.object(LeaderElector, '_get_cm', return_value=None)
+    @mock.patch.object(LeaderElector, '_try_lock_cm', return_value=False)
+    @mock.patch.object(LeaderElector, '_is_cm_mine', return_value=False)
+    @mock.patch.object(LeaderElector, '_is_lock_expired', return_value=True)
+    def test_try_acquire(self, m_lock_expired, m_cm_mine, m_lock_cm, m_get_cm):
+        elector = LeaderElector(self.kube)
+
+        # First test uses the decorator return values
+        self.assertFalse(elector._try_acquire())
+
+        m_get_cm.return_value = {'some': 'thing'}
+        m_lock_cm.return_value = True
+        self.assertTrue(elector._try_acquire())
+
+        m_lock_cm.return_value = False
+        self.assertFalse(elector._try_acquire())
+
+        m_get_cm.return_value = None
+        m_lock_expired.return_value = True
+        self.assertFalse(elector._try_refresh())
+
+        m_lock_cm.return_value = True
+        self.assertTrue(elector._try_refresh())
+
+        m_lock_cm.return_value = True
+        self.assertTrue(elector._try_refresh())

--- a/tests/core/test_leader_elector.py
+++ b/tests/core/test_leader_elector.py
@@ -45,10 +45,11 @@ class TestLeaderElector(KubeTestCase):
                 'resourceVersion': '5563782',
                 'creationTimestamp': '2017-08-21T17:37:32Z',
                 'annotations': {'acquired_time': datetime.datetime.strftime(now, "%Y-%m-%dT%H:%M:%S.%f"),
-                'creator': 'dd-agent-284pl'
+                                'creator': 'dd-agent-284pl'
+                                },
+                'selfLink': '/api/v1/namespaces/default/configmaps/datadog-leader-elector',
+                'uid': '697b957c-8697-11e7-b62f-42010af002d4'
             },
-            'selfLink': '/api/v1/namespaces/default/configmaps/datadog-leader-elector',
-            'uid': '697b957c-8697-11e7-b62f-42010af002d4'}
         }
         time.sleep(1)
         pl = elector._build_update_cm_payload(cm)
@@ -79,7 +80,7 @@ class TestLeaderElector(KubeTestCase):
         self.assertEqual(pl['metadata']['name'], cm['metadata']['name'])
         self.assertEqual(pl['metadata']['namespace'], cm['metadata']['namespace'])
         self.assertEqual(pl['metadata']['annotations'][CREATOR_ANNOTATION], cm['metadata']['annotations'][CREATOR_ANNOTATION])
-        self.assertTrue(pl['metadata']['annotations'][ACQUIRE_TIME_ANNOTATION] > cm['metadata']['annotations'][ACQUIRE_TIME_ANNOTATION])
+        self.assertTrue(pl['metadata']['annotations'][ACQUIRE_TIME_ANNOTATION] >= cm['metadata']['annotations'][ACQUIRE_TIME_ANNOTATION])
 
     def test_is_lock_expired(self):
         elector = LeaderElector(self.kube)
@@ -94,10 +95,11 @@ class TestLeaderElector(KubeTestCase):
                 'resourceVersion': '5563782',
                 'creationTimestamp': '2017-08-21T17:37:32Z',
                 'annotations': {'acquired_time': '2017-08-21T17:37:32.514660',
-                'creator': 'dd-agent-284pl'
-            },
-            'selfLink': '/api/v1/namespaces/default/configmaps/datadog-leader-elector',
-            'uid': '697b957c-8697-11e7-b62f-42010af002d4'}
+                                'creator': 'dd-agent-284pl'
+                                },
+                'selfLink': '/api/v1/namespaces/default/configmaps/datadog-leader-elector',
+                'uid': '697b957c-8697-11e7-b62f-42010af002d4'
+            }
         }
 
         self.assertTrue(elector._is_lock_expired(cm))

--- a/tests/core/test_leader_elector.py
+++ b/tests/core/test_leader_elector.py
@@ -6,16 +6,9 @@ import time
 import mock
 
 # project
-from utils.kubernetes import LeaderElector
 from tests.core.test_kubeutil import KubeTestCase
-
-
-HEALTH_ENDPOINT = '/healthz'
-DEFAULT_NAMESPACE = 'default'  # TODO: use agent's own ns
-CM_ENDPOINT = '/namespaces/{namespace}/configmaps'
-CM_NAME = 'datadog-leader-elector'
-CREATOR_ANNOTATION = 'creator'
-ACQUIRE_TIME_ANNOTATION = 'acquired_time'
+from utils.kubernetes.leader_elector import LeaderElector, \
+    ACQUIRE_TIME_ANNOTATION, CREATOR_ANNOTATION, CM_NAME
 
 
 class TestLeaderElector(KubeTestCase):
@@ -74,7 +67,7 @@ class TestLeaderElector(KubeTestCase):
             'data': {},
             'metadata': {
                 'name': CM_NAME,
-                'namespace': DEFAULT_NAMESPACE,
+                'namespace': 'default',
                 'annotations': {
                     CREATOR_ANNOTATION: 'foo',
                     ACQUIRE_TIME_ANNOTATION: datetime.datetime.strftime(now, "%Y-%m-%dT%H:%M:%S.%f")

--- a/utils/kubernetes/__init__.py
+++ b/utils/kubernetes/__init__.py
@@ -6,3 +6,4 @@ from .kube_event_retriever import KubeEventRetriever  # noqa: F401
 from .pod_service_mapper import PodServiceMapper   # noqa: F401
 from .kubeutil import detect_is_k8s  # noqa: F401
 from .kubeutil import KubeUtil  # noqa: F401
+from .leader_elector import LeaderElector  # noqa: F401

--- a/utils/kubernetes/__init__.py
+++ b/utils/kubernetes/__init__.py
@@ -2,8 +2,8 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
+from .leader_elector import LeaderElector  # noqa: F401
 from .kube_event_retriever import KubeEventRetriever  # noqa: F401
 from .pod_service_mapper import PodServiceMapper   # noqa: F401
 from .kubeutil import detect_is_k8s  # noqa: F401
 from .kubeutil import KubeUtil  # noqa: F401
-from .leader_elector import LeaderElector  # noqa: F401

--- a/utils/kubernetes/kube_event_retriever.py
+++ b/utils/kubernetes/kube_event_retriever.py
@@ -69,8 +69,11 @@ class KubeEventRetriever:
     def get_event_array(self):
         """
         Fetch latest events from the apiserver for the namespaces and kinds set on init
-        and returns an array of event objects
+        and returns an array of event objects.
+        Also triggers leader election.
         """
+        # Leader election
+        self.kubeutil.refresh_leader()
 
         # Request throttling
         if self._request_interval:
@@ -82,7 +85,7 @@ class KubeEventRetriever:
         lastest_resversion = None
         filtered_events = []
 
-        events = self.kubeutil.retrieve_json_auth(self.request_url, params=self.request_params)
+        events = self.kubeutil.retrieve_json_auth(self.request_url, params=self.request_params).json()
 
         for event in events.get('items', []):
             resversion = int(event.get('metadata', {}).get('resourceVersion', None))

--- a/utils/kubernetes/kube_event_retriever.py
+++ b/utils/kubernetes/kube_event_retriever.py
@@ -37,9 +37,8 @@ class KubeEventRetriever:
         self.last_resversion = -1
         self.set_namespaces(namespaces)
         self.set_kinds(kinds)
+        self.set_delay(delay)
 
-        # Request throttling to reduce apiserver traffic
-        self._request_interval = delay
         self._last_lookup_timestamp = -1
 
     def set_namespaces(self, namespaces):
@@ -65,6 +64,10 @@ class KubeEventRetriever:
                 self.kind_filter = set(kinds)
         if isinstance(kinds, basestring):
             self.request_params['fieldSelector'] = 'involvedObject.kind=' + kinds
+
+    def set_delay(self, delay):
+        """Request throttling to reduce apiserver traffic"""
+        self._request_interval = delay
 
     def get_event_array(self):
         """

--- a/utils/kubernetes/kube_event_retriever.py
+++ b/utils/kubernetes/kube_event_retriever.py
@@ -70,10 +70,7 @@ class KubeEventRetriever:
         """
         Fetch latest events from the apiserver for the namespaces and kinds set on init
         and returns an array of event objects.
-        Also triggers leader election.
         """
-        # Leader election
-        self.kubeutil.refresh_leader()
 
         # Request throttling
         if self._request_interval:

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -112,6 +112,7 @@ class KubeUtil:
         # leader status triggers event collection
         self.is_leader = False
         self.leader_elector = None
+        self.leader_lease_duration = instance.get('lease_duration')
 
         # kubelet
         try:

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -369,7 +369,7 @@ class KubeUtil:
 
         cert = self.tls_settings.get('apiserver_client_cert')
         bearer_token = self.tls_settings.get('bearer_token') if not cert else None
-        headers = {'Authorization': 'Bearer {}'.format(bearer_token)} if bearer_token else None
+        headers = {'Authorization': 'Bearer {}'.format(bearer_token)} if bearer_token else {}
         headers['content-type'] = 'application/json'
         return cert, headers, verify
 

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -111,9 +111,6 @@ class KubeUtil:
         # leader status triggers event collection
         self.is_leader = False
         self.leader_elector = None
-        if os.environ.get('DD_LEADER_CANDIDATE'):
-            self.leader_elector = LeaderElector(self)
-            self.leader_elector.try_acquire_or_refresh()
 
         # kubelet
         try:
@@ -365,13 +362,13 @@ class KubeUtil:
         res.raise_for_status()
         return res
 
-    def post_to_apiserver(self, url, data, timeout=3):
+    def post_json_to_apiserver(self, url, data, timeout=3):
         cert, headers, verify = self.get_apiserver_auth_settings()
         res = requests.post(url, timeout=timeout, headers=headers, verify=verify, cert=cert, data=json.dumps(data))
         res.raise_for_status()
         return res
 
-    def put_to_apiserver(self, url, data, timeout=3):
+    def put_json_to_apiserver(self, url, data, timeout=3):
         cert, headers, verify = self.get_apiserver_auth_settings()
         res = requests.put(url, timeout=timeout, headers=headers, verify=verify, cert=cert, data=json.dumps(data))
         res.raise_for_status()
@@ -580,5 +577,6 @@ class KubeUtil:
             return set()
 
     def refresh_leader(self):
-        if self.leader_elector:
-            self.leader_elector.try_acquire_or_refresh()
+        if not self.leader_elector:
+            self.leader_elector = LeaderElector(self)
+        self.leader_elector.try_acquire_or_refresh()

--- a/utils/kubernetes/leader_elector.py
+++ b/utils/kubernetes/leader_elector.py
@@ -1,0 +1,175 @@
+import datetime
+import logging
+from urlparse import urljoin
+
+log = logging.getLogger('collector')
+
+HEALTH_ENDPOINT = '/healthz'
+DEFAULT_NAMESPACE = 'default'  # TODO: use agent's own ns
+CM_ENDPOINT = '/namespaces/{namespace}/configmaps'
+CM_NAME = 'datadog-leader-elector'
+CREATOR_LABEL = 'creator'
+ACQUIRE_TIME_LABEL = 'acquired_time'
+# TODO: make lease duration configurable
+DEFAULT_LEASE_DURATION = 5 * 60  # seconds
+
+class LeaderElector:
+    """
+    Uses the Kubernetes ConfigMap API to elect a leader among agents.
+    This is based on the mechanism described here:
+    https://github.com/kubernetes/kubernetes/blob/v1.7.3/pkg/client/leaderelection/leaderelection.go
+
+    The election process goes like this:
+    - all agents share the same CM name that they will try and lock
+    by overriding its metadata.
+    - if the CM doesn't exist or if its last refresh is too old:
+      create or replace it with fresh metadata and become the leader
+    - if the CM is already locked, there is already a leader agent. Then do nothing
+
+    This process should be triggered regularly (more frequently than the expiration period).
+    The leader needs to refresh its status by overriding the acquire-time label in the CM meta.
+
+    This mechanism doesn't ensure uniqueness of the leader because of clock skew.
+    A clock sync between nodes in the cluster is highly recommended to minimize this issue.
+    """
+
+    def __init__(self, kubeutil):
+        self.kubeutil = kubeutil
+        self.apiserver_url = kubeutil.kubernetes_api_url
+        self.last_acquire_time = None
+        if not self._is_reachable():
+            return
+
+    def _is_reachable(self):
+        health_url = urljoin(self.apiserver_url, HEALTH_ENDPOINT)
+        try:
+            self.kubeutil.retrieve_json_auth(health_url)
+        except Exception as ex:
+            log.error("API server is unreachable, disabling leader election. Error: %s" % str(ex))
+            return False
+
+    def try_acquire_or_refresh(self):
+        """
+        if this agent is leader, try and refresh the lock
+        otherwise try and acquire it.
+        """
+        expiry_time = None
+        if self.last_acquire_time:
+            expiry_time = self.last_acquire_time + datetime.timedelta(seconds=DEFAULT_LEASE_DURATION)
+
+        if self.kubeutil.is_leader:
+            if expiry_time and expiry_time - datetime.timedelta(seconds=30) <= datetime.datetime.utcnow():
+                self.kubeutil.is_leader = self._try_refresh()
+        else:
+            if (not expiry_time) or (expiry_time <= datetime.datetime.utcnow()):
+                self.kubeutil.is_leader = self._try_acquire()
+
+    def _try_acquire(self):
+        """
+        _try_acquire tries to acquire the CM lock and return leader status
+        i.e. whether it succeeded or failed.
+        """
+        try:
+            cm = self._get_cm()
+            if not cm or self._is_lock_expired(cm):
+                return self._try_lock_cm(cm)
+            else:
+                return False
+        except Exception as ex:
+            log.error("Failed to acquire leader status: %s" % str(ex))
+            return False
+
+    def _try_refresh(self):
+        # TODO: implement refresh
+        try:
+            return False
+        except Exception as ex:
+            log.error("Failed to renew leader status: %s" % str(ex))
+            return False
+
+    def _get_cm(self):
+        """
+        _get_cm returns the ConfigMap if it exists, None if it doesn't
+        and raises an exception if several CM with the reserved name exist
+        """
+        try:
+            cm_filter = 'labelSelector=NAME%%3D%s' % CM_NAME
+            cm_url = '{}?{}'.format(urljoin(self.apiserver_url, CM_ENDPOINT.format(namespace=DEFAULT_NAMESPACE)), cm_filter)
+            res = self.kubeutil.retrieve_json_auth(cm_url).json().get('items')
+        except Exception as ex:
+            if ex.response.status_code == 404:
+                return None
+            log.error("Failed to get config map %s. Error: %s" % (CM_NAME, str(ex)))
+            return
+        if len(res) == 0:
+            return None
+        elif len(res) == 1:
+            cm = res[0]
+            acquired_time = cm['metadata'].get('labels', {}).get(ACQUIRE_TIME_LABEL)
+            self.last_acquire_time = datetime.datetime.strptime(acquired_time, "%Y-%m-%dT%H:%M:%S.%f")
+            return cm
+        else:
+            raise Exception("Found more than one config map named %s. Failing leader election." % CM_NAME)
+
+    def _is_lock_expired(self, cm):
+        acquired_time = cm['metadata'].get('labels', {}).get(ACQUIRE_TIME_LABEL)
+
+        if not acquired_time:
+            log.warning("aquired-time wasn't set correctly for the leader lock. Assuming"
+                " it's expired so we can reset it correctly.")
+            return True
+
+        acquired_time = datetime.datetime.strptime(acquired_time, "%Y-%m-%dT%H:%M:%S.%f")
+
+        if acquired_time + datetime.timedelta(seconds=DEFAULT_LEASE_DURATION) <= datetime.datetime.utcnow():
+            return True
+        return False
+
+    def _try_lock_cm(self, cm):
+        """
+        Try and lock the ConfigMap in 2 steps:
+            - delete it
+            - post the new cm as a replacement. If the post failed,
+              a concurrent agent won the race and we're not leader
+        """
+        create_pl = self._build_create_cm_payload(cm)
+        cm_url = self.apiserver_url + CM_ENDPOINT.format(namespace=DEFAULT_NAMESPACE)
+        if cm:
+            try:
+                del_url = '{}/{}'.format(cm_url, cm['metadata']['name'])
+                self.kubeutil.delete_to_apiserver(del_url)
+            except Exception as ex:
+                if ex.response.status_code != 404:  # 404 means another agent removed it already
+                    log.error("Couldn't delete config map %s. Error: %s" % (cm['metadata']['name'], str(ex)))
+                    return False
+
+        try:
+            self.kubeutil.post_to_apiserver(cm_url, create_pl)
+        except Exception as ex:
+            if ex.response.reason == 'AlreadyExists':
+                log.debug("ConfigMap lock '%s' already exists, another agent "
+                    "acquired it." % ex.response.json().get('details', {}).get('name', ''))
+                return False
+            else:
+                log.error("Failed to post the ConfigMap lock. Error: %s" % str(ex))
+                return False
+        return True
+
+    def _build_create_cm_payload(self, cm):
+        now = datetime.datetime.utcnow()
+        pl = {
+            'data': {},
+            'metadata': {
+                'labels': {
+                    CREATOR_LABEL: self.kubeutil.host_name,
+                    ACQUIRE_TIME_LABEL: datetime.datetime.strftime(now, "%Y-%m-%dT%H:%M:%S.%f")
+                },
+                'name': CM_NAME,
+                'namespace': DEFAULT_NAMESPACE  # TODO: use agent namespace
+            }
+        }
+        return pl
+
+    def _build_update_cm_payload(self, cm):
+        pl = {}
+        return pl

--- a/utils/kubernetes/pod_service_mapper.py
+++ b/utils/kubernetes/pod_service_mapper.py
@@ -37,7 +37,7 @@ class PodServiceMapper:
             return
 
         try:
-            reply = self.kube.retrieve_json_auth(self.kube.kubernetes_api_url + '/services')
+            reply = self.kube.retrieve_json_auth(self.kube.kubernetes_api_url + '/services').json()
             self._service_cache_selectors = defaultdict(dict)
             self._service_cache_names = {}
             for service in reply.get('items', []):


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Implement a leader election mechanism among agents on kubernetes to collect events automatically.

### Motivation

It's a pain to create a single deployment for the one agent responsible to collect events. It's also not recommended to have all agents report events due to the load this puts on the apiserver (and the redundant data sent by all agents).

This feature will allow having event collection enabled only once, without needed a snowflake agent deployment. All agents can be started with the `leader_candidate: true` option and take part in this election. Only the leading agent will report events.

### Testing Guidelines

Unit tests were added, integration tests are err... manual for now.

### Additional Notes

Linked with https://github.com/DataDog/integrations-core/pull/687