### PR TITLE
Remove a7 from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,5 @@ tornado==3.2.2
 uptime==3.0.1
 prometheus-client==0.1.0
 distro==1.3.0
-datadog-a7==0.0.5
 # pin pylint to a python2-compatible version
 pylint==1.9.5


### PR DESCRIPTION
### What does this PR do?

Follow-up to https://github.com/DataDog/dd-agent/pull/3856

### Motivation

The Agent calls pylint directly now. No need for a7, and we don't include it in packaged agents anymore.

