### PR TITLE
new docker_histo_striptags config option for use_histogram in checks

### DIFF
--- a/config.py
+++ b/config.py
@@ -374,7 +374,7 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
         'statsd_metric_namespace': None,
         'utf8_decoding': False,
         'apm_enabled': False,
-        'docker_histo_striptags': 'container_name,pod_name,kube_replica_set,kube_replication_controller',
+        'docker_histo_striptags': 'container_name,pod_name,kube_replica_set,kube_replication_controller,kube_pod-template-hash,kube_pod-template-generation',
     }
 
     if Platform.is_mac():

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -109,6 +109,10 @@ gce_updated_hostname: yes
 # histogram_aggregates: max, median, avg, count
 # histogram_percentiles: 0.95
 
+# Tags to remove When using the use_histogram option in the docker_daemon and
+# kubernetes integrations to reduce the metrics' cardinality
+# docker_histo_striptags: container_name,pod_name,kube_replica_set,kube_replication_controller
+
 # ========================================================================== #
 # Service Discovery                                                          #
 # See https://docs.datadoghq.com/guides/autodiscovery/ for details #

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -111,7 +111,7 @@ gce_updated_hostname: yes
 
 # Tags to remove When using the use_histogram option in the docker_daemon and
 # kubernetes integrations to reduce the metrics' cardinality
-# docker_histo_striptags: container_name,pod_name,kube_replica_set,kube_replication_controller
+# docker_histo_striptags: container_name,pod_name,kube_replica_set,kube_replication_controller,kube_pod-template-hash,kube_pod-template-generation
 
 # ========================================================================== #
 # Service Discovery                                                          #


### PR DESCRIPTION
### What does this PR do?

Sister PR for https://github.com/DataDog/integrations-core/pull/725, creates the `docker_histo_striptags` conf option and the helper `get_histogram_submit_methods` method.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

- Added `TestSubmitMethod` test class.
- The kube integration tests `test_historate_1_1` and `test_historate_1_2` use different `docker_histo_striptags` settings and should cover this feature for regressions.

### Additional Notes

Anything else we should know when reviewing?
