### PR TITLE
[windows] fix core cpu check; didn't specify counter instance name

### DIFF
--- a/checks/system/win32.py
+++ b/checks/system/win32.py
@@ -144,7 +144,7 @@ class Cpu(Check):
         self.counter('system.cpu.system')
         self.counter('system.cpu.interrupt')
 
-        self.cpu_interrupt_counter = WinPDHCounter('Processor', '% Interrupt Time', logger)
+        self.cpu_interrupt_counter = WinPDHCounter('Processor', '% Interrupt Time', logger, instance_name="_Total")
 
     def check(self, agentConfig):
         cpu_percent = psutil.cpu_times()
@@ -154,7 +154,7 @@ class Cpu(Check):
         self.save_sample('system.cpu.system', 100 * cpu_percent.system / psutil.cpu_count())
 
         interrupt = self.cpu_interrupt_counter.get_single_value()
-        self.save_sample('system.cpu.interrupt', interrupt)
+        self.save_sample('system.cpu.interrupt', 100 * interrupt)
 
         return self.get_metrics()
 


### PR DESCRIPTION

### What does this PR do?

Fixes regression caused in previous release; conversion of computation of `% Interrupt time`to using windows performance counter wasn't done correctly

### Motivation

regression; customer feedback

### Testing Guidelines

Install on windows; verify metric `system.cpu.interrupt`
### Additional Notes

Anything else we should know when reviewing?
