### PR TITLE
[windows] change default datatype for pdh queries to double. Integer

### DIFF
--- a/checks/libs/win/pdhbasecheck.py
+++ b/checks/libs/win/pdhbasecheck.py
@@ -67,6 +67,15 @@ class PDHBaseCheck(AgentCheck):
                         self.log.error("Failed to make remote connection %s" % str(e))
                         return
 
+                ## counter_data_types allows the precision with which counters are queried
+                ## to be configured on a per-metric basis. In the metric instance, precision
+                ## should be specified as
+                ## counter_data_types:
+                ## - iis.httpd_request_method.get,int
+                ## - iis.net.bytes_rcvd,float
+                ##
+                ## the above would query the counter associated with iis.httpd_request_method.get
+                ## as an integer (LONG) and iis.net.bytes_rcvd as a double
                 datatypes = {}
                 precisions = instance.get('counter_data_types')
                 if precisions is not None:
@@ -91,9 +100,8 @@ class PDHBaseCheck(AgentCheck):
 
                 for counterset, inst_name, counter_name, dd_name, mtype in counter_list:
                     m = getattr(self, mtype.lower())
-                    precision = None
-                    if dd_name in datatypes:
-                        precision = datatypes[dd_name]
+
+                    precision = datatypes.get(dd_name)
 
                     obj = WinPDHCounter(counterset, counter_name, self.log, inst_name, machine_name = remote_machine, precision=precision)
                     entry = [inst_name, dd_name, m, obj]
@@ -107,9 +115,8 @@ class PDHBaseCheck(AgentCheck):
                         if inst_name.lower() == "none" or len(inst_name) == 0 or inst_name == "*" or inst_name.lower() == "all":
                             inst_name = None
                         m = getattr(self, mtype.lower())
-                        precision = None
-                        if dd_name in datatypes:
-                            precision = datatypes[dd_name]
+
+                        precision = datatypes.get(dd_name)
 
                         obj = WinPDHCounter(counterset, counter_name, self.log, inst_name, machine_name = remote_machine, precision = precision)
                         entry = [inst_name, dd_name, m, obj]

--- a/checks/libs/win/pdhbasecheck.py
+++ b/checks/libs/win/pdhbasecheck.py
@@ -8,12 +8,22 @@ from checks import AgentCheck
 from utils.containers import hash_mutable
 # datadog
 try:
-    from checks.libs.win.winpdh import WinPDHCounter
+    from checks.libs.win.winpdh import WinPDHCounter, DATA_TYPE_INT, DATA_TYPE_DOUBLE
 except ImportError:
-    from checks.libs.win.winpdh_stub import WinPDHCounter
+    from checks.libs.win.winpdh_stub import WinPDHCounter,DATA_TYPE_INT, DATA_TYPE_DOUBLE
 
 import win32wnet
 
+int_types = [
+    "int",
+    "long",
+    "uint",
+]
+
+double_types = [
+    "double",
+    "float",
+]
 class PDHBaseCheck(AgentCheck):
     """
     PDH based check.  check.
@@ -57,13 +67,35 @@ class PDHBaseCheck(AgentCheck):
                         self.log.error("Failed to make remote connection %s" % str(e))
                         return
 
+                datatypes = {}
+                precisions = instance.get('counter_data_types')
+                if precisions is not None:
+                    if not isinstance(precisions, list):
+                        self.log.warning("incorrect type for counter_data_type %s" % str(precisions))
+                    else:
+                        for p in precisions:
+                            k, v = p.split(",")
+                            v = v.lower().strip()
+                            if v in int_types:
+                                self.log.info("Setting datatype for %s to integer" % k)
+                                datatypes[k] = DATA_TYPE_INT
+                            elif v in double_types:
+                                self.log.info("Setting datatype for %s to double" % k)
+                                datatypes[k] = DATA_TYPE_DOUBLE
+                            else:
+                                self.log.warning("Unknown data type %s" % str(v))
+
                 # list of the metrics.  Each entry is itself an entry,
                 # which is the pdh name, datadog metric name, type, and the
                 # pdh counter object
 
                 for counterset, inst_name, counter_name, dd_name, mtype in counter_list:
                     m = getattr(self, mtype.lower())
-                    obj = WinPDHCounter(counterset, counter_name, self.log, inst_name, machine_name = remote_machine)
+                    precision = None
+                    if dd_name in datatypes:
+                        precision = datatypes[dd_name]
+
+                    obj = WinPDHCounter(counterset, counter_name, self.log, inst_name, machine_name = remote_machine, precision=precision)
                     entry = [inst_name, dd_name, m, obj]
                     self.log.debug("entry: %s" % str(entry))
                     self._metrics[key].append(entry)
@@ -75,7 +107,11 @@ class PDHBaseCheck(AgentCheck):
                         if inst_name.lower() == "none" or len(inst_name) == 0 or inst_name == "*" or inst_name.lower() == "all":
                             inst_name = None
                         m = getattr(self, mtype.lower())
-                        obj = WinPDHCounter(counterset, counter_name, self.log, inst_name, machine_name = remote_machine)
+                        precision = None
+                        if dd_name in datatypes:
+                            precision = datatypes[dd_name]
+
+                        obj = WinPDHCounter(counterset, counter_name, self.log, inst_name, machine_name = remote_machine, precision = precision)
                         entry = [inst_name, dd_name, m, obj]
                         self.log.debug("additional metric entry: %s" % str(entry))
                         self._metrics[key].append(entry)

--- a/checks/libs/win/winpdh.py
+++ b/checks/libs/win/winpdh.py
@@ -15,7 +15,7 @@ class WinPDHCounter(object):
     # store the dictionary of pdh counter names
     pdh_counter_dict = {}
 
-    def __init__(self, class_name, counter_name, log, instance_name = None, machine_name = None, precision=DATA_TYPE_DOUBLE):
+    def __init__(self, class_name, counter_name, log, instance_name = None, machine_name = None, precision=None):
         self._get_counter_dictionary()
         self._class_name = win32pdh.LookupPerfNameByIndex(None, int(WinPDHCounter.pdh_counter_dict[class_name]))
         self._counter_name = win32pdh.LookupPerfNameByIndex(None, int(WinPDHCounter.pdh_counter_dict[counter_name]))

--- a/checks/libs/win/winpdh.py
+++ b/checks/libs/win/winpdh.py
@@ -7,13 +7,15 @@ import time
 import win32pdh
 import _winreg
 
+DATA_TYPE_INT = win32pdh.PDH_FMT_LONG
+DATA_TYPE_DOUBLE = win32pdh.PDH_FMT_DOUBLE
 DATA_POINT_INTERVAL = 0.10
 SINGLE_INSTANCE_KEY = "__single_instance"
 class WinPDHCounter(object):
     # store the dictionary of pdh counter names
     pdh_counter_dict = {}
 
-    def __init__(self, class_name, counter_name, log, instance_name = None, machine_name = None):
+    def __init__(self, class_name, counter_name, log, instance_name = None, machine_name = None, precision=DATA_TYPE_DOUBLE):
         self._get_counter_dictionary()
         self._class_name = win32pdh.LookupPerfNameByIndex(None, int(WinPDHCounter.pdh_counter_dict[class_name]))
         self._counter_name = win32pdh.LookupPerfNameByIndex(None, int(WinPDHCounter.pdh_counter_dict[counter_name]))
@@ -22,6 +24,10 @@ class WinPDHCounter(object):
         self.hq = win32pdh.OpenQuery()
         self.logger = log
         self.counterdict = {}
+        if precision is None:
+            self._precision = win32pdh.PDH_FMT_DOUBLE
+        else:
+            self._precision = precision
         counters, instances = win32pdh.EnumObjectItems(None, machine_name, self._class_name, win32pdh.PERF_DETAIL_WIZARD)
         if instance_name is None and len(instances) > 0:
             for inst in instances:
@@ -91,7 +97,8 @@ class WinPDHCounter(object):
 
         for inst, counter_handle in self.counterdict.iteritems():
             try:
-                t, val = win32pdh.GetFormattedCounterValue(counter_handle, win32pdh.PDH_FMT_LONG)
+                self.logger.info("Getting %s %d" % (inst, self._precision))
+                t, val = win32pdh.GetFormattedCounterValue(counter_handle, self._precision)
                 ret[inst] = val
             except Exception as e:
                 # exception usually means self type needs two data points to calculate. Wait
@@ -100,7 +107,7 @@ class WinPDHCounter(object):
                 win32pdh.CollectQueryData(self.hq)
                 # if we get exception self time, just return it up
                 try:
-                    t, val = win32pdh.GetFormattedCounterValue(counter_handle, win32pdh.PDH_FMT_LONG)
+                    t, val = win32pdh.GetFormattedCounterValue(counter_handle, self._precision)
                     ret[inst] = val
                 except Exception as e:
                     raise e

--- a/checks/libs/win/winpdh_stub.py
+++ b/checks/libs/win/winpdh_stub.py
@@ -2,7 +2,8 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-
+DATA_TYPE_INT = 1
+DATA_TYPE_DOUBLE = 2
 class WinPDHCounter(object):
 
     def is_single_instance(self):


### PR DESCRIPTION
loses fidelity, especially with values between 0 and 1.
### What does this PR do?
change default pdh counter precision to float from int.
Allows configuration to set specific counter types

### Motivation
customer request

