### PR TITLE
wip - [Logs] Let the agent run logs-agent

### DIFF
--- a/packaging/supervisor.conf
+++ b/packaging/supervisor.conf
@@ -89,5 +89,16 @@ user=dd-agent
 autorestart=unexpected
 exitcodes=0
 
+[program:logs-agent]
+command=/opt/datadog-agent/bin/logs-agent --ddconfig /etc/dd-agent/conf.d
+stdout_logfile=/var/log/datadog/logs-agent.log
+stderr_logfile=/var/log/datadog/logs-agent.log
+startsecs=5
+startretries=3
+priority=997
+user=dd-agent
+autorestart=unexpected
+exitcodes=0
+
 [group:datadog-agent]
-programs=forwarder,collector,dogstatsd,jmxfetch,go-metro,trace-agent,process-agent
+programs=forwarder,collector,dogstatsd,jmxfetch,go-metro,trace-agent,process-agent,logs-agent


### PR DESCRIPTION
### What does this PR do?

Let supervisor start the logs-agent as part of dd-agent

### Motivation

We'd like to include the logs-agent as part of agent 5 for beta customers.

### Additional Notes

#### Related PRs

- https://github.com/DataDog/dd-agent-omnibus/pull/197 and https://github.com/DataDog/mars-jenkins-scripts/pull/75 - update build pipeline to include logs-agent binary when we want to

#### Notes

- We chose to **not always include the logs-agent binary in dd-agent**. We want to allow beta testers to test the logs-agent, but don't want to ship it to everybody, as the code is not open source (for now), and does not have a proper license (for now). I think we're fine embedding proprietary code for a package delivered only to beta users. Thoughts on that?
- The logs-agent expects some additional configuration to start. If not found, it will stop running (and have no impact at all). This means that even if the logs-agent is included in the dd-agent, it will only have an impact if proper configuration is found.
- This PR updates supervisor to run the logs-agent binary at startup. In most of the cases, the logs-agent binary won't be available, and supervisor will try 3 times and stop with an error message. I think we're fine with that, thoughts?

### Tests

- jenkins jobs: [1974](https://roy.datad0g.com/view/Croissant%20team/job/agent-trigger-circleci-builds/1974/) triggers the circle-ci builds including the logs-agent, [1975](https://roy.datad0g.com/view/Croissant%20team/job/agent-trigger-circleci-builds/1975/) triggers it without the logs-agent
- circle-ci builds: [2165](https://circleci.com/gh/DataDog/docker-dd-agent-build-deb-x64/2165) builds the dd-agent with the logs-agent, [2166](https://circleci.com/gh/DataDog/docker-dd-agent-build-deb-x64/2166) builds it without the logs-agent. their artifacts are saved and can be downloaded.

#### Tests the logs-agent included but disabled on a vm

- provision a `ubuntu/trusty64` vagrant box
- download the deb package: `wget https://2165-34269086-gh.circle-artifacts.com/0/home/ubuntu/docker-dd-agent-build-deb-x64/pkg/datadog-agent_5.18.0.git.19.835e728-1_amd64.deb -O datadog-agent5-with-logs.deb`
- configure the dd-agent: in `/etc/dd-agent/datadog.conf`
  ```
  [Main]
  dd_url: https://app.datadoghq.com
  api_key: <api_key>
  ```
- install the package: `sudo dpkg -i datadog-agent5-with-logs.deb`

#### Tests the logs-agent included and enabled on a vm

- start from previous step
- 

#### Tests the logs-agent not included on a vm

- provision a `ubuntu/trusty64` vagrant box
- download the deb package: `wget https://2166-34269086-gh.circle-artifacts.com/0/home/ubuntu/docker-dd-agent-build-deb-x64/pkg/datadog-agent_5.18.0.git.19.835e728-1_amd64.deb -O datadog-agent5-without-logs.deb`

### Next steps

- Answer questions that this PR raises (is it ok to embed proprietary code for a specific version of the agent - is it ok not to have a license)
- Release a new dd-agent (with a specific tag) including the logs-agent
- Logs-agent has been in QA on our own infra. We now need to QA the built agent5 embedding the logs-agent
