### PR TITLE
Cap `system.io.util` to 100%

### DIFF
--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -41,8 +41,8 @@ class IO(Check):
     def _cap_io_util_value(self, val):
         # Cap system.io.util metric value to 102%
         # This is a known won't fix bug in iostat
-        if val > 102:
-            self.logger.exception("The %util value exceeds the limit: {}%".format(val))
+        if val > 100:
+            self.logger.debug("The %util value exceeds the limit: {}%".format(val))
             return 0
         else:
             return val
@@ -81,7 +81,7 @@ class IO(Check):
 
             for headerIndex in range(len(headerNames)):
                 headerName = headerNames[headerIndex]
-                if 'util' in headerName:
+                if '%util' in headerName:
                     values[headerIndex] = self._cap_io_util_value(values[headerIndex])
                 ioStats[device][headerName] = values[headerIndex]
 
@@ -178,7 +178,7 @@ class IO(Check):
                     io[cols[0]] = {}
                     for i in range(1, len(cols)):
                         xlate_header = self.xlate(headers[i], "sunos")
-                        if 'util' in xlate_header:
+                        if '%util' in xlate_header:
                             cols[i] = self._cap_io_util_value(cols[i])
                         io[cols[0]][xlate_header] = cols[i]
 
@@ -209,7 +209,7 @@ class IO(Check):
                     io[cols[0]] = {}
                     for i in range(1, len(cols)):
                         xlate_header = self.xlate(headers[i], "freebsd")
-                        if 'utils' in xlate_header:
+                        if '%util' in xlate_header:
                             cols[i] = self._cap_io_util_value(cols[i])
                         io[cols[0]][xlate_header] = cols[i]
             elif sys.platform == 'darwin':

--- a/checks/system/unix.py
+++ b/checks/system/unix.py
@@ -38,6 +38,15 @@ class IO(Check):
         self.item_re = re.compile(r'^([\-a-zA-Z0-9\/]+)')
         self.value_re = re.compile(r'\d+\.\d+')
 
+    def _cap_io_util_value(self, val):
+        # Cap system.io.util metric value to 102%
+        # This is a known won't fix bug in iostat
+        if val > 102:
+            self.logger.exception("The %util value exceeds the limit: {}%".format(val))
+            return 0
+        else:
+            return val
+
     def _parse_linux2(self, output):
         recentStats = output.split('Device:')[2].split('\n')
         header = recentStats[0]
@@ -72,6 +81,8 @@ class IO(Check):
 
             for headerIndex in range(len(headerNames)):
                 headerName = headerNames[headerIndex]
+                if 'util' in headerName:
+                    values[headerIndex] = self._cap_io_util_value(values[headerIndex])
                 ioStats[device][headerName] = values[headerIndex]
 
         return ioStats
@@ -166,7 +177,10 @@ class IO(Check):
                     # cols[1:] are the values
                     io[cols[0]] = {}
                     for i in range(1, len(cols)):
-                        io[cols[0]][self.xlate(headers[i], "sunos")] = cols[i]
+                        xlate_header = self.xlate(headers[i], "sunos")
+                        if 'util' in xlate_header:
+                            cols[i] = self._cap_io_util_value(cols[i])
+                        io[cols[0]][xlate_header] = cols[i]
 
             elif sys.platform.startswith("freebsd"):
                 output, _, _ = get_subprocess_output(["iostat", "-x", "-d", "1", "2"], self.logger)
@@ -194,7 +208,10 @@ class IO(Check):
                     # cols[1:] are the values
                     io[cols[0]] = {}
                     for i in range(1, len(cols)):
-                        io[cols[0]][self.xlate(headers[i], "freebsd")] = cols[i]
+                        xlate_header = self.xlate(headers[i], "freebsd")
+                        if 'utils' in xlate_header:
+                            cols[i] = self._cap_io_util_value(cols[i])
+                        io[cols[0]][xlate_header] = cols[i]
             elif sys.platform == 'darwin':
                 iostat, _, _ = get_subprocess_output(['iostat', '-d', '-c', '2', '-w', '1'], self.logger)
                 #          disk0           disk1          <-- number of disks


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

There is bug in iostat where the values for %util will sometimes be excessively greater than 100%. We will log the invalid metric value and report to value as 0. 
[Here](https://bugzilla.redhat.com/show_bug.cgi?id=445676) is the redhat won't fix bug report
### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
