### PR TITLE
Add more exceptions to flake8

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
 exclude = venv/*,embedded/*,.git/*
 max-line-length = 700
-ignore = E128,E203,E226,E231,E241,E251,E261,E265,E302,E303
+ignore = E128,E203,E226,E231,E241,E251,E261,E265,E266,E302,E303,E305,E402,E722,E731,E741,W503


### PR DESCRIPTION
### What does this PR do?

Bumped flake8 version to 3.5.0 because of `integrations-core`, requirements have to be in sync but we now need more exceptions for the test to pass.
