### PR TITLE
kubeutil: get nodeName and nodeIP even if the agent isn't inside a Pod

### DIFF
--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -1,21 +1,22 @@
 # stdlib
-import unittest
+import json
 import os.path
+import unittest
 
 # 3rd party
 from mock import patch
-import json
 
 # project
 from utils.kubernetes import KubeUtil
 from .test_orchestrator import MockResponse
+
 
 class KubeTestCase(unittest.TestCase):
     # Patch _locate_kubelet that is used by KubeUtil.__init__
     def setUp(self):
         with patch.object(KubeUtil, '_locate_kubelet', return_value='http://localhost:10255'):
             self.kube = KubeUtil()
-            self.kube.__init__()    # It's a singleton, force re-init
+            self.kube.__init__()  # It's a singleton, force re-init
 
     def tearDown(self):
         self.kube = None
@@ -34,6 +35,7 @@ class KubeTestCase(unittest.TestCase):
         json_array = cls._load_json_array(names)
         return map(lambda x: MockResponse(x, 200), json_array)
 
+
 class TestKubeUtilInit(KubeTestCase):
     @patch.dict(os.environ, {'KUBERNETES_POD_NAME': 'test'})
     def test_pod_name(self):
@@ -41,6 +43,7 @@ class TestKubeUtilInit(KubeTestCase):
             kube = KubeUtil()
             kube.__init__()
             self.assertEqual('test', kube.pod_name)
+
 
 class TestKubeUtilDeploymentTag(KubeTestCase):
     def test_deployment_name_nominal(self):
@@ -64,9 +67,10 @@ class TestKubeUtilDeploymentTag(KubeTestCase):
 
         self.assertEqual('front-end', self.kube.get_deployment_for_replicaset('front-end-768dd754b7'))
 
+
 class TestKubeUtilCreatorTags(KubeTestCase):
     @classmethod
-    def _fake_pod(cls,creator_kind, creator_name):
+    def _fake_pod(cls, creator_kind, creator_name):
         payload = '{"reference": {"kind":"%s", "name":"%s"}}' % (creator_kind, creator_name)
         return {'annotations': {'kubernetes.io/created-by': payload}}
 
@@ -87,3 +91,161 @@ class TestKubeUtilCreatorTags(KubeTestCase):
 
     def test_invalid_input(self):
         self.assertEqual([], self.kube.get_pod_creator_tags({}))
+
+
+class TestKubeGetNodeInfo(KubeTestCase):
+    @staticmethod
+    def mocked_requests_get_without_agent_but_ok(*args, **kwargs):
+        return MockResponse({
+            "kind": "PodList",
+            "apiVersion": "v1",
+            "metadata": {},
+            "items": [
+                # Static Pod
+                {
+                    "metadata": {
+                        "name": "nginx0-cluster-pool-2-66d4cbf5-z9d1",
+                        "namespace": "default",
+                    },
+                    "spec": {
+                        "nodeName": "cluster-pool-2-66d4cbf5-z9d1",
+                    },
+                    "status": {
+                        "phase": "Running",
+                        "podIP": "10.20.5.13",
+                    }
+                },
+                # apiserver Pod on hostNetwork
+                {
+                    "metadata": {
+                        "name": "fluentd-gcp-v2.0.9-07l3b",
+                        "generateName": "fluentd-gcp-v2.0.9-",
+                        "namespace": "kube-system",
+                    },
+                    "spec": {
+                        "nodeName": "cluster-pool-2-66d4cbf5-z9d1",
+                        "hostNetwork": True,
+                    },
+                    "status": {
+                        "phase": "Running",
+                        "hostIP": "10.132.0.22",
+                        "podIP": "10.132.0.22",
+                    }
+                },
+                # apiserver Pod
+                {
+                    "metadata": {
+                        "name": "t1-2306965351-dg611",
+                        "generateName": "t1-2306965351-",
+                        "namespace": "default",
+                    },
+                    "spec": {
+                        "nodeName": "cluster-pool-2-66d4cbf5-z9d1",
+                    },
+                    "status": {
+                        "phase": "Running",
+                        "hostIP": "10.132.0.22",
+                        "podIP": "10.20.5.12",
+                    }
+                }
+            ]
+        }, 200)
+
+    @staticmethod
+    def mocked_requests_get_empty(*args, **kwargs):
+        return MockResponse({
+            "kind": "PodList",
+            "apiVersion": "v1",
+            "metadata": {},
+            "items": []}, 200)
+
+    @staticmethod
+    def mocked_requests_get_without_agent_but_only_node_name(*args, **kwargs):
+        return MockResponse({
+            "kind": "PodList",
+            "apiVersion": "v1",
+            "metadata": {},
+            "items": [
+                # Static Pod
+                {
+                    "metadata": {
+                        "name": "nginx0-cluster-pool-2-66d4cbf5-z9d1",
+                        "namespace": "default",
+                    },
+                    "spec": {
+                        "nodeName": "cluster-pool-2-66d4cbf5-z9d1",
+                    },
+                    "status": {
+                        "phase": "Running",
+                        "podIP": "10.20.5.13",
+                    }
+                }]}, 200)
+
+    @staticmethod
+    def mocked_requests_get_with_agent(*args, **kwargs):
+        return MockResponse({
+            "kind": "PodList",
+            "apiVersion": "v1",
+            "metadata": {},
+            "items": [
+                # apiserver Pod
+                {
+                    "metadata": {
+                        "name": "t1-2306965351-dg611",
+                        "generateName": "t1-2306965351-",
+                        "namespace": "default",
+                    },
+                    "spec": {
+                        "nodeName": "cluster-pool-2-66d4cbf5-z9d1",
+                    },
+                    "status": {
+                        "phase": "Running",
+                        "hostIP": "10.132.0.22",
+                        "podIP": "10.20.5.12",
+                    }
+                },
+                # apiserver Pod -> datadog agent
+                {
+                    "metadata": {
+                        "name": "dd-agent-r38l3",
+                        "generateName": "dd-agent-",
+                        "namespace": "default",
+                    },
+                    "spec": {
+                        "serviceAccountName": "dd-agent",
+                        "serviceAccount": "dd-agent",
+                        "nodeName": "ip-172-31-66-124.eu-east-1.compute.internal",
+                    },
+                    "status": {
+                        "phase": "Running",
+                        "hostIP": "172.31.66.124",
+                        "podIP": "100.112.119.8",
+                    }
+                }
+            ]}, 200)
+
+    def test_get_node_info_ok(self):
+        with patch('utils.kubernetes.kubeutil.requests.get',
+                   side_effect=TestKubeGetNodeInfo.mocked_requests_get_without_agent_but_ok):
+            r = self.kube.get_node_info()
+            self.assertEqual(("10.132.0.22", "cluster-pool-2-66d4cbf5-z9d1"), r)
+
+    def test_get_node_info_empty(self):
+        with patch('utils.kubernetes.kubeutil.requests.get',
+                   side_effect=TestKubeGetNodeInfo.mocked_requests_get_empty):
+            r = self.kube.get_node_info()
+            self.assertEqual((None, None), r)
+
+    def test_get_node_info_only_node_name(self):
+        with patch('utils.kubernetes.kubeutil.requests.get',
+                   side_effect=TestKubeGetNodeInfo.mocked_requests_get_without_agent_but_only_node_name):
+            r = self.kube.get_node_info()
+            self.assertEqual((None, 'cluster-pool-2-66d4cbf5-z9d1'), r)
+
+    @patch.dict(os.environ, {'KUBERNETES_POD_NAME': 'dd-agent-r38l3'})
+    def test_get_node_info_with_agent(self):
+        with patch('utils.kubernetes.kubeutil.requests.get',
+                   side_effect=TestKubeGetNodeInfo.mocked_requests_get_with_agent):
+            self.kube.__init__()
+            r = self.kube.get_node_info()
+            self.assertEqual(('172.31.66.124', 'ip-172-31-66-124.eu-east-1.compute.internal'), r)

--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -196,12 +196,12 @@ class TestKubeGetNodeInfo(KubeTestCase):
                         "namespace": "default",
                     },
                     "spec": {
-                        "nodeName": "cluster-pool-2-66d4cbf5-z9d1",
+                        "nodeName": "ip-172-31-66-124.eu-east-1.compute.internal",
                     },
                     "status": {
                         "phase": "Running",
-                        "hostIP": "10.132.0.22",
-                        "podIP": "10.20.5.12",
+                        "hostIP": "172.31.66.124",
+                        "podIP": "100.112.119.9",
                     }
                 },
                 # apiserver Pod -> datadog agent

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -543,18 +543,6 @@ class KubeUtil:
             log.warning("Unable to retrieve pod list %s. Not fetching host data", str(e))
             return
 
-        for pod in pod_items:
-            metadata = pod.get("metadata", {})
-            name = metadata.get("name")
-            if name == self.pod_name:
-                status = pod.get('status', {})
-                spec = pod.get('spec', {})
-                # if not found, use an empty string - we use None as "not initialized"
-                self._node_ip = status.get('hostIP', '')
-                self._node_name = spec.get('nodeName', '')
-                return
-
-        # At this point the agent isn't inside the podList.
         # Take the first Pod with a status:
         # all running pods have the adapted '.spec.nodeName'
         # static pods doesn't have the '.status.hostIP'
@@ -570,6 +558,9 @@ class KubeUtil:
 
             if self._node_name and self._node_ip:
                 return
+
+        log.warning("Cannot set both node_name: '%s' and node_ip: '%s' from PodList with %d items",
+                    self._node_name, self._node_ip, len(pod_items))
 
     def extract_event_tags(self, event):
         """


### PR DESCRIPTION
### What does this PR do?

Improve the way we are setting the nodeIP / nodeName in kubeutil.

If the agent doesn't run inside a kubernetes Pod, we cannot [get](https://github.com/DataDog/integrations-core/blob/bf7c8aa7dea0af631572f31e84c4fdabd80ccf15/kubernetes/check.py#L517) the hostname for the [events](https://github.com/DataDog/integrations-core/blob/bf7c8aa7dea0af631572f31e84c4fdabd80ccf15/kubernetes/check.py#L554).

All events will have **None** as `node_name` value.

All Pods inside the PodList are running on the same node/kubelet so in theory we could pick any of them and get the `spec.nodeName` for the `node_name` / hostname.

Sadly the static Pods don't have the associated `status.hostIP` so we need to manage that.