### PR TITLE
Add message about check_rate

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -603,7 +603,7 @@ def main():
                         cs = Collector.run_single_check(check, verbose=True)
                         print CollectorStatus.render_check_status(cs)
                     else:
-                        print "Check has run only once, if some metrics are missing you can try again with check_rate appended at the end to see any other metrics if available."
+                        print "Check has run only once, if some metrics are missing you can run the command again with the 'check_rate' argument appended at the end to see any other metrics if available."
                     check.stop()
 
     elif 'configcheck' == command or 'configtest' == command:


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

If the check command is run without `check_rate` then print a message saying that is an available option.

### Motivation

If an integration only submits rates, it can be confusing to see 0 metrics when just running the `check` command.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
