### PR TITLE
pause-container: extend the regex to catch region based.

### DIFF
--- a/tests/core/test_dockerutil.py
+++ b/tests/core/test_dockerutil.py
@@ -174,6 +174,7 @@ class TestDockerUtil(unittest.TestCase):
             self.assertTrue(du.is_k8s())
             pause_containers = [
                 "docker_image:gcr.io/google_containers/pause-amd64:0.3.0",
+                "docker_image:asia.gcr.io/google_containers/pause-amd64:3.0",
                 "docker_image:k8s.gcr.io/pause-amd64:latest",
                 "image_name:openshift/origin-pod",
                 "image_name:kubernetes/pause",

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -47,8 +47,8 @@ DEFAULT_RETRY_INTERVAL = 20  # seconds
 
 # only used if no exclude rule was defined
 DEFAULT_CONTAINER_EXCLUDE = [
-    "docker_image:gcr.io/google_containers/pause.*",
-    "docker_image:k8s.gcr.io/pause.*",
+    "docker_image:(.*)gcr.io/google_containers/pause(.*)",
+    "docker_image:k8s.gcr.io/pause(.*)",
     "image_name:openshift/origin-pod",
     "image_name:kubernetes/pause"
 ]


### PR DESCRIPTION
### What does this PR do?

Extend the support of the pause container regex.

This will catch regional pause containers like:
`asia.gcr.io/google_containers/pause-amd64:3.0`
