### PR TITLE
[jmxfetch] Upgrade to 0.16.0

### DIFF
--- a/config.py
+++ b/config.py
@@ -42,7 +42,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 # CONSTANTS
 AGENT_VERSION = "5.17.0"
-JMX_VERSION = "0.15.0"
+JMX_VERSION = "0.16.0"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
 MAC_CONFIG_PATH = '/opt/datadog-agent/etc'


### PR DESCRIPTION
### What does this PR do?

Upgrades jmxfetch to 0.16.0, see https://github.com/DataDog/jmxfetch/blob/master/CHANGELOG.md#0160--08-21-2017

### Additional Notes

Sister PR: https://github.com/DataDog/omnibus-software/pull/158
