### PR TITLE
Revert "Upgrade requests & protobuf"

### DIFF
--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -18,4 +18,4 @@ psutil==5.5.0
 
 # checks.d/kubernetes_state.py -> used in utils/prometheus/*
 # Pure python module for dev purposes, the Agent is shipped with the optimized version built with --cpp_implementation
-protobuf==3.7.0
+protobuf==3.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ python-etcd==0.4.5
 pyyaml==3.11
 # note: requests is also used in many checks
 # upgrade with caution
-requests==2.21.0
+requests==2.20.1
 urllib3==1.24.1
 # note: simplejson is used in many checks to inteface APIs
 simplejson==3.6.5


### PR DESCRIPTION
Reverts DataDog/dd-agent#3829, since the `master` branch of `dd-agent` now needs to be in-sync with the `agent-v5` branch of integrations-core, which doesn't include (and doesn't need) these changes.