### PR TITLE
[source install] Fix pushd/popd bashism

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -446,7 +446,10 @@ then
   print_console "* Setting up integrations"
   INTEGRATIONS=$(ls $DD_HOME/integrations/)
   for INT in $INTEGRATIONS; do
-    cd "$DD_HOME/integrations/$INT"
+    INT_DIR="$DD_HOME/integrations/$INT"
+    # Only take into account directories with a `manifest.json` file
+    [ -f "$INT_DIR/manifest.json" ] || continue
+    cd "$INT_DIR"
 
     if [ -f "requirements.txt" ]; then
       "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.txt"

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -446,8 +446,7 @@ then
   print_console "* Setting up integrations"
   INTEGRATIONS=$(ls $DD_HOME/integrations/)
   for INT in $INTEGRATIONS; do
-    INT_DIR="$DD_HOME/integrations/$INT"
-    pushd $INT_DIR
+    cd "$DD_HOME/integrations/$INT"
 
     if [ -f "requirements.txt" ]; then
       "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.txt"
@@ -471,7 +470,7 @@ then
       cp "conf.yaml.default" "$DD_HOME/agent/conf.d/$INT.yaml.default"
     fi
 
-    popd
+    cd -
   done
   print_done
 fi


### PR DESCRIPTION
### What does this PR do?

Fixes bashism in source install script. Fixes #3656

### Motivation

Part of the changes in #3650 broke the alpine image build.

Our source install needs to be compatible with ~POSIX shell, so replace
bashisms.

### Testing

I've double-checked this fixes the alpine image build.