### PR TITLE
Remove API key if included in processes metadata payload

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -529,6 +529,8 @@ class Collector(object):
             del data['metrics']
             del data['events']
             del data['service_checks']
+            if data.get('processes'):
+                data['processes']['apiKey'] = '*************************' + data['processes'].get('apiKey', '')[-5:]
             log.debug("Metadata payload: %s", json.dumps(data))
 
         # Persist the status of the collection run.


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Removes API key if included as part of the `processes` field in the metadata payload when log level is set to `DEBUG`

### Motivation

Noticed an API key, as part of the processes field, could be sent if `DEBUG` mode is enabled

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
