### PR TITLE
Accept API key as an argument

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -47,6 +47,8 @@ fi
 
 if [ -n "$DD_API_KEY" ]; then
     apikey=$DD_API_KEY
+elif [ $1 ]; then
+    apikey=$1
 fi
 
 if [ -n "$DD_INSTALL_ONLY" ]; then


### PR DESCRIPTION


*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Allows a user to pass in the Datadog API key to the install script as an argument rather than as an environment variable. 

### Motivation

Trying to get the agent to install using AWS SSM was proving troublesome. Despite exporting the variable correctly, I kept getting the "API key not available in DD_API_KEY environment variable" message. Plus, it seemed a little odd to go through two steps (create variable, run script) when you could do it in a single step (script plus argument). As it appears it's the only external input required, it seems sensible you should be able to put the key in that way! Environment variables take precedence and a blank still throws an error to alert people. 

### Testing Guidelines

It's a 3 line edit to the Agent Installer. The old use case, failure case and this all work. 

### Additional Notes

I didn't upgrade the error message (it still implicitly expects an Environment Variable) as I assume you want that to be the primary method of injecting the key. 
