### PR TITLE
Make the classpath seperator in jmxfetch adjust to the os

### DIFF
--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -240,11 +240,11 @@ class JMXFetch(ProcessRunner):
 
             classpath = path_to_jmxfetch
             if tools_jar_path is not None:
-                classpath = r"%s:%s" % (tools_jar_path, classpath)
+                classpath = r"%s%s%s" % (tools_jar_path, os.pathsep, classpath)
             if custom_jar_paths:
-                classpath = r"%s:%s" % (':'.join(custom_jar_paths), classpath)
+                classpath = r"%s%s%s" % (os.pathsep.join(custom_jar_paths), os.pathsep, classpath)
             if self.config_jar_path:
-                classpath = r"%s:%s" % (self.config_jar_path, classpath)
+                classpath = r"%s%s%s" % (self.config_jar_path, os.pathsep, classpath)
 
             subprocess_args = [
                 path_to_java,  # Path to the java bin


### PR DESCRIPTION
TL;DR Linux uses a colon (:) and Windows a semicolon (;). os.pathsep knows
this.

When using the jmx agent on Windows in combination with a custom_jar_paths and or tools_jar_path the agent will fail because the classpath seperator is a colon. On Windows a path seperator has to be a semicolon. The python function os.pathsep return the correct seperator. 

