### PR TITLE
[requirements] bumping pyyaml to 5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,5 @@ gem 'rake'
 gem 'rubocop', '~>0.50.0'
 
 # Upper versions are incompatible with ruby version on Travis (1.9.3)
-gem 'public_suffix', '~>1.4.0'
 gem 'parallel', '~>1.13.0'
+gem 'public_suffix', '~>1.4.0'

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem 'rubocop', '~>0.50.0'
 
 # Upper versions are incompatible with ruby version on Travis (1.9.3)
 gem 'public_suffix', '~>1.4.0'
+gem 'parallel', '~>1.13.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ python-consul==0.4.7
 # utils/service_discovery/config_stores.py
 python-etcd==0.4.5
 # the libyaml bindings are optional
-pyyaml==3.11
+pyyaml==5.1
 # note: requests is also used in many checks
 # upgrade with caution
 requests==2.20.1


### PR DESCRIPTION

### What does this PR do?

Bumps PyYaml to the latest 5.1.

### Motivation

Enable new `full_load()` option for customers perhaps wanting to use that after `load_all()` was patched for security reasons.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.