### PR TITLE
Add bug fix version to the datadog.agent.check_ready metrics

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -489,6 +489,7 @@ class Collector(object):
                 meta = {'tags': ["check_name:%s" % check.name,
                                  "agent_version_major:%s" % AGENT_VERSION.split(".")[0],
                                  "agent_version_minor:%s" % AGENT_VERSION.split(".")[1],
+                                 "agent_version_bugfix:%s" % AGENT_VERSION.split(".")[2],
                                  "status:%s" % status
                                  ]}
 


### PR DESCRIPTION
### What does this PR do?

Add bug fix version to the `datadog.agent.check_ready` metrics