### PR TITLE
[dogstreams] Declare the feature deprecated

### DIFF
--- a/checks/datadog.py
+++ b/checks/datadog.py
@@ -45,6 +45,7 @@ class Dogstreams(object):
         else:
             dogstreams = []
 
+        logger.warning("Dogstream is a deprecated feature, and is removed from version 6 of the Datadog Agent")
         logger.info("Dogstream parsers: %s" % repr(dogstreams))
 
         return cls(logger, dogstreams)

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -229,7 +229,8 @@ gce_updated_hostname: yes
 # ========================================================================== #
 
 # -------------------------------------------------------------------------- #
-#   Ganglia                                                                  #
+#  Ganglia                                                                   #
+#  DEPRECATED feature, removed from Agent v6                                 #
 # -------------------------------------------------------------------------- #
 
 # Ganglia host where gmetad is running
@@ -240,6 +241,7 @@ gce_updated_hostname: yes
 
 # -------------------------------------------------------------------------- #
 #  Dogstream (log file parser)												 #
+#  DEPRECATED feature, removed from Agent v6                                 #
 # -------------------------------------------------------------------------- #
 
 # Comma-separated list of logs to parse and optionally custom parsers to use.


### PR DESCRIPTION
### What does this PR do?

Declares `dogstreams` deprecated.

### Motivation

Dogstreams is deprecated (see docs page: https://docs.datadoghq.com/agent/faq/dogstream/)

### Testing Guidelines

Manually enabled dogstreams, the warning is logged, and only once.

### Additional Notes

🔥 🔥 🔥

(also, added mention that Ganglia integration is deprecated in the example conf, it's been deprecated for **4 years**)
