### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,5 @@ how to use it on our [Guide to Agent Checks](http://docs.datadoghq.com/guides/ag
 # Contributors
 
 ```bash
-git log --all | gawk '/Author/ {print}' | sort | uniq
+git log --all | grep 'Author' | sort -u
 ```


### PR DESCRIPTION
Updated Contributors command to work without installing gawk

### What does this PR do?

osx does not natively come with gawk installed but does have grep. This patch allows users to see contributors without installing additional software.

### Motivation

I tried to view contributors and needed to install gawk
