### PR TITLE
adds dirmngr to debian install script

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -138,7 +138,12 @@ if [ $OS = "RedHat" ]; then
 elif [ $OS = "Debian" ]; then
     printf "\033[34m\n* Installing apt-transport-https\n\033[0m\n"
     $sudo_cmd apt-get update || printf "\033[31m'apt-get update' failed, the script will not install the latest version of apt-transport-https.\033[0m\n"
-    $sudo_cmd apt-get install -y apt-transport-https dirmngr
+    $sudo_cmd apt-get install -y apt-transport-https
+    # Only install dirmngr if it's available in the cache, it's not always and that is sometimes fine
+    cache_output=`apt-cache search dirmngr`
+    if [ ! -z "$cache_output" ]; then
+      $sudo_cmd apt-get install -y dirmngr
+    fi
     printf "\033[34m\n* Installing APT package sources for Datadog\n\033[0m\n"
     $sudo_cmd sh -c "echo 'deb https://apt.datadoghq.com/ stable main' > /etc/apt/sources.list.d/datadog.list"
     $sudo_cmd apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52

--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -138,7 +138,7 @@ if [ $OS = "RedHat" ]; then
 elif [ $OS = "Debian" ]; then
     printf "\033[34m\n* Installing apt-transport-https\n\033[0m\n"
     $sudo_cmd apt-get update || printf "\033[31m'apt-get update' failed, the script will not install the latest version of apt-transport-https.\033[0m\n"
-    $sudo_cmd apt-get install -y apt-transport-https
+    $sudo_cmd apt-get install -y apt-transport-https dirmngr
     printf "\033[34m\n* Installing APT package sources for Datadog\n\033[0m\n"
     $sudo_cmd sh -c "echo 'deb https://apt.datadoghq.com/ stable main' > /etc/apt/sources.list.d/datadog.list"
     $sudo_cmd apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 C7A7DA52

--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -139,7 +139,8 @@ elif [ $OS = "Debian" ]; then
     printf "\033[34m\n* Installing apt-transport-https\n\033[0m\n"
     $sudo_cmd apt-get update || printf "\033[31m'apt-get update' failed, the script will not install the latest version of apt-transport-https.\033[0m\n"
     $sudo_cmd apt-get install -y apt-transport-https
-    # Only install dirmngr if it's available in the cache, it's not always and that is sometimes fine
+    # Only install dirmngr if it's available in the cache
+    # it may not be available on Ubuntu <= 14.04 but it's not required there
     cache_output=`apt-cache search dirmngr`
     if [ ! -z "$cache_output" ]; then
       $sudo_cmd apt-get install -y dirmngr


### PR DESCRIPTION
### What does this PR do?

The install script should install dirmngr as well, as debian 9 doesn't come with it.

Only install it if it exists in the cach