### PR TITLE
[wheels][auto-discovery] utils.checkfiles support for wheels

### DIFF
--- a/utils/checkfiles.py
+++ b/utils/checkfiles.py
@@ -38,11 +38,13 @@ def get_check_class(agentConfig, check_name):
     osname = get_os()
     checks_places = get_checks_places(osname, agentConfig)
     for check_path_builder in checks_places:
-        check_path, _ = check_path_builder(check_name)
-        if not check_path or not os.path.exists(check_path):
+        check_path, manifest_path = check_path_builder(check_name)
+        is_wheel = not check_path and not manifest_path
+
+        if not (check_path and os.path.exists(check_path)) and not is_wheel:
             continue
 
-        check_is_valid, check_class, load_failure = get_valid_check_class(check_name, check_path)
+        check_is_valid, check_class, load_failure = get_valid_check_class(check_name, check_path, from_site=is_wheel)
         if check_is_valid:
             return check_class
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?
Fixes issue with auto-discovery and wheels. More precisely, if a wheel-check was installed but the bundled check was missing (perfectly plausible scenario as soon as we release standalone wheel checks) the check validation would fail.

### Motivation

Issue discovered in 5.21.0 testing (does not affect 5.21.0, but would affect subsequent releases)

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
