### PR TITLE
[Prometheus Check] add SSL support

### DIFF
--- a/checks/prometheus_check.py
+++ b/checks/prometheus_check.py
@@ -126,6 +126,9 @@ class PrometheusCheck(AgentCheck):
         # Currently, Requests does not support using encrypted keys.
         self.ssl_private_key = None
 
+        # The path to the trusted CA used for generating custom certificates
+        self.ssl_ca_cert = None
+
     def check(self, instance):
         """
         check should take care of getting the url and other params
@@ -415,8 +418,11 @@ class PrometheusCheck(AgentCheck):
             cert = self.ssl_cert
             if isinstance(self.ssl_private_key, basestring):
                 cert = (self.ssl_cert, self.ssl_private_key)
+        verify = True
+        if isinstance(self.ssl_ca_cert, basestring):
+            verify = self.ssl_ca_cert
         try:
-            response = requests.get(endpoint, headers=headers, stream=True, cert=cert)
+            response = requests.get(endpoint, headers=headers, stream=True, cert=cert, verify=verify)
         except (IOError, requests.exceptions.SSLError):
             self.log.error("Invalid SSL settings for requesting {} endpoint".format(endpoint))
             raise

--- a/checks/prometheus_check.py
+++ b/checks/prometheus_check.py
@@ -116,6 +116,16 @@ class PrometheusCheck(AgentCheck):
         # a label can hold this information, this transfer it to the hostname
         self.label_to_hostname = None
 
+        # Can either be only the path to the certificate and thus you should specify the private key
+        # or it can be the path to a file containing both the certificate & the private key
+        self.ssl_cert = None
+
+        # Needed if the certificate does not include the private key
+        #
+        # /!\ The private key to your local certificate must be unencrypted.
+        # Currently, Requests does not support using encrypted keys.
+        self.ssl_private_key = None
+
     def check(self, instance):
         """
         check should take care of getting the url and other params
@@ -400,8 +410,16 @@ class PrometheusCheck(AgentCheck):
             headers['accept'] = 'application/vnd.google.protobuf; ' \
                                 'proto=io.prometheus.client.MetricFamily; ' \
                                 'encoding=delimited'
-
-        response = requests.get(endpoint, headers=headers, stream=True)
+        cert = None
+        if isinstance(self.ssl_cert, basestring):
+            cert = self.ssl_cert
+            if isinstance(self.ssl_private_key, basestring):
+                cert = (self.ssl_cert, self.ssl_private_key)
+        try:
+            response = requests.get(endpoint, headers=headers, stream=True, cert=cert)
+        except (IOError, requests.exceptions.SSLError):
+            self.log.error("Invalid SSL settings for requesting {} endpoint".format(endpoint))
+            raise
         try:
             response.raise_for_status()
             return response


### PR DESCRIPTION
### What does this PR do?

Add SSL/TLS support for the prometheus check and closes #3639 

### Motivation

As reported in #3639 some prometheus endpoint (such as a secured etcd) could be behind https an the prometheus check need to support these

### Additional Notes

This was manually tested on a secure etcd cluster
