### PR TITLE
Redact sensitive infos in config dumps

### DIFF
--- a/utils/configcheck.py
+++ b/utils/configcheck.py
@@ -90,7 +90,8 @@ def get_sd_configcheck(agentConfig, configs):
         Also print containers detected by the agent and templates from the config store."""
     print("\nSource of the configuration objects built by the agent:\n")
     for check_name, config in configs.iteritems():
-        print('Check "%s":\n  source --> %s\n  config --> %s\n' % (check_name, config[0], config[1]))
+        print('Check "%s":\n  source --> %s\n  config --> %s\n' %
+              (check_name, config[0], json.dumps(config[1], indent=2)))
 
     try:
         print_containers()
@@ -131,8 +132,8 @@ def print_templates(agentConfig):
             print(
                 "- Identifier %s:\n\tcheck names: %s\n\tinit_configs: %s\n\tinstances: %s" % (
                     ident,
-                    tpl.get('check_names'),
-                    tpl.get('init_configs'),
-                    tpl.get('instances'),
+                    json.dumps(json.loads(tpl.get('check_names')), indent=2),
+                    json.dumps(json.loads(tpl.get('init_configs')), indent=2),
+                    json.dumps(json.loads(tpl.get('instances')), indent=2),
                 )
             )

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -71,6 +71,12 @@ class Flare(object):
 
     CredentialPattern = namedtuple('CredentialPattern', ['pattern', 'replacement', 'label'])
     CHECK_CREDENTIALS = [
+        # We will parse either a yaml file, or a json.dumps of a config. For the latter, we
+        # need to account for the quote signs printed by the dump.
+        # For example, we can either get:
+        #   password: foo    # if we parse the yaml file
+        # or
+        #   "password": "foo"   # if we parse the json.dumps
         CredentialPattern(
             re.compile('( *"?(\w|_)*pass(word)?"?:).+'),
             r'\1 ********',

--- a/utils/flare.py
+++ b/utils/flare.py
@@ -72,22 +72,22 @@ class Flare(object):
     CredentialPattern = namedtuple('CredentialPattern', ['pattern', 'replacement', 'label'])
     CHECK_CREDENTIALS = [
         CredentialPattern(
-            re.compile('( *(\w|_)*pass(word)?:).+'),
+            re.compile('( *"?(\w|_)*pass(word)?"?:).+'),
             r'\1 ********',
             'password'
         ),
         CredentialPattern(
-            re.compile('( *(\w|_)*token:).+'),
+            re.compile('( *"?(\w|_)*token"?:).+'),
             r'\1 ********',
             'access token'
         ),
         CredentialPattern(
-            re.compile('(.*\ [A-Za-z0-9]+)\:\/\/([A-Za-z0-9_]+)\:(.+)\@'),
+            re.compile('(.*\ "?[A-Za-z0-9]+)\:\/\/([A-Za-z0-9_]+)\:(.+)\@'),
             r'\1://\2:********@',
             'password in a uri'
         ),
         CredentialPattern(
-            re.compile('^(\s*community_string:) *.+$'),
+            re.compile('(\s*"?community_string"?:).+'),
             r'\1 ********',
             'SNMP community string'
         ),
@@ -518,7 +518,8 @@ class Flare(object):
             temp_file.write(">>>> STDERR <<<<\n")
             temp_file.write(err.getvalue())
             err.close()
-        self._add_file_tar(temp_path, name, log_permissions=False)
+        temp_path2, log = self._strip_credentials(temp_path, self.CHECK_CREDENTIALS)
+        self._add_file_tar(temp_path2, name, log_permissions=False)
         os.remove(temp_path)
 
     # Capture the output of a command (from both std streams and loggers) and the


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Redact sensitive infos in config dumps performed by the SD config check

### Additional Notes

Using `json.dumps` makes a pretty printing of the configs, which puts each configuration parameter on a new line, thus making it easy to redact using the existing mechanism of the flare. Only a small modification of the regexes was needed to account for the double quote signs that the dump prints around each parameter