### PR TITLE
[wheel] Don't spam logs with exceptions when checks aren't wheels

### DIFF
--- a/config.py
+++ b/config.py
@@ -869,7 +869,8 @@ def _get_check_module(check_name, check_path, from_site=False):
             check_module = import_module("datadog_checks.{}".format(check_name))
         except ImportError as e:
             error = e
-            log.exception('Unable to import check module %s from site-packages' % check_name)
+            # Log at debug level since this code path is expected if the check is not installed as a wheel
+            log.debug('Unable to import check module %s from site-packages: %s', check_name, e)
     else:
         try:
             check_module = imp.load_source('checksd_%s' % check_name, check_path)


### PR DESCRIPTION
### What does this PR do?

Avoids spamming logs with exceptions when checks aren't wheels.

We always try to load the checks as wheel-installed checks, but it's
not an error if the checks are installed differently, so avoid logging with
exception level.

### Motivation

Without this, we get this error in the logs for every check that's enabled, on agent startup:

```
2017-12-29 13:12:34 UTC | ERROR | dd.collector | config(config.py:872) | Unable to import check module process from site-packages
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/config.py", line 869, in _get_check_module
    check_module = import_module("datadog_checks.{}".format(check_name))
  File "/opt/datadog-agent/embedded/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
ImportError: No module named datadog_checks.process
```