### PR TITLE
Explicilty pin urllib to avoid python-etcd to pull latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ ntplib==0.3.3
 # utils/service_discovery/config_stores.py
 python-consul==0.4.7
 # utils/service_discovery/config_stores.py
+urllib3<1.23
 python-etcd==0.4.5
 # the libyaml bindings are optional
 pyyaml==3.11


### PR DESCRIPTION
### What does this PR do?

See title

### Motivation

`pip install -r requirements.txt` is currently broken, see https://ci.appveyor.com/project/Datadog/integrations-core/build/master.5840

`python-etcd` lists urllib requirement as `urllib3>=1.7.1` which clashes with the one from `requests==2.18.4` that is `urllib3<1.23,>=1.21.1`
