### PR TITLE
Use "safe_load" instead of "load" from PyYaml

### DIFF
--- a/checks/check_status.py
+++ b/checks/check_status.py
@@ -896,7 +896,7 @@ def get_jmx_status():
     check_data = defaultdict(lambda: defaultdict(list))
     try:
         if os.path.exists(java_status_path):
-            java_jmx_stats = yaml.load(file(java_status_path))
+            java_jmx_stats = yaml.safe_load(file(java_status_path))
 
             status_age = time.time() - java_jmx_stats.get('timestamp')/1000  # JMX timestamp is saved in milliseconds
             jmx_checks = java_jmx_stats.get('checks', {})
@@ -941,7 +941,7 @@ def get_jmx_status():
                     check_statuses.append(check_status)
 
         if os.path.exists(python_status_path):
-            python_jmx_stats = yaml.load(file(python_status_path))
+            python_jmx_stats = yaml.safe_load(file(python_status_path))
             jmx_checks = python_jmx_stats.get('invalid_checks', {})
             for check_name, excep in jmx_checks.iteritems():
                 check_statuses.append(CheckStatus(check_name, [], init_failed_error=excep))

--- a/util.py
+++ b/util.py
@@ -11,12 +11,12 @@ import uuid
 # 3p
 import yaml  # noqa, let's guess, probably imported somewhere
 try:
-    from yaml import CLoader as yLoader
-    from yaml import CDumper as yDumper
+    from yaml import CSafeLoader as yLoader
+    from yaml import CSafeDumper as yDumper
 except ImportError:
     # On source install C Extensions might have not been built
-    from yaml import Loader as yLoader  # noqa, imported from here elsewhere
-    from yaml import Dumper as yDumper  # noqa, imported from here elsewhere
+    from yaml import SafeLoader as yLoader  # noqa, imported from here elsewhere
+    from yaml import SafeDumper as yDumper  # noqa, imported from here elsewhere
 
 # These classes are now in utils/, they are just here for compatibility reasons,
 # if a user actually uses them in a custom check

--- a/utils/jmx.py
+++ b/utils/jmx.py
@@ -146,6 +146,6 @@ class JMXFiles(object):
         check_names = []
         jmx_status_path = os.path.join(cls._get_dir(), cls._STATUS_FILE)
         if os.path.exists(jmx_status_path):
-            jmx_checks = yaml.load(file(jmx_status_path)).get('checks', {})
+            jmx_checks = yaml.safe_load(file(jmx_status_path)).get('checks', {})
             check_names = [name for name in jmx_checks.get('initialized_checks', {}).iterkeys()]
         return check_names


### PR DESCRIPTION
### What does this PR do?

PyYAML 'load()' method could execute arbitrary code. We now use
'safe_load' everywhere to avoid it.

### Motivation

Vuln: CVE-2017-18342
