### PR TITLE
Revert "Added Percentage Free Memory Stats (#3472)"

### DIFF
--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -407,7 +407,6 @@ class Memory(Check):
 
                 if memData['physTotal'] > 0:
                     memData['physPctUsable'] = float(memData['physUsable']) / float(memData['physTotal'])
-                    memData['physPctFree'] = float(memData['physFree']) / float(memData['physTotal'])
             except Exception:
                 self.logger.exception('Cannot compute stats from %s', proc_meminfo)
 


### PR DESCRIPTION
### What does this PR do?

Reverts the code introduced in #3472. 

The change does not cause the metric to be submitted. It doesn't get included in the payload in the collector. And even then as it's submitted as a system metric in the payload, and not via a regular gauge, the backend is not prepared to handle it. 

On top of it, it's probably a less helpful metric than physPctUsable which takes into account the page caching, etc... which is in fact usable memory. So I feel like we don't lose value by reverting.

### Motivation

Found issue while testing.

