### PR TITLE
[Core] Utilize sys.exit in configcheck

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -602,8 +602,8 @@ def main():
                     check.stop()
 
     elif 'configcheck' == command or 'configtest' == command:
-        if configcheck() or sd_configcheck(agentConfig):
-            sys.exit(1)
+        sd_configcheck(agentConfig)
+        return configcheck()
 
     elif 'jmx' == command:
         jmx_command(args[1:], agentConfig)

--- a/agent.py
+++ b/agent.py
@@ -602,8 +602,8 @@ def main():
                     check.stop()
 
     elif 'configcheck' == command or 'configtest' == command:
-        configcheck()
-        sd_configcheck(agentConfig)
+        if configcheck() or sd_configcheck(agentConfig):
+            sys.exit(1)
 
     elif 'jmx' == command:
         jmx_command(args[1:], agentConfig)

--- a/utils/configcheck.py
+++ b/utils/configcheck.py
@@ -5,7 +5,6 @@
 # std
 import glob
 import os
-import sys
 
 # project
 from config import (
@@ -31,13 +30,11 @@ def configcheck():
             print "%s is valid" % basename
     if all_valid:
         print "All yaml files passed. You can now run the Datadog agent."
-        sys.exit(0)
         return 0
     else:
         print("Fix the invalid yaml files above in order to start the Datadog agent. "
               "A useful external tool for yaml parsing can be found at "
               "http://yaml-online-parser.appspot.com/")
-        sys.exit(1)
         return 1
 
 

--- a/utils/configcheck.py
+++ b/utils/configcheck.py
@@ -5,6 +5,7 @@
 # std
 import glob
 import os
+import sys
 
 # project
 from config import (
@@ -30,11 +31,13 @@ def configcheck():
             print "%s is valid" % basename
     if all_valid:
         print "All yaml files passed. You can now run the Datadog agent."
+        sys.exit(0)
         return 0
     else:
         print("Fix the invalid yaml files above in order to start the Datadog agent. "
               "A useful external tool for yaml parsing can be found at "
               "http://yaml-online-parser.appspot.com/")
+        sys.exit(1)
         return 1
 
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Utilizes the sys.exit() function in the `configcheck` command utility. This allows the exit code to be determined based on whether or not the yaml configs are good/bad. 

### Motivation

Customer Request. Now when running the one off config check script/command, you can utilize `$?` to determine if there are any bad yaml files. 

Previously, if the configcheck finished and printed that there were errors in the yaml files, the following command:

```
echo $?
```

would output `0. Now this outputs 1, indicating there was a failure. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
