### PR TITLE
Move check_yaml to the utils folder

### DIFF
--- a/config.py
+++ b/config.py
@@ -26,7 +26,8 @@ from urlparse import urlparse
 import simplejson as json
 
 # project
-from util import check_yaml, config_to_yaml
+from util import config_to_yaml
+from utils.check_yaml import check_yaml
 from utils.platform import Platform, get_os
 from utils.proxy import get_proxy
 from utils.sdk import load_manifest

--- a/util.py
+++ b/util.py
@@ -101,25 +101,6 @@ def get_next_id(name):
     return current_id
 
 
-def check_yaml(conf_path):
-    with open(conf_path) as f:
-        check_config = yaml.load(f.read(), Loader=yLoader)
-        assert 'init_config' in check_config, "No 'init_config' section found"
-        assert 'instances' in check_config, "No 'instances' section found"
-
-        valid_instances = True
-        if check_config['instances'] is None or not isinstance(check_config['instances'], list):
-            valid_instances = False
-        else:
-            for i in check_config['instances']:
-                if not isinstance(i, dict):
-                    valid_instances = False
-                    break
-        if not valid_instances:
-            raise Exception('You need to have at least one instance defined in the YAML file for this check')
-        else:
-            return check_config
-
 def config_to_yaml(config):
     '''
     Convert a config dict to YAML

--- a/utils/check_yaml.py
+++ b/utils/check_yaml.py
@@ -1,0 +1,31 @@
+# (C) Datadog, Inc. 2010-2017
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+# 3p
+import yaml  # noqa, let's guess, probably imported somewhere
+try:
+    from yaml import CLoader as yLoader
+except ImportError:
+    # On source install C Extensions might have not been built
+    from yaml import Loader as yLoader  # noqa, imported from here elsewhere
+
+
+def check_yaml(conf_path):
+    with open(conf_path) as f:
+        check_config = yaml.load(f.read(), Loader=yLoader)
+        assert 'init_config' in check_config, "No 'init_config' section found"
+        assert 'instances' in check_config, "No 'instances' section found"
+
+        valid_instances = True
+        if check_config['instances'] is None or not isinstance(check_config['instances'], list):
+            valid_instances = False
+        else:
+            for i in check_config['instances']:
+                if not isinstance(i, dict):
+                    valid_instances = False
+                    break
+        if not valid_instances:
+            raise Exception('You need to have at least one instance defined in the YAML file for this check')
+        else:
+            return check_config

--- a/utils/checkfiles.py
+++ b/utils/checkfiles.py
@@ -5,7 +5,7 @@ import os
 from urlparse import urljoin
 
 # project
-from util import check_yaml
+from utils.check_yaml import check_yaml
 
 log = logging.getLogger(__name__)
 

--- a/utils/configcheck.py
+++ b/utils/configcheck.py
@@ -12,10 +12,10 @@ import simplejson as json
 
 # project
 from config import (
-    check_yaml,
     load_check_directory,
     get_confd_path
 )
+from utils.check_yaml import check_yaml
 from utils.hostname import get_hostname
 from utils.dockerutil import DockerUtil
 from utils.service_discovery.config_stores import get_config_store, SD_CONFIG_BACKENDS, TRACE_CONFIG

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -166,7 +166,7 @@ class DockerUtil:
 
     def get_check_config(self):
         """Read the config from docker_daemon.yaml"""
-        from util import check_yaml
+        from utils.check_yaml import check_yaml
         from utils.checkfiles import get_conf_path
         init_config, instances = {}, []
         try:

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -12,7 +12,7 @@ from urllib import urlencode
 from urlparse import urljoin
 
 # project
-from util import check_yaml
+from utils.check_yaml import check_yaml
 from utils.checkfiles import get_conf_path
 from utils.dockerutil import DockerUtil
 from utils.http import retrieve_json

--- a/utils/ntp.py
+++ b/utils/ntp.py
@@ -8,7 +8,7 @@ import random
 
 # project
 from config import get_confd_path
-from util import check_yaml
+from utils.check_yaml import check_yaml
 from utils.singleton import Singleton
 
 


### PR DESCRIPTION
### What does this PR do?

Move check_yaml to the utils folder.

### Motivation

This is to align shared code between the agent5 and agent6.
