### PR TITLE
Deduplicate tags on metrics, events and service_checks for check and dogstatsd

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -596,6 +596,9 @@ class AgentCheck(object):
                 "tags": (optional) list, a list of tags to associate with this event
             }
         """
+        tags = event.get("tags")
+        if tags:
+            event["tags"] = sorted(set(tags))
         self.events.append(event)
 
     def service_check(self, check_name, status, tags=None, timestamp=None,
@@ -618,6 +621,8 @@ class AgentCheck(object):
             hostname = self.hostname
         if message is not None:
             message = unicode(message) # ascii converts to unicode but not viceversa
+        if tags:
+            tags = sorted(set(tags))
         self.service_checks.append(
             create_service_check(check_name, status, tags, timestamp,
                                  hostname, check_run_id, message)
@@ -957,7 +962,7 @@ def agent_formatter(metric, value, timestamp, tags, hostname, device_name=None,
     """
     attributes = {}
     if tags:
-        attributes['tags'] = list(tags)
+        attributes['tags'] = list(set(tags))
     if hostname:
         attributes['hostname'] = hostname
     if device_name:


### PR DESCRIPTION
### What does this PR do?

De-duplicate tags before pushing to the backend. This avoid pushing hundred of tags if a check is buggy.