### PR TITLE
[unix] add tests for capped iostat util logic

### DIFF
--- a/tests/checks/mock/test_sysstat.py
+++ b/tests/checks/mock/test_sysstat.py
@@ -249,7 +249,7 @@ device      r/s    w/s   kr/s   kw/s wait actv  svc_t  %w  %b
 ramdisk1    0.0    0.0    0.0    0.0  0.0  0.0    0.0   0   0
 sd0         0.0    0.0    0.0    0.0  0.0  0.0    0.0   0   102
 sd1         0.0  139.0    0.0 1850.6  0.0  0.0    0.1   0   10
-"""     
+"""
         return output, 0, 0
 
     def freebsd_output(self, *args, **kwargs):
@@ -259,7 +259,7 @@ ad0        3.1   1.3    49.9    18.8    0   0.7   0
 extended device statistics
 device     r/s   w/s    kr/s    kw/s wait svc_t  %b
 ad0        0.0   2.0     0.0    31.8    0   0.2   102
-"""     
+"""
         return output, 0, 0
 
     @mock.patch('checks.system.unix.sys.platform', 'sunos5')

--- a/tests/checks/mock/test_sysstat.py
+++ b/tests/checks/mock/test_sysstat.py
@@ -2,6 +2,7 @@
 import logging
 import sys
 import unittest
+import mock
 
 # project
 from checks.system.unix import (
@@ -173,3 +174,113 @@ dm-1              0.00     0.00    0.00    0.00     0.00     0.00     0.00     0
 """
         results = checker._parse_linux2(linux_output_dashes)
         self.assertTrue(sorted(results.keys()) == ['dm-0', 'dm-1', 'sda'])
+
+    def testLinuxCapIostat(self):
+        # example output from `iostat -d 1 2 -x -k` on
+        # debian testing x86_64, from Debian package
+        # sysstat@10.0.4-1
+        debian_iostat_output = """Linux 3.2.0-2-amd64 (fireflyvm)   05/29/2012  _x86_64_    (2 CPU)
+
+Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
+sda               0.44     2.58    5.79    2.84   105.53   639.03   172.57     0.17   19.38    1.82   55.26   0.66   0.57
+
+Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
+sda               0.00     0.00    0.00    0.00     0.00     0.00     0.00     0.00    0.00    0.00    0.00   0.00   100.01
+
+"""
+
+        global logger
+        checker = IO(logger)
+        results = checker._parse_linux2(debian_iostat_output)
+        self.assertTrue('sda' in results)
+        # Ensure that value is capped and return to 0 if it surpasses 100
+        expected = 0
+        self.assertEqual(results['sda']['%util'], expected)
+
+        # example output from `iostat -d 1 2 -x -k` on
+        # ubuntu 18.04 x86_64, from deb package
+        # sysstat@11.6.1-1; main breaking change is
+        # that header starts with `Device` instead of `Device:`.
+        newer_iostat_output = """Linux 4.9.60-linuxkit-aufs (f3cf72f6fb4d)     05/09/18    _x86_64_    (2 CPU)
+
+Device            r/s     w/s     rkB/s     wkB/s   rrqm/s   wrqm/s  %rrqm  %wrqm r_await w_await aqu-sz rareq-sz wareq-sz  svctm  %util
+sda              0.07    0.08      0.64      5.44     0.00     0.23   0.41  72.99    2.42   19.91   0.00     8.92    65.13   0.38   0.01
+
+Device            r/s     w/s     rkB/s     wkB/s   rrqm/s   wrqm/s  %rrqm  %wrqm r_await w_await aqu-sz rareq-sz wareq-sz  svctm  %util
+sda              0.00    0.00      0.00      0.00     0.00     0.00   0.00   0.00    0.00    0.00   0.00     0.00     0.00   0.00   99.99
+
+"""
+
+        checker = IO(logger)
+        results = checker._parse_linux2(newer_iostat_output)
+        self.assertTrue('sda' in results)
+        expected = 99.99
+        self.assertEqual(results['sda']['%util'], expected)
+
+        # example output from `iostat -d 1 d -x -k` on
+        # centos 5.8 x86_64, from RPM package
+        # sysstat@7.0.2; it differs from the first one by
+        # not having split-out r_await and w_await fields
+        centos_iostat_output = """Linux 2.6.18-308.el5 (localhost.localdomain)  05/29/2012
+
+Device:         rrqm/s   wrqm/s   r/s   w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await  svctm  %util
+sda               9.44     7.56 16.76  4.40   322.05    47.75    34.96     0.01    0.59   0.35   0.74
+
+Device:         rrqm/s   wrqm/s   r/s   w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await  svctm  %util
+sda               0.00     0.00  0.00  0.00     0.00     0.00     0.00     0.00    0.00   0.00   102.01
+
+"""
+
+        checker = IO(logger)
+        results = checker._parse_linux2(centos_iostat_output)
+        self.assertTrue('sda' in results)
+        # %util value is over 100, and value is set to 0
+        expected = 0
+        self.assertEqual(results['sda']['%util'], expected)
+
+    def sunos5_output(self, *args, **kwargs):
+        output = """extended device statistics <-- since boot
+device      r/s    w/s   kr/s   kw/s wait actv  svc_t  %w  %b
+ramdisk1    0.0    0.0    0.1    0.1  0.0  0.0    0.0   0   0
+sd0         0.0    0.0    0.0    0.0  0.0  0.0    0.0   0   0
+sd1        79.9  149.9 1237.6 6737.9  0.0  0.5    2.3   0  11
+                   extended device statistics <-- past second
+device      r/s    w/s   kr/s   kw/s wait actv  svc_t  %w  %b
+ramdisk1    0.0    0.0    0.0    0.0  0.0  0.0    0.0   0   0
+sd0         0.0    0.0    0.0    0.0  0.0  0.0    0.0   0   102
+sd1         0.0  139.0    0.0 1850.6  0.0  0.0    0.1   0   10
+"""     
+        return output, 0, 0
+
+    def freebsd_output(self, *args, **kwargs):
+        output = """extended device statistics
+device     r/s   w/s    kr/s    kw/s wait svc_t  %b
+ad0        3.1   1.3    49.9    18.8    0   0.7   0
+extended device statistics
+device     r/s   w/s    kr/s    kw/s wait svc_t  %b
+ad0        0.0   2.0     0.0    31.8    0   0.2   102
+"""     
+        return output, 0, 0
+
+    @mock.patch('checks.system.unix.sys.platform', 'sunos5')
+    @mock.patch('checks.system.unix.get_subprocess_output', side_effect=sunos5_output)
+    def testSunos5CapIostat(self, mock_subprocess):
+        global logger
+        checker = IO(logger)
+        results = checker.check({})
+        for res in results:
+            if res == 'sd1':
+                expected = 10
+            else:
+                expected = 0
+            self.assertEqual(results[res]['%util'], expected)
+
+    @mock.patch('checks.system.unix.sys.platform', 'freebsd')
+    @mock.patch('checks.system.unix.get_subprocess_output', side_effect=freebsd_output)
+    def testFreebsdCapIostat(self, mock_subprocess):
+        global logger
+        checker = IO(logger)
+        results = checker.check({})
+        expected = 0
+        for res in results:
+            self.assertEqual(results[res]['%util'], expected)


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

The test_sysstat.py file was wrongly removed during migrating checks to integrations-core. This PR adds tests for capped io `%util` metric on linux, sunos5, and freebsd platforms.
### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
