### PR TITLE
[jmxfetch] 0.26.0 released

### DIFF
--- a/config.py
+++ b/config.py
@@ -48,7 +48,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 # CONSTANTS
 AGENT_VERSION = "5.32.0"
-JMX_VERSION = "0.25.0"
+JMX_VERSION = "0.26.0"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
 MAC_CONFIG_PATH = '/opt/datadog-agent/etc'

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -161,6 +161,24 @@ gce_updated_hostname: yes
 # instead of setting them in the checks' custom_jar_paths option
 # jmx_custom_jars: /jmx-jars/jboss-cli-client.jar:/my/other/custom.jar
 #
+#
+# JMXFetch now collects multiples instances concurrently. The following metrics may
+# help fine-tune the level of concurrency and timeouts that come into play during the
+# collection of metrics from configured instances:
+#
+# thread_pool_size: determines the maximum level of concurrency.
+# jmx_thread_pool_size: 3
+#
+# collection_timeout: the maximum waiting period before timing up on metric collection
+# jmx_collection_timeout: 60
+#
+# reconnection_thread_pool_size: determines the maximum level of concurrency in the reconnection pool.
+# jmx_reconnection_thread_pool_size: 3
+#
+# reconnection_timeout: the maximum waiting period before timing up on instance reconnection
+# jmx_reconnection_timeout: 10
+#
+#
 # Docker labels as tags
 # We can extract docker labels and add them as tags to all metrics reported by service discovery.
 # All you have to do is supply a comma-separated list of label names to extract from containers when found.

--- a/datadog.conf.example
+++ b/datadog.conf.example
@@ -162,20 +162,28 @@ gce_updated_hostname: yes
 # jmx_custom_jars: /jmx-jars/jboss-cli-client.jar:/my/other/custom.jar
 #
 #
-# JMXFetch now collects multiples instances concurrently. The following metrics may
+# JMXFetch collects multiples instances concurrently. The following metrics may
 # help fine-tune the level of concurrency and timeouts that come into play during the
 # collection of metrics from configured instances:
 #
-# thread_pool_size: determines the maximum level of concurrency.
+# Defines the maximum level of concurrency. Higher concurrency will increase CPU
+# utilization during metric collection. Lower concurrency will result in lower CPU
+# usage but also fewer workers in the event of timeouts to continue work - a value of
+# 1 will process instances serially, each taking up to `jmx_collection_timeout`
+# seconds.
 # jmx_thread_pool_size: 3
 #
-# collection_timeout: the maximum waiting period before timing up on metric collection
+# Defines the maximum waiting period in seconds before timing up on metric collection.
 # jmx_collection_timeout: 60
 #
-# reconnection_thread_pool_size: determines the maximum level of concurrency in the reconnection pool.
+# Defines the maximum level of concurrency in the reconnection pool. Higher concurrency
+# will increase CPU utilization during instance recovery/reconnection. Lower concurrency
+# will result in lower CPU usage but also fewer workers in the event of timeouts to continue
+# work - a value of 1 will process instances serially, each taking up to `jmx_reconnection_timeout`
+# seconds.
 # jmx_reconnection_thread_pool_size: 3
 #
-# reconnection_timeout: the maximum waiting period before timing up on instance reconnection
+# Determines the maximum waiting period in seconds before timing up on instance reconnection.
 # jmx_reconnection_timeout: 10
 #
 #

--- a/jmxfetch.py
+++ b/jmxfetch.py
@@ -89,6 +89,12 @@ class JMXFetch(ProcessRunner):
         self.service_discovery = _is_affirmative(self.agent_config.get('sd_jmx_enable', False))
         self.config_jar_path = self.agent_config.get('jmx_custom_jars', "")
 
+        # concurrency options
+        self.pool_size = self.agent_config.get('jmx_thread_pool_size')
+        self.reconnection_pool_size = self.agent_config.get('jmx_reconnection_thread_pool_size')
+        self.collection_to = self.agent_config.get('jmx_collection_timeout')
+        self.reconnection_to = self.agent_config.get('jmx_reconnection_timeout')
+
         self.jmx_process = None
         self.jmx_checks = None
         super(JMXFetch, self).__init__()
@@ -274,6 +280,19 @@ class JMXFetch(ProcessRunner):
                 subprocess_args.insert(4, '--sd_pipe')
                 subprocess_args.insert(5, SD_PIPE_NAME)
                 subprocess_args.insert(4, '--sd_enabled')
+
+            if self.pool_size:
+                subprocess_args.insert(4, '--thread_pool_size')
+                subprocess_args.insert(5, self.pool_size)
+            if self.reconnection_pool_size:
+                subprocess_args.insert(4, '--reconnection_thread_pool_size')
+                subprocess_args.insert(5, self.reconnection_pool_size)
+            if self.collection_to:
+                subprocess_args.insert(4, '--collection_timeout')
+                subprocess_args.insert(5, self.collection_to)
+            if self.reconnection_to:
+                subprocess_args.insert(4, '--reconnection_timeout')
+                subprocess_args.insert(5, self.reconnection_to)
 
             if jmx_checks:
                 subprocess_args.insert(4, '--check')


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Bumps JMXFetch to version 0.26.0. Adding support for new JMXFetch options in the agent configuration.

### Motivation

New JMXFetch release and new options supported.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.