### PR TITLE
[k8s] Fix leader election's lease parameter and node name

### DIFF
--- a/tests/core/test_leader_elector.py
+++ b/tests/core/test_leader_elector.py
@@ -14,7 +14,7 @@ from utils.kubernetes.leader_elector import LeaderElector, \
 class TestLeaderElector(KubeTestCase):
     def test_is_cm_mine(self):
         elector = LeaderElector(self.kube)
-        self.kube.host_name = 'foo'
+        self.kube._node_name = 'foo'
 
         error_cm = [
             ({}, KeyError),
@@ -32,7 +32,7 @@ class TestLeaderElector(KubeTestCase):
 
     def test_build_update_cm_payload(self):
         now = datetime.datetime.utcnow()
-        self.kube.host_name = 'foo'
+        self.kube._node_name = 'foo'
         elector = LeaderElector(self.kube)
 
         cm = {
@@ -61,7 +61,7 @@ class TestLeaderElector(KubeTestCase):
 
     def test_build_create_cm_payload(self):
         now = datetime.datetime.utcnow()
-        self.kube.host_name = 'foo'
+        self.kube._node_name = 'foo'
         elector = LeaderElector(self.kube)
 
         cm = {

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -125,7 +125,7 @@ class KubeUtil:
         # leader status triggers event collection
         self.is_leader = False
         self.leader_elector = None
-        self.leader_lease_duration = instance.get('lease_duration')
+        self.leader_lease_duration = instance.get('leader_lease_duration')
 
         # kubelet
         # If kubelet_api_url is None, init_kubelet didn't succeed yet.

--- a/utils/kubernetes/leader_elector.py
+++ b/utils/kubernetes/leader_elector.py
@@ -198,7 +198,7 @@ class LeaderElector:
             'data': {},
             'metadata': {
                 'annotations': {
-                    CREATOR_ANNOTATION: self.kubeutil.host_name,
+                    CREATOR_ANNOTATION: self.kubeutil.get_node_info()[1],  # node name
                     ACQUIRE_TIME_ANNOTATION: datetime.datetime.strftime(now, "%Y-%m-%dT%H:%M:%S.%f")
                 },
                 'name': CM_NAME,
@@ -221,4 +221,4 @@ class LeaderElector:
         return pl
 
     def _is_cm_mine(self, cm):
-        return cm['metadata']['annotations'].get(CREATOR_ANNOTATION) == self.kubeutil.host_name
+        return cm['metadata']['annotations'].get(CREATOR_ANNOTATION) == self.kubeutil.get_node_info()[1]


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

- fix the lease duration param name
- use the node name instead of the pod name as the lock creator

### Motivation

node name as the lock creator allows to take over the lease in case an agent is killed an a new one is scheduled on the same node.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
