### PR TITLE
[autodiscovery] annotations with multi instances bug

### DIFF
--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -487,13 +487,17 @@ class SDDockerBackend(AbstractSDBackend):
 
         return templates
 
-    def _fill_tpl(self, state, c_id, instance_tpl, variables, tags=None):
+    def _fill_tpl(self, state, c_id, instance_tpl, variables, c_tags=None):
         """Add container tags to instance templates and build a
            dict from template variable names and their values."""
         var_values = {}
         c_image = state.inspect_container(c_id).get('Config', {}).get('Image', '')
 
-        # add default tags to the instance
+        # add only default c_tags to the instance to avoid duplicate tags from conf
+        if c_tags:
+            tags = c_tags[:] # shallow copy of the c_tags array
+        else:
+            tags = []
         if tags:
             tpl_tags = instance_tpl.get('tags', [])
             if isinstance(tpl_tags, dict):


### PR DESCRIPTION
### What does this PR do?
Bug fix of https://github.com/DataDog/dd-agent/pull/3341

Annotations with multi instances configuration leads to check level tags be added to the container level tags array.

While adding container tags with this [method](https://github.com/DataDog/dd-agent/blob/master/utils/service_discovery/sd_docker_backend.py#L490), performs a shallow copy of the container tag array to avoid adding tags from the previous instance ( which would come from [this for loop](https://github.com/DataDog/dd-agent/blob/master/utils/service_discovery/sd_docker_backend.py#L438)), contains its check tags.

### Motivation

Issue encountered by a customer.

### Testing Guidelines

Instantiate a pod with annotations containing several instances (along the lines of [this example](https://gist.github.com/CharlyF/c1220097e45ce9caf77bde567a066723))
The agent will detect the check but it will add the config level tags to the container level ones.
e.g.:

```
 (u'num.empl',
  1503048087,
  300024.0,
  {'hostname': 'i-0xxx',
   'tags': [u'kube_deployment:repl',
            u'kube_namespace:default',
            u'kube_replica_set:repl',
            u'env:prd',
            u'dbinstanceidentifier:dbi2',
            u'name:mysql',
            u'account:analytics',
            u'dbinstanceidentifier:dbi',
            u'team:data',
            u'image_tag:3.0',
            u'docker_image:gcr.io/google_containers/pause-amd64:3.0',
            u'image_name:gcr.io/google_containers/pause-amd64',
            u'table:playcount',
            u'dbinstanceidentifier:dbi2',
            u'env:prd',
            u'account:analytics',
            u'team:data'],
   'type': 'gauge'}),
```

As per the above pod yaml, this metric should only be tagged with `dbinstanceidentifier:dbi2`. 
With the change, we have:

```
 (u'num.empl',
  1503050652,
  300024.0,
  {'hostname': 'i-0xxx',
   'tags': [u'kube_deployment:repl',
            u'kube_namespace:default',
            u'kube_replica_set:repl',
            u'env:prd',
            u'dbinstanceidentifier:dbi2',
            u'name:mysql',
            u'account:analytics',
            u'team:data',
            u'image_tag:3.0',
            u'docker_image:gcr.io/google_containers/pause-amd64:3.0',
            u'image_name:gcr.io/google_containers/pause-amd64',
            u'table:playcount',
            u'dbinstanceidentifier:dbi2',
            u'env:prd',
            u'account:analytics',
            u'team:data'],
   'type': 'gauge'}),
```
