### PR TITLE
[windows] Fix problem with non-English Windows.

### DIFF
--- a/checks/libs/win/winpdh.py
+++ b/checks/libs/win/winpdh.py
@@ -1,17 +1,43 @@
 import time
 import win32pdh
+import _winreg
 
 DATA_POINT_INTERVAL = 0.01
 
 class WinPDHCounter(object):
+    # store the dictionary of pdh counter names
+    pdh_counter_dict = {}
+
     def __init__(self, class_name, instance_name):
-        self._class_name = class_name
-        self._instance_name = instance_name
+        self._get_counter_dictionary()
+        self._class_name = win32pdh.LookupPerfNameByIndex(None, int(WinPDHCounter.pdh_counter_dict[class_name]))
+        self._instance_name = win32pdh.LookupPerfNameByIndex(None, int(WinPDHCounter.pdh_counter_dict[instance_name]))
         self.hq = win32pdh.OpenQuery()
 
     def __del__(self):
         if(self.hq):
             win32pdh.CloseQuery(self.hq)
+
+    def _get_counter_dictionary(self):
+        if WinPDHCounter.pdh_counter_dict:
+            # already populated
+            return
+
+        try:
+            val, t = _winreg.QueryValueEx(_winreg.HKEY_PERFORMANCE_DATA, "Counter 009")
+        except Exception as e:
+            print "Exception %s" % str(e)
+            raise
+
+        # create a table of the keys to the counter index, because we want to look up
+        # by counter index.
+        idx = 0
+        idx_max = len(val)
+        while idx < idx_max:
+            WinPDHCounter.pdh_counter_dict[val[idx+1]] = val[idx]
+            idx += 2
+
+
 
 class WinPDHSingleCounter(WinPDHCounter):
     def __init__(self, class_name, instance_name):


### PR DESCRIPTION
Many PDH counter names are localized.  However, there's a translation
table in the registry.  Implements the lookup table so agent runs on
non-English windows