### PR TITLE
[requirements] pin lazy-object-proxy for successful alpine build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,6 @@ prometheus-client==0.1.0
 distro==1.3.0
 # pin pylint to a python2-compatible version
 pylint==1.9.5
+# lazy-object-proxy is a dependency of pylint and needs to be pinned
+# for a successful build on Alpine (source install)
+lazy-object-proxy==1.3.1


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Fixes the alpine/source build by pinning `lazy-object-proxy`. Newer versions of the python package result in a broken alpine build.

### Motivation

Broken alpine builds.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

To be consistent, let's pin it across the board. Omnibus PR here: https://github.com/DataDog/dd-agent-omnibus/pull/385
