### PR TITLE
Add kube container name in service discovery

### DIFF
--- a/utils/service_discovery/sd_docker_backend.py
+++ b/utils/service_discovery/sd_docker_backend.py
@@ -314,6 +314,11 @@ class SDDockerBackend(AbstractSDBackend):
             namespace = pod_metadata.get('namespace')
             tags.append('kube_namespace:%s' % namespace)
 
+            # get kubernetes container name
+            kube_container_name = state.get_kube_container_name(c_id)
+            if kube_container_name:
+                tags.append('kube_container_name:%s' % kube_container_name)
+
             if not self.kubeutil:
                 log.warning("The agent can't connect to kubelet, creator and "
                             "service tags will be missing for container %s." % c_id[:12])


### PR DESCRIPTION
### What does this PR do?

Extract the tag `kube_container_name` in `sd_docker_backend` and `kubeutil`.

Also improves the coverage of these two packages.


