### PR TITLE
Nick/normalize device name

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -870,6 +870,9 @@ class AgentCheck(object):
             check = cls(check_name, config.get('init_config') or {}, agentConfig or {})
         return check, config.get('instances', [])
 
+    def normalize_device_name(self, device_name):
+        return re.sub(r"[,\@\+\*\-\()\[\]{}\s]", "_", device_name)
+
     def normalize(self, metric, prefix=None, fix_case=False):
         """
         Turn a metric into a well-formed metric name

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -119,7 +119,9 @@ class TestCore(unittest.TestCase):
 
         self.assertEqual(self.ac.normalize("PauseTotalNs", "prefix", fix_case = True), "prefix.pause_total_ns")
         self.assertEqual(self.ac.normalize("Metric.wordThatShouldBeSeparated", "prefix", fix_case = True), "prefix.metric.word_that_should_be_separated")
+        self.assertEqual(self.ac.normalize_device_name("//device@name"), "//device_name")
 
+        
     def test_service_check(self):
         check_name = 'test.service_check'
         status = AgentCheck.CRITICAL

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -121,7 +121,6 @@ class TestCore(unittest.TestCase):
         self.assertEqual(self.ac.normalize("Metric.wordThatShouldBeSeparated", "prefix", fix_case = True), "prefix.metric.word_that_should_be_separated")
         self.assertEqual(self.ac.normalize_device_name("//device@name"), "//device_name")
 
-        
     def test_service_check(self):
         check_name = 'test.service_check'
         status = AgentCheck.CRITICAL

--- a/tests/core/test_common.py
+++ b/tests/core/test_common.py
@@ -119,7 +119,7 @@ class TestCore(unittest.TestCase):
 
         self.assertEqual(self.ac.normalize("PauseTotalNs", "prefix", fix_case = True), "prefix.pause_total_ns")
         self.assertEqual(self.ac.normalize("Metric.wordThatShouldBeSeparated", "prefix", fix_case = True), "prefix.metric.word_that_should_be_separated")
-        self.assertEqual(self.ac.normalize_device_name("//device@name"), "//device_name")
+        self.assertEqual(self.ac.normalize_device_name(",@+*-()[]{}//device@name"), "___________//device_name")
 
     def test_service_check(self):
         check_name = 'test.service_check'


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Converts the device name tag to confirm to tag standards. The existing normalize function will strip out the device name's `\`, so I've created its own function `normalize_device_name` in the Agent Check class. 

### Motivation

Having the @ symbol in the tag seems to cause issues in app.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
