### PR TITLE
do not crash if ENV in CONF is None

### DIFF
--- a/utils/orchestrator/mesosutil.py
+++ b/utils/orchestrator/mesosutil.py
@@ -32,6 +32,7 @@ class MesosUtil(BaseUtil):
         envvars = co.get('Config', {}).get('Env', {})
         if not envvars:
             return tags
+
         for var in envvars:
             if var.startswith(MARATHON_APP_ID):
                 tags.append('marathon_app:%s' % var[len(MARATHON_APP_ID) + 1:])

--- a/utils/orchestrator/mesosutil.py
+++ b/utils/orchestrator/mesosutil.py
@@ -30,7 +30,8 @@ class MesosUtil(BaseUtil):
     def _get_cacheable_tags(self, cid, co=None):
         tags = []
         envvars = co.get('Config', {}).get('Env', {})
-
+        if not envvars:
+            return tags
         for var in envvars:
             if var.startswith(MARATHON_APP_ID):
                 tags.append('marathon_app:%s' % var[len(MARATHON_APP_ID) + 1:])

--- a/utils/orchestrator/nomadutil.py
+++ b/utils/orchestrator/nomadutil.py
@@ -24,6 +24,9 @@ class NomadUtil(BaseUtil):
     def _get_cacheable_tags(self, cid, co=None):
         tags = []
         envvars = co.get('Config', {}).get('Env', {})
+        if not envvars:
+            return tags
+
         for var in envvars:
             if var.startswith(NOMAD_TASK_NAME):
                 tags.append('nomad_task:%s' % var[len(NOMAD_TASK_NAME) + 1:])


### PR DESCRIPTION
### What does this PR do?

If envvar is NoneType, we want to return the tags directly instead of crashing.

### Motivation

Support case brought up by the community.

### Testing Guidelines

Set up a DCOS cluster v 1.9.2, deployed the agent running 5.17.2 and witnessed the successful auto discovery of a redis container along with the collection of Mesos/Marathon specific tags.