### PR TITLE
Bump datadog-a7 to the latest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,6 @@ tornado==3.2.2
 uptime==3.0.1
 prometheus-client==0.1.0
 distro==1.3.0
-datadog-a7==0.0.4
+datadog-a7==0.0.5
 # pin pylint to a python2-compatible version
 pylint==1.9.4


### PR DESCRIPTION
### What does this PR do?

Bump datadog-a7 to the latest version
