### PR TITLE
[kubernetes] fix logic to collect ownerreference for k8 1.9

### DIFF
--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -98,7 +98,8 @@ class TestKubeUtilCreatorTags(KubeTestCase):
 class TestKubeUtilCreatorTagsNoAnnotation(KubeTestCase):
     @classmethod
     def _fake_pod(cls, creator_kind, creator_name):
-        return {'ownerReferences': {'kind': creator_kind, 'name': creator_name}}
+        ownerReferences_entry = [{'kind': creator_kind, 'name': creator_name}]
+        return {'ownerReferences': ownerReferences_entry}
 
     def test_with_replicaset(self):
         self.assertEqual(['kube_replica_set:test-5432', 'kube_deployment:test'],

--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -93,6 +93,31 @@ class TestKubeUtilCreatorTags(KubeTestCase):
         self.assertEqual([], self.kube.get_pod_creator_tags({}))
 
 
+class TestKubeUtilCreatorTagsNoAnnotation(KubeTestCase):
+    @classmethod
+    def _fake_pod(cls, creator_kind, creator_name):
+        payload = '{"reference": {"kind":"%s", "name":"%s"}}' % (creator_kind, creator_name)
+        return {'ownerReferences': {'kind': creator_kind, 'name': creator_name}}
+
+    def test_with_replicaset(self):
+        self.assertEqual(['kube_replica_set:test-5432', 'kube_deployment:test'],
+                         self.kube.get_pod_creator_tags(self._fake_pod("ReplicaSet", "test-5432")))
+
+    def test_with_statefulset(self):
+        self.assertEqual(['kube_stateful_set:test-5432'],
+                         self.kube.get_pod_creator_tags(self._fake_pod("StatefulSet", "test-5432")))
+
+    def test_with_legacy_repcontroller(self):
+        self.assertEqual(['kube_daemon_set:test', 'kube_replication_controller:test'],
+                         self.kube.get_pod_creator_tags(self._fake_pod("DaemonSet", "test"), True))
+
+    def test_with_unknown(self):
+        self.assertEqual([], self.kube.get_pod_creator_tags(self._fake_pod("Unknown", "test")))
+
+    def test_invalid_input(self):
+        self.assertEqual([], self.kube.get_pod_creator_tags({}))
+
+
 class TestKubeGetNodeInfo(KubeTestCase):
     @staticmethod
     def mocked_requests_get_without_agent_but_ok(*args, **kwargs):

--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -68,6 +68,7 @@ class TestKubeUtilDeploymentTag(KubeTestCase):
         self.assertEqual('front-end', self.kube.get_deployment_for_replicaset('front-end-768dd754b7'))
 
 
+# Creator Tags tests for k8 version < 1.9: getting them from the annotation
 class TestKubeUtilCreatorTags(KubeTestCase):
     @classmethod
     def _fake_pod(cls, creator_kind, creator_name):
@@ -93,6 +94,7 @@ class TestKubeUtilCreatorTags(KubeTestCase):
         self.assertEqual([], self.kube.get_pod_creator_tags({}))
 
 
+# Creator Tags tests for k8 version >= 1.9: getting them from the metadata 'ownerReferences'
 class TestKubeUtilCreatorTagsNoAnnotation(KubeTestCase):
     @classmethod
     def _fake_pod(cls, creator_kind, creator_name):

--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -68,8 +68,10 @@ class TestKubeUtilDeploymentTag(KubeTestCase):
         self.assertEqual('front-end', self.kube.get_deployment_for_replicaset('front-end-768dd754b7'))
 
 
-# Creator Tags tests for k8 version < 1.9: getting them from the annotation
 class TestKubeUtilCreatorTags(KubeTestCase):
+    """
+    Creator Tags tests for k8 version < 1.9: getting them from the annotation
+    """
     @classmethod
     def _fake_pod(cls, creator_kind, creator_name):
         payload = '{"reference": {"kind":"%s", "name":"%s"}}' % (creator_kind, creator_name)
@@ -94,12 +96,14 @@ class TestKubeUtilCreatorTags(KubeTestCase):
         self.assertEqual([], self.kube.get_pod_creator_tags({}))
 
 
-# Creator Tags tests for k8 version >= 1.9: getting them from the metadata 'ownerReferences'
 class TestKubeUtilCreatorTagsNoAnnotation(KubeTestCase):
+    """
+    Creator Tags tests for k8 version >= 1.9: getting them from the metadata 'ownerReferences'
+    """
     @classmethod
     def _fake_pod(cls, creator_kind, creator_name):
-        ownerReferences_entry = [{'kind': creator_kind, 'name': creator_name}]
-        return {'ownerReferences': ownerReferences_entry}
+        owner_references_entry = [{'kind': creator_kind, 'name': creator_name}]
+        return {'ownerReferences': owner_references_entry}
 
     def test_with_replicaset(self):
         self.assertEqual(['kube_replica_set:test-5432', 'kube_deployment:test'],

--- a/tests/core/test_kubeutil.py
+++ b/tests/core/test_kubeutil.py
@@ -96,7 +96,6 @@ class TestKubeUtilCreatorTags(KubeTestCase):
 class TestKubeUtilCreatorTagsNoAnnotation(KubeTestCase):
     @classmethod
     def _fake_pod(cls, creator_kind, creator_name):
-        payload = '{"reference": {"kind":"%s", "name":"%s"}}' % (creator_kind, creator_name)
         return {'ownerReferences': {'kind': creator_kind, 'name': creator_name}}
 
     def test_with_replicaset(self):

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -654,13 +654,20 @@ class KubeUtil:
         This allows for consitency across code path
         """
         try:
-            created_by = json.loads(pod_metadata['annotations']['kubernetes.io/created-by'])
-            creator_kind = created_by.get('reference', {}).get('kind')
-            creator_name = created_by.get('reference', {}).get('name')
+            creator_kind = pod_metadata['ownerReferences']['kind']
+            creator_name = pod_metadata['ownerReferences']['name']
             return (creator_kind, creator_name)
-        except Exception:
-            log.debug('Could not parse creator for pod ' + pod_metadata.get('name', ''))
-            return (None, None)
+        except Exception
+            try:
+                log.debug('Could not parse creator for pod ' + pod_metadata.get('name', '') +
+                          ' through `OwnerReferences`, falling back to annotation')
+                created_by = json.loads(pod_metadata['annotations']['kubernetes.io/created-by'])
+                creator_kind = created_by.get('reference', {}).get('kind')
+                creator_name = created_by.get('reference', {}).get('name')
+                return (creator_kind, creator_name)
+            except Exception:
+                log.debug('Could not parse creator for pod ' + pod_metadata.get('name', ''))
+                return (None, None)
 
     def get_pod_creator_tags(self, pod_metadata, legacy_rep_controller_tag=False):
         """

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -660,7 +660,7 @@ class KubeUtil:
             return creator_kind, creator_name
         except LookupError as e:
             try:
-                log.debug('Could not parse creator for pod %s through `OwnerReferences`, falling back to annotation: %s'
+                log.debug('Could not parse creator for pod %s through `OwnerReferences`, falling back to annotation: %s',
                           pod_metadata.get('name', ''), type(e))
                 created_by = json.loads(pod_metadata['annotations']['kubernetes.io/created-by'])
                 creator_kind = created_by.get('reference', {}).get('kind')

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -657,7 +657,7 @@ class KubeUtil:
             creator_kind = pod_metadata['ownerReferences']['kind']
             creator_name = pod_metadata['ownerReferences']['name']
             return (creator_kind, creator_name)
-        except Exception
+        except Exception:
             try:
                 log.debug('Could not parse creator for pod ' + pod_metadata.get('name', '') +
                           ' through `OwnerReferences`, falling back to annotation')

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -654,21 +654,21 @@ class KubeUtil:
         This allows for consitency across code path
         """
         try:
-            ownerReferences_entry = pod_metadata['ownerReferences'][0]
-            creator_kind = ownerReferences_entry['kind']
-            creator_name = ownerReferences_entry['name']
-            return (creator_kind, creator_name)
-        except Exception:
+            owner_references_entry = pod_metadata['ownerReferences'][0]
+            creator_kind = owner_references_entry['kind']
+            creator_name = owner_references_entry['name']
+            return creator_kind, creator_name
+        except LookupError as e:
             try:
-                log.debug('Could not parse creator for pod ' + pod_metadata.get('name', '') +
-                          ' through `OwnerReferences`, falling back to annotation')
+                log.debug('Could not parse creator for pod %s through `OwnerReferences`, falling back to annotation: %s'
+                          pod_metadata.get('name', ''), type(e))
                 created_by = json.loads(pod_metadata['annotations']['kubernetes.io/created-by'])
                 creator_kind = created_by.get('reference', {}).get('kind')
                 creator_name = created_by.get('reference', {}).get('name')
-                return (creator_kind, creator_name)
-            except Exception:
-                log.debug('Could not parse creator for pod ' + pod_metadata.get('name', ''))
-                return (None, None)
+                return creator_kind, creator_name
+            except Exception as e:
+                log.debug('Could not parse creator for pod %s: %s', pod_metadata.get('name', ''), type(e))
+                return None, None
 
     def get_pod_creator_tags(self, pod_metadata, legacy_rep_controller_tag=False):
         """

--- a/utils/kubernetes/kubeutil.py
+++ b/utils/kubernetes/kubeutil.py
@@ -654,8 +654,9 @@ class KubeUtil:
         This allows for consitency across code path
         """
         try:
-            creator_kind = pod_metadata['ownerReferences']['kind']
-            creator_name = pod_metadata['ownerReferences']['name']
+            ownerReferences_entry = pod_metadata['ownerReferences'][0]
+            creator_kind = ownerReferences_entry['kind']
+            creator_name = ownerReferences_entry['name']
             return (creator_kind, creator_name)
         except Exception:
             try:


### PR DESCRIPTION
### What does this PR do?

The previous code was looking the pod's creator in the annotations, while [kubernetes/kubernetes#54445](https://github.com/kubernetes/kubernetes/pull/54445) removed the pod annotation that the agent code is looking for, from version 1.9.
It now uses the stabilized metadata.ownerReferences field instead, and falls back on the annotations if they are missing.

### Motivation

This issue came up in https://github.com/DataDog/dd-agent/issues/3642 

### Testing Guidelines

Changed tests relatively to the new way to get ownerreferences

- Tested on GKE cluster with k8 1.9.2
- Tested on minikube with k8 1.7.3