### PR TITLE
[install-script] make pkg_list optional for testing purposes

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -59,6 +59,12 @@ if [ -n "$DD_HOST_TAGS" ]; then
     host_tags=$DD_HOST_TAGS
 fi
 
+if [ -n "$DD_PKG_LIST" ]; then
+  pkg_list=$DD_PKG_LIST
+else
+  pkg_list="datadog-agent datadog-signing-keys"
+fi
+
 if [ -n "$DD_KEYS_URL" ]; then
   keys_url=$DD_KEYS_URL
 else
@@ -206,7 +212,7 @@ determine the cause.
 If the cause is unclear, please contact Datadog support.
 *****
 "
-    $sudo_cmd apt-get install -y --force-yes datadog-agent datadog-signing-keys
+    $sudo_cmd apt-get install -y --force-yes $pkg_list
     ERROR_MESSAGE=""
 elif [ $OS = "SUSE" ]; then
   UNAME_M=$(uname -m)


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

This PR is quite simple, it simply aims to allow making the pkg_list configurable. This might be required for some testing repositories. 

### Motivation

Failed `dd-agent` QA pipeline due to missing artifact.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
