### PR TITLE
Add normalized pct metric

### DIFF
--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -143,14 +143,17 @@ class Cpu(Check):
         self.counter('system.cpu.idle')
         self.counter('system.cpu.system')
         self.counter('system.cpu.interrupt')
+        self.gauge('system.cpu_normalised.pct')
 
     def check(self, agentConfig):
         cpu_percent = psutil.cpu_times()
+        cpu_pct = psutil.cpu_percent()
 
         self.save_sample('system.cpu.user', 100 * cpu_percent.user / psutil.cpu_count())
         self.save_sample('system.cpu.idle', 100 * cpu_percent.idle / psutil.cpu_count())
         self.save_sample('system.cpu.system', 100 * cpu_percent.system / psutil.cpu_count())
         self.save_sample('system.cpu.interrupt', 100 * cpu_percent.interrupt / psutil.cpu_count())
+        self.save_sample('system.cpu_normalised.pct', 100 * cpu_pct / psutil.cpu_count())
 
         return self.get_metrics()
 

--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -143,17 +143,19 @@ class Cpu(Check):
         self.counter('system.cpu.idle')
         self.counter('system.cpu.system')
         self.counter('system.cpu.interrupt')
-        self.gauge('system.cpu_normalised.pct')
+        self.gauge('system.cpu.normalized_pct')
+        self.gauge('system.cpu.system_wide_pct')
+
 
     def check(self, agentConfig):
         cpu_percent = psutil.cpu_times()
-        cpu_pct = psutil.cpu_percent()
 
         self.save_sample('system.cpu.user', 100 * cpu_percent.user / psutil.cpu_count())
         self.save_sample('system.cpu.idle', 100 * cpu_percent.idle / psutil.cpu_count())
         self.save_sample('system.cpu.system', 100 * cpu_percent.system / psutil.cpu_count())
         self.save_sample('system.cpu.interrupt', 100 * cpu_percent.interrupt / psutil.cpu_count())
-        self.save_sample('system.cpu_normalised.pct', 100 * cpu_pct / psutil.cpu_count())
+        self.save_sample('system.cpu.normalized_pct', 100 * psutil.cpu_percent() / psutil.cpu_count())
+        self.save_sample('system.cpu.system_wide_pct', 100 * psutil.cpu_percent())
 
         return self.get_metrics()
 


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Feature Request from customer to show metric value of `cpu_percent / cpu_count`
### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
