### PR TITLE
[kube] fix deployment tagging for 1.8+

### DIFF
--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -51,13 +51,17 @@ class TestKubeUtilDeploymentTag(KubeTestCase):
         self.assertIsNone(self.kube.get_deployment_for_replicaset('frontend2891696001'))
         self.assertIsNone(self.kube.get_deployment_for_replicaset('-frontend2891696001'))
         self.assertIsNone(self.kube.get_deployment_for_replicaset('manually-created'))
-        # New 1.8+ names are a 10 runes (consonants + numbers) suffix
-        self.assertIsNone(self.kube.get_deployment_for_replicaset('frontend-56c89cfff'))
-        self.assertIsNone(self.kube.get_deployment_for_replicaset('frontend-56c89cfff77'))
+        # New 1.8+ names are consonants + numbers suffix, undetermined lenght. Let's take 2 as the cutoff lenght
+        self.assertIsNone(self.kube.get_deployment_for_replicaset('frontend-5f'))
+        # Vowels are not allowed in 1.8+ format
         self.assertIsNone(self.kube.get_deployment_for_replicaset('frontend-56a89cfff7'))
 
     def test_deployment_name_k8s_1_8(self):
         self.assertEqual('frontend', self.kube.get_deployment_for_replicaset('frontend-56c89cfff7'))
+        self.assertEqual('frontend', self.kube.get_deployment_for_replicaset('frontend-56c'))
+        self.assertEqual('frontend', self.kube.get_deployment_for_replicaset('frontend-56c89cff'))
+        self.assertEqual('frontend', self.kube.get_deployment_for_replicaset('frontend-56c89cfff7c2'))
+
         self.assertEqual('front-end', self.kube.get_deployment_for_replicaset('front-end-768dd754b7'))
 
 class TestKubeUtilCreatorTags(KubeTestCase):

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -388,7 +388,7 @@ class KubeUtil:
         if end > 0 and rs_name[end + 1:].isdigit():
             # k8s before 1.8
             return rs_name[0:end]
-        if end > 0 and len(rs_name[end + 1:]) == 10:
+        if end > 0 and len(rs_name[end + 1:]) > 2:
             # k8s 1.8+ maybe? Check contents
             for char in rs_name[end + 1:]:
                 if char not in ALLOWED_ENCODESTRING_ALPHANUMS:

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -380,9 +380,13 @@ class KubeUtil:
         to parse and cache /apis/extensions/v1beta1/replicasets, mirroring PodServiceMapper
         In 1.8, the hash generation logic changed: https://github.com/kubernetes/kubernetes/pull/51538/files
 
-        As we are matching both patterns without checking the apiserver version, we might have
-        some false positives. For agent6, we plan on doing this pod->replicaset->deployment matching
-        in the cluster agent, with replicaset data from the apiserver. This will address that risk.
+        As none of these naming schemes have guaranteed suffix lenghts, we have to be pretty permissive
+        in what kind of suffix we match. That can lead to false positives, although their impact would
+        be limited (erroneous kube_deployment tag, but the kube_replica_set tag will be present).
+        For example, the hardcoded replicaset name prefix-34 or prefix-cfd will match.
+
+        For agent6, we plan on doing this pod->replicaset->deployment matching in the cluster agent, with
+        replicaset data from the apiserver. This will address that risk.
         """
         end = rs_name.rfind("-")
         if end > 0 and rs_name[end + 1:].isdigit():


### PR DESCRIPTION
my bad, RS new names' lenght is not constant. Let's try to validate every suffix more than 2 runes long

See https://github.com/DataDog/integrations-core/issues/837#issuecomment-344911890
