### PR TITLE
Remove access to deprecated top-level bridge NetworkSettings

### DIFF
--- a/tests/core/test_ecsutil.py
+++ b/tests/core/test_ecsutil.py
@@ -39,7 +39,7 @@ class TestECSUtil(unittest.TestCase):
         mock_init.return_value = None
         mock_gw.return_value = "10.0.2.2"
 
-        mock_inspect.return_value = {'NetworkSettings': {'IPAddress': '10.0.0.42',
+        mock_inspect.return_value = {'NetworkSettings': {'Networks': {'bridge': {'IPAddress': '10.0.0.42'}},
                                                          'Ports': {'1234/tcp': '1234/tcp'}}}
 
         probe_calls = [mock.call('http://10.0.0.42:1234/', timeout=1),

--- a/tests/core/test_service_discovery.py
+++ b/tests/core/test_service_discovery.py
@@ -245,18 +245,14 @@ class TestServiceDiscovery(unittest.TestCase):
             ({'NetworkSettings': {}}, 'host', None),
             ({'NetworkSettings': {'IPAddress': ''}}, 'host', None),
 
-            ({'NetworkSettings': {'IPAddress': '127.0.0.1'}}, 'host', '127.0.0.1'),
-            ({'NetworkSettings': {'IPAddress': '127.0.0.1', 'Networks': {}}}, 'host', '127.0.0.1'),
+            ({'NetworkSettings': {'Networks': {'bridge': {'IPAddress': '127.0.0.1'}}}}, 'host', '127.0.0.1'),
             ({'NetworkSettings': {
-                'IPAddress': '127.0.0.1',
                 'Networks': {'bridge': {'IPAddress': '127.0.0.1'}}}},
              'host', '127.0.0.1'),
             ({'NetworkSettings': {
-                'IPAddress': '',
                 'Networks': {'bridge': {'IPAddress': '127.0.0.1'}}}},
              'host_bridge', '127.0.0.1'),
             ({'NetworkSettings': {
-                'IPAddress': '127.0.0.1',
                 'Networks': {
                     'bridge': {'IPAddress': '172.17.0.2'},
                     'foo': {'IPAddress': '192.168.0.2'}}}},
@@ -405,10 +401,6 @@ class TestServiceDiscovery(unittest.TestCase):
             # ((inspect, instance_tpl, variables, tags), (expected_instance_tpl, expected_var_values))
             (({}, {'host': 'localhost'}, [], None), ({'host': 'localhost'}, {})),
             (
-                ({'NetworkSettings': {'IPAddress': ''}}, {'host': 'localhost'}, [], None),
-                ({'host': 'localhost'}, {})
-            ),
-            (
                 ({'NetworkSettings': {'Networks': {}}}, {'host': 'localhost'}, [], None),
                 ({'host': 'localhost'}, {})
             ),
@@ -417,18 +409,7 @@ class TestServiceDiscovery(unittest.TestCase):
                 ({'host': 'localhost'}, {})
             ),
             (
-                ({'NetworkSettings': {'IPAddress': '127.0.0.1'}},
-                 {'host': '%%host%%', 'port': 1337}, ['host'], ['foo', 'bar:baz']),
-                ({'host': '%%host%%', 'port': 1337, 'tags': ['foo', 'bar:baz']}, {'host': '127.0.0.1'}),
-            ),
-            (
-                ({'NetworkSettings': {'IPAddress': '127.0.0.1', 'Networks': {}}},
-                 {'host': '%%host%%', 'port': 1337}, ['host'], ['foo', 'bar:baz']),
-                ({'host': '%%host%%', 'port': 1337, 'tags': ['foo', 'bar:baz']}, {'host': '127.0.0.1'}),
-            ),
-            (
                 ({'NetworkSettings': {
-                    'IPAddress': '127.0.0.1',
                     'Networks': {'bridge': {'IPAddress': '172.17.0.2'}}}
                   },
                  {'host': '%%host%%', 'port': 1337}, ['host'], ['foo', 'bar:baz']),
@@ -436,7 +417,6 @@ class TestServiceDiscovery(unittest.TestCase):
             ),
             (
                 ({'NetworkSettings': {
-                    'IPAddress': '',
                     'Networks': {
                         'bridge': {'IPAddress': '172.17.0.2'},
                         'foo': {'IPAddress': '192.168.0.2'}
@@ -448,7 +428,6 @@ class TestServiceDiscovery(unittest.TestCase):
             ),
             (
                 ({'NetworkSettings': {
-                    'IPAddress': '',
                     'Networks': {
                         'bridge': {'IPAddress': '172.17.0.2'},
                         'foo': {'IPAddress': '192.168.0.2'}
@@ -459,14 +438,14 @@ class TestServiceDiscovery(unittest.TestCase):
                  {'host_foo': '192.168.0.2'}),
             ),
             (
-                ({'NetworkSettings': {'IPAddress': '127.0.0.1', 'Ports': {'42/tcp': None, '22/tcp': None}}},
+                ({'NetworkSettings': {'Networks': {'bridge': {'IPAddress': '127.0.0.1'}}, 'Ports': {'42/tcp': None, '22/tcp': None}}},
                  {'host': '%%host%%', 'port': '%%port_1%%', 'tags': ['env:test']},
                  ['host', 'port_1'], ['foo', 'bar:baz']),
                 ({'host': '%%host%%', 'port': '%%port_1%%', 'tags': ['env:test', 'foo', 'bar:baz']},
                  {'host': '127.0.0.1', 'port_1': '42'})
             ),
             (
-                ({'NetworkSettings': {'IPAddress': '127.0.0.1', 'Ports': {'42/tcp': None, '22/tcp': None}}},
+                ({'NetworkSettings': {'Networks': {'bridge': {'IPAddress': '127.0.0.1'}}, 'Ports': {'42/tcp': None, '22/tcp': None}}},
                  {'host': '%%host%%', 'port': '%%port_1%%', 'tags': {'env': 'test'}},
                  ['host', 'port_1'], ['foo', 'bar:baz']),
                 ({'host': '%%host%%', 'port': '%%port_1%%', 'tags': ['env:test', 'foo', 'bar:baz']},
@@ -481,7 +460,6 @@ class TestServiceDiscovery(unittest.TestCase):
             # specify bridge but there is also a default IPAddress (networks should be preferred)
             (
                 ({'NetworkSettings': {
-                    'IPAddress': '127.0.0.1',
                     'Networks': {'bridge': {'IPAddress': '172.17.0.2'}}}},
                  {'host': '%%host_bridge%%', 'port': 1337}, ['host_bridge'], ['foo', 'bar:baz']),
                 ({'host': '%%host_bridge%%', 'port': 1337, 'tags': ['foo', 'bar:baz']},
@@ -490,7 +468,6 @@ class TestServiceDiscovery(unittest.TestCase):
             # specify index but there is a default IPAddress (there's a specifier, even if it's wrong, walking networks should be preferred)
             (
                 ({'NetworkSettings': {
-                    'IPAddress': '127.0.0.1',
                     'Networks': {'bridge': {'IPAddress': '172.17.0.2'}}}},
                  {'host': '%%host_0%%', 'port': 1337}, ['host_0'], ['foo', 'bar:baz']),
                 ({'host': '%%host_0%%', 'port': 1337, 'tags': ['foo', 'bar:baz']}, {'host_0': '172.17.0.2'}),
@@ -505,7 +482,7 @@ class TestServiceDiscovery(unittest.TestCase):
             ),
             # missing index for port
             (
-                ({'NetworkSettings': {'IPAddress': '127.0.0.1', 'Ports': {'42/tcp': None, '22/tcp': None}}},
+                ({'NetworkSettings': {'Networks': {'bridge': {'IPAddress': '127.0.0.1'}}, 'Ports': {'42/tcp': None, '22/tcp': None}}},
                  {'host': '%%host%%', 'port': '%%port_2%%', 'tags': ['env:test']},
                  ['host', 'port_2'], ['foo', 'bar:baz']),
                 ({'host': '%%host%%', 'port': '%%port_2%%', 'tags': ['env:test', 'foo', 'bar:baz']},

--- a/utils/orchestrator/ecsutil.py
+++ b/utils/orchestrator/ecsutil.py
@@ -45,7 +45,7 @@ class ECSUtil(BaseUtil):
 
         # Try to detect the ecs-agent container's IP (net=bridge)
         ecs_config = self.docker_util.inspect_container('ecs-agent')
-        ip = ecs_config.get('NetworkSettings', {}).get('IPAddress')
+        ip = ecs_config.get('NetworkSettings', {}).get('Networks', {}).get('bridge', {}).get('IPAddress')
         if ip:
             ports = ecs_config.get('NetworkSettings', {}).get('Ports')
             port = ports.keys()[0].split('/')[0] if ports else str(ECS_AGENT_DEFAULT_PORT)

--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -195,13 +195,6 @@ class SDDockerBackend(AbstractSDBackend):
         if ip_addr:
             return ip_addr
 
-        # try to get the bridge (default) IP address
-        log.debug("No IP address was found in container %s (%s) "
-            "networks, trying with the IPAddress field" % (c_id[:12], c_img))
-        ip_addr = c_inspect.get('NetworkSettings', {}).get('IPAddress')
-        if ip_addr:
-            return ip_addr
-
         if Platform.is_k8s():
             # kubernetes case
             log.debug("Couldn't find the IP address for container %s (%s), "


### PR DESCRIPTION
### What does this PR do?

This PR removes access to deprecated top-level bridge NetworkSettings from Docker and update test fixtures

### Motivation

Top-level bridge NetworkSettings were deprecated by Docker since 1.13 and will be removed in future versions (see https://github.com/moby/moby/pull/28437) 

