### PR TITLE
add forward-compatibility to ad_identifiers superseeding docker_images

### DIFF
--- a/utils/checkfiles.py
+++ b/utils/checkfiles.py
@@ -103,7 +103,7 @@ def get_auto_conf_images(full_tpl=False):
                 log.error("Unable to load the auto-config, yaml file.\n%s" % str(e))
                 auto_conf = {}
             # extract the supported image list
-            images = auto_conf.get('docker_images', [])
+            images = auto_conf.get('ad_identifiers', auto_conf.get('docker_images', []))
             for image in images:
                 if full_tpl:
                     init_tpl = auto_conf.get('init_config') or {}


### PR DESCRIPTION
Agent6 will still support docker_images in AD templates but will
print a warning asking to move to the docker-agnostic ad_identifiers
field. integrations-core templates will be updated accordingly. This
ensures we can use the new default AD templates.

If both are present, the new name takes precedence, like in agent6.
