### PR TITLE
[docker] catch docker.errors.NotFound for nonexisting images

### DIFF
--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -598,8 +598,8 @@ class DockerUtil:
                         return name
                     except (LookupError, TypeError) as e:
                         log.debug("Failed finding image name in RepoTag and RepoDigests: %s", e)
-            except Exception:
-                log.error("Exception getting docker image name")
+            except Exception as ex:
+                log.error("Exception getting docker image name: %s" % str(ex))
         else:
             return image
 

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -12,6 +12,7 @@ import time
 
 # 3rd party
 from docker import Client, tls
+from docker.errors import NotFound
 
 # project
 from utils.singleton import Singleton
@@ -580,7 +581,10 @@ class DockerUtil:
                 if image in self._image_sha_to_name_mapping:
                     return self._image_sha_to_name_mapping[image]
                 else:
-                    image_spec = self.client.inspect_image(image)
+                    try:
+                        image_spec = self.client.inspect_image(image)
+                    except NotFound:
+                        return
                     try:
                         name = image_spec['RepoTags'][0]
                         self._image_sha_to_name_mapping[image] = name
@@ -595,7 +599,7 @@ class DockerUtil:
                     except (LookupError, TypeError) as e:
                         log.debug("Failed finding image name in RepoTag and RepoDigests: %s", e)
             except Exception:
-                log.exception("Exception getting docker image name")
+                log.error("Exception getting docker image name")
         else:
             return image
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Inspecting non existant images raise a NotFound error that spams the collector logs. This PR catches it and return None. If the image doesn't exist the process stops here.

### Motivation

Sometimes a container is stopped, and its image is forcibly removed. In this case when we try and extract the image info from the container, we hit a NotFound error that was not expected. Customers using Nomad seem to hit this issue often. Not sure if it's Nomad that force removes images, or users' scripts, but we can and should handle it.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
