### PR TITLE
[AD] make Auto Discovery wait on docker/kubelet

### DIFF
--- a/tests/core/test_orchestrator.py
+++ b/tests/core/test_orchestrator.py
@@ -7,6 +7,7 @@ import requests  # noqa: F401
 
 # project
 from utils.orchestrator import BaseUtil
+from utils.dockerutil import DockerUtil
 
 CO_ID = 1234
 
@@ -77,10 +78,11 @@ class TestBaseUtil(unittest.TestCase):
         dummy.reset_cache()
         self.assertFalse(CO_ID in dummy._container_tags_cache)
 
-    @mock.patch('docker.Client.inspect_container')
-    @mock.patch('docker.Client.__init__')
-    def test_auto_inspect(self, mock_init, mock_inspect):
-        mock_init.return_value = None
+    def test_auto_inspect(self):
+        du = DockerUtil()
+        du._client = mock.MagicMock()
+        mock_inspect = mock.MagicMock(name='inspect_container', return_value = {'RepoTags': ["redis:3.2"], 'RepoDigests': []})
+        du._client.inspect_container = mock_inspect
 
         dummy = self.NeedLabelsUtil()
         dummy.reset_cache()
@@ -88,10 +90,11 @@ class TestBaseUtil(unittest.TestCase):
         dummy.get_container_tags(cid=CO_ID)
         mock_inspect.assert_called_once()
 
-    @mock.patch('docker.Client.inspect_container')
-    @mock.patch('docker.Client.__init__')
-    def test_no_inspect_if_cached(self, mock_init, mock_inspect):
-        mock_init.return_value = None
+    def test_no_inspect_if_cached(self):
+        du = DockerUtil()
+        du._client = mock.MagicMock()
+        mock_inspect = mock.MagicMock(name='inspect_container', return_value = {'RepoTags': ["redis:3.2"], 'RepoDigests': []})
+        du._client.inspect_container = mock_inspect
 
         dummy = self.NeedLabelsUtil()
         dummy.reset_cache()
@@ -117,10 +120,11 @@ class TestBaseUtil(unittest.TestCase):
         dummy.get_container_tags(co=co)
         mock_inspect.assert_not_called()
 
-    @mock.patch('docker.Client.inspect_container')
-    @mock.patch('docker.Client.__init__')
-    def test_auto_env_inspect(self, mock_init, mock_inspect):
-        mock_init.return_value = None
+    def test_auto_env_inspect(self):
+        du = DockerUtil()
+        du._client = mock.MagicMock()
+        mock_inspect = mock.MagicMock(name='inspect_container', return_value = {'RepoTags': ["redis:3.2"], 'RepoDigests': []})
+        du._client.inspect_container = mock_inspect
 
         dummy = self.NeedEnvUtil()
         dummy.reset_cache()

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -95,11 +95,11 @@ class KubeUtil:
             # kubernetes.yaml was not found
             except IOError as ex:
                 log.error(ex.message)
-                instance = {}
+                init_config, instance = {}, {}
             except Exception:
                 log.error('Kubernetes configuration file is invalid. '
                           'Trying connecting to kubelet with default settings anyway...')
-                instance = {}
+                init_config, instance = {}, {}
 
         self.method = instance.get('method', KubeUtil.DEFAULT_METHOD)
         self._node_ip = self._node_name = None  # lazy evaluation

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -6,17 +6,18 @@
 from collections import defaultdict
 import logging
 import os
-from urlparse import urljoin
-from urllib import urlencode
 import simplejson as json
+import time
+from urllib import urlencode
+from urlparse import urljoin
 
 # project
 from util import check_yaml
 from utils.checkfiles import get_conf_path
-from utils.http import retrieve_json
-from utils.singleton import Singleton
 from utils.dockerutil import DockerUtil
+from utils.http import retrieve_json
 from utils.kubernetes import LeaderElector, KubeEventRetriever, PodServiceMapper
+from utils.singleton import Singleton
 
 import requests
 
@@ -35,6 +36,9 @@ CREATOR_KIND_TO_TAG = {
     'Deployment': 'kube_deployment',
     'Job': 'kube_job'
 }
+
+DEFAULT_INIT_RETRIES = 0
+DEFAULT_RETRY_INTERVAL = 20  # seconds
 
 
 def detect_is_k8s():
@@ -109,48 +113,32 @@ class KubeUtil:
 
         self.kubernetes_api_url = '%s/api/v1' % self.kubernetes_api_root_url
 
+        # Service mapping helper class
+        self._service_mapper = PodServiceMapper(self)
+        from config import _is_affirmative
+        self.collect_service_tag = _is_affirmative(instance.get('collect_service_tags', KubeUtil.DEFAULT_COLLECT_SERVICE_TAG))
+
+
         # leader status triggers event collection
         self.is_leader = False
         self.leader_elector = None
         self.leader_lease_duration = instance.get('lease_duration')
 
         # kubelet
-        try:
-            self.kubelet_api_url = self._locate_kubelet(instance)
-            if not self.kubelet_api_url:
-                raise Exception("Couldn't find a method to connect to kubelet.")
-        except Exception as ex:
-            log.error("Kubernetes check exiting, cannot run without access to kubelet.")
-            raise ex
+        # If kubelet_api_url is None, init_kubelet didn't succeed yet.
+        self.init_success = False
+        self.kubelet_api_url = None
+        self.init_retry_interval = instance.get('init_retry_interval', DEFAULT_RETRY_INTERVAL)
+        self.last_init_retry = None
+        self.left_init_retries = instance.get('init_retries', DEFAULT_INIT_RETRIES) + 1
+        self.init_kubelet(instance)
 
-        # Service mapping helper class
-        self._service_mapper = PodServiceMapper(self)
-
-        self.kubelet_host = self.kubelet_api_url.split(':')[1].lstrip('/')
-        self.pods_list_url = urljoin(self.kubelet_api_url, KubeUtil.PODS_LIST_PATH)
-        self.kube_health_url = urljoin(self.kubelet_api_url, KubeUtil.KUBELET_HEALTH_PATH)
         self.kube_label_prefix = instance.get('label_to_tag_prefix', KubeUtil.DEFAULT_LABEL_PREFIX)
         self.kube_node_labels = instance.get('node_labels_to_host_tags', {})
-
-        # cadvisor
-        self.cadvisor_port = instance.get('port', KubeUtil.DEFAULT_CADVISOR_PORT)
-        self.cadvisor_url = '%s://%s:%d' % (self.method, self.kubelet_host, self.cadvisor_port)
-        self.metrics_url = urljoin(self.cadvisor_url, KubeUtil.METRICS_PATH)
-        self.machine_info_url = urljoin(self.cadvisor_url, KubeUtil.MACHINE_INFO_PATH)
-
-        try:
-            self.self_namespace = self.get_self_namespace()
-        except Exception:
-            log.warning("Failed to get the agent pod namespace, defaulting to default.")
-            self.self_namespace = DEFAULT_NAMESPACE
-
-        from config import _is_affirmative
-        self.collect_service_tag = _is_affirmative(instance.get('collect_service_tags', KubeUtil.DEFAULT_COLLECT_SERVICE_TAG))
 
         # keep track of the latest k8s event we collected and posted
         # default value is 0 but TTL for k8s events is one hour anyways
         self.last_event_collection_ts = 0
-
 
     def _init_tls_settings(self, instance):
         """
@@ -189,43 +177,90 @@ class KubeUtil:
 
         return tls_settings
 
+    def init_kubelet(self, instance):
+        """
+        Handles the retry logic around _locate_kubelet.
+        Once _locate_kubelet succeeds, initialize all kubelet-related
+        URLs and settings.
+        """
+        if self.left_init_retries == 0:
+            raise Exception("Kubernetes client initialization failed permanently. "
+                "Kubernetes-related features will fail.")
+
+        now = time.time()
+
+        # last retry was less than retry_interval ago
+        if self.last_init_retry and now <= self.last_init_retry + self.init_retry_interval:
+            return
+        # else it's the first try, or last retry was long enough ago
+        self.last_init_retry = now
+        self.left_init_retries -= 1
+
+        try:
+            self.kubelet_api_url = self._locate_kubelet(instance)
+        except Exception as ex:
+            log.error("Failed to initialize kubelet connection. Will retry %s time(s). Error: %s" % (self.left_init_retries, str(ex)))
+            return
+        if not self.kubelet_api_url:
+            log.error("Failed to initialize kubelet connection. Will retry %s time(s)." % self.left_init_retries)
+            return
+
+        self.init_success = True
+
+        self.kubelet_host = self.kubelet_api_url.split(':')[1].lstrip('/')
+        self.pods_list_url = urljoin(self.kubelet_api_url, KubeUtil.PODS_LIST_PATH)
+        self.kube_health_url = urljoin(self.kubelet_api_url, KubeUtil.KUBELET_HEALTH_PATH)
+
+        # namespace of the agent pod
+        try:
+            self.self_namespace = self.get_self_namespace()
+        except Exception:
+            log.warning("Failed to get the agent pod namespace, defaulting to default.")
+            self.self_namespace = DEFAULT_NAMESPACE
+
+        # cadvisor
+        self.cadvisor_port = instance.get('port', KubeUtil.DEFAULT_CADVISOR_PORT)
+        self.cadvisor_url = '%s://%s:%d' % (self.method, self.kubelet_host, self.cadvisor_port)
+        self.metrics_url = urljoin(self.cadvisor_url, KubeUtil.METRICS_PATH)
+        self.machine_info_url = urljoin(self.cadvisor_url, KubeUtil.MACHINE_INFO_PATH)
+
     def _locate_kubelet(self, instance):
         """
         Kubelet may or may not accept un-authenticated http requests.
         If it doesn't we need to use its HTTPS API that may or may not
         require auth.
+        Returns the kubelet URL or raises.
         """
         host = os.environ.get('KUBERNETES_KUBELET_HOST') or instance.get("host")
         if not host:
             # if no hostname was provided, use the docker hostname if cert
             # validation is not required, the kubernetes hostname otherwise.
-            docker_hostname = self.docker_util.get_hostname(should_resolve=True)
+            host = self.docker_util.get_hostname(should_resolve=True)
             if self.tls_settings.get('kubelet_verify'):
                 try:
-                    k8s_hostname = self.get_node_hostname(docker_hostname)
-                    host = k8s_hostname or docker_hostname
-                except Exception as ex:
-                    log.error(str(ex))
-                    host = docker_hostname
-            else:
-                host = docker_hostname
+                    host = self.get_node_hostname(host)
+                except Exception:
+                    pass
+
+        # check if the no-auth endpoint is enabled
+        port = instance.get('kubelet_port', KubeUtil.DEFAULT_HTTP_KUBELET_PORT)
+        no_auth_url = 'http://%s:%s' % (host, port)
+        test_url = urljoin(no_auth_url, KubeUtil.KUBELET_HEALTH_PATH)
         try:
-            # check if the no-auth endpoint is enabled
-            port = instance.get('kubelet_port', KubeUtil.DEFAULT_HTTP_KUBELET_PORT)
-            no_auth_url = 'http://%s:%s' % (host, port)
-            test_url = urljoin(no_auth_url, KubeUtil.KUBELET_HEALTH_PATH)
             self.perform_kubelet_query(test_url)
             return no_auth_url
         except Exception:
             log.debug("Couldn't query kubelet over HTTP, assuming it's not in no_auth mode.")
 
         port = instance.get('kubelet_port', KubeUtil.DEFAULT_HTTPS_KUBELET_PORT)
-
         https_url = 'https://%s:%s' % (host, port)
         test_url = urljoin(https_url, KubeUtil.KUBELET_HEALTH_PATH)
-        self.perform_kubelet_query(test_url)
-
-        return https_url
+        try:
+            self.perform_kubelet_query(test_url)
+            return https_url
+        except Exception as ex:
+            log.warning("Couldn't query kubelet over HTTP, assuming it's not in no_auth mode.")
+            raise ex
 
     def get_self_namespace(self):
         pods = self.retrieve_pods_list()
@@ -258,6 +293,9 @@ class KubeUtil:
         Gets pods' labels as tags + creator and service tags.
         Returns a dict{namespace/podname: [tags]}
         """
+        if not self.init_success:
+            log.warning("Kubernetes client is not initialized, can't get pod tags.")
+            return {}
         pods = self.retrieve_pods_list()
         return self.extract_kube_pod_tags(pods, excluded_keys=excluded_keys)
 
@@ -421,6 +459,9 @@ class KubeUtil:
             log.debug("Error getting Kube master version: %s" % str(e))
 
         # Kubelet version & labels
+        if not self.init_success:
+            log.warning("Kubelet client failed to initialize, kubelet host tags will be missing for now.")
+            return tags
         try:
             _, node_name = self.get_node_info()
             if not node_name:

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -81,17 +81,20 @@ class KubeUtil:
     NAMESPACE_LABEL = "io.kubernetes.pod.namespace"
     CONTAINER_NAME_LABEL = "io.kubernetes.container.name"
 
-    def __init__(self, instance=None):
+    def __init__(self, **kwargs):
         self.docker_util = DockerUtil()
-        if instance is None:
+        if 'init_config' in kwargs and 'instance' in kwargs:
+            init_config = kwargs.get('init_config')
+            instance = kwargs.get('instance')
+        else:
             try:
                 config_file_path = get_conf_path(KUBERNETES_CHECK_NAME)
                 check_config = check_yaml(config_file_path)
+                init_config = check_config['init_config']
                 instance = check_config['instances'][0]
             # kubernetes.yaml was not found
             except IOError as ex:
                 log.error(ex.message)
-
                 instance = {}
             except Exception:
                 log.error('Kubernetes configuration file is invalid. '
@@ -128,9 +131,9 @@ class KubeUtil:
         # If kubelet_api_url is None, init_kubelet didn't succeed yet.
         self.init_success = False
         self.kubelet_api_url = None
-        self.init_retry_interval = instance.get('init_retry_interval', DEFAULT_RETRY_INTERVAL)
+        self.init_retry_interval = init_config.get('init_retry_interval', DEFAULT_RETRY_INTERVAL)
         self.last_init_retry = None
-        self.left_init_retries = instance.get('init_retries', DEFAULT_INIT_RETRIES) + 1
+        self.left_init_retries = init_config.get('init_retries', DEFAULT_INIT_RETRIES) + 1
         self.init_kubelet(instance)
 
         self.kube_label_prefix = instance.get('label_to_tag_prefix', KubeUtil.DEFAULT_LABEL_PREFIX)

--- a/utils/platform.py
+++ b/utils/platform.py
@@ -86,7 +86,10 @@ class Platform(object):
     @staticmethod
     def is_ecs_instance():
         from utils.dockerutil import DockerUtil
-        return DockerUtil().is_ecs()
+        try:
+            return DockerUtil().is_ecs()
+        except Exception:
+            return False
 
     @staticmethod
     def is_containerized():
@@ -95,17 +98,26 @@ class Platform(object):
     @staticmethod
     def is_k8s():
         from utils.dockerutil import DockerUtil
-        return DockerUtil().is_k8s()
+        try:
+            return DockerUtil().is_k8s()
+        except Exception:
+            return False
 
     @staticmethod
     def is_rancher():
         from utils.dockerutil import DockerUtil
-        return DockerUtil().is_rancher()
+        try:
+            return DockerUtil().is_rancher()
+        except Exception:
+            return False
 
     @staticmethod
     def is_swarm():
         from utils.dockerutil import DockerUtil
-        return DockerUtil().is_swarm()
+        try:
+            return DockerUtil().is_swarm()
+        except Exception:
+            return False
 
     @staticmethod
     def is_nomad():

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -297,12 +297,16 @@ class SDDockerBackend(AbstractSDBackend):
         tags = self.dockerutil.extract_container_tags(c_inspect)
 
         if Platform.is_k8s():
+            if not self.kubeutil.init_success:
+                log.warning("kubelet client not initialized, kubernetes tags will be missing.")
+                return tags
+
             pod_metadata = state.get_kube_config(c_id, 'metadata')
 
             if pod_metadata is None:
                 log.warning("Failed to fetch pod metadata for container %s."
-                            " Kubernetes tags may be missing." % c_id[:12])
-                return []
+                            " Kubernetes tags will be missing." % c_id[:12])
+                return tags
 
             # get pod labels
             kube_labels = pod_metadata.get('labels', {})

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -90,7 +90,7 @@ class SDDockerBackend(AbstractSDBackend):
 
         self.dockerutil = DockerUtil(config_store=self.config_store)
         self.kubeutil = None
-        if self.dockerutil.client and Platform.is_k8s():
+        if Platform.is_k8s():
             try:
                 self.kubeutil = KubeUtil()
             except Exception as ex:
@@ -112,8 +112,8 @@ class SDDockerBackend(AbstractSDBackend):
     def _make_fetch_state(self):
         pod_list = []
         if Platform.is_k8s():
-            if not self.kubeutil:
-                log.error("kubelet client not created, cannot retrieve pod list.")
+            if not self.kubeutil or not self.kubeutil.init_success:
+                log.error("kubelet client not initialized, cannot retrieve pod list.")
             else:
                 try:
                     pod_list = self.kubeutil.retrieve_pods_list().get('items', [])

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -182,7 +182,8 @@ class SDDockerBackend(AbstractSDBackend):
     def _get_host_address(self, state, c_id, tpl_var):
         """Extract the container IP from a docker inspect object, or the kubelet API."""
         c_inspect = state.inspect_container(c_id)
-        c_id, c_img = c_inspect.get('Id', ''), c_inspect.get('Config', {}).get('Image', '')
+        c_id = c_inspect.get('Id', '')
+        c_img = self.dockerutil.image_name_extractor(c_inspect)
 
         networks = c_inspect.get('NetworkSettings', {}).get('Networks') or {}
         ip_dict = {}


### PR DESCRIPTION
### What does this PR do?

Until now AD would fail if docker wasn't reachable.
This change make AD retry 5 times with a 15s interval
before failing to give docker a chance to start. Same for the kubelet.


### Motivation

user request

### Testing Guidelines

Updated related tests.

### Additional Notes

linked PR: https://github.com/DataDog/integrations-core/pull/722