### PR TITLE
[init scripts] Fix agent invocations when dd-agent has no login shell

### DIFF
--- a/packaging/centos/datadog-agent.init
+++ b/packaging/centos/datadog-agent.init
@@ -141,7 +141,7 @@ start() {
         exit 0
     fi
 
-    su $AGENTUSER -c "$AGENTPATH configcheck" > /dev/null 2>&1
+    su $AGENTUSER --shell "/bin/sh" -c "$AGENTPATH configcheck" > /dev/null 2>&1
     if [ $? -ne 0 ]; then
         echo -n $'\n'"Invalid check configuration. Please run sudo /etc/init.d/datadog-agent configtest for more details."
         echo -n $'\n'"Resuming starting process."$'\n'
@@ -189,13 +189,13 @@ info() {
     shift # Shift 'info' out of the args so we can pass any
           # additional options to the real command
           # (right now only dd-agent supports additional flags)
-    su $AGENTUSER -c "$AGENTPATH info $@"
+    su $AGENTUSER --shell "/bin/sh" -c "$AGENTPATH info $@"
     COLLECTOR_RETURN=$?
-    su $AGENTUSER -c "$DOGSTATSDPATH info"
+    su $AGENTUSER --shell "/bin/sh" -c "$DOGSTATSDPATH info"
     DOGSTATSD_RETURN=$?
-    su $AGENTUSER -c "$FORWARDERPATH info"
+    su $AGENTUSER --shell "/bin/sh" -c "$FORWARDERPATH info"
     FORWARDER_RETURN=$?
-    su $AGENTUSER -c "$TRACEAGENTPATH -info"
+    su $AGENTUSER --shell "/bin/sh" -c "$TRACEAGENTPATH -info"
     TRACEAGENT_RETURN=$? # not used for now, Trace/APM not a core feature yet
     exit $(($FORWARDER_RETURN+$COLLECTOR_RETURN+$DOGSTATSD_RETURN))
 }
@@ -206,7 +206,7 @@ reload() {
 }
 
 configcheck() {
-    su $AGENTUSER -c "$AGENTPATH configcheck"
+    su $AGENTUSER --shell "/bin/sh" -c "$AGENTPATH configcheck"
     exit $?
 }
 
@@ -262,7 +262,7 @@ case "$1" in
 
     jmx)
         shift
-        su $AGENTUSER -c "$AGENTPATH jmx $@"
+        su $AGENTUSER --shell "/bin/sh" -c "$AGENTPATH jmx $@"
         exit $?
         ;;
 

--- a/packaging/debian/datadog-agent.init
+++ b/packaging/debian/datadog-agent.init
@@ -137,7 +137,7 @@ case "$1" in
             $0 stop > /dev/null 2>&1
         fi
 
-        su $AGENTUSER -c "$AGENTPATH configcheck" > /dev/null 2>&1
+        su $AGENTUSER  --shell "/bin/sh" -c "$AGENTPATH configcheck" > /dev/null 2>&1
         if [ $? -ne 0 ]; then
             log_daemon_msg "Invalid check configuration. Please run sudo /etc/init.d/datadog-agent configtest for more details."
             log_daemon_msg "Resuming starting process."
@@ -180,13 +180,13 @@ case "$1" in
         shift # Shift 'info' out of args so we can pass any
               # addtional options to the real command
               # (right now only dd-agent supports additional flags)
-        su $AGENTUSER -c "$AGENTPATH info $@"
+        su $AGENTUSER --shell "/bin/sh" -c "$AGENTPATH info $@"
         COLLECTOR_RETURN=$?
-        su $AGENTUSER -c "$DOGSTATSDPATH info"
+        su $AGENTUSER --shell "/bin/sh" -c "$DOGSTATSDPATH info"
         DOGSTATSD_RETURN=$?
-        su $AGENTUSER -c "$FORWARDERPATH info"
+        su $AGENTUSER --shell "/bin/sh" -c "$FORWARDERPATH info"
         FORWARDER_RETURN=$?
-        su $AGENTUSER -c "$TRACEAGENTPATH -info"
+        su $AGENTUSER --shell "/bin/sh" -c "$TRACEAGENTPATH -info"
         TRACEAGENT_RETURN=$? # not used for now, Trace/APM not a core feature yet
         exit $(($COLLECTOR_RETURN+$DOGSTATSD_RETURN+$FORWARDER_RETURN))
         ;;
@@ -223,18 +223,18 @@ case "$1" in
         ;;
 
     configcheck)
-        su $AGENTUSER -c "$AGENTPATH configcheck"
+        su $AGENTUSER --shell "/bin/sh" -c "$AGENTPATH configcheck"
         exit $?
         ;;
 
     configtest)
-        su $AGENTUSER -c "$AGENTPATH configcheck"
+        su $AGENTUSER --shell "/bin/sh" -c "$AGENTPATH configcheck"
         exit $?
         ;;
 
     jmx)
         shift
-        su $AGENTUSER -c "$AGENTPATH jmx $@"
+        su $AGENTUSER --shell "/bin/sh" -c "$AGENTPATH jmx $@"
         exit $?
         ;;
 

--- a/packaging/suse/datadog-agent.init
+++ b/packaging/suse/datadog-agent.init
@@ -369,7 +369,7 @@ case "$1" in
             $0 stop > /dev/null 2>&1
         fi
 
-        su $AGENTUSER -c "$AGENTPATH configcheck" > /dev/null 2>&1
+        su $AGENTUSER --shell "/bin/sh" -c "$AGENTPATH configcheck" > /dev/null 2>&1
         if [ $? -ne 0 ]; then
             log_daemon_msg "Invalid check configuration. Please run sudo /etc/init.d/datadog-agent configtest for more details."
             log_daemon_msg "Resuming starting process."
@@ -412,13 +412,13 @@ case "$1" in
         shift # Shift 'info' out of args so we can pass any
               # addtional options to the real command
               # (right now only dd-agent supports additional flags)
-        su $AGENTUSER -c "$AGENTPATH info $@"
+        su $AGENTUSER --shell "/bin/sh" -c "$AGENTPATH info $@"
         COLLECTOR_RETURN=$?
-        su $AGENTUSER -c "$DOGSTATSDPATH info"
+        su $AGENTUSER --shell "/bin/sh" -c "$DOGSTATSDPATH info"
         DOGSTATSD_RETURN=$?
-        su $AGENTUSER -c "$FORWARDERPATH info"
+        su $AGENTUSER --shell "/bin/sh" -c "$FORWARDERPATH info"
         FORWARDER_RETURN=$?
-        su $AGENTUSER -c "$TRACEAGENTPATH -info"
+        su $AGENTUSER --shell "/bin/sh" -c "$TRACEAGENTPATH -info"
         TRACEAGENT_RETURN=$? # not used for now, Trace/APM not a core feature yet
         exit $(($COLLECTOR_RETURN+$DOGSTATSD_RETURN+$FORWARDER_RETURN))
         ;;
@@ -455,18 +455,18 @@ case "$1" in
         ;;
 
     configcheck)
-        su $AGENTUSER -c "$AGENTPATH configcheck"
+        su $AGENTUSER --shell "/bin/sh" -c "$AGENTPATH configcheck"
         exit $?
         ;;
 
     configtest)
-        su $AGENTUSER -c "$AGENTPATH configcheck"
+        su $AGENTUSER --shell "/bin/sh" -c "$AGENTPATH configcheck"
         exit $?
         ;;
 
     jmx)
         shift
-        su $AGENTUSER -c "$AGENTPATH jmx $@"
+        su $AGENTUSER --shell "/bin/sh" -c "$AGENTPATH jmx $@"
         exit $?
         ;;
 


### PR DESCRIPTION
### What does this PR do?

Fix agent invocations when dd-agent has no login shell. We don't need the login shell per-se to run these commands, we can simply specify a shell to `su`.

Should fix these errors on Linux when the Agent 6 was installed on a clean env and is then downgraded to Agent 5, even when all configs are correct:

1. when downgrading the agent:
```
Setting up datadog-agent (1:5.28.0~rc.5-1) ...
Registering service datadog-agent
Enabling service datadog-agent
Invalid check configuration. Please run sudo /etc/init.d/datadog-agent configcheck for more details.
dpkg: error processing package datadog-agent (--configure):
 subprocess installed post-installation script returned error exit status 127
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

2. when executing a service command on the Agent 5:

```sh
$ sudo /etc/init.d/datadog-agent configcheck
This account is currently not available.
```

### Motivation

Agent 6 creates the dd-agent user with no login shell since https://github.com/DataDog/datadog-agent/pull/1800. So, if a user install Agent 6 from scratch, and then downgrades to Agent 5, the `dd-agent` user still has no login shell set.

We don't make the Agent 5 create the dd-agent user with no login shell though, this is a change that may break some setups, so we want to make it in the major v6 version only.

### Testing

Tested on debian and centOS
