### PR TITLE
[CODEOWNERS] Add @DataDog/agent-shared-components as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# See https://help.github.com/articles/about-codeowners/ for syntax
+# Rules are matched bottom-to-top, so one team can own subdirectories
+# and another the rest of the directory.
+
+# All file changes should be reviewed by the maintainer team unless
+# specified otherwise
+*     @DataDog/agent-shared-components


### PR DESCRIPTION
### What does this PR do?

Adds @DataDog/agent-shared-components as codeowners

### Motivation

Since this repo is owned by the whole team, any changes should ping all members
of this team for reviews.

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
