### PR TITLE
[macos][install script] Update URL of latest Agent 5

### DIFF
--- a/packaging/osx/install.sh
+++ b/packaging/osx/install.sh
@@ -7,7 +7,7 @@
 set -e
 logfile=ddagent-install.log
 dmg_file=/tmp/datadog-agent.dmg
-dmg_url="https://s3.amazonaws.com/dd-agent/datadogagent.dmg"
+dmg_url="https://s3.amazonaws.com/dd-agent/datadog-agent-5.11.3-1.dmg"
 
 # Root user detection
 if [ $(echo "$UID") = "0" ]; then


### PR DESCRIPTION
It's v5.11.3 and will remain at that version. The latest URL points
to Agent 6 now.