### PR TITLE
change restart to stop/start with deps

### DIFF
--- a/win32/gui.py
+++ b/win32/gui.py
@@ -735,7 +735,7 @@ def restartServiceWithDeps(serviceName):
                     for restart_dep in stopped_deps:
                         try:
                             win32serviceutil.StartService(restart_dep)
-                        except:
+                        except Exception:
                             # this is best effort, just continue restarting
                             pass
                     raise
@@ -746,16 +746,16 @@ def restartServiceWithDeps(serviceName):
         hs = win32service.OpenService(hscm, serviceName, win32service.SERVICE_ALL_ACCESS)
         try:
             win32serviceutil.__StopServiceWithTimeout(hs)
-        except:
+        except Exception:
             # if this fails to stop, then restart the dependent services we
             # already stopped.
             for restart_dep in stopped_deps:
                 try:
                     win32serviceutil.StartService(restart_dep)
-                except:
+                except Exception:
                     # this is best effort, just continue restarting
                     pass
-                raise
+            raise
         finally:
             win32service.CloseServiceHandle(hs)
     finally:

--- a/win32/gui.py
+++ b/win32/gui.py
@@ -717,11 +717,12 @@ def check_yaml_syntax(content):
 def service_manager(action):
     try:
         if action == 'stop':
-            win32serviceutil.StopService(DATADOG_SERVICE)
+            win32serviceutil.StopServiceWithDeps(DATADOG_SERVICE)
         elif action == 'start':
             win32serviceutil.StartService(DATADOG_SERVICE)
         elif action == 'restart':
-            win32serviceutil.RestartService(DATADOG_SERVICE)
+            win32serviceutil.StopServiceWithDeps(DATADOG_SERVICE)
+            win32serviceutil.StartService(DATADOG_SERVICE)
     except Exception as e:
         warning_popup("Couldn't %s service: \n %s" % (action, str(e)))
 

--- a/win32/gui.py
+++ b/win32/gui.py
@@ -98,6 +98,8 @@ AGENT_UNKNOWN = 4
 # Windows management
 # Import Windows stuff only on Windows
 if Platform.is_windows():
+    import pywintypes
+    import winerror
     import win32serviceutil
     import win32service
 
@@ -713,6 +715,58 @@ def check_yaml_syntax(content):
         warning_popup("Unable to parse yaml: \n %s" % str(e))
         raise
 
+def restartServiceWithDeps(serviceName):
+    # stop the service recursively, looking for dependent services.
+    # if it fails, attempt to restart the ones that were stopped
+    # (so that things are left in the correct state)
+    stopped_deps = list()
+    hscm = win32service.OpenSCManager(None,None,win32service.SC_MANAGER_ALL_ACCESS)
+    try:
+        deps = win32serviceutil.__FindSvcDeps(serviceName)
+
+        for dep in deps:
+            hs = win32service.OpenService(hscm, dep, win32service.SERVICE_ALL_ACCESS)
+            try:
+                win32serviceutil.__StopServiceWithTimeout(hs)
+                stopped_deps.insert(0, dep)
+            except pywintypes.error as exc:
+                if exc.winerror != winerror.ERROR_SERVICE_NOT_ACTIVE:
+                    # walk through and start all the services that have been stopped
+                    for restart_dep in stopped_deps:
+                        try:
+                            win32serviceutil.StartService(restart_dep)
+                        except:
+                            # this is best effort, just continue restarting
+                            pass
+                    raise
+            finally:
+                win32service.CloseServiceHandle(hs)
+
+        # all the deps are stopped.  Stop the one we really wanted to stop
+        hs = win32service.OpenService(hscm, serviceName, win32service.SERVICE_ALL_ACCESS)
+        try:
+            win32serviceutil.__StopServiceWithTimeout(hs)
+        except:
+            # if this fails to stop, then restart the dependent services we
+            # already stopped.
+            for restart_dep in stopped_deps:
+                try:
+                    win32serviceutil.StartService(restart_dep)
+                except:
+                    # this is best effort, just continue restarting
+                    pass
+                raise
+        finally:
+            win32service.CloseServiceHandle(hs)
+    finally:
+        win32service.CloseServiceHandle(hscm)
+
+    # everything's stopped.  Now just start it back up.  Don't need to restart
+    # the dependent services.  If they're to be started, the config file will
+    # indicate that, and the agent service will restart the subservices
+    win32serviceutil.StartService(DATADOG_SERVICE)
+
+
 
 def service_manager(action):
     try:
@@ -721,8 +775,7 @@ def service_manager(action):
         elif action == 'start':
             win32serviceutil.StartService(DATADOG_SERVICE)
         elif action == 'restart':
-            win32serviceutil.StopServiceWithDeps(DATADOG_SERVICE)
-            win32serviceutil.StartService(DATADOG_SERVICE)
+            restartServiceWithDeps(DATADOG_SERVICE)
     except Exception as e:
         warning_popup("Couldn't %s service: \n %s" % (action, str(e)))
 


### PR DESCRIPTION
Changes gui implementation to deal with the fact that the datadog-agent service now may have dependent services.  Stop them all, and then restart (or just stop them all when stopping).