### PR TITLE
[config] bump jmxfetch to java1.6 compatible 0.26.8

### DIFF
--- a/config.py
+++ b/config.py
@@ -44,7 +44,7 @@ from utils.windows_configuration import get_registry_conf, get_windows_sdk_check
 
 # CONSTANTS
 AGENT_VERSION = "5.32.8"
-JMX_VERSION = "0.26.7"
+JMX_VERSION = "0.26.8"
 DATADOG_CONF = "datadog.conf"
 UNIX_CONFIG_PATH = '/etc/dd-agent'
 MAC_CONFIG_PATH = '/opt/datadog-agent/etc'


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Bumps the expected JMXFetch version to 0.26.8.


### Motivation

JMXFetch 0.26.7 had a Java 1.6 incompatibility, that was since fixed in 0.26.8.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.
