### PR TITLE
Avoid conflict when installing bundler

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,8 @@ services:
 install:
   # Use the 64-bit ruby so that all the Powershell classes are accessible when running shell commands from ruby
   - set PATH=C:\Ruby22-x64\bin;%PATH%
-  - gem install bundler --quiet --no-ri --no-rdoc
+  # If bundler is already install '--conservative' will avoid upgrading gems who already meet the version requirement (and avoid conflicts)
+  - gem install bundler --conservative --quiet --no-ri --no-rdoc
   - bundle install
   - bundle package
   - if not exist %PIP_CACHE% mkdir %PIP_CACHE%


### PR DESCRIPTION
### What does this PR do?

Avoid conflict when installing bundler
'--conservative' will prevent gem to upgrade bundler if it already meet version requirement.

### Motivation

Appveyor jobs would fail when install bundler due to a conflict with appveyor cache.