### PR TITLE
Added: env var for config path override

### DIFF
--- a/config.py
+++ b/config.py
@@ -238,6 +238,11 @@ def get_config_path(cfg_path=None, os_name=None):
     if cfg_path is not None and os.path.exists(cfg_path):
         return cfg_path
 
+    env_path_override = os.environ.get('DD_CONF_PATH')
+
+    if env_path_override is not None and os.path.exists(env_path_override):
+        return env_path_override
+
     # Check if there's a config stored in the current agent directory
     try:
         path = os.path.realpath(__file__)


### PR DESCRIPTION
### What does this PR do?

Adds a way to specify a separate path for a config file.

### Motivation

Would like to manage the config file at a separate location from the default.

Specifically, I would like to mount the config file to a container separate from the whole directory. I cannot create a separate docker image with a config file baked in since it needs to be templated at runtime dependent on what the host is. This is managed by the CM tool at the moment.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

I am happy to write tests if there's some sort of acceptance on the approach going forward.

### Additional Notes

I am not sure if
* this is the best place to make this change (it seemed like it)
* there will be any interference with a variable of the same name in `dogstatsd`. I see that we leverage `os.environ` to fetch the variable there and thought injecting it here may help in defining that. Happy to work in a different place if my assumptions are incorrect.