### PR TITLE
Remove check for pidfile on windows.

### DIFF
--- a/daemon.py
+++ b/daemon.py
@@ -22,6 +22,7 @@ import tempfile
 import time
 
 # project
+from utils.platform import Platform
 from utils.process import is_my_process
 from utils.subprocess_output import subprocess
 from config import get_logging_config
@@ -231,22 +232,26 @@ class Daemon(object):
 
     def start(self, foreground=False):
         log.info("Starting")
-        pid = self.pid()
+        if not Platform.is_windows():
+            pid = self.pid()
 
-        if pid:
-            # Check if the pid in the pidfile corresponds to a running process
-            # and if psutil is installed, check if it's a datadog-agent one
-            if is_my_process(pid):
-                log.error("Not starting, another instance is already running"
-                          " (using pidfile {0})".format(self.pidfile))
-                sys.exit(1)
-            else:
-                log.warn("pidfile doesn't contain the pid of an agent process."
-                         ' Starting normally')
+            if pid:
+                # Check if the pid in the pidfile corresponds to a running process
+                # and if psutil is installed, check if it's a datadog-agent one
+                if is_my_process(pid):
+                    log.error("Not starting, another instance is already running"
+                            " (using pidfile {0})".format(self.pidfile))
+                    sys.exit(1)
+                else:
+                    log.warn("pidfile doesn't contain the pid of an agent process."
+                            ' Starting normally')
 
-        if not foreground:
-            self.daemonize()
-        self.write_pidfile()
+            if not foreground:
+                self.daemonize()
+            self.write_pidfile()
+        else:
+            log.debug("Skipping pidfile check for Windows")
+
         self.run()
 
     def stop(self):

--- a/utils/windows_configuration.py
+++ b/utils/windows_configuration.py
@@ -44,7 +44,12 @@ def get_registry_conf(agentConfig):
                 if option != '':
                     registry_conf[attribute] = option
     except (ImportError, WindowsError) as e:
-        log.error('Unable to get config keys from Registry: %s', e)
+        # don't log this as an error.  Since the keys are deleted after
+        # they're used, they're almost certain to not be there.
+        # however, log as `info` so it will show by default after install
+        # (i.e. before user has had a chance to change the config file)
+        # so it can be seen if necessary
+        log.info('Unable to get config keys from Registry (this is probably OK): %s', e)
 
     return registry_conf
 
@@ -87,7 +92,9 @@ def get_sdk_integration_paths():
                 except WindowsError as e:
                     log.error('Unable to get keys from Registry for %s: %s', integration_name, e)
     except WindowsError as e:
-        log.error('Unable to get config keys from Registry: %s', e)
+        # don't log this as an error.  Unless someone has installed a standalone
+        # integration, this key won't be present.
+        log.debug('Unable to get config keys from Registry: %s', e)
 
     return integrations
 


### PR DESCRIPTION
SCM protects against multiple instances running; causes more harm than good.

Change logging output for registry entries that aren't found.  Mostly,
they're not expected to be present and they create confusion

