### PR TITLE
Add case for swarm image name with @sha256

### DIFF
--- a/tests/core/test_dockerutil.py
+++ b/tests/core/test_dockerutil.py
@@ -79,6 +79,9 @@ class TestDockerUtil(unittest.TestCase):
             [{'Image': 'redis'}, ['docker_image:redis', 'image_name:redis']],
             # No image
             [{}, []],
+            # Image containing 'sha256'
+            [{'Image': 'datadog/docker-dd-agent:latest@sha256:769418c18c3e9e0b6ab2c18147c3599d6e27f40fb3dee56418bf897147ff84d0'},
+                ['docker_image:datadog/docker-dd-agent:latest', 'image_name:datadog/docker-dd-agent', 'image_tag:latest']],
         ]
         labeled_test_data = [
             # No labels

--- a/tests/core/test_dockerutil.py
+++ b/tests/core/test_dockerutil.py
@@ -74,8 +74,9 @@ class TestDockerUtil(unittest.TestCase):
     def test_extract_container_tags(self):
         #mocks
         du = DockerUtil()
-        with mock.patch.dict(du._image_sha_to_name_mapping, {'gcr.io/google_containers/hyperkube@sha256:7653dfb091e9524ecb1c2c472ec27e9d2e0ff9addc199d91b5c532a2cdba5b9e': 'gcr.io/google_containers/hyperkube:latest',
-            'myregistry.local:5000/testing/test-image@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0': 'myregistry.local:5000/testing/test-image:version'}):
+        with mock.patch.dict(du._image_sha_to_name_mapping,
+          {'gcr.io/google_containers/hyperkube@sha256:7653dfb091e9524ecb1c2c472ec27e9d2e0ff9addc199d91b5c532a2cdba5b9e': 'gcr.io/google_containers/hyperkube:latest',
+          'myregistry.local:5000/testing/test-image@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0': 'myregistry.local:5000/testing/test-image:version'}):
             no_label_test_data = [
                 # Nominal case
                 [{'Image': 'redis:3.2'}, ['docker_image:redis:3.2', 'image_name:redis', 'image_tag:3.2']],

--- a/tests/core/test_dockerutil.py
+++ b/tests/core/test_dockerutil.py
@@ -72,74 +72,86 @@ class TestDockerUtil(unittest.TestCase):
         self.assertEqual('alpine', du.image_name_extractor(co))
 
     def test_extract_container_tags(self):
-        no_label_test_data = [
-            # Nominal case
-            [{'Image': 'redis:3.2'}, ['docker_image:redis:3.2', 'image_name:redis', 'image_tag:3.2']],
-            # No tag
-            [{'Image': 'redis'}, ['docker_image:redis', 'image_name:redis']],
-            # No image
-            [{}, []],
-            # Image containing 'sha256'
-            [{'Image': 'datadog/docker-dd-agent:latest@sha256:769418c18c3e9e0b6ab2c18147c3599d6e27f40fb3dee56418bf897147ff84d0'},
-                ['docker_image:datadog/docker-dd-agent:latest', 'image_name:datadog/docker-dd-agent', 'image_tag:latest']],
-        ]
-        labeled_test_data = [
-            # No labels
-            (
-                # ctr inspect
-                {
-                    'Image': 'redis:3.2',
-                    'Config': {
-                        'Labels': {}
-                    }
-                },
-                # labels as tags
-                [],
-                # expected result
-                ['docker_image:redis:3.2', 'image_name:redis', 'image_tag:3.2']
-            ),
-            # Un-monitored labels
-            (
-                {
-                    'Image': 'redis:3.2',
-                    'Config': {
-                        'Labels': {
-                            'foo': 'bar'
+        #mocks
+        du = DockerUtil()
+        with mock.patch.dict(du._image_sha_to_name_mapping, {'gcr.io/google_containers/hyperkube@sha256:7653dfb091e9524ecb1c2c472ec27e9d2e0ff9addc199d91b5c532a2cdba5b9e': 'gcr.io/google_containers/hyperkube:latest',
+            'myregistry.local:5000/testing/test-image@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0': 'myregistry.local:5000/testing/test-image:version'}):
+            no_label_test_data = [
+                # Nominal case
+                [{'Image': 'redis:3.2'}, ['docker_image:redis:3.2', 'image_name:redis', 'image_tag:3.2']],
+                # No tag
+                [{'Image': 'redis'}, ['docker_image:redis', 'image_name:redis']],
+                # No image
+                [{}, []],
+                # Image containing 'sha256', swarm fashion
+                [{'Image': 'datadog/docker-dd-agent:latest@sha256:769418c18c3e9e0b6ab2c18147c3599d6e27f40fb3dee56418bf897147ff84d0'},
+                    ['docker_image:datadog/docker-dd-agent:latest', 'image_name:datadog/docker-dd-agent', 'image_tag:latest']],
+                # Image containing 'sha256', kubernetes fashion
+                [{'Image': 'gcr.io/google_containers/hyperkube@sha256:7653dfb091e9524ecb1c2c472ec27e9d2e0ff9addc199d91b5c532a2cdba5b9e'},
+                    ['docker_image:gcr.io/google_containers/hyperkube:latest', 'image_name:gcr.io/google_containers/hyperkube', 'image_tag:latest']],
+                # Images with several ':'
+                [{'Image': 'myregistry.local:5000/testing/test-image:version'},
+                    ['docker_image:myregistry.local:5000/testing/test-image:version', 'image_name:myregistry.local:5000/testing/test-image', 'image_tag:version']],
+                [{'Image': 'myregistry.local:5000/testing/test-image@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0'},
+                    ['docker_image:myregistry.local:5000/testing/test-image:version', 'image_name:myregistry.local:5000/testing/test-image', 'image_tag:version']]
+            ]
+            labeled_test_data = [
+                # No labels
+                (
+                    # ctr inspect
+                    {
+                        'Image': 'redis:3.2',
+                        'Config': {
+                            'Labels': {}
                         }
-                    }
-                },
-                [],
-                ['docker_image:redis:3.2', 'image_name:redis', 'image_tag:3.2']
-            ),
-            # no labels, with labels_as_tags list
-            (
-                {
-                    'Image': 'redis:3.2',
-                    'Config': {
-                        'Labels': {}
-                    }
-                },
-                ['foo'],
-                ['docker_image:redis:3.2', 'image_name:redis', 'image_tag:3.2']
-            ),
-            # labels and labels_as_tags list
-            (
-                {
-                    'Image': 'redis:3.2',
-                    'Config': {
-                        'Labels': {'foo': 'bar', 'f00': 'b4r'}
-                    }
-                },
-                ['foo'],
-                ['docker_image:redis:3.2', 'image_name:redis', 'image_tag:3.2', 'foo:bar']
-            ),
+                    },
+                    # labels as tags
+                    [],
+                    # expected result
+                    ['docker_image:redis:3.2', 'image_name:redis', 'image_tag:3.2']
+                ),
+                # Un-monitored labels
+                (
+                    {
+                        'Image': 'redis:3.2',
+                        'Config': {
+                            'Labels': {
+                                'foo': 'bar'
+                            }
+                        }
+                    },
+                    [],
+                    ['docker_image:redis:3.2', 'image_name:redis', 'image_tag:3.2']
+                ),
+                # no labels, with labels_as_tags list
+                (
+                    {
+                        'Image': 'redis:3.2',
+                        'Config': {
+                            'Labels': {}
+                        }
+                    },
+                    ['foo'],
+                    ['docker_image:redis:3.2', 'image_name:redis', 'image_tag:3.2']
+                ),
+                # labels and labels_as_tags list
+                (
+                    {
+                        'Image': 'redis:3.2',
+                        'Config': {
+                            'Labels': {'foo': 'bar', 'f00': 'b4r'}
+                        }
+                    },
+                    ['foo'],
+                    ['docker_image:redis:3.2', 'image_name:redis', 'image_tag:3.2', 'foo:bar']
+                ),
 
-        ]
-        for test in no_label_test_data:
-            self.assertEqual(test[1], DockerUtil().extract_container_tags(test[0], []))
+            ]
+            for test in no_label_test_data:
+                self.assertEqual(test[1], du.extract_container_tags(test[0], []))
 
-        for test in labeled_test_data:
-            self.assertEqual(test[2], DockerUtil().extract_container_tags(test[0], test[1]))
+            for test in labeled_test_data:
+                self.assertEqual(test[2], du.extract_container_tags(test[0], test[1]))
 
 
     def test_docker_host_metadata_ok(self):

--- a/tests/core/test_dockerutil.py
+++ b/tests/core/test_dockerutil.py
@@ -94,7 +94,10 @@ class TestDockerUtil(unittest.TestCase):
                 [{'Image': 'myregistry.local:5000/testing/test-image:version'},
                     ['docker_image:myregistry.local:5000/testing/test-image:version', 'image_name:myregistry.local:5000/testing/test-image', 'image_tag:version']],
                 [{'Image': 'myregistry.local:5000/testing/test-image@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0'},
-                    ['docker_image:myregistry.local:5000/testing/test-image:version', 'image_name:myregistry.local:5000/testing/test-image', 'image_tag:version']]
+                    ['docker_image:myregistry.local:5000/testing/test-image:version', 'image_name:myregistry.local:5000/testing/test-image', 'image_tag:version']],
+                # Here, since the tag is present, we should not try to resolve it in the sha256, and so returning 'latest'
+                [{'Image': 'myregistry.local:5000/testing/test-image:latest@sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0'},
+                    ['docker_image:myregistry.local:5000/testing/test-image:latest', 'image_name:myregistry.local:5000/testing/test-image', 'image_tag:latest']]
             ]
             labeled_test_data = [
                 # No labels

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -588,7 +588,7 @@ class DockerUtil:
         return image
 
     def image_name_resolver(self, image):
-        if image.startswith('sha256:') or '@sha256:' in image:
+        if image.startswith('sha256:'):
             # Some orchestrators setup containers with image checksum instead of image name
             try:
                 if image in self._image_sha_to_name_mapping:
@@ -613,6 +613,10 @@ class DockerUtil:
                         log.debug("Failed finding image name in RepoTag and RepoDigests: %s", e)
             except Exception as ex:
                 log.error("Exception getting docker image name: %s" % str(ex))
+        elif '@sha256:' in image: # Swarm case where image = name:tag@sha256SHA, keep only name:tag
+            pos = image.rfind('@sha256')
+            if pos > 0:
+                return image[0:pos]
         else:
             return image
 

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -616,9 +616,9 @@ class DockerUtil:
         elif '@sha256:' in image: # Swarm case where image = name:tag@sha256SHA, keep only name:tag
             pos = image.rfind('@sha256')
             if pos > 0:
-                return image[0:pos]
-        else:
-            return image
+                return image[:pos]
+            log.error("Invalid image parsing: %s", image)
+        return image
 
     def label_extractor(self, ctr, lbl_to_tags):
         """Returns a list of tags based on a container and a label name list"""


### PR DESCRIPTION
### What does this PR do?
Fixes the parsing of swarm images such as `datadog/docker-dd-agent:latest@sha256:769418c18c3e9e0b6ab2c18147c3599d6e27f40fb3dee56418bf897147ff84d0` when gathering tags in dockerutil. The issue here was with the `@sha256`

### Motivation

A user was missing his tags on his hosts.

### Testing Guidelines
Added a test case

### Additional Notes

Similar to the [maching agent 6 code](https://github.com/DataDog/datadog-agent/blob/c0d3dc9bdd3ce0dbc379c01b010487e927464095/pkg/util/docker/util_common.go#L90-L93) 
