### PR TITLE
[config] bump to `5.19.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Please refer to the [Process Agent 5.18.0 tag](https://github.com/DataDog/datado
 * [FEATURE] JMXFetch: add canonical rate. See [#3494][], [jmxfetch-156](https://github.com/DataDog/jmxfetch/pull/154) (Thanks [@arrawatia][])
 * [IMPROVEMENT] Core: adding docker inspect to flare. See [#3536][]
 * [IMPROVEMENT] Windows: enhanced PDH counter support. See [#3536][]
+* [BUGFIX] RHEL/CentOS7[systemd]: enable datadog-agent service on post-install. See [dd-agent-omnibus-201](https://github.com/DataDog/omnibus-software/pull/201)
 * [BUGFIX] Windows: fix PDH counter i18n issues. See [#3536][]
 * [BUGFIX] Kubernetes: fix image lookup. See [#3532][]
 * [BUGFIX] Mesos: do not crash if `ENV` in `CONF` is none. See [#3528][]

--- a/config.py
+++ b/config.py
@@ -41,7 +41,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 
 # CONSTANTS
-AGENT_VERSION = "5.18.0"
+AGENT_VERSION = "5.19.0"
 JMX_VERSION = "0.17.0"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Bumps the version on config.py to the next minor: `5.19.0`.

Also snuck in an amendment to the changelog.

### Motivation

Minor release ✅ 