### PR TITLE
Return total count value as a metric

### DIFF
--- a/aggregator.py
+++ b/aggregator.py
@@ -268,6 +268,7 @@ class Histogram(Metric):
             ('avg', avg, MetricTypes.GAUGE),
             ('sum', sum_, MetricTypes.GAUGE),
             ('count', self.count/interval, MetricTypes.RATE),
+            ('total', self.count, MetricTypes.COUNT),
         ]
 
         metric_aggrs = [


### PR DESCRIPTION
# What does this PR do?

Sends the total metric count value of histogram metrics.

### Motivation

When migrating from regular statsd to dogstatsd we noticed that the count was aggregated differently.

### Testing Guidelines

Hoping the PR creation will run the tests.


