### PR TITLE
Fix issue with creating tags from conf in IIS

### DIFF
--- a/checks/libs/win/pdhbasecheck.py
+++ b/checks/libs/win/pdhbasecheck.py
@@ -33,7 +33,7 @@ class PDHBaseCheck(AgentCheck):
 
                 cfg_tags = instance.get('tags')
                 if cfg_tags is not None:
-                    tags = cfg_tags.join(",")
+                    tags = (",").join(cfg_tags)
                     self._tags[key] = list(tags) if tags else []
                 remote_machine = None
                 host = instance.get('host')

--- a/checks/libs/win/pdhbasecheck.py
+++ b/checks/libs/win/pdhbasecheck.py
@@ -33,7 +33,7 @@ class PDHBaseCheck(AgentCheck):
 
                 cfg_tags = instance.get('tags')
                 if cfg_tags is not None:
-                    tags = (",").join(cfg_tags)
+                    tags = ",".join(cfg_tags)
                     self._tags[key] = list(tags) if tags else []
                 remote_machine = None
                 host = instance.get('host')


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Fixes an issue when pulling tags from a yaml config file with any integration that uses the `PDHBaseCheck` class

### Motivation

A customer reached out with a report of the IIS check, which now collects metric via PDH, failing after upgrading to 5.21

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
