### PR TITLE
[install script] import the gpg key for suse explicitly

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -182,6 +182,9 @@ elif [ $OS = "SUSE" ]; then
   echo -e "\033[34m\n* Installing YUM Repository for Datadog\n\033[0m"
   $sudo_cmd sh -c "echo -e '[datadog]\nname=datadog\nenabled=1\nbaseurl=https://yum.datadoghq.com/suse/rpm/x86_64\ntype=rpm-md\ngpgcheck=1\nrepo_gpgcheck=0\ngpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public' > /etc/zypp/repos.d/datadog.repo"
 
+  echo -e "\033[34m\n* Importing the Datadog GPG Key\n\033[0m"
+  $sudo_cmd rpm --import https://yum.${dd_url}/DATADOG_RPM_KEY.public
+
   echo -e "\033[34m\n* Refreshing repositories\n\033[0m"
   $sudo_cmd zypper --non-interactive --no-gpg-check refresh datadog
 


### PR DESCRIPTION
### What does this PR do?

SUSE's protections make it so that you need to explicitly import the GPG key with `rpm --import...`