### PR TITLE
Add Generic Prometheus Check class

### DIFF
--- a/checks/generic_prometheus_check.py
+++ b/checks/generic_prometheus_check.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 from checks import CheckException
-from checks.prometheus_check import PrometheusCheck, PrometheusFormat
+from checks.prometheus_check import PrometheusCheck
 from checks import AgentCheck
 
 # GenericPrometheusCheck is a class that helps instanciating PrometheusCheck only
@@ -27,9 +27,12 @@ class GenericPrometheusCheck(AgentCheck):
             endpoint = instance.get("prometheus_url", None)
             if endpoint is None:
                 raise CheckException("Unable to find prometheus URL in config file.")
+            namespace = instance.get("namespace", None)
+            if namespace is None:
+                raise CheckException("You have to define a namespace for each prometheus check")
             # Instanciate check
             check = PrometheusCheck(name, init_config, agentConfig, instance)
-            check.NAMESPACE = instance.get("namespace", "")
+            check.NAMESPACE = namespace
             # metrics are preprocessed if no mapping
             metrics_mapper = {}
             for metric in instance.get("metrics", []):
@@ -42,6 +45,7 @@ class GenericPrometheusCheck(AgentCheck):
             check.label_joins = instance.get("label_joins", {})
             check.exclude_labels = instance.get("exclude_labels", [])
             check.label_to_hostname = instance.get("label_to_hostname", None)
+            check.health_service_check = instance.get("health_service_check", True)
             # use the parent aggregator
             check.aggregator = self.aggregator
             self.check_map[instance["prometheus_url"]] = check

--- a/checks/generic_prometheus_check.py
+++ b/checks/generic_prometheus_check.py
@@ -1,0 +1,59 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+from checks import CheckException
+from checks.prometheus_check import PrometheusCheck, PrometheusFormat
+from checks import AgentCheck
+
+# GenericPrometheusCheck is a class that helps instanciating PrometheusCheck only
+# with YAML configurations. As each check has it own states it maintains a map
+# of all checks so that the one corresponding to the instance is executed
+#
+# Minimal example configuration:
+# instances:
+#   - prometheus_url: http://foobar/endpoint
+#     namespace: "foobar"
+#     metrics:
+#       - bar
+#       - foo
+class GenericPrometheusCheck(AgentCheck):
+
+    def __init__(self, name, init_config, agentConfig, instances=None):
+        AgentCheck.__init__(self, name, init_config, agentConfig, instances)
+        self.check_map = {}
+        for instance in instances:
+            # Check mandatory settings
+            endpoint = instance.get("prometheus_url", None)
+            if endpoint is None:
+                raise CheckException("Unable to find prometheus URL in config file.")
+            # Instanciate check
+            check = PrometheusCheck(name, init_config, agentConfig, instance)
+            check.NAMESPACE = instance.get("namespace", "")
+            # metrics are preprocessed if no mapping
+            metrics_mapper = {}
+            for metric in instance.get("metrics", []):
+                if isinstance(metric, basestring):
+                    metrics_mapper[metric] = metric
+                else:
+                    metrics_mapper.update(metric)
+            check.metrics_mapper = metrics_mapper
+            check.labels_mapper = instance.get("labels_mapper", {})
+            check.label_joins = instance.get("label_joins", {})
+            check.exclude_labels = instance.get("exclude_labels", [])
+            check.label_to_hostname = instance.get("label_to_hostname", None)
+            # use the parent aggregator
+            check.aggregator = self.aggregator
+            self.check_map[instance["prometheus_url"]] = check
+
+    def check(self, instance):
+        endpoint = instance["prometheus_url"]
+        check = self.check_map[endpoint]
+        if not check.metrics_mapper:
+            raise CheckException("You have to collect at least one metric from the endpoint: " + endpoint)
+        check.process(
+            endpoint,
+            send_histograms_buckets=instance.get('send_histograms_buckets', True),
+            instance=instance,
+            ignore_unmapped=True
+        )

--- a/checks/generic_prometheus_check.py
+++ b/checks/generic_prometheus_check.py
@@ -23,36 +23,11 @@ class GenericPrometheusCheck(AgentCheck):
         AgentCheck.__init__(self, name, init_config, agentConfig, instances)
         self.check_map = {}
         for instance in instances:
-            # Check mandatory settings
-            endpoint = instance.get("prometheus_url", None)
-            if endpoint is None:
-                raise CheckException("Unable to find prometheus URL in config file.")
-            namespace = instance.get("namespace", None)
-            if namespace is None:
-                raise CheckException("You have to define a namespace for each prometheus check")
-            # Instanciate check
-            check = PrometheusCheck(name, init_config, agentConfig, instance)
-            check.NAMESPACE = namespace
-            # metrics are preprocessed if no mapping
-            metrics_mapper = {}
-            for metric in instance.get("metrics", []):
-                if isinstance(metric, basestring):
-                    metrics_mapper[metric] = metric
-                else:
-                    metrics_mapper.update(metric)
-            check.metrics_mapper = metrics_mapper
-            check.labels_mapper = instance.get("labels_mapper", {})
-            check.label_joins = instance.get("label_joins", {})
-            check.exclude_labels = instance.get("exclude_labels", [])
-            check.label_to_hostname = instance.get("label_to_hostname", None)
-            check.health_service_check = instance.get("health_service_check", True)
-            # use the parent aggregator
-            check.aggregator = self.aggregator
-            self.check_map[instance["prometheus_url"]] = check
+            self.get_instance_check(instance)
 
     def check(self, instance):
         endpoint = instance["prometheus_url"]
-        check = self.check_map[endpoint]
+        check = self.get_instance_check(instance)
         if not check.metrics_mapper:
             raise CheckException("You have to collect at least one metric from the endpoint: " + endpoint)
         check.process(
@@ -61,3 +36,37 @@ class GenericPrometheusCheck(AgentCheck):
             instance=instance,
             ignore_unmapped=True
         )
+
+    def get_instance_check(self, instance):
+        endpoint = instance.get("prometheus_url", "")
+        # If we already created the PrometheusCheck, return it
+        if endpoint in self.check_map:
+            return self.check_map[endpoint]
+
+        # Otherwise we create the PrometheusCheck
+        if endpoint == "":
+            raise CheckException("Unable to find prometheus URL in config file.")
+        namespace = instance.get("namespace", "")
+        if namespace == "":
+            raise CheckException("You have to define a namespace for each prometheus check")
+        # Instanciate check
+        check = PrometheusCheck(self.name, self.init_config, self.agentConfig, instance)
+        check.NAMESPACE = namespace
+        # Metrics are preprocessed if no mapping
+        metrics_mapper = {}
+        for metric in instance.get("metrics", []):
+            if isinstance(metric, basestring):
+                metrics_mapper[metric] = metric
+            else:
+                metrics_mapper.update(metric)
+        check.metrics_mapper = metrics_mapper
+        check.labels_mapper = instance.get("labels_mapper", {})
+        check.label_joins = instance.get("label_joins", {})
+        check.exclude_labels = instance.get("exclude_labels", [])
+        check.label_to_hostname = instance.get("label_to_hostname", None)
+        check.health_service_check = instance.get("health_service_check", True)
+        # Use the parent aggregator
+        check.aggregator = self.aggregator
+        self.check_map[instance["prometheus_url"]] = check
+
+        return check

--- a/tests/core/fixtures/prometheus/generic_conf.yaml
+++ b/tests/core/fixtures/prometheus/generic_conf.yaml
@@ -1,0 +1,27 @@
+instances:
+  - prometheus_url: http://service/prometheus
+    namespace: "service"
+    metrics:
+      - processor: cpu
+      - memory: mem
+      - io
+    label_to_hostname: node
+    label_joins:
+      target_metric:
+        label_to_match: matched_label
+        labels_to_get:
+          - extra_label_1
+          - extra_label_2
+    labels_mapper:
+      flavor: origin
+    tags:
+      - foo:bar
+    send_histograms_buckets: True
+    exclude_labels:
+      - timestamp
+  - prometheus_url: http://foobar/endpoint
+    namespace: "foobar"
+    metrics:
+      - bar
+      - foo
+      - foobar: fb

--- a/tests/core/test_generic_prometheus.py
+++ b/tests/core/test_generic_prometheus.py
@@ -1,0 +1,119 @@
+# (C) Datadog, Inc. 2018
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+import os
+import unittest
+
+from mock import MagicMock, patch, call
+from prometheus_client import generate_latest, CollectorRegistry, Gauge
+
+from checks.generic_prometheus_check import GenericPrometheusCheck
+
+class TestGenericPrometheusCheck(unittest.TestCase):
+
+    def setUp(self):
+        f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'prometheus', 'generic_conf.yaml')
+        self.check, self.instances = GenericPrometheusCheck.from_yaml(f_name)
+
+    def test_init(self):
+        self.assertEqual(2, len(self.check.check_map))
+        check1 = self.check.check_map['http://service/prometheus']
+        check2 = self.check.check_map['http://foobar/endpoint']
+        self.assertEqual(check1.NAMESPACE, "service")
+        self.assertEqual(check2.NAMESPACE, "foobar")
+        self.assertEqual(check1.label_to_hostname, "node")
+        self.assertDictEqual(
+            check1.metrics_mapper,
+            {'processor': 'cpu', 'memory': 'mem', 'io': 'io'}
+        )
+        self.assertDictEqual(
+            check2.metrics_mapper,
+            {'bar': 'bar', 'foo': 'foo', 'foobar': 'fb'}
+        )
+        self.assertDictEqual(
+            check1.label_joins,
+            {'target_metric': {
+                'label_to_match': 'matched_label',
+                'labels_to_get': ['extra_label_1', 'extra_label_2']
+                }
+            }
+        )
+        self.assertDictEqual(check1.labels_mapper, {'flavor': 'origin'})
+        self.assertListEqual(check1.exclude_labels, ['timestamp'])
+
+    @patch('requests.get')
+    def test_multiple_checks(self, mock_get):
+        registry1 = CollectorRegistry()
+        g = Gauge('processor', 'processor usage', registry=registry1)
+        g.set(4.2)
+        data1 = generate_latest(registry1)
+
+        registry2 = CollectorRegistry()
+        g = Gauge('foo', 'foo usage', registry=registry2)
+        g.set(1337)
+        g = Gauge('foobar', 'foo usage', registry=registry2)
+        g.set(42)
+        data2 = generate_latest(registry2)
+
+        def get_side_effect(*args, **kwargs):
+            if args[0] == 'http://service/prometheus':
+                return MagicMock(status_code=200,
+                    iter_lines=lambda **kwargs: data1.split("\n"),
+                    headers={'Content-Type': "text/plain"})
+            if args[0] == 'http://foobar/endpoint':
+                return MagicMock(status_code=500,
+                    iter_lines=lambda **kwargs: data2.split("\n"),
+                    headers={'Content-Type': "text/plain"})
+
+        mock_get.side_effect = get_side_effect
+
+        check1 = self.check.check_map['http://service/prometheus']
+        instance = self.instances[0]
+        check1.gauge = MagicMock()
+        # label_joins is set so there's a dry run
+        self.check.check(instance)
+        self.check.check(instance)
+        check1.gauge.assert_has_calls([
+            call('service.cpu', 4.2, ['foo:bar'], hostname=None),
+        ], any_order=True)
+
+        check2 = self.check.check_map['http://foobar/endpoint']
+        instance = self.instances[1]
+        check2.gauge = MagicMock()
+        self.check.check(instance)
+        check2.gauge.assert_has_calls([
+            call('foobar.foo', 1337.0, [], hostname=None),
+            call('foobar.fb', 42.0, [], hostname=None),
+        ], any_order=True)
+
+    @patch('requests.get')
+    def test_advanced_conf_check(self, mock_get):
+        registry = CollectorRegistry()
+        g1 = Gauge('processor', 'processor usage', ['matched_label', 'node', 'flavor'], registry=registry)
+        g1.labels(matched_label="foobar", node="localhost", flavor="test").set(99.9)
+        g2 = Gauge('memory', 'memory usage', ['matched_label', 'node', 'timestamp'], registry=registry)
+        g2.labels(matched_label="foobar", node="localhost", timestamp="123").set(12.2)
+        g3 = Gauge('target_metric', 'Metric holding labels', ['matched_label', 'extra_label_1', 'extra_label_2'], registry=registry)
+        g3.labels(matched_label="foobar", extra_label_1="extra1", extra_label_2="extra2").inc()
+
+        data = generate_latest(registry)
+
+        def get_side_effect(*args, **kwargs):
+            if args[0] == 'http://service/prometheus':
+                return MagicMock(status_code=200,
+                    iter_lines=lambda **kwargs: data.split("\n"),
+                    headers={'Content-Type': "text/plain"})
+
+        mock_get.side_effect = get_side_effect
+
+        check1 = self.check.check_map['http://service/prometheus']
+        instance = self.instances[0]
+        check1.gauge = MagicMock()
+        # label_joins is set so there's a dry run
+        self.check.check(instance)
+        self.check.check(instance)
+        check1.gauge.assert_has_calls([
+            call('service.cpu', 99.9, ['foo:bar', 'node:localhost', 'origin:test', 'matched_label:foobar', 'extra_label_1:extra1', 'extra_label_2:extra2'], hostname="localhost"),
+            call('service.mem', 12.2, ['foo:bar', 'node:localhost', 'matched_label:foobar', 'extra_label_1:extra1', 'extra_label_2:extra2'], hostname="localhost"),
+        ], any_order=True)

--- a/tests/core/test_generic_prometheus.py
+++ b/tests/core/test_generic_prometheus.py
@@ -33,9 +33,11 @@ class TestGenericPrometheusCheck(unittest.TestCase):
         )
         self.assertDictEqual(
             check1.label_joins,
-            {'target_metric': {
-                'label_to_match': 'matched_label',
-                'labels_to_get': ['extra_label_1', 'extra_label_2']
+            {
+                'target_metric':
+                {
+                    'label_to_match': 'matched_label',
+                    'labels_to_get': ['extra_label_1', 'extra_label_2']
                 }
             }
         )
@@ -45,6 +47,7 @@ class TestGenericPrometheusCheck(unittest.TestCase):
     @patch('requests.get')
     def test_multiple_checks(self, mock_get):
         registry1 = CollectorRegistry()
+        # pylint: disable=E1123,E1120
         g = Gauge('processor', 'processor usage', registry=registry1)
         g.set(4.2)
         data1 = generate_latest(registry1)
@@ -90,6 +93,7 @@ class TestGenericPrometheusCheck(unittest.TestCase):
     @patch('requests.get')
     def test_advanced_conf_check(self, mock_get):
         registry = CollectorRegistry()
+        # pylint: disable=E1123,E1120
         g1 = Gauge('processor', 'processor usage', ['matched_label', 'node', 'flavor'], registry=registry)
         g1.labels(matched_label="foobar", node="localhost", flavor="test").set(99.9)
         g2 = Gauge('memory', 'memory usage', ['matched_label', 'node', 'timestamp'], registry=registry)


### PR DESCRIPTION
### What does this PR do?

Add a generic prometheus check that instanciates prometheus check only through configuration

Follow-up PR to add it to `integrations-core`: https://github.com/DataDog/integrations-core/pull/1006

### Motivation

Have a simple conf-only way to collect metrics from a prometheus endpoint
