### PR TITLE
Use pip version 18.1

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -14,7 +14,7 @@ set -u
 DEFAULT_AGENT_VERSION="5.32.2"
 # Pin pip version, in the past there was some buggy releases and get-pip.py
 # always pulls the latest version
-PIP_VERSION="19.0.3"
+PIP_VERSION="18.1"
 VIRTUALENV_VERSION="1.11.6"
 SUPERVISOR_VERSION="3.3.0"
 SETUPTOOLS_VERSION="20.9.0"


### PR DESCRIPTION
### What does this PR do?
This PR reverts the pip version from 19.0.x to 18.1 for the source installation of Agent v5.32, in hopes of fixing a Backend Unavailable error that is present on some machines.

### Motivation

In trying to install the source agent on a Raspberry Pi Zero W I ran into a pep517 error: "Backend Unavailable."  This error led me to this pip github issue stating that this issue is not present in version 18.1 of pip: https://github.com/pypa/pip/issues/6164

I puled down the dd-agent repo and changed the pip version in setup_agent.sh locally, which allowed the completion of the download, though the agent is still non-functional on the Pi Zero W.

My hope is that using pip 18.1 will allow the source installation to complete on a wider range of machines.

### Additional Notes

This PR is untested at this time, and should not be merged until we're able to test this.  I'm not sure of how we might go about testing this PR out, and would be happy to sit with someone who can guide me on how to best test this PR to make sure it doesn't break installations on supported machines.
