### PR TITLE
Sets apm enabled by default (if there's no indication in the config

### DIFF
--- a/config.py
+++ b/config.py
@@ -616,7 +616,7 @@ def get_config(parse_args=True, cfg_path=None, options=None, can_query_registry=
             agentConfig["gce_updated_hostname"] = _is_affirmative(config.get("Main", "gce_updated_hostname"))
 
         # APM config
-        agentConfig["apm_enabled"] = False
+        agentConfig["apm_enabled"] = True
         if config.has_option("Main", "apm_enabled"):
             agentConfig["apm_enabled"] = _is_affirmative(config.get("Main", "apm_enabled"))
 


### PR DESCRIPTION
file)


### What does this PR do?

Sets the default state for APM to be enabled if not set in the config file

### Motivation

Make behavior consistent between agent5 and agent6

Windows agent uses this value to determine whether to start the apm service on main service startup (the service will not be started automatically by the service control manager).
