### PR TITLE
move headers to utils folder, the last thing we still use from there

### DIFF
--- a/util.py
+++ b/util.py
@@ -52,6 +52,7 @@ def get_uuid():
 
 
 def headers(agentConfig, **kwargs):
+    log.warning("`util.headers` will be deprecated in Agent version 6. Please use `from utils.headers import headers`")
     # Build the request headers
     res = {
         'User-Agent': 'Datadog Agent/%s' % agentConfig['version'],

--- a/utils/headers.py
+++ b/utils/headers.py
@@ -1,0 +1,10 @@
+def headers(agentConfig, **kwargs):
+    # Build the request headers
+    res = {
+        'User-Agent': 'Datadog Agent/%s' % agentConfig['version'],
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'Accept': 'text/html, */*',
+    }
+    if 'http_host' in kwargs:
+        res['Host'] = kwargs['http_host']
+    return res


### PR DESCRIPTION
### What does this PR do?

utils.py should be deprecated. This will deprecate it for agent 6

Related PRs: 
https://github.com/DataDog/integrations-core/pull/743
https://github.com/DataDog/datadog-agent/pull/552