### PR TITLE
[config] bumping jmxfetch to 0.20.1

### DIFF
--- a/config.py
+++ b/config.py
@@ -43,7 +43,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 # CONSTANTS
 AGENT_VERSION = "5.26.0"
-JMX_VERSION = "0.20.0"
+JMX_VERSION = "0.20.1"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
 MAC_CONFIG_PATH = '/opt/datadog-agent/etc'


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Bumping JMXFetch to 0.20.1 after agent release.

### Motivation

New JMXFetch version available.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
