### PR TITLE
[build] Ensure pip version is Python2 compatible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,9 @@ default_steps: &default_steps
     - run: |
         sudo apt-get update
         sudo apt install -y libcurl4-openssl-dev libssl-dev
-        pip install -U pip wheel
+        wget https://bootstrap.pypa.io/pip/2.7/get-pip.py
+        python get-pip.py
+        pip install --upgrade wheel
         cd $HOME/integrations-core/datadog_checks_base && python setup.py bdist_wheel && pip install . && cd -
     - run: |
         bundle install

--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ task 'setup_env' do
   `python venv/virtualenv.py -p python2 --no-site-packages --no-pip --no-setuptools venv/`
   `wget -O venv/ez_setup.py https://bootstrap.pypa.io/ez_setup.py`
   `venv/bin/python venv/ez_setup.py --version="20.9.0"`
-  `wget -O venv/get-pip.py https://bootstrap.pypa.io/get-pip.py`
+  `wget -O venv/get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py`
   `venv/bin/python venv/get-pip.py`
   `venv/bin/pip install -r requirements.txt`
   `venv/bin/pip install -r requirements-test.txt`


### PR DESCRIPTION
### What does this PR do?

Old code was fetching and using the latest pip which no longer supports
Python2. This change ensures that we only use Python v2-compatible
version for our CI/CD. while this doesn't fix all the issues with the pipeline,
it fixes the problems with pip and gets most of the CircleCI builds passing

### Motivation

CI/CD failures

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
