### PR TITLE
Added multiple paths in CHECKSD_OVERRIDE

### DIFF
--- a/config.py
+++ b/config.py
@@ -220,7 +220,7 @@ def _confd_path(directory):
 def _checksd_path(directory):
     checks_override_env = os.environ.get('CHECKSD_OVERRIDE')
     checks_override_env_split = checks_override_env.split(':')
-    path_override=[]
+    path_override = []
     for checks_override_env_individual_path in checks_override_env_split:
         if checks_override_env_individual_path and os.path.exists(checks_override_env_individual_path):
             path_override.append(checks_override_env_individual_path)


### PR DESCRIPTION
Added multiple paths in CHECKSD_OVERRIDE (issue #3758)

### What does this PR do?
Fixes https://github.com/DataDog/dd-agent/issues/3758

### Motivation
Capability to supply multiple paths to CHECKSD_OVERRIDE env variable. Using the ":" separator.

