### PR TITLE
[requirements] bumps psutil to 5.6.7 and ntplib to 0.3.4

### DIFF
--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -14,7 +14,7 @@
 pycurl==7.19.5.1
 
 # core-ish/system -> system check on windows
-psutil==5.6.6
+psutil==5.6.7
 
 # checks.d/kubernetes_state.py -> used in utils/prometheus/*
 # Pure python module for dev purposes, the Agent is shipped with the optimized version built with --cpp_implementation

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -14,7 +14,7 @@
 pycurl==7.19.5.1
 
 # core-ish/system -> system check on windows
-psutil==5.5.0
+psutil==5.6.6
 
 # checks.d/kubernetes_state.py -> used in utils/prometheus/*
 # Pure python module for dev purposes, the Agent is shipped with the optimized version built with --cpp_implementation

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ boto==2.46.1
 docker-py==1.10.6
 # utils/service_discovery/config_stores.py
 kazoo==2.6.0
-ntplib==0.3.3
+ntplib==0.3.4
 # utils/service_discovery/config_stores.py
 python-consul==0.4.7
 # utils/service_discovery/config_stores.py


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Updates a couple deps.

### Motivation

Deps must be updated to address outdated/removed deps.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

(none)