### PR TITLE
Revert "add the next future APT key following 2024 gpg key rotation"

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -95,8 +95,7 @@ fi
 # DATADOG_APT_KEY_382E94DE.public expires in 2022
 # DATADOG_APT_KEY_F14F620E.public expires in 2032
 # DATADOG_APT_KEY_C0962C7D.public expires in 2028
-# DATADOG_APT_KEY_06462314.public expires in 2033
-APT_GPG_KEYS=("DATADOG_APT_KEY_CURRENT.public" "DATADOG_APT_KEY_06462314.public" "DATADOG_APT_KEY_C0962C7D.public" "DATADOG_APT_KEY_F14F620E.public" "DATADOG_APT_KEY_382E94DE.public" "")
+APT_GPG_KEYS=("DATADOG_APT_KEY_CURRENT.public" "DATADOG_APT_KEY_C0962C7D.public" "DATADOG_APT_KEY_F14F620E.public" "DATADOG_APT_KEY_382E94DE.public")
 
 # OS/Distro Detection
 # Try lsb_release, fallback with /etc/issue then uname command


### PR DESCRIPTION
Reverts DataDog/dd-agent#3936

#incident-28254

The "" in this line https://github.com/DataDog/dd-agent/blob/fb2dbb70b42cc70962cc2e7c5e8ba3570dbd4669/packaging/datadog-agent/source/install_agent.sh#L99 is what’s causing https://github.com/DataDog/dd-agent/blob/fb2dbb70b42cc70962cc2e7c5e8ba3570dbd4669/packaging/datadog-agent/source/install_agent.sh#L206 to fail (since key is empty, it tries to overwrite a folder when writing curl