### PR TITLE
Update Agent 5 github docs to mention A6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+Datadog Agent 6 has been officially released and the release notes can be found [here](https://github.com/DataDog/datadog-agent/releases). Agent 5 will continue to see releases. 
+
 Changes
 =======
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ them to [Datadog](https://app.datadoghq.com) on your behalf so that
 you can do something useful with your monitoring and performance data.
 
 You're looking at the source code right now. We provide a number of
-[pre-packaged binaries](https://app.datadoghq.com/account/settings#agent) for your convenience.
+pre-packaged binaries for your convenience for both [Agent 5](https://app.datadoghq.com/account/settings?agent_version=5#agent) and [Agent 6]((https://app.datadoghq.com/account/settings#agent)). 
+
+See the [Datadog Agent Repo](https://github.com/DataDog/datadog-agent) for the source code for Agent 6. 
 
 Note: this repository does not contain the sources of the Trace Agent that
 collects traces for the APM feature. If you choose the installation from source


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Adds a mention to A6 release notes in the Changelog and link to prepackaged binaries for A5 and A6 in the README

### Motivation

Keeps docs up to date with A6 release

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
