### PR TITLE
[info] `unknown` ver if failed module load, `custom` if custom check.

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -379,14 +379,17 @@ class AgentCheck(object):
     def set_manifest_path(self, manifest_path):
         self.manifest_path = manifest_path
 
-    def set_check_version(self, manifest=None):
-        version = AGENT_VERSION
+    def set_check_version(self, version=None, manifest=None):
+        _version = AGENT_VERSION
+
+        if version:
+            _version = version
 
         if manifest is not None:
-            version = "{core}:{sdk}".format(core=AGENT_VERSION,
+            _version = "{core}:{sdk}".format(core=AGENT_VERSION,
                                         sdk=manifest.get('version', 'unknown'))
 
-        self.check_version = version
+        self.check_version = _version
 
     def get_instance_proxy(self, instance, uri):
         proxies = self.proxies.copy()

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -380,10 +380,7 @@ class AgentCheck(object):
         self.manifest_path = manifest_path
 
     def set_check_version(self, version=None, manifest=None):
-        _version = AGENT_VERSION
-
-        if version:
-            _version = version
+        _version = version or AGENT_VERSION
 
         if manifest is not None:
             _version = "{core}:{sdk}".format(core=AGENT_VERSION,

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -475,7 +475,7 @@ class Collector(object):
             if not self.continue_running:
                 return
             check_status = CheckStatus(check_name, None, None, None, None,
-                                       check_version=info.get('version'),
+                                       check_version=info.get('version', 'unknown'),
                                        init_failed_error=info['error'],
                                        init_failed_traceback=info['traceback'])
             check_statuses.append(check_status)


### PR DESCRIPTION
### What does this PR do?

Fixes a couple of issues with the info page:
- if a module fails to load - `unknown` version + show exception in info page.
- if a custom check is used - report `custom` as the version.

### Motivation
https://github.com/DataDog/integrations-core/issues/669
