### PR TITLE
[formtter] tag list already sorted, set

### DIFF
--- a/checks/__init__.py
+++ b/checks/__init__.py
@@ -962,7 +962,7 @@ def agent_formatter(metric, value, timestamp, tags, hostname, device_name=None,
     """
     attributes = {}
     if tags:
-        attributes['tags'] = list(set(tags))
+        attributes['tags'] = tags
     if hostname:
         attributes['hostname'] = hostname
     if device_name:


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

No need to re-call `set()` on the list and build a new one. We already sort and construct the set for the tag list in the aggregator. This code is called from there, passing forth a tag list that has already been sanitized. This is a redundant call/allocation.

### Motivation

While debugging testing issues found in `integrations-core` as collateral from https://github.com/DataDog/dd-agent/pull/3641 - the unneeded call was identified.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
