### PR TITLE
docs: fix simple typo, suspicously -> suspiciously

### DIFF
--- a/tests/core/test_watchdog.py
+++ b/tests/core/test_watchdog.py
@@ -66,7 +66,7 @@ class TestWatchdog(unittest.TestCase):
             for x in xrange(0, 3):
                 ping_watchdog()
 
-            # On the 4th attempt, the watchdog detects a suspicously high activity
+            # On the 4th attempt, the watchdog detects a suspiciously high activity
             self.assertRaises(WatchdogKill, ping_watchdog)
 
         with self.set_time(3):


### PR DESCRIPTION
There is a small typo in tests/core/test_watchdog.py.

Should read `suspiciously` rather than `suspicously`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md