### PR TITLE
Adding unicode interpreter UCS4 note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,8 @@ Please refer to the [Process Agent 6.3.0 tag](https://github.com/DataDog/datadog
 * [IMPROVEMENT] Core: warning message to clarify `check_rate` option available. See [#3727][] 
 * [SANITY] Linux: Reintroduced system stats tests. See [#3733][]
 * [SANITY] Packaging/Build: Explicilty pin urllib to avoid inadverted updated. See [#3746][]
-* [OTHER] APM enabled by default. See [#3749][] 
-
-### Other Notes
-* Our embedded python unicode interpreter is now UCS4.
+* [OTHER] APM enabled by default. See [#3749][]
+* [OTHER] Our embedded python unicode interpreter is now UCS4. See [omnibus-software-191](https://github.com/DataDog/omnibus-software/pull/191)
 
 # 5.24.0 / 05-11-2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Please refer to the [Process Agent 6.3.0 tag](https://github.com/DataDog/datadog
 * [SANITY] Packaging/Build: Explicilty pin urllib to avoid inadverted updated. See [#3746][]
 * [OTHER] APM enabled by default. See [#3749][] 
 
+### Other Notes
+* Our embedded python unicode interpreter is now UCS4.
+
 # 5.24.0 / 05-11-2018
 
 **Linux, Windows, Docker and Source Install**


### PR DESCRIPTION
### What does this PR do?
Adding a note to the version 5.25 of the agent explaining that we changed the embedded python interpreter to USC4.

### Motivation
Some clients updated to the last version and their custom integration were broken.

[Agent 5.25](https://cl.ly/2G3o293Z0d2v)
[Agent 5.24](https://cl.ly/301l3X2t2U3Q)

### Testing Guidelines
Just an update on the changelog, no test has been performed.