### PR TITLE
Fix import of _thread_by_func and pin urllib3==1.23

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,9 @@ pyyaml==3.11
 # note: requests is also used in many checks
 # upgrade with caution
 requests==2.19.1
+# We need to pin this explicitely because both python-etcd and requests depend on urllib3
+# but even though requests pins urllib3 < 1.24, python-etcd does not and pip installs the latest anyway.
+urllib3==1.23
 # note: simplejson is used in many checks to inteface APIs
 simplejson==3.6.5
 supervisor==3.3.3

--- a/tests/core/test_timeout.py
+++ b/tests/core/test_timeout.py
@@ -3,7 +3,8 @@ import unittest
 import time
 
 # datadog
-from utils.timeout import _thread_by_func, timeout, TimeoutException
+from utils.timeout import timeout, TimeoutException
+from datadog_checks.base.utils.timeout import _thread_by_func
 
 count = 0
 

--- a/utils/timeout.py
+++ b/utils/timeout.py
@@ -5,6 +5,5 @@
 from datadog_checks.utils.timeout import ( # noqa F401
     TimeoutException,
     ThreadMethod,
-    timeout,
-    _thread_by_func
+    timeout
 )


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Fix import of `_thread_by_func` from base check utils. It is only used in this test, so this should be safe.

### Motivation

Failed build

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
