### PR TITLE
[urllib3] Upgrade to 1.24.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pyyaml==3.11
 # note: requests is also used in many checks
 # upgrade with caution
 requests==2.20.1
-urllib3==1.24.1
+urllib3==1.24.2
 # note: simplejson is used in many checks to inteface APIs
 simplejson==3.6.5
 supervisor==3.3.3


### PR DESCRIPTION
### What does this PR do?

Upgrades urlllib3 to 1.24.2

### Additional Notes

Not reflected on `omnibus-software` since urllib3 is not pinned there (which is not great btw). I checked urllib3 is already upgraded to 1.24.2 in the latest Agent 5 nightly build.
