### PR TITLE
[Windows]  Fix startup option when API key provided to installer.

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -251,7 +251,11 @@ class Agent(Daemon):
 
         # Intialize the collector.
         if not config:
-            config = get_config(parse_args=True)
+            try:
+                config = get_config(parse_args=True)
+            except:
+                log.warning("Failed to load configuration")
+                sys.exit(2)
 
         self._agentConfig = self._set_agent_config_hostname(config)
         hostname = get_hostname(self._agentConfig)

--- a/config.py
+++ b/config.py
@@ -95,6 +95,11 @@ MANIFEST_VALIDATION = {
 class PathNotFound(Exception):
     pass
 
+class ApiKeyNotFound(Exception):
+    pass
+
+class ApiKeyInvalid(Exception):
+    pass
 
 def get_parsed_args():
     parser = OptionParser()
@@ -390,14 +395,14 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
         # API keys
         if not config.has_option('Main', 'api_key'):
             log.warning(u"No API key was found. Aborting.")
-            sys.exit(2)
+            raise ApiKeyNotFound("No API key was found.")
 
         api_keys = map(lambda el: el.strip(), config.get('Main', 'api_key').split(','))
         for k in api_keys:
             # Basic sanity check
             if len(k) != 32:
                 log.warning(u"API key is invalid. Aborting.")
-                sys.exit(2)
+                raise ApiKeyInvalid("API Key invalid")
 
         # Endpoints
         if not config.has_option('Main', 'dd_url'):

--- a/config.py
+++ b/config.py
@@ -341,7 +341,7 @@ def remove_empty(string_array):
     return filter(lambda x: x, string_array)
 
 
-def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=True):
+def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=True, allow_invalid_api_key=False):
     if parse_args:
         options, _ = get_parsed_args()
 
@@ -393,14 +393,14 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
 
         # Core config
         # API keys
-        if not config.has_option('Main', 'api_key'):
+        if not config.has_option('Main', 'api_key') and not allow_invalid_api_key:
             log.warning(u"No API key was found. Aborting.")
             raise ApiKeyNotFound("No API key was found.")
 
         api_keys = map(lambda el: el.strip(), config.get('Main', 'api_key').split(','))
         for k in api_keys:
             # Basic sanity check
-            if len(k) != 32:
+            if len(k) != 32 and not allow_invalid_api_key:
                 log.warning(u"API key is invalid. Aborting.")
                 raise ApiKeyInvalid("API Key invalid")
 

--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -683,7 +683,11 @@ def main(config_path=None):
                       dest="use_forwarder", default=False)
     opts, args = parser.parse_args()
 
-    c = get_config(parse_args=False, cfg_path=config_path)
+    try:
+        c = get_config(parse_args=False, cfg_path=config_path)
+    except:
+        return 2
+    
     dsd6_enabled = Dogstatsd6.enabled(c)
     in_developer_mode = False
     if not args or args[0] in COMMANDS_START_DOGSTATSD:

--- a/dogstatsd.py
+++ b/dogstatsd.py
@@ -687,7 +687,7 @@ def main(config_path=None):
         c = get_config(parse_args=False, cfg_path=config_path)
     except:
         return 2
-    
+
     dsd6_enabled = Dogstatsd6.enabled(c)
     in_developer_mode = False
     if not args or args[0] in COMMANDS_START_DOGSTATSD:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -16,7 +16,8 @@ from config import (
     load_check_directory,
     validate_sdk_check,
     _conf_path_to_check_name,
-    _version_string_to_tuple
+    _version_string_to_tuple,
+    ApiKeyInvalid
 )
 from util import windows_friendly_colon_split
 from utils.hostname import is_valid_hostname
@@ -38,9 +39,9 @@ class TestConfig(unittest.TestCase):
 
     def test_invalid_api_key(self):
         """
-        The agent will exit if it finds an obviously invalid api key
+        The agent will raise an exception on an obviously invalid api key
         """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ApiKeyInvalid):
             self.get_config('invalid.conf')
 
     def testWhiteSpaceConfig(self):

--- a/win32/service.py
+++ b/win32/service.py
@@ -27,7 +27,7 @@ import servicemanager
 import win32service
 
 # project
-from config import get_config, get_config_path, get_confd_path
+from config import get_config, get_config_path, get_confd_path, ApiKeyInvalid, ApiKeyNotFound
 from jmxfetch import JMXFetch
 from utils.jmx import JMXFiles
 from utils.windows_configuration import get_registry_conf, update_conf_file, remove_registry_conf
@@ -51,9 +51,17 @@ class AgentSvc(win32serviceutil.ServiceFramework):
 
         AgentSvc.devnull = open(os.devnull, 'w')
 
-        config = get_config(parse_args=False, can_query_registry=False)
-        if config['api_key'] == 'APIKEYHERE':
-            self._update_config_file(config)
+        try:
+            config = get_config(parse_args=False, can_query_registry=False)
+        except (ApiKeyInvalid, ApiKeyNotFound) as e:
+            # try updating the config, give it one last try
+            log.warning("Invalid configuration {}, attempting to update config".format(str(e)))
+            try:
+                self._update_config_file(config)
+                config = get_config(parse_args=False, can_query_registry=False)
+            except (ApiKeyInvalid, ApiKeyNotFound) as e:
+                log.error("Configuration still invalid after update, exiting {}".format(str(e)))
+                sys.exit(2)
 
         # Let's have an uptime counter
         self.start_ts = None
@@ -129,7 +137,7 @@ class AgentSvc(win32serviceutil.ServiceFramework):
         return jmxfetch.should_run()
 
     def _update_config_file(self, config):
-        log.debug('Querying registry to get missing config options')
+        log.info('Querying registry to get missing config options')
         registry_conf = get_registry_conf(config)
         config.update(registry_conf)
         if registry_conf:
@@ -140,6 +148,8 @@ class AgentSvc(win32serviceutil.ServiceFramework):
                 remove_registry_conf()
             except Exception:
                 log.warning('Failed to update config file; registry configuration persisted')
+        else:
+            log.info("no registry conf")
 
     def SvcStop(self):
         # Stop all services.


### PR DESCRIPTION
 Check to validate API key occurs before the agent updates the
config from the registry (if the API key is provided on the MSI install
command line).  This causes the agent to fail to run even when a valid
API key has been provided.

Allow the configuration to be processed without a valid api key (by introducing
an override parameter), so that the Windows service can start successfully.

The Windows service must start or (as currently configured) the installation will fail.
Introduced with https://github.com/DataDog/dd-agent/pull/3546