### PR TITLE
Change get-pip.py URL to 2.7

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -403,7 +403,7 @@ rm -f "$DD_HOME/ez_setup.pyc"
 print_done
 
 print_console "* Setting up pip"
-$DOWNLOADER "$DD_HOME/get-pip.py" https://bootstrap.pypa.io/get-pip.py
+$DOWNLOADER "$DD_HOME/get-pip.py" https://bootstrap.pypa.io/2.7/get-pip.py
 $VENV_PYTHON_CMD "$DD_HOME/get-pip.py"
 $VENV_PIP_CMD install "pip==$PIP_VERSION"
 rm -f "$DD_HOME/get-pip.py"


### PR DESCRIPTION
### What does this PR do?
This PR fixes the URL used to download get-pip.py, that points to a now incompatible script with Python 2.7.

### Motivation
Installing datadog-agent from source was broken with the following error:
```
  File "/home/pi/.datadog-agent/get-pip.py", line 24226, in <module>
    main()
  File "/home/pi/.datadog-agent/get-pip.py", line 199, in main
    bootstrap(tmpdir=tmpdir)
  File "/home/pi/.datadog-agent/get-pip.py", line 82, in bootstrap
    from pip._internal.cli.main import main as pip_entry_point
  File "/tmp/tmpJ2mYwm/pip.zip/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")

SyntaxError: invalid syntax
```