### PR TITLE
[config] bumping JMXFetch version to 0.26.4

### DIFF
--- a/config.py
+++ b/config.py
@@ -44,7 +44,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 # CONSTANTS
 AGENT_VERSION = "5.32.7"
-JMX_VERSION = "0.26.3"
+JMX_VERSION = "0.26.4"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
 MAC_CONFIG_PATH = '/opt/datadog-agent/etc'


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Bumps JMXFetch to version 0.26.4.

### Motivation

Just a new bugfix release for JMXFetch that requires being updated here.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

(none)
