### PR TITLE
Revert "Revert "add the next future APT key following 2024 gpg key rotation"" and fix typo

### DIFF
--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -96,7 +96,7 @@ fi
 # DATADOG_APT_KEY_F14F620E.public expires in 2032
 # DATADOG_APT_KEY_C0962C7D.public expires in 2028
 # DATADOG_APT_KEY_06462314.public expires in 2033
-APT_GPG_KEYS=("DATADOG_APT_KEY_CURRENT.public" "DATADOG_APT_KEY_06462314.public" "DATADOG_APT_KEY_C0962C7D.public" "DATADOG_APT_KEY_F14F620E.public" "DATADOG_APT_KEY_382E94DE.public" "")
+APT_GPG_KEYS=("DATADOG_APT_KEY_CURRENT.public" "DATADOG_APT_KEY_06462314.public" "DATADOG_APT_KEY_C0962C7D.public" "DATADOG_APT_KEY_F14F620E.public" "DATADOG_APT_KEY_382E94DE.public")
 
 # OS/Distro Detection
 # Try lsb_release, fallback with /etc/issue then uname command

--- a/packaging/datadog-agent/source/install_agent.sh
+++ b/packaging/datadog-agent/source/install_agent.sh
@@ -95,7 +95,8 @@ fi
 # DATADOG_APT_KEY_382E94DE.public expires in 2022
 # DATADOG_APT_KEY_F14F620E.public expires in 2032
 # DATADOG_APT_KEY_C0962C7D.public expires in 2028
-APT_GPG_KEYS=("DATADOG_APT_KEY_CURRENT.public" "DATADOG_APT_KEY_C0962C7D.public" "DATADOG_APT_KEY_F14F620E.public" "DATADOG_APT_KEY_382E94DE.public")
+# DATADOG_APT_KEY_06462314.public expires in 2033
+APT_GPG_KEYS=("DATADOG_APT_KEY_CURRENT.public" "DATADOG_APT_KEY_06462314.public" "DATADOG_APT_KEY_C0962C7D.public" "DATADOG_APT_KEY_F14F620E.public" "DATADOG_APT_KEY_382E94DE.public" "")
 
 # OS/Distro Detection
 # Try lsb_release, fallback with /etc/issue then uname command


### PR DESCRIPTION
*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Revert "Revert "add the next future APT key following 2024 gpg key rotation"" and fix breaking typo

### Motivation

What inspired you to submit this pull request?

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Anything else we should know when reviewing?
