### PR TITLE
[config] bumping jmxfetch to latest 0.26.6 version 

### DIFF
--- a/config.py
+++ b/config.py
@@ -44,7 +44,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 # CONSTANTS
 AGENT_VERSION = "5.32.8"
-JMX_VERSION = "0.26.5"
+JMX_VERSION = "0.26.6"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
 MAC_CONFIG_PATH = '/opt/datadog-agent/etc'


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Bumps JMXFetch version to 0.26.6 - latest.

### Motivation

Need to add back support for Java7 that was lost with newer log4j2 releases.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

None
