### PR TITLE
Set default value for AGENT_VERSION

### DIFF
--- a/config.py
+++ b/config.py
@@ -42,7 +42,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 
 # CONSTANTS
-AGENT_VERSION = "5.23.0"
+AGENT_VERSION = "5.0.0"
 JMX_VERSION = "0.19.0"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'


### PR DESCRIPTION
### What does this PR do?

Set a default version in the dev env for the agent. The real version will be updated by the package builder.