### PR TITLE
[CI] Use agent-v5 branch of integrations-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
     - PIP_CACHE=$HOME/.cache/pip
     - VOLATILE_DIR=/tmp
     - DD_CASHER_DIR=/tmp/casher
-    - INTEGRATIONS_CORE_BRANCH=master
+    - INTEGRATIONS_CORE_BRANCH=agent-v5
   matrix:
     - TRAVIS_FLAVOR=default
     - TRAVIS_FLAVOR=cassandra FLAVOR_VERSION=2.0.17

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
   NOSE_FILTER: not unix and not fixme
   PYWIN_PATH: C:\projects\dd-agent\.cache\pywin32-py2.7.exe
   SKIP_LINT: true
-  INTEGRATIONS_CORE_BRANCH: master
+  INTEGRATIONS_CORE_BRANCH: agent-v5
   matrix:
   - PYTHON: C:\\Python27
     PYTHON_VERSION: 2.7.9


### PR DESCRIPTION
### What does this PR do?

Switch to use the `agent-v5` branch of `integrations-core`

### Motivation

The code of Agent v5 is meant to work with the `agent-v5` branch of integrations-core now.

### Testing

As long as the CI passes on the PR we should be good

### Additional Notes

Should've done this when we created the `agent-v5` branches on the other repos, but I missed it at the time.
