### PR TITLE
[conf][skip ci] adding canonical_rate to jmx.yaml

### DIFF
--- a/conf.d/jmx.yaml.example
+++ b/conf.d/jmx.yaml.example
@@ -1,8 +1,11 @@
 init_config:
-  # custom_jar_paths: # Optional, allows specifying custom jars that will be added to the classpath of the agent's JVM, 
+  # custom_jar_paths: # Optional, allows specifying custom jars that will be added to the classpath of the agent's JVM,
   # BREAKING CHANGE NOTICE : The agent currently supports a string if there is only one custom JAR. In future versions, this will be deprecated and MUST be a list in all cases.
   #   - /path/to/custom/jarfile.jar
   #   - /path/to/another/custom/jarfile2.jar
+  # canonical_rate: false  # boolean to decide whether to use the canonical definition of rate.
+  #                        # Canonical rates will not submit a negative rate value (considered a reset)
+  #                        # Defaults to false to avoid breaking backward compatibility
 
 instances:
   # - host: localhost


### PR DESCRIPTION
### What does this PR do?

Documents the new `canonical_rate` option: https://github.com/DataDog/jmxfetch/pull/154

### Motivation

Originally rates in `jmxfetch` were not implemented in the canonical DD way (ie. negative rates are considered counter resets and are not submitted - if you have a legit negative rate then you should probably be using a gauge).
