### PR TITLE
Fix `trace.ignore` configuration example

### DIFF
--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -309,4 +309,4 @@ gce_updated_hostname: yes
 # [trace.ignore]
 # a blacklist of regular expressions can be provided to disable certain traces based on their resource name
 # all entries must be surrounded by double quotes and separated by comas
-# resource="GET|POST /healthcheck","GET /V1"
+# resource="(GET|POST) /healthcheck","GET /V1"


### PR DESCRIPTION
### Overview

Component: `trace-agent` configuration example

Updating the config example for ignored resource.