### PR TITLE
[packaging] Fix bashism in init script

### DIFF
--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -136,7 +136,7 @@ start() {
         exit 3
     fi
 
-    if [ "$DATADOG_ENABLED" == "no" ]; then
+    if [ "$DATADOG_ENABLED" = "no" ]; then
         echo "Disabled via $AGENTSYSCONFIG. Exiting."
         exit 0
     fi

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -124,7 +124,7 @@ case "$1" in
             exit 3
         fi
 
-        if [ "$DATADOG_ENABLED" == "no" ]; then
+        if [ "$DATADOG_ENABLED" = "no" ]; then
             echo "Disabled via /etc/default/$NAME. Exiting."
             exit 0
         fi


### PR DESCRIPTION
### What does this PR do?

Only has a real impact on the debian init script, but let's fix that
everywhere.

Introduced in #3301.

### Additional Notes

The bug would only affect Debian by:
- making the `DATADOG_ENABLED` var not work as expected
- always printing a pretty ugly error message
