### PR TITLE
[filehandles] Include allocated, allocated but unused, used, and max filehandler metrics

### DIFF
--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -244,9 +244,16 @@ class FileHandles(Check):
         allocated_unused_fh = float(handle_metrics[1])
         max_fh = float(handle_metrics[2])
 
-        fh_in_use = (allocated_fh - allocated_unused_fh) / max_fh
+        num_used = allocated_fh - allocated_unused_fh
+        fh_in_use = num_used / max_fh
 
-        return {'system.fs.file_handles.in_use': float(fh_in_use)}
+        return {
+            'system.fs.file_handles.allocated': allocated_fh,
+            'system.fs.file_handles.allocated_unused': allocated_unused_fh,
+            'system.fs.file_handles.in_use': fh_in_use,
+            'system.fs.file_handles.used': num_used,
+            'system.fs.file_handles.max': max_fh,
+        }
 
 class Load(Check):
 


### PR DESCRIPTION
### What does this PR do?

This change emits more file handler metrics that weren't previously available: num allocated, num allocated but unused, used (an alias for allocated - allocated and unused), and max num of file handles.

### Motivation

The "% of max file handlers used" metric introduced by https://github.com/DataDog/dd-agent/pull/3395 helps us detect changes in file handler usage, but sometimes I want to know the absolute values (ex: when comparing different hosts with different limits).

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

I verified this by running the agent on my host and seeing the new metrics in the Datadog web UI.
