### PR TITLE
Create datadog-installer.ps1

### DIFF
--- a/packaging/windows/datadog-installer.ps1
+++ b/packaging/windows/datadog-installer.ps1
@@ -38,7 +38,7 @@ process{
 
 Write-Output "Getting versions JSON"
 $InstallerJsonUrl ="https://s3.amazonaws.com/ddagent-windows-stable/installers.json"
-$Req = Invoke-WebRequest -Uri $InstallerJsonUrl
+$Req = Invoke-WebRequest -Uri $InstallerJsonUrl -UseBasicParsing
 
 Write-Output "Calculating latest version"
 $VersionsObject = $Req.Content | ConvertFrom-Json
@@ -53,7 +53,7 @@ $LatestVersion = $Versions | Sort-Object -Descending | Select -First 1
 Write-Output "Collecting Datadog Version $($LatestVersion.ToString())"
 $TargetMSI = $VersionsObject.$($LatestVersion.toString()).amd64
 
-Invoke-WebRequest -Uri $TargetMSI -OutFile $MSI
+Invoke-WebRequest -Uri $TargetMSI -OutFile $MSI -UseBasicParsing
 
 If ( $Tags ){
     $Expression = "msiexec /qn /i `"$MSI`" APIKEY=`"$APIKEY`" HOSTNAME=`"$HOSTNAME`" TAGS=`"$($TAGS -join ",")`""

--- a/packaging/windows/datadog-installer.ps1
+++ b/packaging/windows/datadog-installer.ps1
@@ -1,0 +1,68 @@
+<#
+    .SYNOPSIS
+    This PowerShell script is designed to install the latest Datadog agent seamlessly on windows
+
+    .PARAMETER APIKey
+    The API Key for your datadog installation. Contact support if you don't have one!
+
+    .PARAMETER Location
+    Where the MSI should be dropped. Defaults to C:\Windows\temp
+
+    .PARAMETER Hostname
+    Name of the host. Defaults to the Windows hostname
+
+    .PARAMETER Tags
+    Tags to assign.
+
+    .EXAMPLE
+    .\Datadog-Installer.ps1 -APIKey INSERTKEYHERE -Tags MyTag1,MyTag2
+#>
+[CmdletBinding()]
+Param(
+
+    [Parameter(Mandatory=$True)]
+    [string]   $APIKey,
+
+    [ValidateScript ( { Test-Path $_ } ) ]
+    [string]   $Location = "C:\Windows\Temp",
+    [string]   $Hostname = $env:COMPUTERNAME,
+    [string[]] $Tags
+)
+begin{
+    $MSI = "$location\ddog.msi"
+    If ( Test-path $MSI ) {
+        Remove-Item $MSI -Force
+    }
+}
+process{
+
+Write-Output "Getting versions JSON"
+$InstallerJsonUrl ="https://s3.amazonaws.com/ddagent-windows-stable/installers.json"
+$Req = Invoke-WebRequest -Uri $InstallerJsonUrl
+
+Write-Output "Calculating latest version"
+$VersionsObject = $Req.Content | ConvertFrom-Json
+$VersionStrings = $VersionsObject| Get-Member -MemberType NoteProperty | Select Name 
+
+$Versions = @()
+ForEach ($Version in $VersionStrings){
+    $Versions += [version] $Version.Name
+}
+
+$LatestVersion = $Versions | Sort-Object -Descending | Select -First 1
+Write-Output "Collecting Datadog Version $($LatestVersion.ToString())"
+$TargetMSI = $VersionsObject.$($LatestVersion.toString()).amd64
+
+Invoke-WebRequest -Uri $TargetMSI -OutFile $MSI
+
+If ( $Tags ){
+    $Expression = "msiexec /qn /i `"$MSI`" APIKEY=`"$APIKEY`" HOSTNAME=`"$HOSTNAME`" TAGS=`"$($TAGS -join ",")`""
+}
+Else{
+    $Expression = "msiexec /qn /i `"$MSI`" APIKEY=`"$APIKEY`" HOSTNAME=`"$HOSTNAME`""
+}
+Write-Output "Commencing Installation"
+Write-Verbose "Installation Command: $Expression"
+Invoke-Expression $Expression  
+
+}


### PR DESCRIPTION
### What does this PR do?

A single script that takes arguments (APIKey, Hostname, Tags), downloads the latest version of Datadog and installs it. This makes it easier to automate deployments

### Motivation

I wanted to deploy to a number of Windows hosts and couldn't be bothered to do the copy/paste thing. 

### Testing Guidelines

Much like the last pull request, it stands alone. Input parameters have validation etc. 

### Additional Notes

The S3 buckets with versions is currently hardcoded and I've set it to use MSI rather than exe (no idea which you prefer). 

Apologies if this is in the wrong place, I know the script was needed but no idea where you wanted it!