### PR TITLE
fix proxy skipping

### DIFF
--- a/tests/core/test_proxy.py
+++ b/tests/core/test_proxy.py
@@ -78,6 +78,8 @@ class TestNoProxy(TestCase):
         }
 
         gen_proxies = config_proxy_skip(proxies, 's3://anything', skip_proxy=True)
+        self.assertTrue('http' in gen_proxies)
+        self.assertTrue('https' in gen_proxies)
         self.assertEquals(gen_proxies.get('http'), None)
         self.assertEquals(gen_proxies.get('https'), None)
 

--- a/utils/proxy.py
+++ b/utils/proxy.py
@@ -89,11 +89,10 @@ def config_proxy_skip(proxies, uri, skip_proxy=False):
     parsed_uri = urlparse(uri)
 
     # disable proxy if necessary
+    # keep keys so `requests` doesn't use env var proxies either
     if skip_proxy:
-        if 'http' in proxies:
-            proxies.pop('http')
-        if 'https' in proxies:
-            proxies.pop('https')
+        proxies['http'] = None
+        proxies['https'] = None
     elif proxies.get('no'):
         for url in proxies['no'].replace(';', ',').split(","):
             if url in parsed_uri.netloc:


### PR DESCRIPTION
### What does this PR do?

This makes `requests` correctly ignore environment-declared proxies.

### Motivation

I encountered the bug