### PR TITLE
[Windows] The agent service is no longer responsible for starting the

### DIFF
--- a/win32/service.py
+++ b/win32/service.py
@@ -177,13 +177,6 @@ class AgentSvc(win32serviceutil.ServiceFramework):
         for proc in self.procs.values():
             proc.start()
 
-        # check to see if apm is enabled.
-        if self.config.get('apm_enabled'):
-            try:
-                win32serviceutil.StartService("datadog-trace-agent")
-            except Exception as e:
-                log.error("Unable to start AMP service %s" % str(e))
-
         # Loop to keep the service running since all DD services are
         # running in separate processes
         self.running = True


### PR DESCRIPTION
APM service.  APM service will be installed automatic start, and then it
will stop itself if not enabled.

### What does this PR do?

Changes startup logic.  Main service will no longer start APM service; the APM service will be started automatically by the Service Control Manager

https://github.com/DataDog/dd-agent-omnibus/pull/217

### Motivation

Request to add process agent; make process agent and APM work the same

### Testing Guidelines

### Additional Notes

Should test that APM service stops itself when configured to be not running.
