### PR TITLE
add jmx_custom_jars option to datadog.yaml

### DIFF
--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -157,8 +157,9 @@ gce_updated_hostname: yes
 # Enable JMX checks for service discovery
 # sd_jmx_enable: no
 #
-# If you require a custom jar to be loaded for JMX checks, set its path here
-# jmx_custom_jar: /jmx-jars/jboss-cli-client.jar
+# If you require custom jars to be loaded for JMX checks, you can set their paths here
+# instead of setting them in the checks' custom_jar_paths option
+# jmx_custom_jars: /jmx-jars/jboss-cli-client.jar:/my/other/custom.jar
 #
 # Docker labels as tags
 # We can extract docker labels and add them as tags to all metrics reported by service discovery.

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -157,6 +157,9 @@ gce_updated_hostname: yes
 # Enable JMX checks for service discovery
 # sd_jmx_enable: no
 #
+# If you require a custom jar to be loaded for JMX checks, set its path here
+# jmx_custom_jar: /jmx-jars/jboss-cli-client.jar
+#
 # Docker labels as tags
 # We can extract docker labels and add them as tags to all metrics reported by service discovery.
 # All you have to do is supply a comma-separated list of label names to extract from containers when found.

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -87,6 +87,7 @@ class JMXFetch(ProcessRunner):
         self.agent_config = agent_config
         self.check_frequency = DEFAULT_CHECK_FREQUENCY
         self.service_discovery = _is_affirmative(self.agent_config.get('sd_jmx_enable', False))
+        self.config_jar_path = self.agent_config.get('jmx_custom_jar', "")
 
         self.jmx_process = None
         self.jmx_checks = None
@@ -242,6 +243,8 @@ class JMXFetch(ProcessRunner):
                 classpath = r"%s:%s" % (tools_jar_path, classpath)
             if custom_jar_paths:
                 classpath = r"%s:%s" % (':'.join(custom_jar_paths), classpath)
+            if self.config_jar_path:
+                classpath = r"%s:%s" % (self.config_jar_path, classpath)
 
             subprocess_args = [
                 path_to_java,  # Path to the java bin

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -87,7 +87,7 @@ class JMXFetch(ProcessRunner):
         self.agent_config = agent_config
         self.check_frequency = DEFAULT_CHECK_FREQUENCY
         self.service_discovery = _is_affirmative(self.agent_config.get('sd_jmx_enable', False))
-        self.config_jar_path = self.agent_config.get('jmx_custom_jar', "")
+        self.config_jar_path = self.agent_config.get('jmx_custom_jars', "")
 
         self.jmx_process = None
         self.jmx_checks = None


### PR DESCRIPTION
This enables users to load a custom jar at jmxfetch start,
to allow using them reliably in AD templates

Only supporting a single string in agent5 to enable the use of
the DD_CONF_JMX_CUSTOM_JARS envvar binding, agent6 will support
a string array

`datadog/dev-dd-agent:backport_3648` allows to test it