### PR TITLE
Bump config.py version to 5.18.2

### DIFF
--- a/config.py
+++ b/config.py
@@ -41,7 +41,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 
 # CONSTANTS
-AGENT_VERSION = "5.18.1"
+AGENT_VERSION = "5.18.2"
 JMX_VERSION = "0.17.0"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'


### PR DESCRIPTION
### What does this PR do?

Bump config.py to 5.18.2 for release
