### PR TITLE
[Logs] Let the agent run logs-agent

### DIFF
--- a/packaging/supervisor.conf
+++ b/packaging/supervisor.conf
@@ -89,5 +89,16 @@ user=dd-agent
 autorestart=unexpected
 exitcodes=0
 
+[program:logs-agent]
+command=/opt/datadog-agent/bin/logs-agent --ddconfig /etc/dd-agent/conf.d
+stdout_logfile=/var/log/datadog/logs-agent.log
+stderr_logfile=/var/log/datadog/logs-agent.log
+startsecs=5
+startretries=3
+priority=997
+user=dd-agent
+autorestart=unexpected
+exitcodes=0
+
 [group:datadog-agent]
-programs=forwarder,collector,dogstatsd,jmxfetch,go-metro,trace-agent,process-agent
+programs=forwarder,collector,dogstatsd,jmxfetch,go-metro,trace-agent,process-agent,logs-agent


### PR DESCRIPTION
### What does this PR do?

Let supervisor start the logs-agent as part of dd-agent.
Use this only for a custom built of 5.17.x agent (we do not want to merge in master)

### Motivation

We'd like to include the logs-agent as part of agent 5 for beta customers.

### Additional Notes

#### Related PRs

- https://github.com/DataDog/dd-agent-omnibus/pull/198 - update build pipeline to include logs-agent binary when we want to
- https://github.com/DataDog/dd-agent/pull/3522 - Merge this code into `5.17.x-logbeta`

#### Notes

- We chose to **not always include the logs-agent binary in dd-agent**. We want to allow beta testers to test the logs-agent, but don't want to ship it to everybody, as the code is not open source (for now), and does not have a proper license (for now). I think we're fine embedding proprietary code for a package delivered only to beta users. Thoughts on that?
- The logs-agent expects some additional configuration to start. If not found, it will stop running (and have no impact at all). This means that even if the logs-agent is included in the dd-agent, it will only have an impact if proper configuration is found.

### Tests

- jenkins jobs: [1984](https://roy.datad0g.com/view/Croissant%20team/job/agent-trigger-circleci-builds/1984/) triggers the circle-ci builds including the logs-agent
- circle-ci builds: [2178](https://circleci.com/gh/DataDog/docker-dd-agent-build-deb-x64/2178) builds the dd-agent with the logs-agent, its artifacts are saved and can be downloaded.

#### Tests the logs-agent included but disabled on a vm

- provision a `ubuntu/trusty64` vagrant box
- download the deb package: `wget https://2178-34269086-gh.circle-artifacts.com/0/home/ubuntu/docker-dd-agent-build-deb-x64/pkg/datadog-agent_5.17.1.git.1.42f7b64-1_amd64.deb -O datadog-agent5-with-logs.deb`
- configure the dd-agent: in `/etc/dd-agent/datadog.conf`
  ```
  [Main]
  dd_url: https://app.datadoghq.com
  api_key: <api_key>
  ```
- install the package: `sudo dpkg -i datadog-agent5-with-logs.deb`
- assert dd-agent is up and running: `sudo service datadog-agent info`
- assert it reports metrics in datadog
- assert logs-agent is not running: `tail /var/log/datadog/logs-agent.log`
  ```
  2017/09/15 07:43:37 Starting logs-agent
  2017/09/15 07:43:37 Config File "logs-agent" Not Found in "[/etc/dd-agent/conf.d]"
  2017/09/15 07:43:37 logs-agent disabled
  ```

#### Tests the logs-agent included and enabled on a vm

- start from previous step
- setup proper configuration for the logs agent. See [internal doc](https://docs.google.com/document/d/1CNQg2hNaIn0WNJT9kTXuQAnhUO7qaeepaxpLclzBtfg/edit#heading=h.do7z5blfmc73) or ping #ramen. You should setup `/etc/dd-agent/conf.d/logs-agent.yaml` and `/etc/dd-agent/conf.d/logs-integrations.yaml`
- restart dd-agent: `sudo service datadog-agent restart`
- assert logs-agent is up and running: `tail /var/log/datadog/logs-agent.log`
  ```
  2017/09/15 08:04:38 Starting logs-agent
  2017/09/15 08:04:38 open /opt/datadog-agent/run/registry.json: no such file or directory
  2017/09/15 08:04:38 Starting TCP forwarder on port 10514
  2017/09/15 08:04:38 Opening /home/vagrant/test.log
  ```
  Note: the TCP line means that in integrations I setup tcp on port 10514, the Opening line means I am tailing a file
- assert that it works as expected by submitting logs lines:
  ```
  echo "hello" >> test.log
  tail /var/log/datadog/logs-agent.log
  2017/09/15 08:07:30 Connecting to the backend: intake.sheepdog.datad0g.com:10514 - skip_ssl_validation: true
  ```
  assert the log line appears in your logset

### Next steps

- Answer questions that this PR raises (is it ok to embed proprietary code for a specific version of the agent - is it ok not to have a license)
- Release a new dd-agent (with a specific tag) including the logs-agent
- Logs-agent has been in QA on our own infra. We now need to QA the built agent5 embedding the logs-agent
