### PR TITLE
Patch🐛CRLF injection via CVE-2020-26137

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pyyaml==5.3.1
 # note: requests is also used in many checks
 # upgrade with caution
 requests==2.20.1
-urllib3==1.24.3
+urllib3==1.26.5
 # note: simplejson is used in many checks to inteface APIs
 simplejson==3.6.5
 supervisor==3.3.3


### PR DESCRIPTION
### What does this PR do?
urllib3 before 1.25.9 allows CRLF injection if the attacker controls the HTTP request method, as demonstrated by inserting CR and LF control characters in the first argument of putrequest(). NOTE: this is similar to https://github.com/advisories/GHSA-w7gf-rpqw-gx4f.

**CVE-2020-26137**
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N`
**Severity Moderate**
`6.5/ 10`
