### PR TITLE
Log a warning that file-configs override service-discovery configs

### DIFF
--- a/config.py
+++ b/config.py
@@ -1268,6 +1268,7 @@ def load_check_directory(agentConfig, hostname):
         if check_name in initialized_checks or \
                 check_name in init_failed_checks or \
                 check_name in JMX_CHECKS:
+            log.warning('Ignoring config for service discovery check %s because it was already configured by file.' % check_name)
             continue
 
         sd_init_config, sd_instances = service_disco_check_config[1]


### PR DESCRIPTION

### What does this PR do?

Logs a warning if a service-discovery configured check will be ignored if the same-named check was already configured from a file.

### Motivation

I have an haproxy.yaml file pointing at one instance of haproxy that I want to monitor on all servers. I am using Docker service discovery to configure other containers for service checks. This week I wanted to deploy a new use case for an haproxy container, and so I diligently added the Docker labels for an haproxy check. Nothing happened. Radio silence in the logs files.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

A better fix would be to merge the `instances` list from the file with the service discovered-instances list. Ironically, there is code in the service discovery config module to do exactly this, and then it is dutifully discarded if a file config exists. But first I want to solve the head-banging-on-wall problem of failing to log the discarded config.