### PR TITLE
Revert "Fixes issue #3700"

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -355,11 +355,6 @@ class Collector(object):
         if self._ganglia is not None:
             payload['ganglia'] = self._ganglia.check(self.agentConfig)
         if self._dogstream is not None:
-            # every 10 run (~2min) we reload the list of files watched by
-            # dogstream
-            if (self.run_count % 10) == 0:
-                log.info("reloading list of files watched by Dogstreams")
-                self._dogstream = Dogstreams.init(log, self.agentConfig)
             dogstreamData = self._dogstream.check(self.agentConfig)
             dogstreamEvents = dogstreamData.get('dogstreamEvents', None)
             if dogstreamEvents:


### PR DESCRIPTION
### What does this PR do?

This reverts commit 78e9ad46749b319fa4aff57bea0b232136ef0e6d,
which introduced a significant file descriptor leak when dogstreams is enabled.
