### PR TITLE
[aggregator] Ignore all dist metrics (metric type starting with 'd')

### DIFF
--- a/aggregator.py
+++ b/aggregator.py
@@ -474,7 +474,7 @@ class Aggregator(object):
 
             if metric_type in self.ALLOW_STRINGS:
                 value = raw_value
-            elif metric_type in self.IGNORE_TYPES:
+            elif len(metric_type) > 0 and metric_type[0] in self.IGNORE_TYPES:
                 continue
             else:
                 # Try to cast as an int first to avoid precision issues, then as a

--- a/tests/core/test_aggregator.py
+++ b/tests/core/test_aggregator.py
@@ -291,6 +291,7 @@ class TestMetricsAggregator(unittest.TestCase):
     def test_ignore_distribution(self):
         stats = MetricsAggregator('myhost')
         stats.submit_packets('my.dist:5.0|d')
+        stats.submit_packets('my.other.dist:5.0|dk')
         stats.submit_packets('my.gauge:1|g')
 
         # Assert that it's treated normally, and that the distribution is ignored


### PR DESCRIPTION
### What does this PR do?

Ignore all dist metrics (i.e. metric types starting with 'd')

### Motivation

Avoid dropping packets, just ignore these metrics.

### Testing

unit test + no noticeable impact on performance (used benchmark in `benchmark_aggregator`)
