### PR TITLE
Nick/update ddconf and fix logs source

### DIFF
--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -279,20 +279,20 @@ gce_updated_hostname: yes
 # Extra global sample rate to apply on all the traces
 # This sample rate is combined to the sample rate from the sampler logic, still promoting interesting traces
 # From 1 (no extra rate) to 0 (don't sample at all)
-extra_sample_rate=1
+# extra_sample_rate=1
 
 # Maximum number of traces per second to sample.
 # The limit is applied over an average over a few minutes ; much bigger spikes are possible.
 # Set to 0 to disable the limit.
-max_traces_per_second=10
+# max_traces_per_second=10
 
 [trace.receiver]
 # the port that the Receiver should listen on
 receiver_port=8126
 # how many unique client connections to allow during one 30 second lease period
-connection_limit=2000
+# connection_limit=2000
 
 [trace.ignore]
 # a blacklist of regular expressions can be provided to disable certain traces based on their resource name
 # all entries must be surrounded by double quotes and separated by comas
-resource="GET|POST /healthcheck","GET /V1"
+# resource="GET|POST /healthcheck","GET /V1"

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -510,7 +510,7 @@ else
     log_suffix="_log_file"
     for prog in collector forwarder dogstatsd jmxfetch; do
         if ! grep "^[[:space:]]*$prog$log_suffix" "$dd_conf_file"; then
-            $SED_CMD -i -e "/^api_key:/a\\$prog$log_suffix: $DD_HOME/logs/$prog.log" "$dd_conf_file"
+            $SED_CMD -i -e "/^api_key:/a\\$prog$log_suffix: $DD_HOME/logs/$prog.log" $dd_conf_file
         fi
     done
 fi

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -510,7 +510,7 @@ else
     log_suffix="_log_file"
     for prog in collector forwarder dogstatsd jmxfetch; do
         if ! grep "^[[:space:]]*$prog$log_suffix" "$dd_conf_file"; then
-            $SED_CMD -i -e "/^api_key:/a\'$prog$log_suffix': '$DD_HOME'/logs/'$prog'.log' "$dd_conf_file"
+            $SED_CMD -i -e "/^api_key:/a\\$prog$log_suffix: $DD_HOME/logs/$prog.log" "$dd_conf_file"
         fi
     done
 fi

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -510,7 +510,7 @@ else
     log_suffix="_log_file"
     for prog in collector forwarder dogstatsd jmxfetch; do
         if ! grep "^[[:space:]]*$prog$log_suffix" "$dd_conf_file"; then
-            echo "$prog$log_suffix: $DD_HOME/logs/$prog.log" >> "$dd_conf_file"
+            $SED_CMD -i -e "/^api_key:/a\'$prog$log_suffix': '$DD_HOME'/logs/'$prog'.log' "$dd_conf_file"
         fi
     done
 fi

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -510,7 +510,7 @@ else
     log_suffix="_log_file"
     for prog in collector forwarder dogstatsd jmxfetch; do
         if ! grep "^[[:space:]]*$prog$log_suffix" "$dd_conf_file"; then
-            $SED_CMD -i -e "/^api_key:/a\\$prog$log_suffix: $DD_HOME/logs/$prog.log" $dd_conf_file
+            $SED_CMD -i -e "/^api_key/a\\$prog$log_suffix: $DD_HOME/logs/$prog.log" $dd_conf_file
         fi
     done
 fi


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Moves the log locations in datadog.conf directly underneath the API key field in datadog.conf for Source Installs

### Motivation

Currently we place log locations at the bottom of the datadog.conf file when performing a source install. However, since there are more fields being added into datadog.conf, such as [trace receiver], we can't rely on this anymore. Using the old approach has the log locations outside the expected [MAIN] location. 

Since we can rely on the API key being available in the datadog.conf file, I've placed it directly below there. 

Regex now supports `api_key:` and `api_key=`, or more simply `api_key`.

Reported here - https://github.com/DataDog/docker-dd-agent/issues/252

### Testing Guidelines

Modified the setup.sh locally to build from source from my branch. The Log locations now appear correctly within the `[MAIN]` header, underneath the api_key field. 

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
