### PR TITLE
Disable ADMS dependency update PRs

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -1,0 +1,5 @@
+schema-version: v2
+kind: adms
+auto-version-updates:
+  disabled:
+    reason: Disable dependency update PRs


### PR DESCRIPTION
### What does this PR do?

Disable ADMS dependency update PRs.

### Motivation

We can't merge them as is so they are just noisy.

### Testing Guidelines

n/a

### Additional Notes
