### PR TITLE
[Core] Update the Main Credential regex to support

### DIFF
--- a/utils/flare.py
+++ b/utils/flare.py
@@ -94,13 +94,8 @@ class Flare(object):
     ]
     MAIN_CREDENTIALS = [
         CredentialPattern(
-            re.compile('^\s*api_key\s*[=, :]( *\w+(\w{5}) ?,?)+$'),
-            lambda matchobj:  'api_key: ' + ', '.join(map(
-                lambda key: '*' * 26 + key[-5:],
-                map(lambda x: x.strip(),
-                    matchobj.string.split("api_key")[1].split(',')
-                    )
-            )),
+            re.compile(r'^\s*api_key\s*[=, :]\s*\w{27}(\w{5})$'),
+            r'api_key: ***************************\1',
             'api_key'
         ),
         CredentialPattern(

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -93,7 +93,7 @@ class Flare(object):
         ),
     ]
     MAIN_CREDENTIALS = [
-         CredentialPattern(
+        CredentialPattern(
             re.compile('^\s*api_key\s*[=, :]( *\w+(\w{5}) ?,?)+$'),
             lambda matchobj:  'api_key: ' + ', '.join(map(
                 lambda key: '*' * 26 + key[-5:],

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -94,11 +94,11 @@ class Flare(object):
     ]
     MAIN_CREDENTIALS = [
         CredentialPattern(
-            re.compile('^\s*api_key:( *\w+(\w{5}) ?,?)+$'),
+            re.compile('^\s*api_key\s*[=, :]( *\w+(\w{5}) ?,?)+$'),
             lambda matchobj:  'api_key: ' + ', '.join(map(
                 lambda key: '*' * 26 + key[-5:],
                 map(lambda x: x.strip(),
-                    matchobj.string.split(':')[1].split(',')
+                    matchobj.string.split("api_key")[1].split(',')
                     )
             )),
             'api_key'

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -93,9 +93,14 @@ class Flare(object):
         ),
     ]
     MAIN_CREDENTIALS = [
-        CredentialPattern(
-            re.compile(r'^\s*api_key\s*[=, :]\s*\w{27}(\w{5})$'),
-            r'api_key: ***************************\1',
+         CredentialPattern(
+            re.compile('^\s*api_key\s*[=, :]( *\w+(\w{5}) ?,?)+$'),
+            lambda matchobj:  'api_key: ' + ', '.join(map(
+                lambda key: '*' * 26 + key[-5:],
+                map(lambda x: x.strip(),
+                    matchobj.string.split("api_key")[1].split(',')
+                    )
+            )),
             'api_key'
         ),
         CredentialPattern(


### PR DESCRIPTION
multiple types of API input in datadog.conf

*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Modified the regex used when checking for the API Key in datadog.conf or other locations. Currently we only support the syntax `api_key: <KEY>` However, this doesn't allow for a space before the `:` or using `api_key = <KEY>`

### Motivation

Currently the API key isn't being fully redacted in the flare if it doesn't use the aforementioned format. It seems like K8s Agents use the `=` syntax by default.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

Performed a series of manual tests locally based on the above syntaxes.

### Additional Notes

Anything else we should know when reviewing?

With this PR, the flare will be unsuccessful if the key is <YOUR_API_KEY_HERE> with a seemingly helpful message saying the API key is invalid. So the flare will not be sent at all, but the user sees this message. 


Initially attempted to remove lambdas to make it a bit cleaner, however this doesn't work for the case where there are multiple API keys, comma delimited. We would need another function to be called in the replacement piece that split the matched group into segments. 