### PR TITLE
[AD] Fix port parsing

### DIFF
--- a/utils/service_discovery/config.py
+++ b/utils/service_discovery/config.py
@@ -28,8 +28,8 @@ def extract_agent_config(config):
         agentConfig['service_discovery'] = False
 
     if conf_backend is None:
-        log.warning('No configuration backend provided for service discovery. '
-                    'Only auto config templates will be used.')
+        log.debug('No configuration backend provided for service discovery. '
+                  'Only auto config templates will be used.')
     elif conf_backend not in SD_CONFIG_BACKENDS:
         log.error("The config backend {0} is not supported. "
                   "Only auto config templates will be used.".format(conf_backend))


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

We shouldn't rely on `ExposedPorts`. Let's just work with `Ports`. 

### Motivation

This is confusing and ExposedPorts is only indicative anyway. Plus if we find something there we skip the Kubernetes pod lookup which we should do by all means.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
