### PR TITLE
Enable the apm service based on the configuration file

### DIFF
--- a/config.py
+++ b/config.py
@@ -361,7 +361,8 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
         'additional_checksd': '/etc/dd-agent/checks.d/',
         'bind_host': get_default_bind_host(),
         'statsd_metric_namespace': None,
-        'utf8_decoding': False
+        'utf8_decoding': False,
+        'apm_enabled': False
     }
 
     if Platform.is_mac():
@@ -607,6 +608,11 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
         agentConfig["gce_updated_hostname"] = False
         if config.has_option("Main", "gce_updated_hostname"):
             agentConfig["gce_updated_hostname"] = _is_affirmative(config.get("Main", "gce_updated_hostname"))
+
+        # APM config
+        agentConfig["apm_enabled"] = False
+        if config.has_option("Main", "apm_enabled"):
+            agentConfig["apm_enabled"] = _is_affirmative(config.get("Main", "apm_enabled"))
 
     except ConfigParser.NoSectionError as e:
         sys.stderr.write('Config file not found or incorrectly formatted.\n')

--- a/win32/service.py
+++ b/win32/service.py
@@ -50,11 +50,12 @@ class AgentSvc(win32serviceutil.ServiceFramework):
         win32serviceutil.ServiceFramework.__init__(self, args)
 
         AgentSvc.devnull = open(os.devnull, 'w')
+        self.config = None
 
         try:
-            config = get_config(parse_args=False, can_query_registry=False, allow_invalid_api_key=True)
-            if config['api_key'] == 'APIKEYHERE':
-                self._update_config_file(config)
+            self.config = get_config(parse_args=False, can_query_registry=False, allow_invalid_api_key=True)
+            if self.config['api_key'] == 'APIKEYHERE':
+                self._update_config_file(self.config)
         except Exception as e:
             log.warning("Failed to get_config {}".format(str(e)))
 
@@ -86,14 +87,14 @@ class AgentSvc(win32serviceutil.ServiceFramework):
                 "dogstatsd",
                 [embedded_python, "dogstatsd.py", "--use-local-forwarder"],
                 agent_env,
-                enabled=config.get("use_dogstatsd", True)
+                enabled=self.config.get("use_dogstatsd", True)
             ),
             'jmxfetch': JMXFetchProcess(
                 "jmxfetch",
                 [embedded_python, "jmxfetch.py"],
                 agent_env,
                 max_restarts=self._MAX_JMXFETCH_RESTARTS,
-                enabled=self._is_jmxfetch_enabled(config)
+                enabled=self._is_jmxfetch_enabled(self.config)
             ),
         }
 
@@ -175,6 +176,13 @@ class AgentSvc(win32serviceutil.ServiceFramework):
         # Start all services.
         for proc in self.procs.values():
             proc.start()
+
+        # check to see if apm is enabled.
+        if self.config["apm_enabled"]:
+            try:
+                win32serviceutil.StartService("datadog-trace-agent")
+            except Exception as e:
+                log.error("Unable to start AMP service %s" % str(e))
 
         # Loop to keep the service running since all DD services are
         # running in separate processes

--- a/win32/service.py
+++ b/win32/service.py
@@ -50,7 +50,7 @@ class AgentSvc(win32serviceutil.ServiceFramework):
         win32serviceutil.ServiceFramework.__init__(self, args)
 
         AgentSvc.devnull = open(os.devnull, 'w')
-        self.config = None
+        self.config = {}
 
         try:
             self.config = get_config(parse_args=False, can_query_registry=False, allow_invalid_api_key=True)
@@ -178,7 +178,7 @@ class AgentSvc(win32serviceutil.ServiceFramework):
             proc.start()
 
         # check to see if apm is enabled.
-        if self.config["apm_enabled"]:
+        if self.config.get('apm_enabled'):
             try:
                 win32serviceutil.StartService("datadog-trace-agent")
             except Exception as e:


### PR DESCRIPTION

### What does this PR do?

Checks datadog.conf. If `apm_enabled` is set to true, then it starts the trace agent service.  Trace agent service will be installed by parallel checkin

