### PR TITLE
Fixed pip installation failures during source install

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -14,7 +14,7 @@ set -u
 DEFAULT_AGENT_VERSION="5.22.3"
 # Pin pip version, in the past there was some buggy releases and get-pip.py
 # always pulls the latest version
-PIP_VERSION="6.1.1"
+PIP_VERSION="9.0.3"
 VIRTUALENV_VERSION="1.11.6"
 SUPERVISOR_VERSION="3.3.0"
 SETUPTOOLS_VERSION="20.9.0"
@@ -455,7 +455,11 @@ elif check_version $PRE_SDK_RELEASE $AGENT_VERSION; then
 
   # Install `datadog-checks-base` dependency before any checks
   cd "$DD_HOME/integrations/datadog-checks-base"
-  "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.txt"
+  if $VENV_PIP_CMD install -r "requirements.txt" 2>&1; then
+      echo "$INT is installed"
+  else
+      echo "Could not install $INT, skipping"
+  fi
   $PYTHON_CMD "setup.py" bdist_wheel
   $VENV_PIP_CMD install dist/*.whl
   cd -
@@ -471,7 +475,11 @@ elif check_version $PRE_SDK_RELEASE $AGENT_VERSION; then
     cd "$INT_DIR"
 
     if [ -f "requirements.txt" ]; then
-      "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.txt"
+        if $VENV_PIP_CMD install -r "requirements.txt" 2>&1; then
+            echo "$INT is installed"
+        else
+            echo "Could not install $INT, skipping"
+        fi
     fi
     if [ -f "setup.py" ]; then
       $PYTHON_CMD "setup.py" bdist_wheel


### PR DESCRIPTION
### What does this PR do?

Edit (@arbll):

This bug seems to be linked to the introduction of hashes in `requirements.txt` during the wheels migration. This script was not made to run with hashes : https://github.com/DataDog/dd-agent/blob/master/utils/pip-allow-failures.sh and will try to run things like 
```
pip install "psutil==4.4.1     --hash=sha256:7e77ec1a9c75a858781c1fb46fe81c999e1ae0e711198b4aaf59e5f5bd373b11     --hash=sha256:0f7f830db35c1baeb0131b2bba458b77f7db98944b2fedafc34922168e467d09"
```
during the install of the integrations :
https://github.com/DataDog/dd-agent/blob/97f2c6bff6f01923347fbcd467ffa4109e27de13/packaging/datadog-agent/source/setup_agent.sh#L473-L475

 See https://trello.com/c/HH6k8YyF/1039-source-install-script-installs-wrong-version-of-pip.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

The changes could be moved to pip-allow-failures.sh.
