### PR TITLE
Fix source install

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -460,9 +460,7 @@ elif check_version $PRE_SDK_RELEASE $AGENT_VERSION; then
   elif [ -f "requirements.txt" ]; then
     "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.txt"
   fi
-  if [ -f "setup.py" ]; then
-    $PYTHON_CMD "setup.py" bdist_wheel && $VENV_PIP_CMD install dist/*.whl
-  else
+  $PYTHON_CMD "setup.py" bdist_wheel && $VENV_PIP_CMD install dist/*.whl
   cd -
 
   for INT in $INTEGRATIONS; do

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -456,8 +456,7 @@ elif check_version $PRE_SDK_RELEASE $AGENT_VERSION; then
   # Install `datadog-checks-base` dependency before any checks
   cd "$DD_HOME/integrations/datadog-checks-base"
   "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.in"
-  $PYTHON_CMD "setup.py" bdist_wheel
-  $VENV_PIP_CMD install dist/*.whl
+  ($PYTHON_CMD "setup.py" bdist_wheel && $VENV_PIP_CMD install dist/*.whl) || true
   cd -
 
   for INT in $INTEGRATIONS; do

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -474,8 +474,7 @@ elif check_version $PRE_SDK_RELEASE $AGENT_VERSION; then
       "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.in"
     fi
     if [ -f "setup.py" ]; then
-      $PYTHON_CMD "setup.py" bdist_wheel
-      $VENV_PIP_CMD install dist/*.whl
+      ($PYTHON_CMD "setup.py" bdist_wheel && $VENV_PIP_CMD install dist/*.whl) || true
     else
       if [ -f "datadog_checks/$INT/$INT.py" ]; then
         cp "datadog_checks/$INT/$INT.py" "$DD_HOME/agent/checks.d/$INT.py"

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -455,7 +455,7 @@ elif check_version $PRE_SDK_RELEASE $AGENT_VERSION; then
 
   # Install `datadog-checks-base` dependency before any checks
   cd "$DD_HOME/integrations/datadog-checks-base"
-  "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.txt"
+  "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.in"
   $PYTHON_CMD "setup.py" bdist_wheel
   $VENV_PIP_CMD install dist/*.whl
   cd -
@@ -471,7 +471,7 @@ elif check_version $PRE_SDK_RELEASE $AGENT_VERSION; then
     cd "$INT_DIR"
 
     if [ -f "requirements.txt" ]; then
-      "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.txt"
+      "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.in"
     fi
     if [ -f "setup.py" ]; then
       $PYTHON_CMD "setup.py" bdist_wheel

--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -455,8 +455,14 @@ elif check_version $PRE_SDK_RELEASE $AGENT_VERSION; then
 
   # Install `datadog-checks-base` dependency before any checks
   cd "$DD_HOME/integrations/datadog-checks-base"
-  "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.in"
-  ($PYTHON_CMD "setup.py" bdist_wheel && $VENV_PIP_CMD install dist/*.whl) || true
+  if [ -f "requirements.in" ]; then
+    "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.in"
+  elif [ -f "requirements.txt" ]; then
+    "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.txt"
+  fi
+  if [ -f "setup.py" ]; then
+    $PYTHON_CMD "setup.py" bdist_wheel && $VENV_PIP_CMD install dist/*.whl
+  else
   cd -
 
   for INT in $INTEGRATIONS; do
@@ -469,8 +475,10 @@ elif check_version $PRE_SDK_RELEASE $AGENT_VERSION; then
 
     cd "$INT_DIR"
 
-    if [ -f "requirements.txt" ]; then
+    if [ -f "requirements.in" ]; then
       "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.in"
+    elif [ -f "requirements.txt" ]; then
+      "$DD_HOME/agent/utils/pip-allow-failures.sh" "requirements.txt"
     fi
     if [ -f "setup.py" ]; then
       ($PYTHON_CMD "setup.py" bdist_wheel && $VENV_PIP_CMD install dist/*.whl) || true


### PR DESCRIPTION
### What does this PR do?

The migration to wheels added hashes in the integrations `requirements.txt`s. The source install was not made to handle theses hashes. As a quick fix, this PR uses `requirements.in` instead.

This also allows wheel installations to fail.

### Motivation

Install from source was broken.

