### PR TITLE
[jmxfetch] bumping to 0.18.1

### DIFF
--- a/config.py
+++ b/config.py
@@ -42,7 +42,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 # CONSTANTS
 AGENT_VERSION = "5.19.0"
-JMX_VERSION = "0.17.0"
+JMX_VERSION = "0.18.0"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
 MAC_CONFIG_PATH = '/opt/datadog-agent/etc'

--- a/config.py
+++ b/config.py
@@ -43,7 +43,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 # CONSTANTS
 AGENT_VERSION = "5.22.0"
-JMX_VERSION = "0.18.0"
+JMX_VERSION = "0.18.1"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
 MAC_CONFIG_PATH = '/opt/datadog-agent/etc'


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Bumps JMXFetch to 0.18.1

### Motivation

Released new version.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Sister omnibus PR: https://github.com/DataDog/omnibus-software/pull/170
