### PR TITLE
[config] Use : instead of = in APM config

### DIFF
--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -293,20 +293,20 @@ gce_updated_hostname: yes
 # Extra global sample rate to apply on all the traces
 # This sample rate is combined to the sample rate from the sampler logic, still promoting interesting traces
 # From 1 (no extra rate) to 0 (don't sample at all)
-# extra_sample_rate=1
+# extra_sample_rate: 1
 
 # Maximum number of traces per second to sample.
 # The limit is applied over an average over a few minutes ; much bigger spikes are possible.
 # Set to 0 to disable the limit.
-# max_traces_per_second=10
+# max_traces_per_second: 10
 
 # [trace.receiver]
 # the port that the Receiver should listen on
-# receiver_port=8126
+# receiver_port: 8126
 # how many unique client connections to allow during one 30 second lease period
-# connection_limit=2000
+# connection_limit: 2000
 
 # [trace.ignore]
 # a blacklist of regular expressions can be provided to disable certain traces based on their resource name
 # all entries must be surrounded by double quotes and separated by comas
-# resource="(GET|POST) /healthcheck","GET /V1"
+# resource: "(GET|POST) /healthcheck","GET /V1"


### PR DESCRIPTION
### What does this PR do?

This commit switches the use of = to : in the tracing section of the
example configuration file. Just a cosmetic change for better
consistency.

### Motivation

I was reading the example config and noticed a style inconsistency between the sections. Decided to submit a PR just in case it bothered anyone else.

### Testing Guidelines

No code change. The configurations I'm currently using uses `:` everywhere.