### PR TITLE
Fix Boto HTTP proxy configuration

### DIFF
--- a/utils/cloud_metadata.py
+++ b/utils/cloud_metadata.py
@@ -6,6 +6,7 @@
 import logging
 import types
 import os
+import re
 import socket
 
 # 3rd party
@@ -198,12 +199,17 @@ class EC2(object):
 
             import boto.ec2
             proxy_settings = get_proxy(agentConfig) or {}
+
+            proxy_host = proxy_settings.get('host')
+            if proxy_host is not None:
+                proxy_host = re.sub(r'^http(s?)://', '', proxy_host)
+
             connection = boto.ec2.connect_to_region(
                 region,
                 aws_access_key_id=iam_params['AccessKeyId'],
                 aws_secret_access_key=iam_params['SecretAccessKey'],
                 security_token=iam_params['Token'],
-                proxy=proxy_settings.get('host'), proxy_port=proxy_settings.get('port'),
+                proxy=proxy_host, proxy_port=proxy_settings.get('port'),
                 proxy_user=proxy_settings.get('user'), proxy_pass=proxy_settings.get('password')
             )
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes Boto's HTTP proxy configuration within the agent.

Boto's proxy argument don't want the protocol on the proxy host.
Configuration within Datadog itself requires this protocol, so strip it
before we pass the proxy host to Boto.

### Motivation

We need to proxy our dd-agent traffic out via a HTTP proxy. After configuring the HTTP proxy for the dd-agent we noticed it started failing to retrieve EC2 tags from the AWS API. We tracked the issue down to this misconfigured Boto proxy argument.

We've deployed this fix and seen the dd-agent successfully fetch tags via an HTTP proxy.