### PR TITLE
[agent] do not always start the Agent profile dumps when the developer_mode is enabled.

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -313,7 +313,7 @@ class Agent(Daemon):
         self.restart_interval = int(self._agentConfig.get('restart_interval', RESTART_INTERVAL))
         self.agent_start = time.time()
 
-        self.allow_profiling = self._agentConfig.get('allow_profiling', True)
+        self.allow_profiling = _is_affirmative(self._agentConfig.get('allow_profiling', True))
 
         profiled = False
         collector_profiled_runs = 0


### PR DESCRIPTION
The `allow_profiling` configuration field isn't properly converted to a boolean (and is then a string), + is default value is True when not set. 

It means that when tested again the `developer_mode` boolean, only the `developer_mode` value matters because `allow_profiling` is always True either because it is a non-empty string, or because it has the default value `True`. The only way of setting it to false is to set it to an empty string in the configuration (`allow_profiling: ""`).

In other words:

```
allow_profiling = 'false'
developer_mode = True

if allow_profiling and developer_mode
→ this returns True

allow_profiling = 'false'
developer_mode = False

if allow_profiling and developer_mode
→ this returns False
```

It is only an issue when the `developer_mode` is enabled.