### PR TITLE
Docker_daemon puts tags ECS's task-id (task:arn)

### DIFF
--- a/tests/core/test_ecsutil.py
+++ b/tests/core/test_ecsutil.py
@@ -23,11 +23,16 @@ class TestECSUtil(unittest.TestCase):
         util.agent_url = 'http://dummy'
 
         mock_get.reset_mock()
-        mock_get.return_value = MockResponse({"Tasks": [{"Family": "dd-agent-latest", "Version": "12",
-                                                         "Containers": [{"DockerId": CO_ID}]}]}, 200)
+        mock_get.return_value = MockResponse(
+            {"Tasks": [{"Arn": "arn:aws:ecs:us-east-1:123456789012:task/11111111-2222-3333-4444-123456789012",
+                        "Family": "dd-agent-latest", "Version": "12",
+                        "Containers": [{"DockerId": CO_ID}]}]}, 200)
 
         tags = util._get_cacheable_tags(CO_ID)
-        self.assertEqual(['task_name:dd-agent-latest', 'task_version:12'], tags)
+        self.assertEqual([
+            'task_arn:arn:aws:ecs:us-east-1:123456789012:task/11111111-2222-3333-4444-123456789012',
+            'task_name:dd-agent-latest',
+            'task_version:12'], tags)
         mock_get.assert_called_once_with('http://dummy/v1/tasks', timeout=1)
 
     @mock.patch('requests.get')

--- a/utils/orchestrator/ecsutil.py
+++ b/utils/orchestrator/ecsutil.py
@@ -86,7 +86,9 @@ class ECSUtil(BaseUtil):
                     if skip_known and cid in self.ecs_tags:
                         continue
 
-                    tags = ['task_name:%s' % task['Family'], 'task_version:%s' % task['Version']]
+                    tags = ['task_name:%s' % task['Family'],
+                            'task_version:%s' % task['Version'],
+                            'task_arn:%s' % task['Arn']]
                     self.ecs_tags[container['DockerId']] = tags
         except requests.exceptions.HTTPError as ex:
             self.log.warning("Unable to collect ECS task names: %s" % ex)

--- a/utils/orchestrator/ecsutil.py
+++ b/utils/orchestrator/ecsutil.py
@@ -86,9 +86,9 @@ class ECSUtil(BaseUtil):
                     if skip_known and cid in self.ecs_tags:
                         continue
 
-                    tags = ['task_name:%s' % task['Family'],
-                            'task_version:%s' % task['Version'],
-                            'task_arn:%s' % task['Arn']]
+                    tags = ['task_arn:%s' % task['Arn'],
+                            'task_name:%s' % task['Family'],
+                            'task_version:%s' % task['Version']]
                     self.ecs_tags[container['DockerId']] = tags
         except requests.exceptions.HTTPError as ex:
             self.log.warning("Unable to collect ECS task names: %s" % ex)


### PR DESCRIPTION
### What does this PR do?

Via docker_daemon with ecs orchestration, put ecs's task-id (=task-arn) as a tag.

### Motivation

We want to draining ecs tasks that contains NG container.
Now, I found NG container's name & instance-id, but no task-id(arn). 

### Testing Guidelines

Unit test, `tests/core/test_ecsutil.py` passed `nosetests tests/core/test_ecsutil.py` 
No config-file change.

### Additional Notes

