### PR TITLE
[kube] restore kube_deployment tag on k8s 1.8+ clusters

### DIFF
--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -43,6 +43,14 @@ class TestKubeUtilDeploymentTag(KubeTestCase):
         self.assertIsNone(self.kube.get_deployment_for_replicaset('frontend2891696001'))
         self.assertIsNone(self.kube.get_deployment_for_replicaset('-frontend2891696001'))
         self.assertIsNone(self.kube.get_deployment_for_replicaset('manually-created'))
+        # New 1.8+ names are a 10 runes (consonants + numbers) suffix
+        self.assertIsNone(self.kube.get_deployment_for_replicaset('frontend-56c89cfff'))
+        self.assertIsNone(self.kube.get_deployment_for_replicaset('frontend-56c89cfff77'))
+        self.assertIsNone(self.kube.get_deployment_for_replicaset('frontend-56a89cfff7'))
+
+    def test_deployment_name_k8s_1_8(self):
+        self.assertEqual('frontend', self.kube.get_deployment_for_replicaset('frontend-56c89cfff7'))
+        self.assertEqual('front-end', self.kube.get_deployment_for_replicaset('front-end-768dd754b7'))
 
 class TestKubeUtilCreatorTags(KubeTestCase):
     @classmethod


### PR DESCRIPTION

### What does this PR do?

Kubernetes 1.8 changed the generation of ReplicaSet names, they’re no longer digits only, and this broke the agent’s metric collection code, see https://github.com/kubernetes/kubernetes/pull/51538/files and https://github.com/DataDog/integrations-core/issues/837

### Testing Guidelines

Updated unit test cases to cover valid and invalid cases for this new format.
