### PR TITLE
[config] bumping to 5.32.7

### DIFF
--- a/config.py
+++ b/config.py
@@ -43,7 +43,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 
 # CONSTANTS
-AGENT_VERSION = "5.32.6"
+AGENT_VERSION = "5.32.7"
 JMX_VERSION = "0.26.3"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Bumps the config version to 5.32.7

### Motivation

New release.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Will just ship cert changes.
