### PR TITLE
Charly/adding docker inspect to flare

### DIFF
--- a/utils/flare.py
+++ b/utils/flare.py
@@ -50,7 +50,7 @@ from utils.hostname import get_hostname
 from utils.jmx import jmx_command, JMXFiles
 from utils.platform import Platform
 from utils.sdk import load_manifest
-from utils.configcheck import configcheck, sd_configcheck
+from utils.configcheck import configcheck, sd_configcheck, agent_container_inspect
 from utils.windows_configuration import get_sdk_integration_paths
 
 from utils.logger import DisableLoggerInit
@@ -177,6 +177,10 @@ class Flare(object):
         self._permissions_file.close()
         self._add_file_tar(self._permissions_file.name, 'permissions.log',
                            log_permissions=False)
+
+        # Only add docker inspect if dockerized agent
+        if Platform.is_containerized():
+            self._add_command_output_tar('docker_inspect.log', agent_container_inspect)
 
     # Set the proxy settings, if they exist
     def set_proxy(self, options):


### PR DESCRIPTION
### What does this PR do?

This PR adds the `docker inspect` of the Datadog containerized agent and redacts the API_KEY(s).
Placed as a separate file in the tar.bz2 called docker_inspect.log

### Motivation

When investigating, it's important to have a good grasp of the environment on top of the logs captured by the agent. With the inspect of the agent, it'll be easier to identify if the core components are correctly configured (socket, volumes, cgroups...)

### Testing Guidelines

Reproduction in my local environment.
Launching a flare in local creates the log correctly and it contains all the expected information.
