### PR TITLE
Adds an option to disable IPv6.

### DIFF
--- a/config.py
+++ b/config.py
@@ -577,6 +577,11 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
             # Default to False as there are some issues with the curl client and ELB
             agentConfig["use_curl_http_client"] = False
 
+        if config.has_option("Main", "allow_ipv6"):
+            agentConfig["allow_ipv6"] = _is_affirmative(config.get("Main", "allow_ipv6"))
+        else:
+            agentConfig["allow_ipv6"] = True
+
         if config.has_section('WMI'):
             agentConfig['WMI'] = {}
             for key, value in config.items('WMI'):

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -95,6 +95,9 @@ gce_updated_hostname: yes
 # between curl client and simple http client (default: simple http client)
 # use_curl_http_client: no
 
+# Select whether the Tornado HTTP Client used in the Forwarder should use IPv6, if available (default: yes)
+# allow_ipv6: yes
+
 # The loopback address the Forwarder and Dogstatsd will bind.
 # Optional, it is mainly used when running the agent on Openshift
 # bind_host: localhost

--- a/ddagent.py
+++ b/ddagent.py
@@ -226,7 +226,7 @@ class AgentTransaction(Transaction):
             'body': self._data,
             'headers': self._headers,
             'validate_cert': not self._application.skip_ssl_validation,
-            'allow_ipv6': True,
+            'allow_ipv6': self._application._agentConfig.get('allow_ipv6'),
             'request_timeout': self._request_timeout,
         }
 


### PR DESCRIPTION
### What does this PR do?

By default, the Tornado HTTP Client (either the simple client or the curl client) in the forwarder will use IPv6 if it is available. Sometimes users wish to force the agent to use IPv4. This PR adds a config option that allows users to force the forwarder's HTTP client to use IPv4.

### Motivation

This feature has been requested by several customers.

### Testing Guidelines

Test strategy:
On a network that support IPv6:
- Set the agent's log level to debug
- Verify that the forwarder is using IPv6 addresses
- Set `allow_ipv6: no` in the agent config
- Verify that the forwarder is using IPv4 addresses
- Set `use_curl_http_client: yes` in the agent config
- Repeat the previous tests

The curl client persists connections after each request, so I could see which IP version it was using with `lsof -i -a -p $(pgrep -f ddagent.py)` (it also logs the IPs it's using). The simple client does not persist connections, but I could check the IPs it was connecting to with `strace -p $(pgrep -f ddagent.py) -f -e trace=network -s 10000`.

The agent behaved as expected in these tests.