### PR TITLE
Fixed #3550 - Add host tagging to install_agent.sh

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -55,6 +55,10 @@ else
     no_start=false
 fi
 
+if [ -n "$DD_HOST_TAGS" ]; then
+    host_tags=$DD_HOST_TAGS
+fi
+
 if [ ! $apikey ]; then
     printf "\033[31mAPI key not available in DD_API_KEY environment variable.\033[0m\n"
     exit 1;
@@ -201,6 +205,10 @@ else
     if [ $dd_hostname ]; then
         printf "\033[34m\n* Adding your HOSTNAME to the Agent configuration: /etc/dd-agent/datadog.conf\n\033[0m\n"
         $sudo_cmd sh -c "sed -i 's/# hostname:.*/hostname: $dd_hostname/' /etc/dd-agent/datadog.conf"
+    fi
+    if [ $host_tags ]; then
+        printf "\033[34m\n* Adding your HOST TAGS to the Agent configuraton: /etc/dd-agent/datadog.conf\n\033[0m\n"
+        $sudo_cmd sh -c "sed -i 's/# tags:.*/tags: $host_tags/' /etc/dd-agent/datadog.conf"
     fi
     $sudo_cmd chown dd-agent:dd-agent /etc/dd-agent/datadog.conf
     $sudo_cmd chmod 640 /etc/dd-agent/datadog.conf


### PR DESCRIPTION
### What does this PR do?

Adds the ability to add host tags via the `curl | sh` installation script

### Motivation

Quickly deploy the datadog agent to public cloud instances via cloud-init while also being able to add host tags (e.g. to indicate what application the instance runs)

### Testing Guidelines

I exported the `DD_API_KEY` and `DD_HOST_TAGS` variables and ran the script on a host without the agent installed. The agent was properly installed and also had the host tags set appropriately.

### Additional Notes

I looked into adding capability to specify package version but it looked
pretty involved and I really just wanted host tagging.
