### PR TITLE
[Core] Update the normalize to also convert @ symbol to _

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -93,7 +93,7 @@ class Check(object):
         """Turn a metric into a well-formed metric name
         prefix.b.c
         """
-        name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", metric)
+        name = re.sub(r"[,\@\+\*\-/()\[\]{}\s]", "_", metric)
         # Eliminate multiple _
         name = re.sub(r"__+", "_", name)
         # Don't start/end with _

--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -889,7 +889,7 @@ class AgentCheck(object):
             if prefix is not None:
                 prefix = self.convert_to_underscore_separated(prefix)
         else:
-            name = re.sub(r"[,\+\*\-/()\[\]{}\s]", "_", metric_name)
+            name = re.sub(r"[,\@\+\*\-/()\[\]{}\s]", "_", metric_name)
         # Eliminate multiple _
         name = re.sub(r"__+", "_", name)
         # Don't start/end with _

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -106,6 +106,7 @@ class TestCore(unittest.TestCase):
         self.assertEquals(self.c.normalize("__metric__", "prefix"), "prefix.metric")
         self.assertEquals(self.c.normalize("abc.metric(a+b+c{}/5)", "prefix"), "prefix.abc.metric_a_b_c_5")
         self.assertEquals(self.c.normalize("VBE.default(127.0.0.1,,8080).happy", "varnish"), "varnish.VBE.default_127.0.0.1_8080.happy")
+        self.assertEquals(self.c.normalize("metric@device"), "metric_device")
 
         # Same tests for the AgentCheck
         self.setUpAgentCheck()
@@ -114,6 +115,7 @@ class TestCore(unittest.TestCase):
         self.assertEquals(self.ac.normalize("__metric__", "prefix"), "prefix.metric")
         self.assertEquals(self.ac.normalize("abc.metric(a+b+c{}/5)", "prefix"), "prefix.abc.metric_a_b_c_5")
         self.assertEquals(self.ac.normalize("VBE.default(127.0.0.1,,8080).happy", "varnish"), "varnish.VBE.default_127.0.0.1_8080.happy")
+        self.assertEquals(self.ac.normalize("metric@device"), "metric_device")
 
         self.assertEqual(self.ac.normalize("PauseTotalNs", "prefix", fix_case = True), "prefix.pause_total_ns")
         self.assertEqual(self.ac.normalize("Metric.wordThatShouldBeSeparated", "prefix", fix_case = True), "prefix.metric.word_that_should_be_separated")


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Some device names can have the `@` symbol in them. This PR converts that symbol to a `_` using the standard normalize method.

### Motivation

Since some deice names can have this symbol, and we aren't currently sanitizing, it can cause undesired behaviour in the UI, since its not one of our supported tag chars. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

This is to go along with an integrations core PR for the disk check so that can use this updated normalize method.