### PR TITLE
[psutil] Upgrade to 5.5.0

### DIFF
--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -14,7 +14,7 @@
 pycurl==7.19.5.1
 
 # core-ish/system -> system check on windows
-psutil==4.4.1
+psutil==5.5.0
 
 # checks.d/kubernetes_state.py -> used in utils/prometheus/*
 # Pure python module for dev purposes, the Agent is shipped with the optimized version built with --cpp_implementation


### PR DESCRIPTION
### What does this PR do?

Upgrades psutil to 5.5.0.

Reflects https://github.com/DataDog/omnibus-software/pull/291

### Motivation

Keep source install deps in sync with Agent

### Testing

Will have to be QA'ed well on Windows, since we use `psutil` in the windows system checks of Agent 5.

