### PR TITLE
[packaging] Release 5.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changes
 =======
 
-# 5.17.0 / Unreleased
+# 5.17.0 / 08-28-2017
 **Linux, Windows, Docker and Source Install**
 
 ### Details

--- a/config.py
+++ b/config.py
@@ -41,7 +41,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 
 # CONSTANTS
-AGENT_VERSION = "5.17.0"
+AGENT_VERSION = "5.18.0"
 JMX_VERSION = "0.16.0"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -11,7 +11,7 @@ set -u
 # SCRIPT KNOBS
 #######################################################################
 # Update for new releases, will pull this tag in the repo
-DEFAULT_AGENT_VERSION="5.16.0"
+DEFAULT_AGENT_VERSION="5.17.0"
 # Pin pip version, in the past there was some buggy releases and get-pip.py
 # always pulls the latest version
 PIP_VERSION="6.1.1"


### PR DESCRIPTION
* Source install version
* Changelog date
* Bump `AGENT_VERSION` in `config.py` for nightlies' versioning