### PR TITLE
Fix 'Unable to get file_handles metrics' in FileHandles handles unix check

### DIFF
--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -232,7 +232,7 @@ class FileHandles(Check):
             proc_location = agentConfig.get('procfs_path', '/proc').rstrip('/')
             proc_fh = "{}/sys/fs/file-nr".format(proc_location)
             with open(proc_fh, 'r') as file_handle:
-                handle_contents = file_handle.read()
+                handle_contents = file_handle.readline()
         except Exception:
             self.logger.exception("Cannot extract system file handles stats")
             return False


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?
On a centos 7.3 system with dd agent running in alpine-latest we get flooded with errors like 'Unable to get file_handles metrics'. After some debugging I found out that file.read only returns the first number of the file content from /proc/sys/fs/file-nr
The code then expects to have 3 numbers after calling split which fails. 
I don't know why read only returns the first number here (it should return the complete file content), maybe some magic or based on the fact that it's a pseudo file, but readline actually returns the correct line. read(256) does it too, but since the content is in one line readline makes more sense to me here.


### Motivation

What inspired you to submit this pull request?
Too many errors in the log files.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
