### PR TITLE
[core] update deprecated pip install url

### DIFF
--- a/packaging/datadog-agent/source/setup_agent.sh
+++ b/packaging/datadog-agent/source/setup_agent.sh
@@ -403,7 +403,7 @@ rm -f "$DD_HOME/ez_setup.pyc"
 print_done
 
 print_console "* Setting up pip"
-$DOWNLOADER "$DD_HOME/get-pip.py" https://bootstrap.pypa.io/2.7/get-pip.py
+$DOWNLOADER "$DD_HOME/get-pip.py" https://bootstrap.pypa.io/pip/2.7/get-pip.py
 $VENV_PYTHON_CMD "$DD_HOME/get-pip.py"
 $VENV_PIP_CMD install "pip==$PIP_VERSION"
 rm -f "$DD_HOME/get-pip.py"


### PR DESCRIPTION
### What does this PR do?

Updates the link to install pip from https://bootstrap.pypa.io/2.7/get-pip.py to https://bootstrap.pypa.io/pip/2.7/get-pip.py. 

### Motivation

When installing from source using the setup_agent.sh script:
`DD_API_KEY=<YOUR-API-KEY> sh -c "$(curl -L https://raw.githubusercontent.com/DataDog/dd-agent/master/packaging/datadog-agent/source/setup_agent.sh)"`

The script contains a link to install pip: https://bootstrap.pypa.io/2.7/get-pip.py

This causes the install script to fail as it links to a page with the following message:

> The URL you are using to fetch this script has changed, and this one will no
> longer work. Please use get-pip.py from the following URL instead:
> 
>     https://bootstrap.pypa.io/pip/2.7/get-pip.py
> 
> Sorry if this change causes any inconvenience for you!