### PR TITLE
adds option to disable gohai metadata collection

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -806,7 +806,7 @@ class Collector(object):
 
     def _run_gohai(self, options):
         # Gohai is disabled on Mac for now
-        if Platform.is_mac() or self.agentConfig.get('disable_gohai'):
+        if Platform.is_mac() or not self.agentConfig.get('enable_gohai'):
             return None
         output = None
         try:

--- a/checks/collector.py
+++ b/checks/collector.py
@@ -806,7 +806,7 @@ class Collector(object):
 
     def _run_gohai(self, options):
         # Gohai is disabled on Mac for now
-        if Platform.is_mac():
+        if Platform.is_mac() or self.agentConfig.get('disable_gohai'):
             return None
         output = None
         try:

--- a/config.py
+++ b/config.py
@@ -614,9 +614,9 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
         if config.has_option("Main", "apm_enabled"):
             agentConfig["apm_enabled"] = _is_affirmative(config.get("Main", "apm_enabled"))
 
-        agentConfig["disable_gohai"] = False
+        agentConfig["enable_gohai"] = True
         if config.has_option("Main", "disable_gohai"):
-            agentConfig["disable_gohai"] = _is_affirmative(config.get("Main", "disable_gohai"))
+            agentConfig["enable_gohai"] = _is_affirmative(config.get("Main", "disable_gohai"))
 
     except ConfigParser.NoSectionError as e:
         sys.stderr.write('Config file not found or incorrectly formatted.\n')

--- a/config.py
+++ b/config.py
@@ -614,6 +614,10 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
         if config.has_option("Main", "apm_enabled"):
             agentConfig["apm_enabled"] = _is_affirmative(config.get("Main", "apm_enabled"))
 
+        agentConfig["disable_gohai"] = False
+        if config.has_option("Main", "disable_gohai"):
+            agentConfig["disable_gohai"] = _is_affirmative(config.get("Main", "disable_gohai"))
+
     except ConfigParser.NoSectionError as e:
         sys.stderr.write('Config file not found or incorrectly formatted.\n')
         sys.exit(2)

--- a/config.py
+++ b/config.py
@@ -615,8 +615,8 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
             agentConfig["apm_enabled"] = _is_affirmative(config.get("Main", "apm_enabled"))
 
         agentConfig["enable_gohai"] = True
-        if config.has_option("Main", "disable_gohai"):
-            agentConfig["enable_gohai"] = _is_affirmative(config.get("Main", "disable_gohai"))
+        if config.has_option("Main", "enable_gohai"):
+            agentConfig["enable_gohai"] = _is_affirmative(config.get("Main", "enable_gohai"))
 
     except ConfigParser.NoSectionError as e:
         sys.stderr.write('Config file not found or incorrectly formatted.\n')

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -27,8 +27,8 @@ api_key:
 # Enable the trace agent.
 # apm_enabled: false
 
-# Disable gohai metadata collection
-# disable_gohai: false
+# Enable gohai metadata collection
+# enable_gohai: true
 
 # Set the host's tags (optional)
 # tags: mytag, env:prod, role:database

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -27,6 +27,9 @@ api_key:
 # Enable the trace agent.
 # apm_enabled: false
 
+# Disable gohai metadata collection
+# disable_gohai: false
+
 # Set the host's tags (optional)
 # tags: mytag, env:prod, role:database
 


### PR DESCRIPTION
### What does this PR do?

Sometimes customers want to disable gohai metadata collection, but it's currently not possible without removing the binary. It should be possible through a configuration option. This adds a config option, `disable_gohai`, which disables the collection of metadata by the gohai binary. 