### PR TITLE
[wheels] allow running checks packaged as wheels

### DIFF
--- a/config.py
+++ b/config.py
@@ -843,7 +843,7 @@ def _get_check_module(check_name, check_path, from_site=False):
     traceback_message = None
     if from_site:
         try:
-            check_module = import_module("datadog.{}".format(check_name))
+            check_module = import_module("datadog_checks.{}".format(check_name))
         except ImportError as e:
             error = e
             log.exception('Unable to import check module %s from site-packages' % check_name)

--- a/setup.py
+++ b/setup.py
@@ -1,124 +1,70 @@
-# (C) Datadog, Inc. 2010-2016
-# All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+# To use a consistent encoding
+from codecs import open
+from os import path
 
-# stdlib
-from datetime import date
-import os
-import sys
+here = path.abspath(path.dirname(__file__))
 
-# 3p
-from setuptools import setup
-
-# project
-from config import get_version
-
-# Extra arguments to pass to the setup function
-extra_args = {}
-
-# Prereqs of the build. Won't get installed when deploying the egg.
-setup_requires = []
-
-# Prereqs of the install. Will install when deploying the egg.
-install_requires = []
-
-# Modified on mac
-app_name = 'datadog-agent'
-# plist (used only on mac)
-plist = None
-
-if sys.platform == 'win32':
-    # noqa for flake8, these imports are probably here to force packaging of these modules
-    import py2exe  # noqa
-
-    # windows-specific deps
-    install_requires.append('pywin32==217')
-
-    # Modules to force-include in the exe
-    include_modules = [
-        # 3p
-        'psutil',
-        'servicemanager',
-        'subprocess',
-        'win32api',
-        'win32event',
-        'win32service',
-        'win32serviceutil',
-        'wmi',
-    ]
-
-    class Target(object):
-        def __init__(self, **kw):
-            self.__dict__.update(kw)
-            self.version = get_version()
-            self.company_name = 'Datadog, Inc.'
-            self.copyright = 'Copyright {} Datadog, Inc.'.format(date.today().year)
-            self.cmdline_style = 'pywin32'
-
-    agent_svc = Target(name='Datadog Agent', modules='win32.service', dest_base='ddagent')
-    sys.path.append("C:\\omnibus-ruby\\src\\vc_redist")
-
-    extra_args = {
-        'options': {
-            'py2exe': {
-                'includes': ','.join(include_modules),
-                'optimize': 0,
-                'compressed': True,
-                'bundle_files': 3,
-                'excludes': ['numpy'],
-                'dll_excludes': ["IPHLPAPI.DLL", "NSI.dll",  "WINNSI.DLL",  "WTSAPI32.dll", "crypt32.dll"],
-                'ascii': False,
-            },
-        },
-        'console': ['win32\shell.py'],
-        'service': [agent_svc],
-        'windows': [{'script': 'win32\gui.py',
-                     'dest_base': "agent-manager",
-                     'uac_info': "requireAdministrator", # The manager needs to be administrator to stop/start the service
-                     'icon_resources': [(1, r"packaging\datadog-agent\win32\install_files\dd_agent_win_256.ico")],
-                     }],
-        'data_files': [],
-    }
-
-elif sys.platform == 'darwin':
-    app_name = 'Datadog Agent'
-
-    from plistlib import Plist
-    plist = Plist.fromFile(os.path.dirname(os.path.realpath(__file__)) + '/packaging/Info.plist')
-    plist.update(dict(
-        CFBundleGetInfoString="{0}, Copyright (c) 2009-{1}, Datadog Inc.".format(
-            get_version(), date.today().year),
-        CFBundleVersion=get_version()
-    ))
-
-    extra_args = {
-        'app': ['gui.py'],
-        'data_files': [
-            'images',
-            'status.html',
-        ],
-        'options': {
-            'py2app': {
-                'optimize': 0,
-                'iconfile': 'packaging/Agent.icns',
-                'plist': plist
-            }
-        }
-    }
-
+# Get the long description from the README file
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
 
 setup(
-    name=app_name,
-    version=get_version(),
-    description="DevOps' best friend",
-    author='DataDog',
-    author_email='dev@datadoghq.com',
-    url='http://www.datadoghq.com',
-    install_requires=install_requires,
-    setup_requires=setup_requires,
-    packages=[],
-    include_package_data=True,
-    test_suite='nose.collector',
-    zip_safe=False,
-    **extra_args
+    name='datadog_agent_tk',
+    # Version should always match one from an agent release
+    version='5.15.0',
+    description='The Datadog Agent Toolkit',
+    long_description=long_description,
+    keywords='datadog agent check toolkit',
+
+    # The project's main homepage.
+    url='https://github.com/DataDog/dd-agent',
+
+    # Author details
+    author='Datadog',
+    author_email='packages@datadoghq.com',
+
+    # License
+    license='MIT',
+
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Topic :: System :: Monitoring',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+    ],
+
+
+    # Include all we need from the agent to run tests and
+    # execute checks in a dedicated virtualenv.
+    packages=find_packages(exclude=[
+        "tests.checks.fixtures*",
+        "tests.checks.mock*",
+        "tests.core*",
+        "dogstream",
+    ]),
+
+    # These are plain python modules, not packages, we need
+    # to list them manually to include in the wheel.
+    py_modules=[
+        "config",
+        "util",
+        "tests.checks.common",
+        "aggregator"
+    ],
+
+    # This is more than we would need but this is a POC, so...
+    install_requires=[
+        'requests==2.11.1',
+        'pyyaml==3.11',
+        'simplejson==3.6.5',
+        'docker-py==1.10.6',
+        'python-etcd==0.4.5',
+        'python-consul==0.4.7',
+        'kazoo==2.2.1',
+    ],
 )

--- a/setup_tk.py
+++ b/setup_tk.py
@@ -1,0 +1,74 @@
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+# To use a consistent encoding
+from codecs import open
+from os import path
+
+from config import get_version
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='datadog_agent_tk',
+    # Version should always match one from an agent release
+    version=get_version(),
+    description='The Datadog Agent Toolkit',
+    long_description=long_description,
+    keywords='datadog agent check toolkit',
+
+    # The project's main homepage.
+    url='https://github.com/DataDog/dd-agent',
+
+    # Author details
+    author='Datadog',
+    author_email='packages@datadoghq.com',
+
+    # License
+    license='MIT',
+
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Topic :: System :: Monitoring',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+    ],
+
+
+    # Include all we need from the agent to run tests and
+    # execute checks in a dedicated virtualenv.
+    packages=find_packages(exclude=[
+        "tests.checks.fixtures*",
+        "tests.checks.mock*",
+        "tests.core*",
+        "dogstream",
+        "venv",
+        "win32",
+    ]),
+
+    # These are plain python modules, not packages, we need
+    # to list them manually to include in the wheel.
+    py_modules=[
+        "config",
+        "util",
+        "tests.checks.common",
+        "aggregator"
+    ],
+
+    # This is more than we would need but this is a POC, so...
+    install_requires=[
+        'requests==2.11.1',
+        'pyyaml==3.11',
+        'simplejson==3.6.5',
+        'docker-py==1.10.6',
+        'python-etcd==0.4.5',
+        'python-consul==0.4.7',
+        'kazoo==2.2.1',
+    ],
+)

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -27,14 +27,10 @@ from utils.platform import get_os
 
 log = logging.getLogger('tests')
 
-def _is_sdk():
-    # for the POC scope, let's assume it's always SDK time
-    return True
-
 def _load_sdk_module(name):
     try:
         # see whether the check was installed as a wheel package
-        return import_module("check.{}".format(name))
+        return import_module("datadog.{}".format(name))
     except ImportError:
         sdk_path = get_sdk_integrations_path(get_os())
         module_path = os.path.join(sdk_path, name)
@@ -56,14 +52,7 @@ def _load_sdk_module(name):
         return module
 
 def get_check_class(name):
-    if not _is_sdk():
-        checksd_path = get_checksd_path(get_os())
-        if checksd_path not in sys.path:
-            sys.path.append(checksd_path)
-
-        check_module = __import__(name)
-    else:
-        check_module = _load_sdk_module(name)
+    check_module = _load_sdk_module(name)
 
     check_class = None
     classes = inspect.getmembers(check_module, inspect.isclass)
@@ -83,14 +72,7 @@ def load_class(check_name, class_name):
     """
     Retrieve a class with the given name within the given check module.
     """
-    check_module_name = check_name
-    if not _is_sdk():
-        checksd_path = get_checksd_path(get_os())
-        if checksd_path not in sys.path:
-            sys.path.append(checksd_path)
-        check_module = __import__(check_module_name)
-    else:
-        check_module = _load_sdk_module(check_name)
+    check_module = _load_sdk_module(check_name)
 
     classes = inspect.getmembers(check_module, inspect.isclass)
     for name, clsmember in classes:
@@ -101,14 +83,7 @@ def load_class(check_name, class_name):
 
 
 def load_check(name, config, agentConfig):
-    if not _is_sdk():
-        checksd_path = agentConfig.get('additional_checksd', get_checksd_path(get_os()))
-
-        # find (in checksd_path) and load the check module
-        fd, filename, desc = imp.find_module(name, [checksd_path])
-        check_module = imp.load_module(name, fd, filename, desc)
-    else:
-        check_module = _load_sdk_module(name) # parent module
+    check_module = _load_sdk_module(name) # parent module
 
     check_class = None
     classes = inspect.getmembers(check_module, inspect.isclass)

--- a/tests/checks/common.py
+++ b/tests/checks/common.py
@@ -34,7 +34,7 @@ def _is_sdk():
 def _load_sdk_module(name):
     try:
         # see whether the check was installed as a wheel package
-        return import_module("datadog.{}".format(name))
+        return import_module("datadog_checks.{}".format(name))
     except ImportError:
         sdk_path = get_sdk_integrations_path(get_os())
         module_path = os.path.join(sdk_path, name)

--- a/utils/checkfiles.py
+++ b/utils/checkfiles.py
@@ -39,7 +39,7 @@ def get_check_class(agentConfig, check_name):
     checks_places = get_checks_places(osname, agentConfig)
     for check_path_builder in checks_places:
         check_path, _ = check_path_builder(check_name)
-        if not os.path.exists(check_path):
+        if not check_path or not os.path.exists(check_path):
             continue
 
         check_is_valid, check_class, load_failure = get_valid_check_class(check_name, check_path)


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

The goal of this PR is to allow running checks packages as pip wheels just like any other check. These checks would typically packaged as follows such that they will be installed to `./datadog/<integration>/` site in `site-packages`. 

It should remain completely backward compatible as far as previous functionality goes.

### Motivation

Improved packaging of checks, improved developer experience.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

