### PR TITLE
Report amazon linux in metadata using the distro module

### DIFF
--- a/config.py
+++ b/config.py
@@ -25,6 +25,7 @@ from importlib import import_module
 
 # 3p
 import simplejson as json
+import distro
 
 # project
 from util import check_yaml, config_to_yaml
@@ -689,7 +690,11 @@ def get_system_stats(proc_path=None):
         log.warning("unable to retrieve number of cpuCores. Failed with error %s", e)
 
     if Platform.is_linux(platf):
-        systemStats['nixV'] = platform.dist()
+        name, version, codename = distro.linux_distribution(full_distribution_name=False)
+        if name == 'amzn':
+            name = 'amazon'
+
+        systemStats['nixV'] = (name, version, codename)
 
     elif Platform.is_darwin(platf):
         systemStats['macV'] = platform.mac_ver()

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ supervisor==3.3.3
 tornado==3.2.2
 uptime==3.0.1
 prometheus-client==0.1.0
+distro==1.3.0


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### Motivation

amazon linux is not reported corrrectly with the builtin `platform` module. We use the `distro` module which is the recommended replacement since `platform.dist` and `platform.linux_distribution` are deprecated and will be removed in python 3.8: https://docs.python.org/3.7/library/platform.html#platform.linux_distribution.

We change `amzn` to `amazon` to match what `gopsutil` reports in agent 6: https://github.com/shirou/gopsutil/blob/0f70a4a06f7a1039305ec9b3ba9c2800f8929fba/host/host_linux.go#L403.
