### PR TITLE
Disable use of PEP517 in setup_agent

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -412,7 +412,7 @@ print_done
 
 print_console "* Installing requirements"
 $DOWNLOADER "$DD_HOME/requirements.txt" "$BASE_GITHUB_URL/requirements.txt"
-$VENV_PIP_CMD install -r "$DD_HOME/requirements.txt"
+$VENV_PIP_CMD install -r "$DD_HOME/requirements.txt" --no-use-pep517
 rm -f "$DD_HOME/requirements.txt"
 print_done
 


### PR DESCRIPTION
### What does this PR do?

It will disable the use of PEP517 during installing python packages with pip.

### Motivation

Execution failed on Raspberry Pi 4B with BackendUnavailable during installation of the dependency `lazy-object-proxy`

### Testing Guidelines

None
