### PR TITLE
Call pylint directly instead of using a7

### DIFF
--- a/checks/collector.py
+++ b/checks/collector.py
@@ -31,8 +31,8 @@ from checks.check_status import (
 from checks.datadog import Dogstreams
 from checks.ganglia import Ganglia
 from config import (
-    A7_COMPATIBILITY_ATTR,
-    A7_COMPATIBILITY_READY,
+    PY3_COMPATIBILITY_ATTR,
+    PY3_COMPATIBILITY_READY,
     AGENT_VERSION,
     get_system_stats,
     get_version,
@@ -58,7 +58,7 @@ FLUSH_LOGGING_INITIAL = 5
 DD_CHECK_TAG = 'dd_check:{0}'
 
 def a7_compatible_to_int(status):
-    if status == A7_COMPATIBILITY_READY:
+    if status == PY3_COMPATIBILITY_READY:
         return 1
     return 0
 
@@ -483,9 +483,9 @@ class Collector(object):
                 meta = {'tags': ["check:%s" % check.name]}
                 metrics.append((metric, time.time(), check_run_time, meta))
 
-            if hasattr(check, A7_COMPATIBILITY_ATTR) and isinstance(getattr(check, A7_COMPATIBILITY_ATTR), str):
+            if hasattr(check, PY3_COMPATIBILITY_ATTR) and isinstance(getattr(check, PY3_COMPATIBILITY_ATTR), str):
                 metric = 'datadog.agent.check_ready'
-                status = getattr(check, A7_COMPATIBILITY_ATTR)
+                status = getattr(check, PY3_COMPATIBILITY_ATTR)
                 meta = {'tags': ["check_name:%s" % check.name,
                                  "agent_version_major:%s" % AGENT_VERSION.split(".")[0],
                                  "agent_version_minor:%s" % AGENT_VERSION.split(".")[1],
@@ -494,8 +494,8 @@ class Collector(object):
                                  ]}
 
                 # datadog.agent.check_ready:
-                # 0: is not compatible with A7 (or unknown)
-                # 1: is compatible with A7
+                # 0: is not compatible with Py3 (or unknown)
+                # 1: is compatible with Py3
                 metrics.append((metric, time.time(), a7_compatible_to_int(status), meta))
 
         for check_name, info in self.init_failed_checks_d.iteritems():

--- a/config.py
+++ b/config.py
@@ -56,10 +56,10 @@ SD_PIPE_UNIX_PATH = '/opt/datadog-agent/run'
 SD_PIPE_WIN_PATH = "\\\\.\\pipe\\{pipename}"
 UNKNOWN_WHEEL_VERSION_MSG = 'Unknown Wheel'
 CUSTOM_CHECK_VERSION_MSG = 'custom'
-A7_COMPATIBILITY_ATTR = 'a7_compatible'
-A7_COMPATIBILITY_READY = 'ready'
-A7_COMPATIBILITY_NOT_READY = 'not_ready'
-A7_COMPATIBILITY_UNKNOWN = 'unknown'
+PY3_COMPATIBILITY_ATTR = 'py3_compatible'
+PY3_COMPATIBILITY_READY = 'ready'
+PY3_COMPATIBILITY_NOT_READY = 'not_ready'
+PY3_COMPATIBILITY_UNKNOWN = 'unknown'
 
 log = logging.getLogger(__name__)
 
@@ -1194,7 +1194,7 @@ def load_check_from_places(check_config, check_name, checks_places, agentConfig)
         # Validate custom checks and wheels without a `datadog_checks` namespace
         if not agentConfig.get("disable_py3_validation", False):
             if version_override in (UNKNOWN_WHEEL_VERSION_MSG, CUSTOM_CHECK_VERSION_MSG):
-                a7_compatible = A7_COMPATIBILITY_UNKNOWN
+                py3_compatible = PY3_COMPATIBILITY_UNKNOWN
                 warnings = []
                 try:
                     file_path = os.path.realpath(check_path.decode(sys.getfilesystemencoding()))
@@ -1202,7 +1202,7 @@ def load_check_from_places(check_config, check_name, checks_places, agentConfig)
                         [sys.executable, "-m", "pylint", "-f", "json", "--py3k", "-d", "W1618", "--persistent", "no", "--exit-zero", file_path], log)
                     warnings = json.loads(output)
                 except SubprocessOutputEmptyError as e:
-                    a7_compatible = A7_COMPATIBILITY_READY
+                    py3_compatible = PY3_COMPATIBILITY_READY
                 except Exception as e:
                     log.error("error running 'validate' on custom check: %s", e)
 
@@ -1211,12 +1211,12 @@ def load_check_from_places(check_config, check_name, checks_places, agentConfig)
                     if message:
                         # for now we don't display anything in the status page
                         # log.warn("check '{}' is not Python3 compatible: {}".format(check_name, message))
-                        a7_compatible = A7_COMPATIBILITY_NOT_READY
+                        py3_compatible = PY3_COMPATIBILITY_NOT_READY
 
                 # for now we don't display anything in the status page
-                # if not a7_compatible:
+                # if not py3_compatible:
                 #     load_success[check_name].persistent_warning("check is not compatible with Python3 (see logs for more information)")
-                setattr(load_success[check_name], A7_COMPATIBILITY_ATTR, a7_compatible)
+                setattr(load_success[check_name], PY3_COMPATIBILITY_ATTR, py3_compatible)
 
         if is_wheel:
             log.debug('Loaded %s' % check_name)


### PR DESCRIPTION
### What does this PR do?

Makes the Agent call pylint directly in a subprocess instead of using a7.

### Testing Guidelines

Checked this worked on local dev env and custom check.

This will have to be QA'ed on Windows as well.

### Additional Notes

Also renamed the constants since they're actually related to python 3.

Requires https://github.com/DataDog/dd-agent-omnibus/pull/383
