### PR TITLE
[AgentCheck] Deprecate `read_config`

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -921,6 +921,8 @@ class AgentCheck(object):
 
     @staticmethod
     def read_config(instance, key, message=None, cast=None):
+        log.warning("Deprecation notice: the `read_config` method of `AgentCheck` is deprecated and will be removed " +
+            "in the next major version of the Agent")
         val = instance.get(key)
         if val is None:
             message = message or 'Must provide `%s` value in instance config' % key


### PR DESCRIPTION
### What does this PR do?

Deprecates `AgentCheck.read_config`.

### Motivation

It's only used in one check (kafka_consumer) and its usefulness in
AgentCheck is dubious IMO.

Related to https://github.com/DataDog/integrations-core/pull/733 (which removes the use of this method from the `kafka_consumer` check)
