### PR TITLE
[docker] Add host tag for docker swarm node role.

### DIFF
--- a/tests/core/test_dockerutil.py
+++ b/tests/core/test_dockerutil.py
@@ -185,6 +185,25 @@ class TestDockerUtil(unittest.TestCase):
         self.assertEqual({'docker_version': '1.13.1', 'docker_swarm': 'active'}, DockerUtil().get_host_metadata())
         mock_version.assert_called_once()
 
+    def test_docker_host_tags_ok(self):
+        du = DockerUtil()
+        mock_isswarm = mock.MagicMock(name='is_swarm', return_value=False)
+        du._client = mock.MagicMock()
+        du.is_swarm = mock_isswarm
+
+        self.assertEqual([], DockerUtil().get_host_tags())
+
+    def test_docker_host_tags_swarm_ok(self):
+        du = DockerUtil()
+        mock_info = mock.MagicMock(name='info', return_value={'Swarm': {'ControlAvailable' : True}})
+        mock_isswarm = mock.MagicMock(name='is_swarm', return_value=True)
+        du._client = mock.MagicMock()
+        du._client.info = mock_info
+        du.is_swarm = mock_isswarm
+
+        self.assertEqual(['docker_swarm_node_role:manager'], DockerUtil().get_host_tags())
+        mock_info.assert_called_once()
+
     def test_docker_are_tags_filtered(self):
         with mock.patch.object(DockerUtil, 'is_k8s', side_effect=lambda: True):
             DockerUtil._drop()

--- a/utils/dockerutil.py
+++ b/utils/dockerutil.py
@@ -323,6 +323,23 @@ class DockerUtil:
 
         return meta
 
+    def get_host_tags(self):
+        """
+        Returns tags for the swarm node role for the local host.
+        """
+
+        tags = []
+
+        if self.is_swarm():
+            try:
+                info = self.client.info()
+                node_role = 'manager' if info.get('Swarm', {}).get('ControlAvailable') else 'worker'
+                tags.append('%s:%s' % ("docker_swarm_node_role", node_role))
+            except Exception:
+                pass
+
+        return tags
+
     def set_docker_settings(self, init_config, instance):
         """Update docker settings"""
         self._docker_root = init_config.get('docker_root', '/')

--- a/utils/orchestrator/dockerutilproxy.py
+++ b/utils/orchestrator/dockerutilproxy.py
@@ -20,5 +20,8 @@ class DockerUtilProxy(BaseUtil):
         except Exception:
             return False
 
+    def get_host_tags(self):
+        return self.docker_util.get_host_tags()
+
     def get_host_metadata(self):
         return self.docker_util.get_host_metadata()


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

This adds a host tag to docker swarm nodes containing the node role (manager or worker). 

### Motivation

### Testing Guidelines

<img width="349" alt="screen shot 2018-05-10 at 10 14 54 am" src="https://user-images.githubusercontent.com/5367914/39874208-28ffb3c8-543b-11e8-815b-6b03881f412d.png">

<img width="393" alt="screen shot 2018-05-10 at 10 15 43 am" src="https://user-images.githubusercontent.com/5367914/39874195-1f9d5bd2-543b-11e8-9be6-e5d9b1ef5660.png">

### Additional Notes

To determine if the node is a manager/worker this checks the `ControlAvailable` flag in the response from `docker info` the same it is done by the [docker cli](https://github.com/docker/cli/blob/c889ea1bca95f78d10e9e8f7869d5cfd755850eb/cli/command/system/info.go#L259).
