### PR TITLE
Create Install-Datadog.ps1

### DIFF
--- a/packaging/windows/Install-Datadog.ps1
+++ b/packaging/windows/Install-Datadog.ps1
@@ -1,0 +1,68 @@
+<#
+    .SYNOPSIS
+    This PowerShell script is designed to install the latest Datadog agent seamlessly on windows
+
+    .PARAMETER APIKey
+    The API Key for your datadog installation. Contact support if you don't have one!
+
+    .PARAMETER Location
+    Where the MSI should be dropped. Defaults to C:\Windows\temp
+
+    .PARAMETER Hostname
+    Name of the host. Defaults to the Windows hostname
+
+    .PARAMETER Tags
+    Tags to assign.
+
+    .EXAMPLE
+    .\Datadog-Installer.ps1 -APIKey INSERTKEYHERE -Tags MyTag1,MyTag2
+#>
+[CmdletBinding()]
+Param(
+
+    [Parameter(Mandatory=$True)]
+    [string]   $APIKey,
+
+    [ValidateScript ( { Test-Path $_ } ) ]
+    [string]   $Location = "C:\Windows\Temp",
+    [string]   $Hostname = $env:COMPUTERNAME,
+    [string[]] $Tags
+)
+begin{
+    $MSI = "$location\ddog.msi"
+    If ( Test-path $MSI ) {
+        Remove-Item $MSI -Force
+    }
+}
+process{
+
+Write-Output "Getting versions JSON"
+$InstallerJsonUrl ="https://s3.amazonaws.com/ddagent-windows-stable/installers.json"
+$Req = Invoke-WebRequest -Uri $InstallerJsonUrl -UseBasicParsing
+
+Write-Output "Calculating latest version"
+$VersionsObject = $Req.Content | ConvertFrom-Json
+$VersionStrings = $VersionsObject| Get-Member -MemberType NoteProperty | Select Name 
+
+$Versions = @()
+ForEach ($Version in $VersionStrings){
+    $Versions += [version] $Version.Name
+}
+
+$LatestVersion = $Versions | Sort-Object -Descending | Select -First 1
+Write-Output "Collecting Datadog Version $($LatestVersion.ToString())"
+$TargetMSI = $VersionsObject.$($LatestVersion.toString()).amd64
+
+Invoke-WebRequest -Uri $TargetMSI -OutFile $MSI -UseBasicParsing
+
+If ( $Tags ){
+    $Expression = "msiexec /qn /i `"$MSI`" APIKEY=`"$APIKEY`" HOSTNAME=`"$HOSTNAME`" TAGS=`"$($TAGS -join ",")`""
+}
+Else{
+    $Expression = "msiexec /qn /i `"$MSI`" APIKEY=`"$APIKEY`" HOSTNAME=`"$HOSTNAME`""
+}
+Write-Output "Commencing Installation"
+Write-Verbose "Installation Command: $Expression"
+Invoke-Expression $Expression  
+
+}


### PR DESCRIPTION
### What does this PR do?

Single install script that takes arguments, grabs the JSON with versions, selects the highest and then installs in a one liner. The use of the JSON may seem odd (why not just use latest) but it means a later iteration will be able to select a specific version of the agent and thus allow teams to upgrade in a sustainable manner. 

### Motivation

Needed a single script for an SSM document. Essentially ripped off your idea of grabbing this from Github and then running it with the API key as a parameter

### Testing Guidelines

I've tested it on several windows machines (hence patch-3, I had to make a tweak to patch-2 branch). 

### Additional Notes

Apologies if it's in the wrong place - I know I needed a one line fetch and install but wasn't sure where you'd want it!