### PR TITLE
[config] setting the right agent and jmxfetch versions

### DIFF
--- a/config.py
+++ b/config.py
@@ -43,8 +43,8 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 
 # CONSTANTS
-AGENT_VERSION = "5.32.7"
-JMX_VERSION = "0.26.4"
+AGENT_VERSION = "5.32.8"
+JMX_VERSION = "0.26.5"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
 MAC_CONFIG_PATH = '/opt/datadog-agent/etc'


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Bumps the agent version to `5.32.8` as we prepeare that release + bumps JMXFetch to the latest A5-version. 

related PR: https://github.com/DataDog/omnibus-software/pull/368

### Motivation

Release prep.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.
