### PR TITLE
Ianb/dogstreams aggregate

### DIFF
--- a/checks/datadog.py
+++ b/checks/datadog.py
@@ -27,7 +27,7 @@ def partition(s, sep):
 def point_sorter(p):
     # Sort and group by timestamp, metric name, host_name, device_name, (tags or attributes)
     tags = p[3].get('tags', None)
-    attribs = sorted(tags) if tags is not None else p[3]
+    attribs = sorted(tags.split(",")) if tags is not None else p[3]
     # Include tags (or attibutes if tags do not exists) to determine the uniqueness of a metric.
     return (p[1], p[0], p[3].get('host_name', None), p[3].get('device_name', None), attribs)
 

--- a/checks/datadog.py
+++ b/checks/datadog.py
@@ -25,9 +25,11 @@ def partition(s, sep):
 
 
 def point_sorter(p):
-    # Sort and group by timestamp, metric name, host_name, device_name
-    return (p[1], p[0], p[3].get('host_name', None), p[3].get('device_name', None),sorted(p[3].get('tags', None)))
-
+    # Sort and group by timestamp, metric name, host_name, device_name, (tags or attributes)
+    tags = p[3].get('tags', None)
+    attribs = sorted(tags) if tags is not None else p[3]
+    # Include tags (or attibutes if tags do not exists) to determine the uniqueness of a metric.
+    return (p[1], p[0], p[3].get('host_name', None), p[3].get('device_name', None), attribs)
 
 class EventDefaults(object):
     EVENT_TYPE = 'dogstream_event'
@@ -307,7 +309,7 @@ class Dogstream(object):
 
         values.sort(key=point_sorter)
 
-        for (timestamp, metric, host_name, device_name, tags), val_attrs in groupby(values, key=point_sorter):
+        for (timestamp, metric, host_name, device_name, attribs), val_attrs in groupby(values, key=point_sorter):
             attributes = {}
             vals = []
             for _metric, _timestamp, v, a in val_attrs:

--- a/checks/datadog.py
+++ b/checks/datadog.py
@@ -26,7 +26,7 @@ def partition(s, sep):
 
 def point_sorter(p):
     # Sort and group by timestamp, metric name, host_name, device_name
-    return (p[1], p[0], p[3].get('host_name', None), p[3].get('device_name', None))
+    return (p[1], p[0], p[3].get('host_name', None), p[3].get('device_name', None),sorted(p[3].get('tags', None)))
 
 
 class EventDefaults(object):
@@ -189,7 +189,9 @@ class Dogstream(object):
                 # reset generator to try again during the next check interval
                 self._gen = None
 
+            self.logger.debug("Pre-aggregated metrics: {0}".format(self._values))
             check_output = self._aggregate(self._values)
+            self.logger.debug("Aggregated metrics: {0}".format(check_output))
             if self._events:
                 check_output.update({"dogstreamEvents": self._events})
                 self.logger.debug("Found {0} events".format(len(self._events)))
@@ -305,7 +307,7 @@ class Dogstream(object):
 
         values.sort(key=point_sorter)
 
-        for (timestamp, metric, host_name, device_name), val_attrs in groupby(values, key=point_sorter):
+        for (timestamp, metric, host_name, device_name, tags), val_attrs in groupby(values, key=point_sorter):
             attributes = {}
             vals = []
             for _metric, _timestamp, v, a in val_attrs:

--- a/checks/datadog.py
+++ b/checks/datadog.py
@@ -26,10 +26,10 @@ def partition(s, sep):
 
 def point_sorter(p):
     # Sort and group by timestamp, metric name, host_name, device_name, (tags or attributes)
-    tags = p[3].get('tags', None)
+    tags = p[3].get('tags')
     attribs = sorted(tags.split(",")) if tags is not None else p[3]
     # Include tags (or attibutes if tags do not exists) to determine the uniqueness of a metric.
-    return (p[1], p[0], p[3].get('host_name', None), p[3].get('device_name', None), attribs)
+    return (p[1], p[0], p[3].get('host_name'), p[3].get('device_name'), attribs)
 
 class EventDefaults(object):
     EVENT_TYPE = 'dogstream_event'
@@ -39,7 +39,7 @@ class EventDefaults(object):
 class Dogstreams(object):
     @classmethod
     def init(cls, logger, config):
-        dogstreams_config = config.get('dogstreams', None)
+        dogstreams_config = config.get('dogstreams')
         if dogstreams_config:
             dogstreams = cls._instantiate_dogstreams(logger, config, dogstreams_config)
         else:


### PR DESCRIPTION
### What does this PR do?

Includes the tags (metric attributes if there's none) as part of the metric aggregation.

### Motivation

Given the following logs, dogstreams will only submit one of the metric (usually the last one) and drop the others even if they are tagged differently.

```
my.vcurrency 1525651200 100 tags=curr:usd
my.vcurrency 1525651202 100 tags=curr:usd
my.vcurrency 1525651203 200 tags=curr:aud
my.vcurrency 1525651204 100 tags=curr:usd
my.vcurrency 1525651205 200 tags=curr:aud
my.vcurrency 1525651206 300 tags=curr:eur
```
Expected metrics to be sent to DD after aggregation:
3 unique:
```
my.vcurrency 1525651204 100 tags=curr:usd
my.vcurrency 1525651205 200 tags=curr:aud
my.vcurrency 1525651206 300 tags=curr:eur
```

Actual result: (just one)
```
my.vcurrency 1525651206 300 tags=curr:eur
```
