### PR TITLE
Switch most of container host tags to host metadata

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -650,6 +650,12 @@ class Collector(object):
             payload['systemStats'] = get_system_stats(
                 proc_path=self.agentConfig.get('procfs_path', '/proc').rstrip('/')
             )
+
+            if self.agentConfig['collect_orchestrator_tags']:
+                host_container_metadata = MetadataCollector().get_host_metadata()
+                if host_container_metadata:
+                    payload['container-meta'] = host_container_metadata
+
             payload['meta'] = self._get_hostname_metadata()
 
             self.hostname_metadata_cache = payload['meta']

--- a/tests/core/test_dockerutil.py
+++ b/tests/core/test_dockerutil.py
@@ -83,25 +83,25 @@ class TestDockerUtil(unittest.TestCase):
         for test in test_data:
             self.assertEqual(test[1], DockerUtil().extract_container_tags(test[0]))
 
-    def test_docker_host_tags_ok(self):
+    def test_docker_host_metadata_ok(self):
         mock_version = mock.MagicMock(name='version', return_value={'Version': '1.13.1'})
         du = DockerUtil()
         du._client = mock.MagicMock()
         du._client.version = mock_version
         du.swarm_node_state = 'inactive'
-        self.assertEqual(['docker_version:1.13.1'], du.get_host_tags())
+        self.assertEqual({'docker_version': '1.13.1', 'docker_swarm': 'inactive'}, du.get_host_metadata())
         mock_version.assert_called_once()
 
-    def test_docker_host_tags_invalid_response(self):
+    def test_docker_host_metadata_invalid_response(self):
         mock_version = mock.MagicMock(name='version', return_value=None)
         du = DockerUtil()
         du._client = mock.MagicMock()
         du._client.version = mock_version
         du.swarm_node_state = 'inactive'
-        self.assertEqual([], DockerUtil().get_host_tags())
+        self.assertEqual({'docker_swarm': 'inactive'}, DockerUtil().get_host_metadata())
         mock_version.assert_called_once()
 
-    def test_docker_host_tags_swarm_ok(self):
+    def test_docker_host_metadata_swarm_ok(self):
         du = DockerUtil()
         mock_version = mock.MagicMock(name='version', return_value={'Version': '1.13.1'})
         mock_isswarm = mock.MagicMock(name='is_swarm', return_value=True)
@@ -109,5 +109,5 @@ class TestDockerUtil(unittest.TestCase):
         du._client.version = mock_version
         du.is_swarm = mock_isswarm
 
-        self.assertEqual(['docker_version:1.13.1', 'docker_swarm:active'], DockerUtil().get_host_tags())
+        self.assertEqual({'docker_version': '1.13.1', 'docker_swarm': 'active'}, DockerUtil().get_host_metadata())
         mock_version.assert_called_once()

--- a/tests/core/test_ecsutil.py
+++ b/tests/core/test_ecsutil.py
@@ -55,7 +55,7 @@ class TestECSUtil(unittest.TestCase):
     @mock.patch('requests.get')
     @mock.patch('utils.dockerutil.DockerUtil.inspect_container')
     @mock.patch('docker.Client.__init__')
-    def test_host_tags(self, mock_init, mock_inspect, mock_get):
+    def test_host_metadata(self, mock_init, mock_inspect, mock_get):
         mock_inspect.return_value = {}
         mock_get.return_value = MockResponse({"Cluster": "default-xvello",
                                               "Version": "Amazon ECS Agent - v1.14.1 (467c3d7)"}, 200)
@@ -65,6 +65,6 @@ class TestECSUtil(unittest.TestCase):
         util.agent_url = 'http://dummy'
 
         mock_get.reset_mock()
-        tags = util.get_host_tags()
-        self.assertEqual(['ecs_version:1.14.1'], tags)
+        meta = util.get_host_metadata()
+        self.assertEqual({'ecs_version': '1.14.1'}, meta)
         mock_get.assert_called_once_with('http://dummy/v1/metadata', timeout=1)

--- a/tests/core/test_mesosutil.py
+++ b/tests/core/test_mesosutil.py
@@ -79,7 +79,7 @@ class TestMesosUtil(unittest.TestCase):
     @mock.patch.dict(os.environ, {"LIBPROCESS_IP": "a"})
     @mock.patch('requests.get')
     @mock.patch('docker.Client.__init__')
-    def test_host_tags(self, mock_init, mock_get):
+    def test_host_metadata(self, mock_init, mock_get):
         mock_get.side_effect = [
             MockResponse({'version': '1.2.1'}, 200),
             MockResponse({'dcos_version': '1.9.0'}, 200),
@@ -93,6 +93,6 @@ class TestMesosUtil(unittest.TestCase):
 
         util = MesosUtil()
         util.__init__()
-        tags = util.get_host_tags()
+        metadata = util.get_host_metadata()
 
-        self.assertEqual(['mesos_version:1.2.1', 'dcos_version:1.9.0'], tags)
+        self.assertEqual({'mesos_version': '1.2.1', 'dcos_version': '1.9.0'}, metadata)

--- a/tests/core/test_nomadutil.py
+++ b/tests/core/test_nomadutil.py
@@ -39,13 +39,13 @@ class TestNomadUtil(unittest.TestCase):
 
     @mock.patch('requests.get')
     @mock.patch('docker.Client.__init__')
-    def test_host_tags(self, mock_init, mock_get):
+    def test_host_metadata(self, mock_init, mock_get):
         mock_get.return_value = MockResponse({"config": {"Datacenter": "dc1", "Region": "global",
                                                          "Version": "0.5.4"}}, 200)
         mock_init.return_value = None
 
         util = NomadUtil()
         util.__init__()
-        tags = util.get_host_tags()
+        metadata = util.get_host_metadata()
 
-        self.assertEqual(['nomad_version:0.5.4', 'nomad_region:global', 'nomad_datacenter:dc1'], tags)
+        self.assertEqual({'nomad_version': '0.5.4', 'nomad_region': 'global', 'nomad_datacenter': 'dc1'}, metadata)

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -292,21 +292,26 @@ class DockerUtil:
 
         return self._default_gateway
 
-    def get_host_tags(self):
-        tags = []
+    def get_host_metadata(self):
+        """
+        Returns swarm state and docker version for the local host
+        """
+        meta = {}
         if not self.client:
-            log.warning("Docker client is not initialized, host tags will be missing.")
-            return tags
+            log.warning("Docker client is not initialized, host metadata will be missing.")
+            return meta
         version = self.client.version()
         if version and 'Version' in version:
-            tags.append('docker_version:%s' % version['Version'])
+            meta['docker_version'] = version['Version']
         else:
             log.debug("Could not determine Docker version")
 
         if self.is_swarm():
-            tags.append('docker_swarm:active')
+            meta['docker_swarm'] = 'active'
+        else:
+            meta['docker_swarm'] = 'inactive'
 
-        return tags
+        return meta
 
     def set_docker_settings(self, init_config, instance):
         """Update docker settings"""

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -480,7 +480,7 @@ class KubeUtil:
             meta['kubelet_version'] = version[1:]
         except Exception as ex:
             log.debug("Error getting Kubelet version: %s" % str(ex))
-            
+
         return meta
 
 
@@ -496,7 +496,7 @@ class KubeUtil:
             _, node_name = self.get_node_info()
             if not node_name:
                 raise ValueError("node name missing or empty")
-            
+
             request_url = "%s/nodes/%s" % (self.kubernetes_api_url, node_name)
             node_info = self.retrieve_json_auth(request_url).json()
             node_labels = node_info.get('metadata', {}).get('labels', {})
@@ -548,6 +548,10 @@ class KubeUtil:
             tags.append('node_name:%s' % event['source']['host'])
         if 'kind' in event.get('involvedObject', {}):
             tags.append('object_type:%s' % event['involvedObject'].get('kind', '').lower())
+        if 'name' in event.get('involvedObject', {}):
+            tags.append('object_name:%s' % event['involvedObject'].get('name','').lower())
+        if 'component' in event.get('source', {}):
+            tags.append('source_component:%s' % event['source'].get('component','').lower())
 
         return tags
 

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -451,24 +451,25 @@ class KubeUtil:
             self._fetch_host_data()
         return self._node_ip, self._node_name
 
-    def get_node_hosttags(self):
-        tags = []
+    def get_node_metadata(self):
+        """Returns host metadata about the local k8s node"""
+        meta = {}
 
         # API server version
         try:
             request_url = "%s/version" % self.kubernetes_api_root_url
             master_info = self.retrieve_json_auth(request_url).json()
             version = master_info.get("gitVersion")
-            tags.append("kube_master_version:%s" % version[1:])
-        except Exception as e:
+            meta['kube_master_version'] = version[1:]
+        except Exception as ex:
             # Intentional use of non-safe lookups to get the exception in the debug logs
             # if the parsing were to fail
-            log.debug("Error getting Kube master version: %s" % str(e))
+            log.debug("Error getting Kube master version: %s" % str(ex))
 
         # Kubelet version & labels
         if not self.init_success:
             log.warning("Kubelet client failed to initialize, kubelet host tags will be missing for now.")
-            return tags
+            return meta
         try:
             _, node_name = self.get_node_info()
             if not node_name:
@@ -476,15 +477,36 @@ class KubeUtil:
             request_url = "%s/nodes/%s" % (self.kubernetes_api_url, node_name)
             node_info = self.retrieve_json_auth(request_url).json()
             version = node_info.get("status").get("nodeInfo").get("kubeletVersion")
-            tags.append("kubelet_version:%s" % version[1:])
+            meta['kubelet_version'] = version[1:]
+        except Exception as ex:
+            log.debug("Error getting Kubelet version: %s" % str(ex))
+            
+        return meta
 
+
+    def get_node_hosttags(self):
+        """
+        Returns node labels as tags. Tag name is transformed as defined
+        in node_labels_to_host_tags in the kubernetes check configuration.
+        Note: queries the API server for node info. Configure RBAC accordingly.
+        """
+        tags = []
+
+        try:
+            _, node_name = self.get_node_info()
+            if not node_name:
+                raise ValueError("node name missing or empty")
+            
+            request_url = "%s/nodes/%s" % (self.kubernetes_api_url, node_name)
+            node_info = self.retrieve_json_auth(request_url).json()
             node_labels = node_info.get('metadata', {}).get('labels', {})
+
             for l_name, t_name in self.kube_node_labels.iteritems():
                 if l_name in node_labels:
                     tags.append('%s:%s' % (t_name, node_labels[l_name]))
 
-        except Exception as e:
-            log.debug("Error getting Kubelet version: %s" % str(e))
+        except Exception as ex:
+            log.debug("Error getting node labels: %s" % str(ex))
 
         return tags
 
@@ -526,10 +548,6 @@ class KubeUtil:
             tags.append('node_name:%s' % event['source']['host'])
         if 'kind' in event.get('involvedObject', {}):
             tags.append('object_type:%s' % event['involvedObject'].get('kind', '').lower())
-        if 'name' in event.get('involvedObject', {}):
-            tags.append('object_name:%s' % event['involvedObject'].get('name','').lower())
-        if 'component' in event.get('source', {}):
-            tags.append('source_component:%s' % event['source'].get('component','').lower())
 
         return tags
 

--- a/utils/orchestrator/baseutil.py
+++ b/utils/orchestrator/baseutil.py
@@ -13,7 +13,7 @@ from utils.singleton import Singleton
 
 class BaseUtil:
     """
-    Base class for orchestrator utils. Only handles container tags for now.
+    Base class for orchestrator utils. Handles container tags and host metadata.
     Users should go through the orchestrator.Tagger class to simplify the code
 
     Children classes can implement:
@@ -22,6 +22,8 @@ class BaseUtil:
       - _get_transient_tags: tags can change and won't be cached (TODO)
       - invalidate_cache: custom cache invalidation logic
       - is_detected (staticmethod)
+      - get_host_tags: list of tags that are applied to the host in Datadog
+      - get_host_metadata: dict of container-related host metadata (typically node labels)
     """
     __metaclass__ = Singleton
 
@@ -36,6 +38,15 @@ class BaseUtil:
 
         # Tags cache as a dict {co_id: [tags]}
         self._container_tags_cache = {}
+    
+    def _get_cacheable_tags(self, cid, co):
+        raise NotImplementedError()
+    
+    def get_host_tags(self):
+        return []
+
+    def get_host_metadata(self):
+        return {}
 
     def get_container_tags(self, cid=None, co=None):
         """

--- a/utils/orchestrator/baseutil.py
+++ b/utils/orchestrator/baseutil.py
@@ -38,10 +38,10 @@ class BaseUtil:
 
         # Tags cache as a dict {co_id: [tags]}
         self._container_tags_cache = {}
-    
+
     def _get_cacheable_tags(self, cid, co):
         raise NotImplementedError()
-    
+
     def get_host_tags(self):
         return []
 

--- a/utils/orchestrator/baseutil.py
+++ b/utils/orchestrator/baseutil.py
@@ -22,8 +22,8 @@ class BaseUtil:
       - _get_transient_tags: tags can change and won't be cached (TODO)
       - invalidate_cache: custom cache invalidation logic
       - is_detected (staticmethod)
-      - get_host_tags: list of tags that are applied to the host in Datadog
-      - get_host_metadata: dict of container-related host metadata (typically node labels)
+      - get_host_tags: list of tags that are applied to the host in Datadog (typically node labels)
+      - get_host_metadata: dict of container-related host metadata
     """
     __metaclass__ = Singleton
 

--- a/utils/orchestrator/dockerutilproxy.py
+++ b/utils/orchestrator/dockerutilproxy.py
@@ -20,5 +20,5 @@ class DockerUtilProxy(BaseUtil):
         except Exception:
             return False
 
-    def get_host_tags(self):
-        return self.docker_util.get_host_tags()
+    def get_host_metadata(self):
+        return self.docker_util.get_host_metadata()

--- a/utils/orchestrator/ecsutil.py
+++ b/utils/orchestrator/ecsutil.py
@@ -115,16 +115,16 @@ class ECSUtil(BaseUtil):
         BaseUtil.reset_cache(self)
         self.ecs_tags = {}
 
-    def get_host_tags(self):
-        tags = []
+    def get_host_metadata(self):
+        meta = {}
         if self.agent_url:
             try:
                 resp = requests.get(self.agent_url + ECS_AGENT_METADATA_PATH, timeout=1).json()
                 if "Version" in resp:
                     match = AGENT_VERSION_EXP.search(resp.get("Version"))
                     if match is not None and len(match.groups()) == 1:
-                        tags.append('ecs_version:%s' % match.group(1))
+                        meta['ecs_version'] = match.group(1)
             except Exception as e:
                 self.log.debug("Error getting ECS version: %s" % str(e))
 
-        return tags
+        return meta

--- a/utils/orchestrator/kubeutilproxy.py
+++ b/utils/orchestrator/kubeutilproxy.py
@@ -17,3 +17,6 @@ class KubeUtilProxy(BaseUtil):
 
     def get_host_tags(self):
         return KubeUtil().get_node_hosttags()
+
+    def get_host_metadata(self):
+        return KubeUtil().get_node_metadata()

--- a/utils/orchestrator/mesosutil.py
+++ b/utils/orchestrator/mesosutil.py
@@ -98,22 +98,22 @@ class MesosUtil(BaseUtil):
     def is_detected():
         return MESOS_TASK_ID in os.environ
 
-    def get_host_tags(self):
-        tags = []
+    def get_host_metadata(self):
+        meta = {}
         if self.mesos_agent_url:
             try:
                 resp = requests.get(self.mesos_agent_url, timeout=1).json()
                 if "version" in resp:
-                    tags.append('mesos_version:%s' % resp.get("version"))
-            except Exception as e:
-                self.log.debug("Error getting Mesos version: %s" % str(e))
+                    meta['mesos_version'] = resp.get("version")
+            except Exception as ex:
+                self.log.debug("Error getting Mesos version: %s" % str(ex))
 
         if self.dcos_agent_url:
             try:
                 resp = requests.get(self.dcos_agent_url, timeout=1).json()
                 if "dcos_version" in resp:
-                    tags.append('dcos_version:%s' % resp.get("dcos_version"))
-            except Exception as e:
-                self.log.debug("Error getting DCOS version: %s" % str(e))
+                    meta['dcos_version'] = resp.get("dcos_version")
+            except Exception as ex:
+                self.log.debug("Error getting DCOS version: %s" % str(ex))
 
-        return tags
+        return meta

--- a/utils/orchestrator/metadata_collector.py
+++ b/utils/orchestrator/metadata_collector.py
@@ -42,6 +42,9 @@ class MetadataCollector():
             util.reset_cache()
 
     def get_host_tags(self):
+        """
+        Return a list of host tags related to containers
+        """
         concat_tags = []
         for util in self._utils:
             meta = util.get_host_tags()
@@ -49,6 +52,18 @@ class MetadataCollector():
                 concat_tags.extend(meta)
 
         return concat_tags
+
+    def get_host_metadata(self):
+        """
+        Return a dict of host metadata related to containers
+        """
+        meta = {}
+        for util in self._utils:
+            util_meta = util.get_host_metadata()
+            if util_meta:
+                meta.update(util_meta)
+
+        return meta
 
     def reset(self):
         """

--- a/utils/orchestrator/nomadutil.py
+++ b/utils/orchestrator/nomadutil.py
@@ -77,18 +77,18 @@ class NomadUtil(BaseUtil):
 
         return nomad_url
 
-    def get_host_tags(self):
-        tags = []
+    def get_host_metadata(self):
+        meta = {}
         if self.agent_url:
             try:
                 resp = requests.get(self.agent_url, timeout=1).json().get('config', {})
                 if "Version" in resp:
-                    tags.append('nomad_version:%s' % resp.get("Version"))
+                    meta['nomad_version'] = resp.get("Version")
                 if "Region" in resp:
-                    tags.append('nomad_region:%s' % resp.get("Region"))
+                    meta['nomad_region'] = resp.get("Region")
                 if "Datacenter" in resp:
-                    tags.append('nomad_datacenter:%s' % resp.get("Datacenter"))
-            except Exception as e:
-                self.log.debug("Error getting Nomad version: %s" % str(e))
+                    meta['nomad_datacenter'] = resp.get("Datacenter")
+            except Exception as ex:
+                self.log.debug("Error getting Nomad version: %s" % str(ex))
 
-        return tags
+        return meta


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Move all host tags coming from docker and orchestrators to host metadata with the exception of node labels in k8s because they're legit.

### Motivation

This metadata is not really useful as tags and it's mostly for analysis purpose. Therefore metadata is a better fit that tags - especially because host metadata doesn't churn contexts when updated.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

This will require some work in the app to display it. Still figuring that out.
