### PR TITLE
Bump requests version to 2.20.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,8 +32,6 @@ pyyaml==3.11
 # note: requests is also used in many checks
 # upgrade with caution
 requests==2.20.1
-# We need to pin this explicitely because both python-etcd and requests depend on urllib3
-# but even though requests pins urllib3 < 1.24, python-etcd does not and pip installs the latest anyway.
 urllib3==1.24.1
 # note: simplejson is used in many checks to inteface APIs
 simplejson==3.6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ python-etcd==0.4.5
 pyyaml==3.11
 # note: requests is also used in many checks
 # upgrade with caution
-requests==2.20.0
+requests==2.20.1
 # We need to pin this explicitely because both python-etcd and requests depend on urllib3
 # but even though requests pins urllib3 < 1.24, python-etcd does not and pip installs the latest anyway.
 urllib3==1.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ pyyaml==3.11
 requests==2.20.1
 # We need to pin this explicitely because both python-etcd and requests depend on urllib3
 # but even though requests pins urllib3 < 1.24, python-etcd does not and pip installs the latest anyway.
-urllib3==1.23
+urllib3==1.24.1
 # note: simplejson is used in many checks to inteface APIs
 simplejson==3.6.5
 supervisor==3.3.3

--- a/tests/core/test_proxy.py
+++ b/tests/core/test_proxy.py
@@ -57,7 +57,9 @@ class TestNoProxy(TestCase):
             'https': 'http://localhost:3128',
             'no': '127.0.0.1,localhost,169.254.169.254'
         }
+
         environ_proxies = get_environ_proxies("https://www.google.com")
+        environ_proxies.pop('travis_apt', None)
         self.assertEquals(expected_proxies, environ_proxies, (expected_proxies, environ_proxies))
 
         # Clear the env variables set


### PR DESCRIPTION
### What does this PR do?

Bump requests version to 2.20.1

### Additional Notes

related PR: https://github.com/DataDog/omnibus-software/pull/276
