### PR TITLE
[Source Support] Let the user enter email

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -259,7 +259,10 @@ error_trap() {
         print_console "Do you want to send a failure report to Datadog (Content of the report is in $LOGFILE)? (y/n)"
         read yn
         case $yn in
-            [Yy]* ) report; break;;
+            [Yy]* );
+            print_console "Please enter your email address so Datadog Support can be sure to follow up!";
+            read email;
+            print_console "Email Address: " email; report; break;;
             [Nn]* ) report_manual; break;;
             * ) print_console "Please answer yes or no.";;
         esac

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -262,7 +262,7 @@ error_trap() {
             [Yy]* );
             print_console "Please enter your email address so Datadog Support can be sure to follow up!";
             read email;
-            print_console "Email Address: " email; report; break;;
+            print_console "Email Address: " $email; report; break;;
             [Nn]* ) report_manual; break;;
             * ) print_console "Please answer yes or no.";;
         esac


### PR DESCRIPTION
### What does this PR do?

Has the user enter an email address if they choose to send an install failure report to Datadog Support. 

### Motivation

Ensures Support can reach back out with any help on resolving their install issue. Will provide a smoother experience. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
