### PR TITLE
pause-container: update the list of the pause containers

### DIFF
--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -46,7 +46,12 @@ DEFAULT_INIT_RETRIES = 0
 DEFAULT_RETRY_INTERVAL = 20  # seconds
 
 # only used if no exclude rule was defined
-DEFAULT_CONTAINER_EXCLUDE = ["docker_image:gcr.io/google_containers/pause.*", "image_name:openshift/origin-pod"]
+DEFAULT_CONTAINER_EXCLUDE = [
+    "docker_image:gcr.io/google_containers/pause.*",
+    "docker_image:k8s.gcr.io/pause.*",
+    "image_name:openshift/origin-pod",
+    "image_name:kubernetes/pause"
+]
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
### What does this PR do?

This PR update the list of the excluded pause containers.

See the PR of the [agent6](https://github.com/DataDog/datadog-agent/pull/1233) for more details.