### PR TITLE
Avoid starting the agent if the api key is too short

### DIFF
--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -131,15 +131,15 @@ def validate_api_key(config):
             timeout=3, verify=(not config.get('skip_ssl_validation', False)))
 
         if r.status_code == 403:
-            return "API Key is invalid"
+            return "[ERROR] API Key is invalid"
 
         r.raise_for_status()
 
     except requests.RequestException:
-        return "Unable to validate API Key. Please try again later"
+        return "[ERROR] Unable to validate API Key. Please try again later"
     except Exception:
         log.exception("Unable to validate API Key")
-        return "Unable to validate API Key (unexpected error). Please try again later"
+        return "[ERROR] Unable to validate API Key (unexpected error). Please try again later"
 
     return "API Key is valid"
 

--- a/config.py
+++ b/config.py
@@ -387,18 +387,24 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
             agentConfig['developer_mode'] = True
 
         # Core config
-        #ap
+        # API keys
         if not config.has_option('Main', 'api_key'):
             log.warning(u"No API key was found. Aborting.")
             sys.exit(2)
 
+        api_keys = map(lambda el: el.strip(), config.get('Main', 'api_key').split(','))
+        for k in api_keys:
+            # Basic sanity check
+            if len(k) != 32:
+                log.warning(u"API key is invalid. Aborting.")
+                sys.exit(2)
+
+        # Endpoints
         if not config.has_option('Main', 'dd_url'):
             log.warning(u"No dd_url was found. Aborting.")
             sys.exit(2)
 
-        # Endpoints
         dd_urls = map(clean_dd_url, config.get('Main', 'dd_url').split(','))
-        api_keys = map(lambda el: el.strip(), config.get('Main', 'api_key').split(','))
 
         # For collector and dogstatsd
         agentConfig['dd_url'] = dd_urls[0]

--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -205,14 +205,14 @@ class Reporter(threading.Thread):
     """
 
     def __init__(self, interval, metrics_aggregator, api_host, api_key=None,
-                 use_watchdog=False, event_chunk_size=None):
+                 use_watchdog=False, event_chunk_size=None, hostname=None):
         threading.Thread.__init__(self)
         self.interval = int(interval)
         self.finished = threading.Event()
         self.metrics_aggregator = metrics_aggregator
         self.flush_count = 0
         self.log_count = 0
-        self.hostname = get_hostname()
+        self.hostname = hostname or get_hostname()
 
         self.watchdog = None
         if use_watchdog:
@@ -617,7 +617,7 @@ def init5(agent_config=None, use_watchdog=False, use_forwarder=False, args=None)
     )
 
     # Start the reporting thread.
-    reporter = Reporter(interval, aggregator, target, api_key, use_watchdog, event_chunk_size)
+    reporter = Reporter(interval, aggregator, target, api_key, use_watchdog, event_chunk_size, hostname)
 
     # NOTICE: when `non_local_traffic` is passed we need to bind to any interface on the box. The forwarder uses
     # Tornado which takes care of sockets creation (more than one socket can be used at once depending on the

--- a/tests/core/fixtures/config/bad.conf
+++ b/tests/core/fixtures/config/bad.conf
@@ -1,12 +1,12 @@
 [Main]
 
-# The host of the Datadog intake server to send agent data to 
+# The host of the Datadog intake server to send agent data to
 dd_url: https://app.datadoghq.com
 
-# The Datadog api key to associate your agent's data with your organization. 
-# Can be found here: 
+# The Datadog api key to associate your agent's data with your organization.
+# Can be found here:
 # https://app.datadoghq.com/account/settings
-api_key: 1234
+api_key: 0123456789abcdefghijklmnopqrstuv
 
 # Force the hostname to whatever you want.
 #hostname: mymachine.mydomain

--- a/tests/core/fixtures/config/invalid.conf
+++ b/tests/core/fixtures/config/invalid.conf
@@ -1,0 +1,3 @@
+[Main]
+
+api_key: not-empty-but-too-short

--- a/tests/core/fixtures/config/multiple_apikeys.conf
+++ b/tests/core/fixtures/config/multiple_apikeys.conf
@@ -6,4 +6,4 @@ dd_url: https://app.datadoghq.com
 # The Datadog api key to associate your agent's data with your organization.
 # Can be found here:
 # https://app.datadoghq.com/account/settings
-api_key: 1234, 5678 ,  901
+api_key: 0123456789abcdefghijklmnopqrstuv, 123456789abcdefghijklmnopqrstuv0 ,  23456789abcdefghijklmnopqrstuv01

--- a/tests/core/fixtures/config/multiple_endpoints.conf
+++ b/tests/core/fixtures/config/multiple_endpoints.conf
@@ -6,4 +6,4 @@ dd_url: https://app.datadoghq.com, https://app.example.com, https://app.example.
 # The Datadog api key to associate your agent's data with your organization.
 # Can be found here:
 # https://app.datadoghq.com/account/settings
-api_key: 1234,5678,  901
+api_key: 0123456789abcdefghijklmnopqrstuv,123456789abcdefghijklmnopqrstuv0 ,  23456789abcdefghijklmnopqrstuv01

--- a/tests/core/fixtures/config/multiple_endpoints_bad.conf
+++ b/tests/core/fixtures/config/multiple_endpoints_bad.conf
@@ -6,4 +6,4 @@ dd_url: https://app.datadoghq.com, https://app.example.com
 # The Datadog api key to associate your agent's data with your organization.
 # Can be found here:
 # https://app.datadoghq.com/account/settings
-api_key: 1234, 5678,  901
+api_key: 0123456789abcdefghijklmnopqrstuv, 123456789abcdefghijklmnopqrstuv0 ,  23456789abcdefghijklmnopqrstuv01

--- a/tests/core/fixtures/config/one_endpoint.conf
+++ b/tests/core/fixtures/config/one_endpoint.conf
@@ -6,4 +6,4 @@ dd_url: https://app.datadoghq.com
 # The Datadog api key to associate your agent's data with your organization.
 # Can be found here:
 # https://app.datadoghq.com/account/settings
-api_key: 1234
+api_key: 0123456789abcdefghijklmnopqrstuv

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -36,6 +36,13 @@ class TestConfig(unittest.TestCase):
         """
         return get_config(cfg_path=os.path.join(self.CONFIG_FOLDER, name), parse_args=parse_args)
 
+    def test_invalid_api_key(self):
+        """
+        The agent will exit if it finds an obviously invalid api key
+        """
+        with self.assertRaises(SystemExit):
+            self.get_config('invalid.conf')
+
     def testWhiteSpaceConfig(self):
         """Leading whitespace confuse ConfigParser
         """

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -42,7 +42,7 @@ class TestConfig(unittest.TestCase):
         agentConfig = self.get_config('bad.conf')
 
         self.assertEquals(agentConfig["dd_url"], "https://app.datadoghq.com")
-        self.assertEquals(agentConfig["api_key"], "1234")
+        self.assertEquals(agentConfig["api_key"], "0123456789abcdefghijklmnopqrstuv")
         self.assertEquals(agentConfig["nagios_log"], "/var/log/nagios3/nagios.log")
         self.assertEquals(agentConfig["graphite_listen_port"], 17126)
         self.assertTrue("statsd_metric_namespace" in agentConfig)
@@ -50,17 +50,17 @@ class TestConfig(unittest.TestCase):
     def test_one_endpoint(self):
         agent_config = self.get_config('one_endpoint.conf')
         self.assertEquals(agent_config["dd_url"], "https://app.datadoghq.com")
-        self.assertEquals(agent_config["api_key"], "1234")
-        endpoints = {'https://app.datadoghq.com': ['1234']}
+        self.assertEquals(agent_config["api_key"], "0123456789abcdefghijklmnopqrstuv")
+        endpoints = {'https://app.datadoghq.com': ['0123456789abcdefghijklmnopqrstuv']}
         self.assertEquals(agent_config['endpoints'], endpoints)
 
     def test_multiple_endpoints(self):
         agent_config = self.get_config('multiple_endpoints.conf')
         self.assertEquals(agent_config["dd_url"], "https://app.datadoghq.com")
-        self.assertEquals(agent_config["api_key"], "1234")
+        self.assertEquals(agent_config["api_key"], "0123456789abcdefghijklmnopqrstuv")
         endpoints = {
-            'https://app.datadoghq.com': ['1234'],
-            'https://app.example.com': ['5678', '901']
+            'https://app.datadoghq.com': ['0123456789abcdefghijklmnopqrstuv'],
+            'https://app.example.com': ['123456789abcdefghijklmnopqrstuv0', '23456789abcdefghijklmnopqrstuv01']
         }
         self.assertEquals(agent_config['endpoints'], endpoints)
         with self.assertRaises(AssertionError):
@@ -69,9 +69,9 @@ class TestConfig(unittest.TestCase):
     def test_multiple_apikeys(self):
         agent_config = self.get_config('multiple_apikeys.conf')
         self.assertEquals(agent_config["dd_url"], "https://app.datadoghq.com")
-        self.assertEquals(agent_config["api_key"], "1234")
+        self.assertEquals(agent_config["api_key"], "0123456789abcdefghijklmnopqrstuv")
         endpoints = {
-            'https://app.datadoghq.com': ['1234', '5678', '901']
+            'https://app.datadoghq.com': ['0123456789abcdefghijklmnopqrstuv', '123456789abcdefghijklmnopqrstuv0', '23456789abcdefghijklmnopqrstuv01']
         }
         self.assertEquals(agent_config['endpoints'], endpoints)
 

--- a/tests/core/test_dogstatsd.py
+++ b/tests/core/test_dogstatsd.py
@@ -40,6 +40,7 @@ class TestFunctions(TestCase):
         cfg = defaultdict(str)
         cfg['non_local_traffic'] = True
         cfg['use_dogstatsd'] = True
+        cfg['api_key'] = "0123456789abcdefghijklmnopqrstuv"
 
         init5(cfg)
 
@@ -51,7 +52,7 @@ class TestFunctions(TestCase):
     @mock.patch('dogstatsd.get_config_path')
     def test_init6(self, gcp):
         cfg = defaultdict(str)
-        cfg['api_key'] = "deadbeeffeebdaed"
+        cfg['api_key'] = "0123456789abcdefghijklmnopqrstuv"
         cfg['use_dogstatsd'] = True
         cfg['dogstatsd6_enable'] = True
         cfg['dogstatsd6_stats_port'] = 5050
@@ -67,6 +68,7 @@ class TestFunctions(TestCase):
         cfg = defaultdict(str)
         cfg['use_dogstatsd'] = True
         cfg['statsd_so_rcvbuf'] = '1024'
+        cfg['api_key'] = "0123456789abcdefghijklmnopqrstuv"
 
         init5(cfg)
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Performs a sanity check before starting the agent to avoid collecting anything if the api key is obviously wrong.

Enhance the message on the status page when an api key is invalid

### Motivation

The agent might start collecting metrics but never flush if users paste a wrong api key

