### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Datadog Agent 6 has been officially released and the release notes can be found 
 Changes
 =======
 
+go-metro is no longer supported on CentOS 5
+
+
 # 5.26.0 / 08-01-2018
 
 **Linux, Windows, Docker and Source Install**


### PR DESCRIPTION


### What does this PR do?

Updates the changelog to include that gometro is no longer supported on centos 5.
This PR is more of a way not to forget to add this when 5.27.0 is released.