### PR TITLE
[source_install] Fix sed command in source install for macOS

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -510,7 +510,9 @@ else
     log_suffix="_log_file"
     for prog in collector forwarder dogstatsd jmxfetch; do
         if ! grep "^[[:space:]]*$prog$log_suffix" "$dd_conf_file"; then
-            $SED_CMD -i -e "/^api_key/a\\$prog$log_suffix: $DD_HOME/logs/$prog.log" $dd_conf_file
+            $SED_CMD -i -e "/^api_key/a\\
+$prog$log_suffix: $DD_HOME/logs/$prog.log
+" $dd_conf_file
         fi
     done
 fi


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

This fixes the sed command that adds the log files paths to
`datadog.conf`. It was giving the error 
`sed: 1: "/^api_key/a\collector ...": extra characters after \ at the end of a command` on macOS. This is because sed expects a new line after the command `a`. It works on linux because there is a GNU extension that allows skipping the newline.
This fixes it and should keep working on the other distributions.

### Motivation

Encountered this while trying a source install on my mac.

### Testing Guidelines

Tested on macOS and on an ubuntu VM.

### Additional Notes

Anything else we should know when reviewing?