### PR TITLE
[dockerutil] logs info if Dockerless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changes
 =======
 
-# 5.21.1 / Unreleased 
+# 5.21.1 / 01-31-2018
 
 **Linux, Windows, Docker**
 

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -137,7 +137,7 @@ class DockerUtil:
         except Exception as ex:
             # No docker_daemon.yaml + no existing Docker socket file = Dockerless
             if self._no_conf_file and not os.path.isfile(DEFAULT_SOCK_PATH):
-                log.info("Docker features disbled: No running Docker instance detected. Will not retry since no docker_daemon configuration file was found.")
+                log.info("Docker features disabled: No running Docker instance detected. Will not retry since no docker_daemon configuration file was found.")
             else:
                 log.error("Failed to initialize the docker client. Docker-related features "
                     "will fail. Will retry %s time(s). Error: %s" % (self.left_init_retries, str(ex)))

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -137,7 +137,7 @@ class DockerUtil:
         except Exception as ex:
             # No docker_daemon.yaml + no existing Docker socket file = Dockerless
             if self._no_conf_file and not os.path.isfile(DEFAULT_SOCK_PATH):
-                log.info("No docker_daemon conf and no Docker instance detected.")
+                log.info("Docker features disbled: No running Docker instance detected. Will not retry since no docker_daemon configuration file was found.")
             else:
                 log.error("Failed to initialize the docker client. Docker-related features "
                     "will fail. Will retry %s time(s). Error: %s" % (self.left_init_retries, str(ex)))


### PR DESCRIPTION
### What does this PR do?

Logs an INFO message instead of an ERROR when the host is deemed as Dockerless. 
Basically, if there was no docker_daemon.yaml file detected, assume that a running Docker instance will use a default socket file /var/run/docker.sock. If both the yaml file and the socket file do not exist, then the host is Dockerless; raise an INFO instead of an ERROR so as not to alarm customers.

### Motivation

A question often asked by (new) support engineers and customers.
