### PR TITLE
Clean trace-agent ini config options

### DIFF
--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -306,7 +306,21 @@ gce_updated_hostname: yes
 # Tracing
 # ========================================================================== #
 
+# [trace.config]
+
+# Configure a non-default environment for the traces reported from this Agent
+# env: none
+
+# File destination of trace-agent logs
+# log_file: /var/log/datadog/trace-agent.log
+
+# [trace.receiver]
+
+# Port that the trace-agent will listen
+# receiver_port: 8126
+
 # [trace.sampler]
+
 # Extra global sample rate to apply on all the traces
 # This sample rate is combined to the sample rate from the sampler logic, still promoting interesting traces
 # From 1 (no extra rate) to 0 (don't sample at all)
@@ -317,14 +331,9 @@ gce_updated_hostname: yes
 # Set to 0 to disable the limit.
 # max_traces_per_second: 10
 
-# [trace.receiver]
-# the port that the Receiver should listen on
-# receiver_port: 8126
-# how many unique client connections to allow during one 30 second lease period
-# connection_limit: 2000
-
 # [trace.ignore]
-# a blacklist of regular expressions can be provided to disable certain traces based on their resource name
+
+# Blacklist of regular expressions can be provided to disable certain traces based on their resource name
 # all entries must be surrounded by double quotes and separated by commas
 # Example: "(GET|POST) /healthcheck","GET /V1"
-# resource: ""
+# resource:


### PR DESCRIPTION
### What does this PR do?

Update `datadog.conf.example` to exhaustively document the supported configuration options for the trace-agent.


### Motivation

The config example was outdated, not suggesting the the user the right options.

### Testing Guidelines

No-op change.

