### PR TITLE
allow default proxies

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -389,8 +389,8 @@ class AgentCheck(object):
 
         self.check_version = _version
 
-    def get_instance_proxy(self, instance, uri):
-        proxies = self.proxies.copy()
+    def get_instance_proxy(self, instance, uri, proxies=None):
+        proxies = proxies if proxies is not None else self.proxies.copy()
         proxies['no'] = get_no_proxy_from_env()
 
         return config_proxy_skip(proxies, uri, _is_affirmative(instance.get('no_proxy', False)))


### PR DESCRIPTION
### What does this PR do?

This allows one to set default proxies. If the uri doesn't match the env var `no_proxy` and the user hasn't enabled the config flag, you can now pass `proxies={}` to have `requests` preserve environment-declared proxies.

### Motivation

Customer uses `HTTP_PROXY`/`HTTPS_PROXY` https://github.com/DataDog/integrations-core/pull/1051