### PR TITLE
[collector] Only add service check fields if non-null

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -963,12 +963,17 @@ def create_service_check(check_name, status, tags=None, timestamp=None,
     """
     if check_run_id is None:
         check_run_id = get_next_id('service_check')
-    return {
+    service_check = {
         'id': check_run_id,
         'check': check_name,
         'status': status,
-        'host_name': hostname,
-        'tags': tags,
         'timestamp': float(timestamp or time.time()),
-        'message': message
     }
+    if hostname is not None:
+        service_check['host_name'] = hostname
+    if tags is not None:
+        service_check['tags'] = tags
+    if message is not None:
+        service_check["message"] = message
+
+    return service_check

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -126,7 +126,24 @@ class TestCore(unittest.TestCase):
         timestamp = time.time()
 
         check = AgentCheck('test', {}, {'checksd_hostname':'foo'})
-        check.service_check(check_name, status, tags, timestamp, host_name)
+        # No "message"/"tags" field
+        check.service_check(check_name, status, timestamp=timestamp, hostname=host_name)
+        self.assertEquals(len(check.service_checks), 1, check.service_checks)
+        val = check.get_service_checks()
+        self.assertEquals(len(val), 1)
+        check_run_id = val[0].get('id', None)
+        self.assertNotEquals(check_run_id, None)
+        self.assertEquals([{
+            'id': check_run_id,
+            'check': check_name,
+            'status': status,
+            'host_name': host_name,
+            'timestamp': timestamp,
+        }], val)
+        self.assertEquals(len(check.service_checks), 0, check.service_checks)
+
+        # With "message" field
+        check.service_check(check_name, status, tags, timestamp, host_name, message='foomessage')
         self.assertEquals(len(check.service_checks), 1, check.service_checks)
         val = check.get_service_checks()
         self.assertEquals(len(val), 1)
@@ -139,9 +156,10 @@ class TestCore(unittest.TestCase):
             'host_name': host_name,
             'tags': tags,
             'timestamp': timestamp,
-            'message': None,
+            'message': 'foomessage',
         }], val)
         self.assertEquals(len(check.service_checks), 0, check.service_checks)
+
 
     def test_no_proxy(self):
         """ Starting with Agent 5.0.0, there should always be a local forwarder


### PR DESCRIPTION
### What does this PR do?

Avoids `null` values on service check fields.

### Motivation

The `api/v1/check_run` endpoint doesn't accept payloads with a `message` value of `null`, so avoid that. #3446 was not working because of this.

Do the same thing on the `tags` and `hostname` fields as it makes sense to be consistent.

cc @remh 