### PR TITLE
[Windows] Start subservices (trace/process) if they're configured on

### DIFF
--- a/config.py
+++ b/config.py
@@ -620,6 +620,11 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
         if config.has_option("Main", "apm_enabled"):
             agentConfig["apm_enabled"] = _is_affirmative(config.get("Main", "apm_enabled"))
 
+        agentConfig["process_agent_enabled"] = False
+        if config.has_option("Main", "process_agent_enabled"):
+            agentConfig["process_agent_enabled"] = _is_affirmative(config.get("Main", "process_agent_enabled"))
+
+
         agentConfig["enable_gohai"] = True
         if config.has_option("Main", "enable_gohai"):
             agentConfig["enable_gohai"] = _is_affirmative(config.get("Main", "enable_gohai"))

--- a/win32/service.py
+++ b/win32/service.py
@@ -177,6 +177,31 @@ class AgentSvc(win32serviceutil.ServiceFramework):
         for proc in self.procs.values():
             proc.start()
 
+        #
+        # If process and/or trace are/is enabled, then start them manually here
+        # otherwise, on restart (especially via the gui) they won't be restarted
+        #
+        # allow the startservice to fail, however, as the service may already be
+        # started, or in the progress of starting, especially after install or
+        # first boot.
+        #
+
+        # check to see if apm is enabled.
+        if self.config.get('apm_enabled'):
+            try:
+                win32serviceutil.StartService("datadog-trace-agent")
+            except Exception as e:
+                log.warning("Unable to start Trace Agent service %s" % str(e))
+                pass
+
+        # check to see if process is enabled.
+        if self.config.get('process_agent_enabled'):
+            try:
+                win32serviceutil.StartService("datadog-process-agent")
+            except Exception as e:
+                log.warning("Unable to start Process Agent service %s" % str(e))
+                pass
+
         # Loop to keep the service running since all DD services are
         # running in separate processes
         self.running = True


### PR DESCRIPTION
service start.  They're installed as auto-start services, however, if
the user restarts the agent (especially via the gui) they won't be
restarted on their own.

### Motivation

Services aren't correctly started when reconfiguring.
