### PR TITLE
Fix split on NoneType

### DIFF
--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -583,7 +583,7 @@ class DockerUtil:
         If short is true, the repository is stripped from the result
         """
         image = self.image_name_resolver(co.get('Image', ''))
-        if short:
+        if image and short:
             return image.split('/')[-1]
         return image
 


### PR DESCRIPTION
### What does this PR do?

Fix a crash if the image is not defined

### Motivation

```
"/opt/datadog-agent/agent/utils/dockerutil.py", line 587, in image_name_extractor return image.split('/')[-1] AttributeError: 'NoneType' object has no attribute 'split'
```
