### PR TITLE
[setup-script] bump default version to 5.18.0

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -11,7 +11,7 @@ set -u
 # SCRIPT KNOBS
 #######################################################################
 # Update for new releases, will pull this tag in the repo
-DEFAULT_AGENT_VERSION="5.17.2"
+DEFAULT_AGENT_VERSION="5.18.0"
 # Pin pip version, in the past there was some buggy releases and get-pip.py
 # always pulls the latest version
 PIP_VERSION="6.1.1"


### PR DESCRIPTION

### What does this PR do?

Bumps the source install to `5.18.0`.

### Motivation

New release.
