### PR TITLE
 [install_agent] Install datadog-signing-keys package along with the agent

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -206,7 +206,7 @@ determine the cause.
 If the cause is unclear, please contact Datadog support.
 *****
 "
-    $sudo_cmd apt-get install -y --force-yes datadog-agent
+    $sudo_cmd apt-get install -y --force-yes datadog-agent datadog-signing-keys
     ERROR_MESSAGE=""
 elif [ $OS = "SUSE" ]; then
   UNAME_M=$(uname -m)


### PR DESCRIPTION
### What does this PR do?

Adds datadog-signing-keys package to be installed along with the agent in the `install_agent.sh` script.

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
