### PR TITLE
[kubernetes] Allow overriding the pod name

### DIFF
--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -34,6 +34,14 @@ class KubeTestCase(unittest.TestCase):
         json_array = cls._load_json_array(names)
         return map(lambda x: MockResponse(x, 200), json_array)
 
+class TestKubeUtilInit(KubeTestCase):
+    @patch.dict(os.environ, {'KUBERNETES_POD_NAME': 'test'})
+    def test_pod_name(self):
+        with patch.object(KubeUtil, '_locate_kubelet', return_value='http://localhost:10255'):
+            kube = KubeUtil()
+            kube.__init__()
+            self.assertEqual('test', kube.pod_name)
+
 class TestKubeUtilDeploymentTag(KubeTestCase):
     def test_deployment_name_nominal(self):
         self.assertEqual('frontend', self.kube.get_deployment_for_replicaset('frontend-2891696001'))

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -107,6 +107,7 @@ class KubeUtil:
         self.method = instance.get('method', KubeUtil.DEFAULT_METHOD)
         self._node_ip = self._node_name = None  # lazy evaluation
         self.host_name = os.environ.get('HOSTNAME')
+        self.pod_name = os.environ.get('KUBERNETES_POD_NAME') or self.host_name
         self.tls_settings = self._init_tls_settings(instance)
 
         # apiserver
@@ -275,7 +276,7 @@ class KubeUtil:
     def get_self_namespace(self):
         pods = self.retrieve_pods_list()
         for pod in pods.get('items', []):
-            if pod.get('metadata', {}).get('name') == self.host_name:
+            if pod.get('metadata', {}).get('name') == self.pod_name:
                 return pod['metadata']['namespace']
         log.warning("Couldn't find the agent pod and namespace, using the default.")
         return DEFAULT_NAMESPACE
@@ -541,7 +542,7 @@ class KubeUtil:
         for pod in pod_items:
             metadata = pod.get("metadata", {})
             name = metadata.get("name")
-            if name == self.host_name:
+            if name == self.pod_name:
                 status = pod.get('status', {})
                 spec = pod.get('spec', {})
                 # if not found, use an empty string - we use None as "not initialized"


### PR DESCRIPTION
### What does this PR do?

Allows the default pod name to be set by an environment variable named `KUBERNETES_POD_NAME`.

### Motivation

Currently in Kubernetes, when a pod is created, its hostname is the Pod's `metadata.name` value. As a result, the Kubernetes check assumes that the pod's hostname is the same as the pod's name when locating pod metadata information.

But that's not necessarily always the case as the hostname can be set to any other value using a Pod annotation. If that's the case, the Kubernetes check is not able to locate pod _and_ node information as it expects the hostname to be the same as the pod name.

This is especially problematic when a pod uses host networking, where the pod's hostname is the same as the host's hostname.