### PR TITLE
Pin pylint to last python2-compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,5 @@ uptime==3.0.1
 prometheus-client==0.1.0
 distro==1.3.0
 datadog-a7==0.0.4
+# pin pylint to a python2-compatible version
+pylint==1.9.4


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*


### Motivation

Fix building alpine docker image
