### PR TITLE
Use a publicly accessible GitHub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Required:
 
 ```
 # Clone the repository
-git clone git@github.com:DataDog/dd-agent.git
+git clone https://github.com/DataDog/dd-agent
 
 # Create a virtual environment and install the dependencies:
 cd dd-agent


### PR DESCRIPTION
Only contributors can clone a git@github.com ssh link.