### PR TITLE
[alpine] fix source install dep resolution: bump pip

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -14,7 +14,7 @@ set -u
 DEFAULT_AGENT_VERSION="5.31.0"
 # Pin pip version, in the past there was some buggy releases and get-pip.py
 # always pulls the latest version
-PIP_VERSION="6.1.1"
+PIP_VERSION="19.0.3"
 VIRTUALENV_VERSION="1.11.6"
 SUPERVISOR_VERSION="3.3.0"
 SETUPTOOLS_VERSION="20.9.0"


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Fixes the source install. After a new release of `isort` (pulled in by pylint) an issue with the dependency resolution of the old pip we used to use was uncovered with transitive dependencies. This PR bumps the pip version to a more current release.

On a different note, it's debatable the `pylint` dependency belongs in the `requirements`, but let's address the root cause here - the outdated pip.

### Motivation

Broken alpine build, source installs.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Change fixes the source install.